### PR TITLE
chore: add CI status badges and Codecov to README

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -46,6 +46,12 @@ jobs:
       - name: Test
         run: go test -race -coverprofile=coverage.txt ./...
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.txt
+          fail_ci_if_error: false
+
       - name: Vet
         run: go vet ./...
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,12 @@
 <p align="center">Open-source multi-tenant knowledge base platform with AI-powered chat, voice, and WhatsApp</p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/build-passing-brightgreen" alt="Build Status" />
+  <a href="https://github.com/ravencloak-org/Raven/actions/workflows/go.yml"><img src="https://github.com/ravencloak-org/Raven/actions/workflows/go.yml/badge.svg" alt="Go CI" /></a>
+  <a href="https://github.com/ravencloak-org/Raven/actions/workflows/frontend.yml"><img src="https://github.com/ravencloak-org/Raven/actions/workflows/frontend.yml/badge.svg" alt="Frontend CI" /></a>
+  <a href="https://github.com/ravencloak-org/Raven/actions/workflows/python.yml"><img src="https://github.com/ravencloak-org/Raven/actions/workflows/python.yml/badge.svg" alt="Python CI" /></a>
+  <a href="https://github.com/ravencloak-org/Raven/actions/workflows/docker.yml"><img src="https://github.com/ravencloak-org/Raven/actions/workflows/docker.yml/badge.svg" alt="Docker Build" /></a>
+  <a href="https://github.com/ravencloak-org/Raven/actions/workflows/security.yml"><img src="https://github.com/ravencloak-org/Raven/actions/workflows/security.yml/badge.svg" alt="Security" /></a>
+  <a href="https://codecov.io/gh/ravencloak-org/Raven"><img src="https://codecov.io/gh/ravencloak-org/Raven/branch/main/graph/badge.svg" alt="Coverage" /></a>
   <img src="https://img.shields.io/badge/license-TBD-lightgrey" alt="License" />
   <img src="https://img.shields.io/badge/PRs-welcome-blue" alt="PRs Welcome" />
 </p>


### PR DESCRIPTION
## Summary
- Replace placeholder build badge with live GitHub Actions badges (Go CI, Frontend CI, Python CI, Docker Build, Security)
- Add Codecov coverage badge
- Add `codecov/codecov-action@v5` upload step to Go CI workflow so coverage is tracked on every push

## Notes
- Codecov badge will show once `CODECOV_TOKEN` secret is added to repo settings (or auto-links for public repos)
- `claude-code-review.yml` is kept as-is — works when usage limit is not hit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Project status badges have been significantly enhanced to provide comprehensive visibility into CI/CD pipeline health and status across all development platforms and test suites. Code coverage metrics are now integrated into project documentation, offering improved transparency into code quality measurements and overall project reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->