### PR TITLE
ci: add PR-Agent AI code review with Anthropic Claude

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -1,0 +1,42 @@
+name: AI Code Review (PR-Agent)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  pr-agent:
+    if: >
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'issue_comment' &&
+       contains(github.event.comment.body, '/review') &&
+       github.event.issue.pull_request)
+    runs-on: ubuntu-latest
+    name: PR-Agent Review
+    steps:
+      - name: PR-Agent Auto Review
+        uses: qodo-ai/pr-agent@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CONFIG.MODEL: "anthropic/claude-sonnet-4-20250514"
+          CONFIG.MODEL_TURBO: "anthropic/claude-sonnet-4-20250514"
+          CONFIG.FALLBACK_MODELS: '["anthropic/claude-sonnet-4-20250514"]'
+          ANTHROPIC.KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          PR_REVIEWER.REQUIRE_FOCUSED_REVIEW: "true"
+          PR_REVIEWER.REQUIRE_SECURITY_REVIEW: "true"
+          PR_REVIEWER.EXTRA_INSTRUCTIONS: >
+            Focus on: security vulnerabilities (SQL injection, XSS, auth bypass),
+            AGPL/copyleft license violations, proper error handling, and Go/Python
+            idioms. Flag any hardcoded secrets.
+          PR_CODE_SUGGESTIONS.EXTRA_INSTRUCTIONS: >
+            Prefer idiomatic Go patterns. For Python, ensure type hints and
+            proper async handling. Check for RLS policy gaps in SQL migrations.
+        with:
+          command: auto_review


### PR DESCRIPTION
## Summary
- Self-hosted AI code review using [PR-Agent](https://github.com/qodo-ai/pr-agent) (Apache 2.0)
- Uses Anthropic Claude Sonnet — no external SaaS rate limits
- Triggers automatically on PR open/sync, or manually via `/review` comment
- Security-focused review instructions for Go, Python, SQL

## Setup required
Add `ANTHROPIC_API_KEY` to repo secrets: Settings → Secrets → Actions → New repository secret

## Test plan
- [ ] Add ANTHROPIC_API_KEY secret
- [ ] Open a test PR and verify PR-Agent posts a review

🤖 Generated with [Claude Code](https://claude.com/claude-code)