### PR TITLE
fix: resolve CI failures (TypeScript, ruff format, grpc CVE)

### DIFF
--- a/ai-worker/raven_worker/processors/scraper.py
+++ b/ai-worker/raven_worker/processors/scraper.py
@@ -26,6 +26,5 @@ class WebScraper:
         """
         logger.info("scrape_url", url=url)
         raise NotImplementedError(
-            f"Web scraping not yet implemented for url={url}. "
-            "Crawl4AI integration is pending."
+            f"Web scraping not yet implemented for url={url}. Crawl4AI integration is pending."
         )

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,7 +24,7 @@
         "eslint-plugin-vue": "^10.8.0",
         "prettier": "^3.8.1",
         "tailwindcss": "^4.2.2",
-        "typescript": "^6.0.2",
+        "typescript": "^5.9.3",
         "typescript-eslint": "^8.57.2",
         "vite": "^8.0.1",
         "vue-tsc": "^3.2.5"
@@ -2894,9 +2894,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "peer": true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,7 @@
     "eslint-plugin-vue": "^10.8.0",
     "prettier": "^3.8.1",
     "tailwindcss": "^4.2.2",
-    "typescript": "^6.0.2",
+    "typescript": "^5.9.3",
     "typescript-eslint": "^8.57.2",
     "vite": "^8.0.1",
     "vue-tsc": "^3.2.5"

--- a/go.mod
+++ b/go.mod
@@ -112,7 +112,7 @@ require (
 	golang.org/x/text v0.34.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260209200024-4cfbd4190f57 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260217215200-42d3e9bedb6d // indirect
-	google.golang.org/grpc v1.79.2 // indirect
+	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -268,8 +268,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260209200024-4cfbd4190f57 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260209200024-4cfbd4190f57/go.mod h1:kSJwQxqmFXeo79zOmbrALdflXQeAYcUbgS7PbpMknCY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260217215200-42d3e9bedb6d h1:t/LOSXPJ9R0B6fnZNyALBRfZBH0Uy0gT+uR+SJ6syqQ=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260217215200-42d3e9bedb6d/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.79.2 h1:fRMD94s2tITpyJGtBBn7MkMseNpOZU8ZxgC3MMBaXRU=
-google.golang.org/grpc v1.79.2/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
+google.golang.org/grpc v1.79.3 h1:sybAEdRIEtvcD68Gx7dmnwjZKlyfuc61Dyo9pGXXkKE=
+google.golang.org/grpc v1.79.3/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## Summary
- **Frontend CI**: Revert TypeScript 6.0.2 → 5.9.3 (typescript-eslint peer dep requires <6.0.0)
- **Python CI**: Fix ruff format on `scraper.py`
- **Security**: Bump `google.golang.org/grpc` v1.79.2 → v1.79.3 (fixes CVE-2026-33186 critical — auth bypass via missing leading slash)

## Test plan
- [ ] Frontend CI passes (npm ci + lint + build)
- [ ] Python CI passes (ruff check + format + pytest)
- [ ] Security scan passes (no critical/high vulns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development and build dependencies to latest patch versions for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->