### PR TITLE
feat: resolve workspace role from DB + RBAC convenience wrappers (#28)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -147,21 +147,27 @@ func main() {
 		api.DELETE("/orgs/:org_id", middleware.RequireOrgRole("org_admin"), orgHandler.Delete)
 
 		// --- Workspace routes (nested under org) ---
+		// ResolveWorkspaceRole looks up the caller's workspace role from the
+		// workspace_members table and stores it in the Gin context. It is applied
+		// to all routes that contain a :ws_id parameter so that downstream
+		// RequireWorkspaceRole checks have the role available.
+		resolveWSRole := middleware.ResolveWorkspaceRole(pool)
+
 		ws := api.Group("/orgs/:org_id/workspaces")
 		{
 			ws.POST("", middleware.RequireOrgRole("org_admin"), wsHandler.Create)
 			ws.GET("", wsHandler.List)
-			ws.GET("/:ws_id", wsHandler.Get)
-			ws.PUT("/:ws_id", middleware.RequireWorkspaceRole("admin"), wsHandler.Update)
+			ws.GET("/:ws_id", resolveWSRole, wsHandler.Get)
+			ws.PUT("/:ws_id", resolveWSRole, middleware.RequireWorkspaceRole("admin"), wsHandler.Update)
 			ws.DELETE("/:ws_id", middleware.RequireOrgRole("org_admin"), wsHandler.Delete)
 
 			// Workspace member management
-			ws.POST("/:ws_id/members", middleware.RequireWorkspaceRole("admin"), wsHandler.AddMember)
-			ws.PUT("/:ws_id/members/:user_id", middleware.RequireWorkspaceRole("admin"), wsHandler.UpdateMember)
-			ws.DELETE("/:ws_id/members/:user_id", middleware.RequireWorkspaceRole("admin"), wsHandler.RemoveMember)
+			ws.POST("/:ws_id/members", resolveWSRole, middleware.RequireWorkspaceRole("admin"), wsHandler.AddMember)
+			ws.PUT("/:ws_id/members/:user_id", resolveWSRole, middleware.RequireWorkspaceRole("admin"), wsHandler.UpdateMember)
+			ws.DELETE("/:ws_id/members/:user_id", resolveWSRole, middleware.RequireWorkspaceRole("admin"), wsHandler.RemoveMember)
 
 			// Knowledge Base routes (nested under workspace)
-			kb := ws.Group("/:ws_id/knowledge-bases")
+			kb := ws.Group("/:ws_id/knowledge-bases", resolveWSRole)
 			{
 				kb.POST("", middleware.RequireWorkspaceRole("member"), kbHandler.Create)
 				kb.GET("", kbHandler.List)

--- a/internal/middleware/rbac.go
+++ b/internal/middleware/rbac.go
@@ -1,11 +1,26 @@
 package middleware
 
 import (
+	"context"
+	"errors"
 	"net/http"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/gin-gonic/gin"
 	"github.com/ravencloak-org/Raven/pkg/apierror"
 )
+
+// PoolQuerier abstracts the QueryRow method used by ResolveWorkspaceRole so
+// that a *pgxpool.Pool can be passed in production and a lightweight stub in
+// tests.
+type PoolQuerier interface {
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+// compile-time check: *pgxpool.Pool satisfies PoolQuerier.
+var _ PoolQuerier = (*pgxpool.Pool)(nil)
 
 // workspaceRoleRank maps workspace role names to their permission level.
 // Higher index means more permissions; an org_admin bypasses all workspace checks.
@@ -57,4 +72,117 @@ func RequireWorkspaceRole(minimum string) gin.HandlerFunc {
 			Detail:  "requires workspace role: " + minimum,
 		})
 	}
+}
+
+// ---------------------------------------------------------------------------
+// ResolveWorkspaceRole — database-backed workspace role resolver
+// ---------------------------------------------------------------------------
+
+// ResolveWorkspaceRole returns a Gin middleware that looks up the caller's
+// workspace role from the workspace_members table and stores it in the
+// context under ContextKeyWorkspaceRole.
+//
+// It expects the following to already be in the Gin context (set by JWTMiddleware):
+//   - ContextKeyUserID  (string)
+//   - ContextKeyOrgRole (string)
+//
+// URL parameter required: :ws_id
+//
+// Behaviour:
+//   - org_admin users bypass the DB lookup entirely; their workspace role is
+//     not set (downstream RequireWorkspaceRole already short-circuits for
+//     org_admin).
+//   - If the user is not a member of the workspace, the request is aborted
+//     with 403.
+//   - On DB errors the request is aborted with 500.
+func ResolveWorkspaceRole(db PoolQuerier) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// org_admin bypasses workspace membership check.
+		orgRole, _ := c.Get(string(ContextKeyOrgRole))
+		if orgRole == "org_admin" {
+			c.Next()
+			return
+		}
+
+		wsID := c.Param("ws_id")
+		if wsID == "" {
+			c.AbortWithStatusJSON(http.StatusBadRequest, apierror.AppError{
+				Code:    http.StatusBadRequest,
+				Message: "Bad Request",
+				Detail:  "missing workspace id in URL",
+			})
+			return
+		}
+
+		userID, _ := c.Get(string(ContextKeyUserID))
+		userIDStr, _ := userID.(string)
+		if userIDStr == "" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, apierror.AppError{
+				Code:    http.StatusUnauthorized,
+				Message: "Unauthorized",
+				Detail:  "missing user identity",
+			})
+			return
+		}
+
+		var role string
+		err := db.QueryRow(
+			c.Request.Context(),
+			`SELECT role FROM workspace_members WHERE workspace_id = $1 AND user_id = $2`,
+			wsID, userIDStr,
+		).Scan(&role)
+
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				c.AbortWithStatusJSON(http.StatusForbidden, apierror.AppError{
+					Code:    http.StatusForbidden,
+					Message: "Forbidden",
+					Detail:  "not a member of this workspace",
+				})
+				return
+			}
+			c.AbortWithStatusJSON(http.StatusInternalServerError, apierror.AppError{
+				Code:    http.StatusInternalServerError,
+				Message: "Internal Server Error",
+				Detail:  "failed to resolve workspace role",
+			})
+			return
+		}
+
+		c.Set(string(ContextKeyWorkspaceRole), role)
+		c.Next()
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Convenience wrappers
+// ---------------------------------------------------------------------------
+
+// RequireOrgAdmin is a convenience wrapper that requires the org_admin role.
+func RequireOrgAdmin() gin.HandlerFunc {
+	return RequireOrgRole("org_admin")
+}
+
+// RequireWorkspaceOwner is a convenience wrapper that requires at least the
+// workspace owner role.
+func RequireWorkspaceOwner() gin.HandlerFunc {
+	return RequireWorkspaceRole("owner")
+}
+
+// RequireWorkspaceAdmin is a convenience wrapper that requires at least the
+// workspace admin role.
+func RequireWorkspaceAdmin() gin.HandlerFunc {
+	return RequireWorkspaceRole("admin")
+}
+
+// RequireWorkspaceMember is a convenience wrapper that requires at least the
+// workspace member role.
+func RequireWorkspaceMember() gin.HandlerFunc {
+	return RequireWorkspaceRole("member")
+}
+
+// RequireWorkspaceViewer is a convenience wrapper that requires at least the
+// workspace viewer role.
+func RequireWorkspaceViewer() gin.HandlerFunc {
+	return RequireWorkspaceRole("viewer")
 }

