### PR TITLE
Add OpenTelemetry instrumentation for Go API and Python AI worker

### DIFF
--- a/internal/middleware/otel.go
+++ b/internal/middleware/otel.go
@@ -1,0 +1,84 @@
+package middleware
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const instrumentationName = "github.com/ravencloak-org/Raven/internal/middleware"
+
+// OTelMiddleware returns a Gin middleware that creates a span per HTTP request,
+// records request duration as a histogram metric, and sets the X-Trace-ID
+// response header.
+//
+// When the global TracerProvider is a no-op (i.e. OTel is not configured) the
+// middleware still runs but produces zero overhead because the SDK short-
+// circuits all recording.
+func OTelMiddleware() gin.HandlerFunc {
+	tracer := otel.Tracer(instrumentationName)
+	meter := otel.Meter(instrumentationName)
+
+	// Best-effort histogram; if creation fails we continue without metrics.
+	duration, _ := meter.Float64Histogram(
+		"http.server.request.duration",
+		metric.WithDescription("Duration of HTTP server requests"),
+		metric.WithUnit("s"),
+	)
+
+	return func(c *gin.Context) {
+		start := time.Now()
+
+		// Derive a readable span name: "GET /healthz".
+		spanName := fmt.Sprintf("%s %s", c.Request.Method, c.FullPath())
+		if c.FullPath() == "" {
+			spanName = fmt.Sprintf("%s %s", c.Request.Method, c.Request.URL.Path)
+		}
+
+		ctx, span := tracer.Start(c.Request.Context(), spanName,
+			trace.WithSpanKind(trace.SpanKindServer),
+			trace.WithAttributes(
+				semconv.HTTPRequestMethodKey.String(c.Request.Method),
+				semconv.URLPath(c.Request.URL.Path),
+			),
+		)
+		defer span.End()
+
+		// Propagate the trace context into the request so downstream
+		// handlers and services can join the trace.
+		c.Request = c.Request.WithContext(ctx)
+
+		// Expose the trace ID as a response header for easy debugging.
+		if span.SpanContext().HasTraceID() {
+			c.Header("X-Trace-ID", span.SpanContext().TraceID().String())
+		}
+
+		// Process request.
+		c.Next()
+
+		// After the request completes record status on the span.
+		status := c.Writer.Status()
+		span.SetAttributes(
+			semconv.HTTPResponseStatusCode(status),
+			semconv.HTTPRoute(c.FullPath()),
+		)
+
+		// Record duration metric.
+		elapsed := time.Since(start).Seconds()
+		if duration != nil {
+			duration.Record(ctx,
+				elapsed,
+				metric.WithAttributes(
+					semconv.HTTPRequestMethodKey.String(c.Request.Method),
+					semconv.HTTPRoute(c.FullPath()),
+					semconv.HTTPResponseStatusCode(status),
+				),
+			)
+		}
+	}
+}

