### PR TITLE
deps(actions): bump all GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,14 +39,14 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GHCR
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -63,6 +63,6 @@ jobs:
           cache: true
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.11.4

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           scan-type: fs
           scan-ref: .


### PR DESCRIPTION
## Summary
- golangci/golangci-lint-action: v6 → v9
- aquasecurity/trivy-action: 0.28.0 → v0.35.0
- docker/setup-qemu-action: v3 → v4
- docker/setup-buildx-action: v3 → v4
- docker/login-action: v3 → v4

Supersedes Dependabot PRs #83, #87, #88, #89, #90 (blocked by `workflow` scope).

## Test plan
- [ ] CI workflows pass with updated action versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)