--- a/internal/middleware/rbac_test.go
+++ b/internal/middleware/rbac_test.go
@@ -1,13 +1,48 @@
 package middleware_test
 
 import (
+	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5"
 	"github.com/ravencloak-org/Raven/internal/middleware"
 )
+
+// ---------------------------------------------------------------------------
+// Mock PoolQuerier for ResolveWorkspaceRole tests
+// ---------------------------------------------------------------------------
+
+// mockRow implements pgx.Row, returning a preconfigured role or error.
+type mockRow struct {
+	role string
+	err  error
+}
+
+func (r *mockRow) Scan(dest ...any) error {
+	if r.err != nil {
+		return r.err
+	}
+	if len(dest) > 0 {
+		if p, ok := dest[0].(*string); ok {
+			*p = r.role
+		}
+	}
+	return nil
+}
+
+// mockPool implements middleware.PoolQuerier for testing.
+type mockPool struct {
+	role string
+	err  error
+}
+
+func (m *mockPool) QueryRow(_ context.Context, _ string, _ ...any) pgx.Row {
+	return &mockRow{role: m.role, err: m.err}
+}
 
 func TestRequireOrgRole_OrgAdminAllowed(t *testing.T) {
 	gin.SetMode(gin.TestMode)
@@ -151,5 +186,550 @@ func TestRequireWorkspaceRole_ExactMinimumAllowed(t *testing.T) {
 	r.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
 		t.Errorf("exact minimum role should be allowed, got %d", w.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ResolveWorkspaceRole tests
+// ---------------------------------------------------------------------------
+
+func TestResolveWorkspaceRole_SetsRoleFromDB(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	pool := &mockPool{role: "admin"}
+
+	var capturedRole string
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(string(middleware.ContextKeyUserID), "user-123")
+		c.Set(string(middleware.ContextKeyOrgRole), "member")
+		c.Next()
+	})
+	r.GET("/orgs/:org_id/workspaces/:ws_id", middleware.ResolveWorkspaceRole(pool), func(c *gin.Context) {
+		role, _ := c.Get(string(middleware.ContextKeyWorkspaceRole))
+		capturedRole, _ = role.(string)
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/orgs/org-1/workspaces/ws-1", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if capturedRole != "admin" {
+		t.Errorf("expected workspace role 'admin', got %q", capturedRole)
+	}
+}
+
+func TestResolveWorkspaceRole_OrgAdminBypassesDBLookup(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	// The mock returns an error to prove the DB is never queried.
+	pool := &mockPool{err: fmt.Errorf("should not be called")}
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(string(middleware.ContextKeyUserID), "user-123")
+		c.Set(string(middleware.ContextKeyOrgRole), "org_admin")
+		c.Next()
+	})
+	r.GET("/orgs/:org_id/workspaces/:ws_id", middleware.ResolveWorkspaceRole(pool), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/orgs/org-1/workspaces/ws-1", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("org_admin should bypass DB lookup, got %d", w.Code)
+	}
+}
+
+func TestResolveWorkspaceRole_NonMember_Returns403(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	pool := &mockPool{err: pgx.ErrNoRows}
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(string(middleware.ContextKeyUserID), "user-456")
+		c.Set(string(middleware.ContextKeyOrgRole), "member")
+		c.Next()
+	})
+	r.GET("/orgs/:org_id/workspaces/:ws_id", middleware.ResolveWorkspaceRole(pool), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/orgs/org-1/workspaces/ws-1", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("non-member should get 403, got %d", w.Code)
+	}
+}
+
+func TestResolveWorkspaceRole_DBError_Returns500(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	pool := &mockPool{err: fmt.Errorf("connection refused")}
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(string(middleware.ContextKeyUserID), "user-789")
+		c.Set(string(middleware.ContextKeyOrgRole), "member")
+		c.Next()
+	})
+	r.GET("/orgs/:org_id/workspaces/:ws_id", middleware.ResolveWorkspaceRole(pool), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/orgs/org-1/workspaces/ws-1", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("DB error should return 500, got %d", w.Code)
+	}
+}
+
+func TestResolveWorkspaceRole_MissingUserID_Returns401(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	pool := &mockPool{role: "member"}
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		// user_id intentionally not set
+		c.Set(string(middleware.ContextKeyOrgRole), "member")
+		c.Next()
+	})
+	r.GET("/orgs/:org_id/workspaces/:ws_id", middleware.ResolveWorkspaceRole(pool), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/orgs/org-1/workspaces/ws-1", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("missing user_id should return 401, got %d", w.Code)
+	}
+}
+
+func TestResolveWorkspaceRole_MissingWsID_Returns400(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	pool := &mockPool{role: "member"}
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(string(middleware.ContextKeyUserID), "user-123")
+		c.Set(string(middleware.ContextKeyOrgRole), "member")
+		c.Next()
+	})
+	// Route without :ws_id param
+	r.GET("/orgs/:org_id/workspaces", middleware.ResolveWorkspaceRole(pool), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/orgs/org-1/workspaces", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("missing ws_id should return 400, got %d", w.Code)
+	}
+}
+
+func TestResolveWorkspaceRole_AllRoles(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	roles := []string{"viewer", "member", "admin", "owner"}
+	for _, role := range roles {
+		t.Run(role, func(t *testing.T) {
+			pool := &mockPool{role: role}
+			var capturedRole string
+
+			r := gin.New()
+			r.Use(func(c *gin.Context) {
+				c.Set(string(middleware.ContextKeyUserID), "user-123")
+				c.Set(string(middleware.ContextKeyOrgRole), "member")
+				c.Next()
+			})
+			r.GET("/orgs/:org_id/workspaces/:ws_id", middleware.ResolveWorkspaceRole(pool), func(c *gin.Context) {
+				v, _ := c.Get(string(middleware.ContextKeyWorkspaceRole))
+				capturedRole, _ = v.(string)
+				c.Status(http.StatusOK)
+			})
+
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest(http.MethodGet, "/orgs/org-1/workspaces/ws-1", nil)
+			r.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d", w.Code)
+			}
+			if capturedRole != role {
+				t.Errorf("expected role %q, got %q", role, capturedRole)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end: ResolveWorkspaceRole + RequireWorkspaceRole chained
+// ---------------------------------------------------------------------------
+
+func TestResolveAndRequire_MemberAccessesMemberRoute(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	pool := &mockPool{role: "member"}
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(string(middleware.ContextKeyUserID), "user-123")
+		c.Set(string(middleware.ContextKeyOrgRole), "member")
+		c.Next()
+	})
+	r.GET("/orgs/:org_id/workspaces/:ws_id/kb",
+		middleware.ResolveWorkspaceRole(pool),
+		middleware.RequireWorkspaceRole("member"),
+		func(c *gin.Context) { c.Status(http.StatusOK) },
+	)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/orgs/org-1/workspaces/ws-1/kb", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("member should access member route, got %d", w.Code)
+	}
+}
+
+func TestResolveAndRequire_ViewerBlockedFromAdminRoute(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	pool := &mockPool{role: "viewer"}
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(string(middleware.ContextKeyUserID), "user-123")
+		c.Set(string(middleware.ContextKeyOrgRole), "member")
+		c.Next()
+	})
+	r.PUT("/orgs/:org_id/workspaces/:ws_id",
+		middleware.ResolveWorkspaceRole(pool),
+		middleware.RequireWorkspaceRole("admin"),
+		func(c *gin.Context) { c.Status(http.StatusOK) },
+	)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPut, "/orgs/org-1/workspaces/ws-1", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("viewer should be blocked from admin route, got %d", w.Code)
+	}
+}
+
+func TestResolveAndRequire_OwnerAccessesAdminRoute(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	pool := &mockPool{role: "owner"}
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(string(middleware.ContextKeyUserID), "user-123")
+		c.Set(string(middleware.ContextKeyOrgRole), "member")
+		c.Next()
+	})
+	r.PUT("/orgs/:org_id/workspaces/:ws_id",
+		middleware.ResolveWorkspaceRole(pool),
+		middleware.RequireWorkspaceRole("admin"),
+		func(c *gin.Context) { c.Status(http.StatusOK) },
+	)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPut, "/orgs/org-1/workspaces/ws-1", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("owner should access admin route (hierarchy), got %d", w.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Convenience wrapper tests
+// ---------------------------------------------------------------------------
+
+func TestRequireOrgAdmin_AllowsOrgAdmin(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(string(middleware.ContextKeyOrgRole), "org_admin")
+		c.Next()
+	})
+	r.GET("/test", middleware.RequireOrgAdmin(), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/test", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("RequireOrgAdmin should allow org_admin, got %d", w.Code)
+	}
+}
+
+func TestRequireOrgAdmin_BlocksNonAdmin(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(string(middleware.ContextKeyOrgRole), "member")
+		c.Next()
+	})
+	r.GET("/test", middleware.RequireOrgAdmin(), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/test", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("RequireOrgAdmin should block non-admin, got %d", w.Code)
+	}
+}
+
+func TestRequireWorkspaceOwner_AllowsOwner(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(string(middleware.ContextKeyOrgRole), "member")
+		c.Set(string(middleware.ContextKeyWorkspaceRole), "owner")
+		c.Next()
+	})
+	r.GET("/test", middleware.RequireWorkspaceOwner(), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/test", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("RequireWorkspaceOwner should allow owner, got %d", w.Code)
+	}
+}
+
+func TestRequireWorkspaceOwner_BlocksAdmin(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(string(middleware.ContextKeyOrgRole), "member")
+		c.Set(string(middleware.ContextKeyWorkspaceRole), "admin")
+		c.Next()
+	})
+	r.GET("/test", middleware.RequireWorkspaceOwner(), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/test", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("RequireWorkspaceOwner should block admin, got %d", w.Code)
+	}
+}
+
+func TestRequireWorkspaceAdmin_AllowsAdmin(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(string(middleware.ContextKeyOrgRole), "member")
+		c.Set(string(middleware.ContextKeyWorkspaceRole), "admin")
+		c.Next()
+	})
+	r.GET("/test", middleware.RequireWorkspaceAdmin(), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/test", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("RequireWorkspaceAdmin should allow admin, got %d", w.Code)
+	}
+}
+
+func TestRequireWorkspaceAdmin_BlocksMember(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(string(middleware.ContextKeyOrgRole), "member")
+		c.Set(string(middleware.ContextKeyWorkspaceRole), "member")
+		c.Next()
+	})
+	r.GET("/test", middleware.RequireWorkspaceAdmin(), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/test", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("RequireWorkspaceAdmin should block member, got %d", w.Code)
+	}
+}
+
+func TestRequireWorkspaceMember_AllowsMember(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(string(middleware.ContextKeyOrgRole), "member")
+		c.Set(string(middleware.ContextKeyWorkspaceRole), "member")
+		c.Next()
+	})
+	r.GET("/test", middleware.RequireWorkspaceMember(), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/test", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("RequireWorkspaceMember should allow member, got %d", w.Code)
+	}
+}
+
+func TestRequireWorkspaceMember_BlocksViewer(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(string(middleware.ContextKeyOrgRole), "member")
+		c.Set(string(middleware.ContextKeyWorkspaceRole), "viewer")
+		c.Next()
+	})
+	r.GET("/test", middleware.RequireWorkspaceMember(), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/test", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("RequireWorkspaceMember should block viewer, got %d", w.Code)
+	}
+}
+
+func TestRequireWorkspaceViewer_AllowsViewer(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(string(middleware.ContextKeyOrgRole), "member")
+		c.Set(string(middleware.ContextKeyWorkspaceRole), "viewer")
+		c.Next()
+	})
+	r.GET("/test", middleware.RequireWorkspaceViewer(), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/test", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("RequireWorkspaceViewer should allow viewer, got %d", w.Code)
+	}
+}
+
+func TestRequireWorkspaceViewer_NoRoleFallsThroughAtViewerLevel(t *testing.T) {
+	// When workspace_role is not set, wsRoleStr is "" and workspaceRoleRank[""]
+	// returns 0 (Go zero value). Viewer also has rank 0, so the check passes.
+	// In practice, ResolveWorkspaceRole always runs first and either sets a
+	// valid role or aborts the request before RequireWorkspaceRole executes.
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(string(middleware.ContextKeyOrgRole), "member")
+		// workspace_role intentionally not set
+		c.Next()
+	})
+	r.GET("/test", middleware.RequireWorkspaceViewer(), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/test", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("unset role maps to rank 0 which equals viewer rank, got %d", w.Code)
+	}
+}
+
+func TestRequireWorkspaceMember_BlocksNoRole(t *testing.T) {
+	// When workspace_role is not set, the rank is 0 which is below member (1).
+	// This confirms that ResolveWorkspaceRole is essential: without it, a user
+	// with no workspace membership would pass viewer-level checks but not member+.
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set(string(middleware.ContextKeyOrgRole), "member")
+		// workspace_role intentionally not set
+		c.Next()
+	})
+	r.GET("/test", middleware.RequireWorkspaceMember(), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/test", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("unset role should not satisfy member requirement, got %d", w.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Full role hierarchy test
+// ---------------------------------------------------------------------------
+
+func TestRoleHierarchy_FullMatrix(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	type testCase struct {
+		wsRole   string
+		required string
+		allowed  bool
+	}
+
+	tests := []testCase{
+		// viewer
+		{"viewer", "viewer", true},
+		{"viewer", "member", false},
+		{"viewer", "admin", false},
+		{"viewer", "owner", false},
+		// member
+		{"member", "viewer", true},
+		{"member", "member", true},
+		{"member", "admin", false},
+		{"member", "owner", false},
+		// admin
+		{"admin", "viewer", true},
+		{"admin", "member", true},
+		{"admin", "admin", true},
+		{"admin", "owner", false},
+		// owner
+		{"owner", "viewer", true},
+		{"owner", "member", true},
+		{"owner", "admin", true},
+		{"owner", "owner", true},
+	}
+
+	for _, tc := range tests {
+		name := fmt.Sprintf("ws=%s_requires=%s", tc.wsRole, tc.required)
+		t.Run(name, func(t *testing.T) {
+			r := gin.New()
+			r.Use(func(c *gin.Context) {
+				c.Set(string(middleware.ContextKeyOrgRole), "member")
+				c.Set(string(middleware.ContextKeyWorkspaceRole), tc.wsRole)
+				c.Next()
+			})
+			r.GET("/test", middleware.RequireWorkspaceRole(tc.required), func(c *gin.Context) {
+				c.Status(http.StatusOK)
+			})
+
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest(http.MethodGet, "/test", nil)
+			r.ServeHTTP(w, req)
+
+			if tc.allowed && w.Code != http.StatusOK {
+				t.Errorf("role %q should satisfy %q, got %d", tc.wsRole, tc.required, w.Code)
+			}
+			if !tc.allowed && w.Code != http.StatusForbidden {
+				t.Errorf("role %q should NOT satisfy %q, got %d", tc.wsRole, tc.required, w.Code)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- Add `ResolveWorkspaceRole` middleware that looks up user's workspace role from `workspace_members` table and sets `ContextKeyWorkspaceRole` in Gin context
- Add convenience wrappers: `RequireOrgAdmin()`, `RequireWorkspaceOwner()`, `RequireWorkspaceAdmin()`, `RequireWorkspaceMember()`, `RequireWorkspaceViewer()`
- Wire `ResolveWorkspaceRole` into workspace and KB route groups in main.go (after JWT, before RequireWorkspaceRole checks)
- Comprehensive unit tests for role resolution, hierarchy, org_admin bypass, and convenience wrappers

## Test plan
- [x] Unit tests for ResolveWorkspaceRole with mocked DB
- [x] Tests for org_admin bypass (no DB lookup needed)
- [x] Tests for non-member returns 403
- [x] Tests for role hierarchy enforcement (full 4x4 matrix)
- [x] Tests for convenience wrappers
- [x] `go test ./...` passes
- [x] `golangci-lint run ./internal/middleware/...` passes
- [x] `go vet ./...` passes

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)