--- a/internal/middleware/otel_test.go
+++ b/internal/middleware/otel_test.go
@@ -1,0 +1,176 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// setupTestOTel configures an in-memory span exporter and metric reader so
+// tests can inspect what the middleware recorded.
+func setupTestOTel(t *testing.T) (*tracetest.InMemoryExporter, *sdkmetric.ManualReader) {
+	t.Helper()
+
+	spanExporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithSyncer(spanExporter),
+	)
+
+	metricReader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(metricReader),
+	)
+
+	otel.SetTracerProvider(tp)
+	otel.SetMeterProvider(mp)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+		_ = mp.Shutdown(context.Background())
+	})
+
+	return spanExporter, metricReader
+}
+
+// newTestRouter returns a Gin engine with the OTel middleware and a single
+// GET /healthz route that returns 200.
+func newTestRouter() *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(OTelMiddleware())
+	r.GET("/healthz", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	})
+	return r
+}
+
+func TestSpanCreatedForRequest(t *testing.T) {
+	spanExporter, _ := setupTestOTel(t)
+
+	router := newTestRouter()
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	router.ServeHTTP(w, req)
+
+	spans := spanExporter.GetSpans()
+	if len(spans) == 0 {
+		t.Fatal("expected at least one span to be recorded")
+	}
+}
+
+func TestTraceIDHeaderSet(t *testing.T) {
+	setupTestOTel(t)
+
+	router := newTestRouter()
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	router.ServeHTTP(w, req)
+
+	traceID := w.Header().Get("X-Trace-ID")
+	if traceID == "" {
+		t.Fatal("expected X-Trace-ID header to be set")
+	}
+	if len(traceID) != 32 {
+		t.Fatalf("expected 32-char trace ID, got %d chars: %s", len(traceID), traceID)
+	}
+}
+
+func TestSpanAttributes(t *testing.T) {
+	spanExporter, _ := setupTestOTel(t)
+
+	router := newTestRouter()
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	router.ServeHTTP(w, req)
+
+	spans := spanExporter.GetSpans()
+	if len(spans) == 0 {
+		t.Fatal("expected at least one span")
+	}
+
+	span := spans[0]
+
+	// Check span name includes method and route.
+	if span.Name != "GET /healthz" {
+		t.Errorf("expected span name 'GET /healthz', got %q", span.Name)
+	}
+
+	// Collect attributes into a map for easy lookup.
+	attrs := make(map[string]interface{})
+	for _, a := range span.Attributes {
+		attrs[string(a.Key)] = a.Value.AsInterface()
+	}
+
+	if v, ok := attrs["http.request.method"]; !ok || v != "GET" {
+		t.Errorf("expected http.request.method=GET, got %v", v)
+	}
+	if _, ok := attrs["http.response.status_code"]; !ok {
+		t.Error("expected http.response.status_code attribute to be set")
+	}
+	if _, ok := attrs["http.route"]; !ok {
+		t.Error("expected http.route attribute to be set")
+	}
+}
+
+func TestRequestDurationMetric(t *testing.T) {
+	_, metricReader := setupTestOTel(t)
+
+	router := newTestRouter()
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	router.ServeHTTP(w, req)
+
+	var rm metricdata.ResourceMetrics
+	if err := metricReader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("failed to collect metrics: %v", err)
+	}
+
+	found := false
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == "http.server.request.duration" {
+				found = true
+			}
+		}
+	}
+
+	if !found {
+		t.Error("expected http.server.request.duration metric to be recorded")
+	}
+}
+
+func TestNoOpModeNoPanic(t *testing.T) {
+	// Use the default no-op providers by creating a fresh tracer/meter
+	// provider with no exporters. This simulates the state when OTel is
+	// not configured.
+	noopTP := sdktrace.NewTracerProvider()
+	noopMP := sdkmetric.NewMeterProvider()
+
+	otel.SetTracerProvider(noopTP)
+	otel.SetMeterProvider(noopMP)
+	t.Cleanup(func() {
+		_ = noopTP.Shutdown(context.Background())
+		_ = noopMP.Shutdown(context.Background())
+	})
+
+	router := newTestRouter()
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+
+	// Must not panic.
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -1,0 +1,102 @@
+// Package telemetry initialises OpenTelemetry tracing and metrics for the
+// Raven API.  When no OTLP endpoint is configured the package gracefully
+// degrades to no-op providers so the rest of the application works without
+// any observable overhead.
+package telemetry
+
+import (
+	"context"
+	"errors"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+	"go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+)
+
+// InitProvider sets up a TracerProvider and MeterProvider.
+//
+// If endpoint is non-empty, OTLP gRPC exporters are configured for both traces
+// and metrics.  Otherwise no-op providers are used so that callers never need
+// to nil-check.
+//
+// The returned shutdown function flushes pending telemetry and releases
+// resources.  It is safe to call even when the providers are no-ops.
+func InitProvider(ctx context.Context, serviceName, serviceVersion, endpoint, environment string) (shutdown func(context.Context) error, err error) {
+	// Build the OTel resource that describes this service.
+	// We use NewSchemaless to avoid schema-URL conflicts with resource.Default().
+	res, err := resource.Merge(
+		resource.Default(),
+		resource.NewSchemaless(
+			semconv.ServiceName(serviceName),
+			semconv.ServiceVersion(serviceVersion),
+			semconv.DeploymentEnvironment(environment),
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// When there is no endpoint we leave the global providers at their
+	// defaults (no-op).  Return a no-op shutdown.
+	if endpoint == "" {
+		return func(context.Context) error { return nil }, nil
+	}
+
+	var shutdownFuncs []func(context.Context) error
+
+	// Helper that aggregates all shutdown functions.
+	shutdownAll := func(ctx context.Context) error {
+		var errs []error
+		for _, fn := range shutdownFuncs {
+			if e := fn(ctx); e != nil {
+				errs = append(errs, e)
+			}
+		}
+		return errors.Join(errs...)
+	}
+
+	// --- Trace exporter ---
+	traceExporter, err := otlptracegrpc.New(ctx,
+		otlptracegrpc.WithEndpoint(endpoint),
+		otlptracegrpc.WithInsecure(),
+	)
+	if err != nil {
+		return shutdownAll, err
+	}
+
+	tp := trace.NewTracerProvider(
+		trace.WithBatcher(traceExporter),
+		trace.WithResource(res),
+	)
+	shutdownFuncs = append(shutdownFuncs, tp.Shutdown)
+	otel.SetTracerProvider(tp)
+
+	// --- Metric exporter ---
+	metricExporter, err := otlpmetricgrpc.New(ctx,
+		otlpmetricgrpc.WithEndpoint(endpoint),
+		otlpmetricgrpc.WithInsecure(),
+	)
+	if err != nil {
+		return shutdownAll, err
+	}
+
+	mp := metric.NewMeterProvider(
+		metric.WithReader(metric.NewPeriodicReader(metricExporter)),
+		metric.WithResource(res),
+	)
+	shutdownFuncs = append(shutdownFuncs, mp.Shutdown)
+	otel.SetMeterProvider(mp)
+
+	// --- Propagation ---
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+
+	return shutdownAll, nil
+}

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -1,0 +1,69 @@
+package telemetry
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel"
+)
+
+func TestInitProvider_EmptyEndpoint_ReturnsNoOp(t *testing.T) {
+	shutdown, err := InitProvider(context.Background(), "test-service", "0.1.0", "", "test")
+	if err != nil {
+		t.Fatalf("expected no error for empty endpoint, got: %v", err)
+	}
+	if shutdown == nil {
+		t.Fatal("expected non-nil shutdown function")
+	}
+	// The shutdown function should work without error.
+	if err := shutdown(context.Background()); err != nil {
+		t.Fatalf("expected no error from no-op shutdown, got: %v", err)
+	}
+}
+
+func TestInitProvider_WithEndpoint_ConfiguresTracer(t *testing.T) {
+	// Use a dummy endpoint -- the exporter is created but never dialled
+	// during the test because we shut down immediately.
+	shutdown, err := InitProvider(context.Background(), "test-service", "0.1.0", "localhost:4317", "test")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if shutdown == nil {
+		t.Fatal("expected non-nil shutdown function")
+	}
+
+	// Verify a real TracerProvider was installed (not the default no-op).
+	tp := otel.GetTracerProvider()
+	typeName := typeNameOf(tp)
+	if typeName == "tracerProvider" {
+		t.Error("expected a real TracerProvider to be set, got the default no-op")
+	}
+
+	// Shutdown with a short timeout -- the exporter targets an unreachable
+	// endpoint so the flush will fail. We only care that shutdown does not
+	// panic; export errors are expected in this test scenario.
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	_ = shutdown(ctx) // error is expected (unreachable endpoint)
+}
+
+func TestShutdown_CalledTwice_NoPanic(t *testing.T) {
+	shutdown, err := InitProvider(context.Background(), "test-service", "0.1.0", "", "test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Calling shutdown multiple times should not panic.
+	_ = shutdown(context.Background())
+	_ = shutdown(context.Background())
+}
+
+// typeNameOf returns the short type name for debugging.
+func typeNameOf(v interface{}) string {
+	if v == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%T", v)
+}


### PR DESCRIPTION
## Summary
- Add Go `internal/telemetry` package with OTLP exporter setup, tracer/meter providers, and graceful shutdown
- Add `internal/middleware/otel.go` HTTP middleware for request tracing and metrics collection
- Wire OTel initialization into `cmd/api/main.go` and extend `internal/config/config.go` with OTel settings
- Add Python `ai-worker/raven_worker/telemetry.py` with OTLP exporter, gRPC interceptors, and span helpers
- Update `ai-worker/raven_worker/server.py` and `config.py` to integrate OTel, add OTel deps to `pyproject.toml`
- Include unit tests for both Go (`otel_test.go`, `telemetry_test.go`) and Python (`test_telemetry.py`) components

## Test plan
- [ ] `go test ./internal/telemetry/... ./internal/middleware/...` passes
- [ ] `cd ai-worker && pytest tests/test_telemetry.py` passes
- [ ] Review OTLP exporter configuration for both services
- [ ] Verify graceful shutdown of tracer/meter providers
- [ ] Confirm middleware captures HTTP method, status, duration metrics

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Launched AI Worker service with embeddings and RAG query capabilities
  * Deployed HTTP API server with health check functionality
  * Enabled OpenTelemetry observability for tracing and metrics collection

* **Tests**
  * Added comprehensive test coverage for telemetry and middleware components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->