### PR TITLE
feat: document CRUD API with processing status (#11)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -97,18 +97,21 @@ func main() {
 	wsRepo := repository.NewWorkspaceRepository(pool)
 	userRepo := repository.NewUserRepository(pool)
 	kbRepo := repository.NewKBRepository(pool)
+	docRepo := repository.NewDocumentRepository(pool)
 
 	// --- Wire services ---
 	orgSvc := service.NewOrgService(orgRepo)
 	wsSvc := service.NewWorkspaceService(wsRepo, pool)
 	userSvc := service.NewUserService(userRepo)
 	kbSvc := service.NewKBService(kbRepo, pool)
+	docSvc := service.NewDocumentService(docRepo, pool)
 
 	// --- Wire handlers ---
 	orgHandler := handler.NewOrgHandler(orgSvc)
 	wsHandler := handler.NewWorkspaceHandler(wsSvc)
 	userHandler := handler.NewUserHandler(userSvc)
 	kbHandler := handler.NewKBHandler(kbSvc)
+	docHandler := handler.NewDocumentHandler(docSvc)
 
 	// Create router
 	router := gin.Default()
@@ -168,6 +171,15 @@ func main() {
 				kb.GET("/:kb_id", kbHandler.Get)
 				kb.PUT("/:kb_id", middleware.RequireWorkspaceRole("member"), kbHandler.Update)
 				kb.DELETE("/:kb_id", middleware.RequireWorkspaceRole("admin"), kbHandler.Archive)
+
+				// Document routes (nested under knowledge base)
+				doc := kb.Group("/:kb_id/documents")
+				{
+					doc.GET("", docHandler.List)                                                // viewer
+					doc.GET("/:doc_id", docHandler.Get)                                         // viewer
+					doc.PUT("/:doc_id", middleware.RequireWorkspaceRole("member"), docHandler.Update)  // member
+					doc.DELETE("/:doc_id", middleware.RequireWorkspaceRole("admin"), docHandler.Delete) // admin
+				}
 			}
 		}
 

--- a/internal/handler/document.go
+++ b/internal/handler/document.go
@@ -1,0 +1,153 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/ravencloak-org/Raven/internal/model"
+	"github.com/ravencloak-org/Raven/pkg/apierror"
+)
+
+// DocumentServicer is the interface the handler requires from the service layer.
+type DocumentServicer interface {
+	GetByID(ctx context.Context, orgID, docID string) (*model.Document, error)
+	List(ctx context.Context, orgID, kbID string, page, pageSize int) (*model.DocumentListResponse, error)
+	Update(ctx context.Context, orgID, docID string, req model.UpdateDocumentRequest) (*model.Document, error)
+	Delete(ctx context.Context, orgID, docID string) error
+	UpdateStatus(ctx context.Context, orgID, docID string, newStatus model.ProcessingStatus, errorMsg string) error
+}
+
+// DocumentHandler handles HTTP requests for document management.
+type DocumentHandler struct {
+	svc DocumentServicer
+}
+
+// NewDocumentHandler creates a new DocumentHandler.
+func NewDocumentHandler(svc DocumentServicer) *DocumentHandler {
+	return &DocumentHandler{svc: svc}
+}
+
+// List handles GET /api/v1/orgs/:org_id/workspaces/:ws_id/knowledge-bases/:kb_id/documents.
+//
+// @Summary     List documents in a knowledge base
+// @Tags        documents
+// @Produce     json
+// @Security    BearerAuth
+// @Param       org_id    path  string true "Organisation ID"
+// @Param       ws_id     path  string true "Workspace ID"
+// @Param       kb_id     path  string true "Knowledge Base ID"
+// @Param       page      query int    false "Page number (default 1)"
+// @Param       page_size query int    false "Page size (default 20, max 100)"
+// @Success     200 {object} model.DocumentListResponse
+// @Failure     401 {object} apierror.AppError
+// @Router      /orgs/{org_id}/workspaces/{ws_id}/knowledge-bases/{kb_id}/documents [get]
+func (h *DocumentHandler) List(c *gin.Context) {
+	orgID := c.Param("org_id")
+	kbID := c.Param("kb_id")
+
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	pageSize, _ := strconv.Atoi(c.DefaultQuery("page_size", "20"))
+
+	resp, err := h.svc.List(c.Request.Context(), orgID, kbID, page, pageSize)
+	if err != nil {
+		_ = c.Error(err)
+		c.Abort()
+		return
+	}
+	c.JSON(http.StatusOK, resp)
+}
+
+// Get handles GET /api/v1/orgs/:org_id/workspaces/:ws_id/knowledge-bases/:kb_id/documents/:doc_id.
+//
+// @Summary     Get document by ID
+// @Tags        documents
+// @Produce     json
+// @Security    BearerAuth
+// @Param       org_id path string true "Organisation ID"
+// @Param       ws_id  path string true "Workspace ID"
+// @Param       kb_id  path string true "Knowledge Base ID"
+// @Param       doc_id path string true "Document ID"
+// @Success     200 {object} model.Document
+// @Failure     404 {object} apierror.AppError
+// @Failure     401 {object} apierror.AppError
+// @Router      /orgs/{org_id}/workspaces/{ws_id}/knowledge-bases/{kb_id}/documents/{doc_id} [get]
+func (h *DocumentHandler) Get(c *gin.Context) {
+	orgID := c.Param("org_id")
+	docID := c.Param("doc_id")
+
+	doc, err := h.svc.GetByID(c.Request.Context(), orgID, docID)
+	if err != nil {
+		_ = c.Error(err)
+		c.Abort()
+		return
+	}
+	c.JSON(http.StatusOK, doc)
+}
+
+// Update handles PUT /api/v1/orgs/:org_id/workspaces/:ws_id/knowledge-bases/:kb_id/documents/:doc_id.
+//
+// @Summary     Update document metadata
+// @Tags        documents
+// @Accept      json
+// @Produce     json
+// @Security    BearerAuth
+// @Param       org_id  path string                      true "Organisation ID"
+// @Param       ws_id   path string                      true "Workspace ID"
+// @Param       kb_id   path string                      true "Knowledge Base ID"
+// @Param       doc_id  path string                      true "Document ID"
+// @Param       request body model.UpdateDocumentRequest  true "Document update payload"
+// @Success     200 {object} model.Document
+// @Failure     422 {object} apierror.AppError
+// @Failure     404 {object} apierror.AppError
+// @Failure     401 {object} apierror.AppError
+// @Router      /orgs/{org_id}/workspaces/{ws_id}/knowledge-bases/{kb_id}/documents/{doc_id} [put]
+func (h *DocumentHandler) Update(c *gin.Context) {
+	orgID := c.Param("org_id")
+	docID := c.Param("doc_id")
+
+	var req model.UpdateDocumentRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		_ = c.Error(&apierror.AppError{
+			Code:    http.StatusUnprocessableEntity,
+			Message: "Unprocessable Entity",
+			Detail:  err.Error(),
+		})
+		c.Abort()
+		return
+	}
+
+	doc, err := h.svc.Update(c.Request.Context(), orgID, docID, req)
+	if err != nil {
+		_ = c.Error(err)
+		c.Abort()
+		return
+	}
+	c.JSON(http.StatusOK, doc)
+}
+
+// Delete handles DELETE /api/v1/orgs/:org_id/workspaces/:ws_id/knowledge-bases/:kb_id/documents/:doc_id.
+//
+// @Summary     Delete document
+// @Tags        documents
+// @Security    BearerAuth
+// @Param       org_id path string true "Organisation ID"
+// @Param       ws_id  path string true "Workspace ID"
+// @Param       kb_id  path string true "Knowledge Base ID"
+// @Param       doc_id path string true "Document ID"
+// @Success     204
+// @Failure     404 {object} apierror.AppError
+// @Failure     403 {object} apierror.AppError
+// @Router      /orgs/{org_id}/workspaces/{ws_id}/knowledge-bases/{kb_id}/documents/{doc_id} [delete]
+func (h *DocumentHandler) Delete(c *gin.Context) {
+	orgID := c.Param("org_id")
+	docID := c.Param("doc_id")
+
+	if err := h.svc.Delete(c.Request.Context(), orgID, docID); err != nil {
+		_ = c.Error(err)
+		c.Abort()
+		return
+	}
+	c.Status(http.StatusNoContent)
+}

--- a/internal/handler/document_test.go
+++ b/internal/handler/document_test.go
@@ -1,0 +1,228 @@
+package handler_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/ravencloak-org/Raven/internal/handler"
+	"github.com/ravencloak-org/Raven/internal/middleware"
+	"github.com/ravencloak-org/Raven/internal/model"
+	"github.com/ravencloak-org/Raven/pkg/apierror"
+)
+
+// mockDocumentService implements handler.DocumentServicer for unit tests.
+type mockDocumentService struct {
+	getByIDFn      func(ctx context.Context, orgID, docID string) (*model.Document, error)
+	listFn         func(ctx context.Context, orgID, kbID string, page, pageSize int) (*model.DocumentListResponse, error)
+	updateFn       func(ctx context.Context, orgID, docID string, req model.UpdateDocumentRequest) (*model.Document, error)
+	deleteFn       func(ctx context.Context, orgID, docID string) error
+	updateStatusFn func(ctx context.Context, orgID, docID string, newStatus model.ProcessingStatus, errorMsg string) error
+}
+
+func (m *mockDocumentService) GetByID(ctx context.Context, orgID, docID string) (*model.Document, error) {
+	return m.getByIDFn(ctx, orgID, docID)
+}
+
+func (m *mockDocumentService) List(ctx context.Context, orgID, kbID string, page, pageSize int) (*model.DocumentListResponse, error) {
+	return m.listFn(ctx, orgID, kbID, page, pageSize)
+}
+
+func (m *mockDocumentService) Update(ctx context.Context, orgID, docID string, req model.UpdateDocumentRequest) (*model.Document, error) {
+	return m.updateFn(ctx, orgID, docID, req)
+}
+
+func (m *mockDocumentService) Delete(ctx context.Context, orgID, docID string) error {
+	return m.deleteFn(ctx, orgID, docID)
+}
+
+func (m *mockDocumentService) UpdateStatus(ctx context.Context, orgID, docID string, newStatus model.ProcessingStatus, errorMsg string) error {
+	return m.updateStatusFn(ctx, orgID, docID, newStatus, errorMsg)
+}
+
+func newDocRouter(svc handler.DocumentServicer) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(apierror.ErrorHandler())
+	r.Use(func(c *gin.Context) {
+		c.Set(string(middleware.ContextKeyUserID), "user-1")
+		c.Set(string(middleware.ContextKeyOrgRole), "org_admin")
+		c.Set(string(middleware.ContextKeyOrgID), "org-abc")
+		c.Set(string(middleware.ContextKeyWorkspaceRole), "admin")
+		c.Next()
+	})
+	h := handler.NewDocumentHandler(svc)
+	const base = "/api/v1/orgs/:org_id/workspaces/:ws_id/knowledge-bases/:kb_id/documents"
+	r.GET(base, h.List)
+	r.GET(base+"/:doc_id", h.Get)
+	r.PUT(base+"/:doc_id", h.Update)
+	r.DELETE(base+"/:doc_id", h.Delete)
+	return r
+}
+
+func TestListDocuments_Success(t *testing.T) {
+	svc := &mockDocumentService{
+		listFn: func(_ context.Context, orgID, kbID string, page, pageSize int) (*model.DocumentListResponse, error) {
+			return &model.DocumentListResponse{
+				Documents: []model.Document{{ID: "doc-1", OrgID: orgID, KnowledgeBaseID: kbID, FileName: "test.pdf"}},
+				Total:     1,
+				Page:      page,
+				PageSize:  pageSize,
+			}, nil
+		},
+	}
+	r := newDocRouter(svc)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/orgs/org-abc/workspaces/ws-1/knowledge-bases/kb-1/documents", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp model.DocumentListResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if len(resp.Documents) != 1 {
+		t.Errorf("expected 1 document, got %d", len(resp.Documents))
+	}
+}
+
+func TestListDocuments_EmptyReturnsArray(t *testing.T) {
+	svc := &mockDocumentService{
+		listFn: func(_ context.Context, _, _ string, page, pageSize int) (*model.DocumentListResponse, error) {
+			return &model.DocumentListResponse{
+				Documents: []model.Document{},
+				Total:     0,
+				Page:      page,
+				PageSize:  pageSize,
+			}, nil
+		},
+	}
+	r := newDocRouter(svc)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/orgs/org-abc/workspaces/ws-1/knowledge-bases/kb-1/documents", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestGetDocument_Success(t *testing.T) {
+	svc := &mockDocumentService{
+		getByIDFn: func(_ context.Context, orgID, docID string) (*model.Document, error) {
+			return &model.Document{ID: docID, OrgID: orgID, FileName: "test.pdf"}, nil
+		},
+	}
+	r := newDocRouter(svc)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/orgs/org-abc/workspaces/ws-1/knowledge-bases/kb-1/documents/doc-1", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetDocument_NotFound_Returns404(t *testing.T) {
+	svc := &mockDocumentService{
+		getByIDFn: func(_ context.Context, _, _ string) (*model.Document, error) {
+			return nil, apierror.NewNotFound("document not found")
+		},
+	}
+	r := newDocRouter(svc)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/orgs/org-abc/workspaces/ws-1/knowledge-bases/kb-1/documents/bad-id", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestUpdateDocument_Success(t *testing.T) {
+	title := "Updated Title"
+	svc := &mockDocumentService{
+		updateFn: func(_ context.Context, orgID, docID string, _ model.UpdateDocumentRequest) (*model.Document, error) {
+			return &model.Document{ID: docID, OrgID: orgID, FileName: "test.pdf", Title: title}, nil
+		},
+	}
+	r := newDocRouter(svc)
+	body, _ := json.Marshal(map[string]string{"title": title})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPut, "/api/v1/orgs/org-abc/workspaces/ws-1/knowledge-bases/kb-1/documents/doc-1", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestUpdateDocument_NotFound_Returns404(t *testing.T) {
+	svc := &mockDocumentService{
+		updateFn: func(_ context.Context, _, _ string, _ model.UpdateDocumentRequest) (*model.Document, error) {
+			return nil, apierror.NewNotFound("document not found")
+		},
+	}
+	r := newDocRouter(svc)
+	body, _ := json.Marshal(map[string]string{"title": "X"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPut, "/api/v1/orgs/org-abc/workspaces/ws-1/knowledge-bases/kb-1/documents/bad-id", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestDeleteDocument_Success(t *testing.T) {
+	svc := &mockDocumentService{
+		deleteFn: func(_ context.Context, _, _ string) error { return nil },
+	}
+	r := newDocRouter(svc)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodDelete, "/api/v1/orgs/org-abc/workspaces/ws-1/knowledge-bases/kb-1/documents/doc-1", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("expected 204, got %d", w.Code)
+	}
+}
+
+func TestDeleteDocument_NotFound_Returns404(t *testing.T) {
+	svc := &mockDocumentService{
+		deleteFn: func(_ context.Context, _, _ string) error {
+			return apierror.NewNotFound("document not found")
+		},
+	}
+	r := newDocRouter(svc)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodDelete, "/api/v1/orgs/org-abc/workspaces/ws-1/knowledge-bases/kb-1/documents/bad-id", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestListDocuments_WithPagination(t *testing.T) {
+	svc := &mockDocumentService{
+		listFn: func(_ context.Context, _, _ string, page, pageSize int) (*model.DocumentListResponse, error) {
+			if page != 2 || pageSize != 10 {
+				t.Errorf("expected page=2 pageSize=10, got page=%d pageSize=%d", page, pageSize)
+			}
+			return &model.DocumentListResponse{
+				Documents: []model.Document{},
+				Total:     0,
+				Page:      page,
+				PageSize:  pageSize,
+			}, nil
+		},
+	}
+	r := newDocRouter(svc)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/orgs/org-abc/workspaces/ws-1/knowledge-bases/kb-1/documents?page=2&page_size=10", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}

--- a/internal/model/document.go
+++ b/internal/model/document.go
@@ -1,0 +1,48 @@
+package model
+
+import "time"
+
+// ProcessingStatus represents the processing lifecycle of a document.
+type ProcessingStatus string
+
+// Valid processing statuses for a document.
+const (
+	ProcessingStatusQueued     ProcessingStatus = "queued"
+	ProcessingStatusProcessing ProcessingStatus = "processing"
+	ProcessingStatusCompleted  ProcessingStatus = "completed"
+	ProcessingStatusFailed     ProcessingStatus = "failed"
+)
+
+// Document represents a file uploaded to a knowledge base.
+type Document struct {
+	ID               string           `json:"id"`
+	OrgID            string           `json:"org_id"`
+	KnowledgeBaseID  string           `json:"knowledge_base_id"`
+	FileName         string           `json:"file_name"`
+	FileType         string           `json:"file_type,omitempty"`
+	FileSizeBytes    *int64           `json:"file_size_bytes,omitempty"`
+	FileHash         string           `json:"file_hash,omitempty"`
+	StoragePath      string           `json:"storage_path,omitempty"`
+	ProcessingStatus ProcessingStatus `json:"processing_status"`
+	ProcessingError  string           `json:"processing_error,omitempty"`
+	Title            string           `json:"title,omitempty"`
+	PageCount        *int             `json:"page_count,omitempty"`
+	Metadata         map[string]any   `json:"metadata"`
+	UploadedBy       string           `json:"uploaded_by,omitempty"`
+	CreatedAt        time.Time        `json:"created_at"`
+	UpdatedAt        time.Time        `json:"updated_at"`
+}
+
+// UpdateDocumentRequest is the payload for PUT .../documents/:doc_id.
+type UpdateDocumentRequest struct {
+	Title    *string        `json:"title,omitempty" binding:"omitempty,max=500"`
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+// DocumentListResponse wraps a paginated list of documents.
+type DocumentListResponse struct {
+	Documents []Document `json:"documents"`
+	Total     int        `json:"total"`
+	Page      int        `json:"page"`
+	PageSize  int        `json:"page_size"`
+}

--- a/internal/repository/document.go
+++ b/internal/repository/document.go
@@ -1,0 +1,186 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/ravencloak-org/Raven/internal/model"
+)
+
+// DocumentRepository handles database operations for documents.
+// All operations use a pgx.Tx with org_id set for RLS enforcement.
+type DocumentRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewDocumentRepository creates a new DocumentRepository.
+func NewDocumentRepository(pool *pgxpool.Pool) *DocumentRepository {
+	return &DocumentRepository{pool: pool}
+}
+
+const docColumns = `id, org_id, knowledge_base_id, file_name,
+	COALESCE(file_type, '') AS file_type,
+	file_size_bytes, COALESCE(file_hash, '') AS file_hash,
+	COALESCE(storage_path, '') AS storage_path,
+	processing_status, COALESCE(processing_error, '') AS processing_error,
+	COALESCE(title, '') AS title, page_count,
+	COALESCE(metadata, '{}') AS metadata,
+	COALESCE(uploaded_by::text, '') AS uploaded_by,
+	created_at, updated_at`
+
+func scanDocument(row pgx.Row) (*model.Document, error) {
+	var doc model.Document
+	err := row.Scan(
+		&doc.ID,
+		&doc.OrgID,
+		&doc.KnowledgeBaseID,
+		&doc.FileName,
+		&doc.FileType,
+		&doc.FileSizeBytes,
+		&doc.FileHash,
+		&doc.StoragePath,
+		&doc.ProcessingStatus,
+		&doc.ProcessingError,
+		&doc.Title,
+		&doc.PageCount,
+		&doc.Metadata,
+		&doc.UploadedBy,
+		&doc.CreatedAt,
+		&doc.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &doc, nil
+}
+
+// Create inserts a new document record.
+func (r *DocumentRepository) Create(ctx context.Context, tx pgx.Tx, doc *model.Document) (*model.Document, error) {
+	row := tx.QueryRow(ctx,
+		`INSERT INTO documents (org_id, knowledge_base_id, file_name, file_type,
+			file_size_bytes, file_hash, storage_path, title, metadata, uploaded_by)
+		 VALUES ($1, $2, $3, NULLIF($4, ''), $5, NULLIF($6, ''),
+			NULLIF($7, ''), NULLIF($8, ''), COALESCE($9::jsonb, '{}'), NULLIF($10, '')::uuid)
+		 RETURNING `+docColumns,
+		doc.OrgID, doc.KnowledgeBaseID, doc.FileName, doc.FileType,
+		doc.FileSizeBytes, doc.FileHash, doc.StoragePath, doc.Title,
+		doc.Metadata, doc.UploadedBy,
+	)
+	created, err := scanDocument(row)
+	if err != nil {
+		return nil, fmt.Errorf("DocumentRepository.Create: %w", err)
+	}
+	return created, nil
+}
+
+// GetByID fetches a document by its primary key within an org.
+func (r *DocumentRepository) GetByID(ctx context.Context, tx pgx.Tx, orgID, docID string) (*model.Document, error) {
+	row := tx.QueryRow(ctx,
+		`SELECT `+docColumns+`
+		 FROM documents
+		 WHERE id = $1 AND org_id = $2`,
+		docID, orgID,
+	)
+	doc, err := scanDocument(row)
+	if err != nil {
+		return nil, fmt.Errorf("DocumentRepository.GetByID: %w", err)
+	}
+	return doc, nil
+}
+
+// List returns paginated documents for a knowledge base within an org.
+func (r *DocumentRepository) List(ctx context.Context, tx pgx.Tx, orgID, kbID string, page, pageSize int) ([]model.Document, int, error) {
+	var total int
+	err := tx.QueryRow(ctx,
+		`SELECT COUNT(*) FROM documents WHERE org_id = $1 AND knowledge_base_id = $2`,
+		orgID, kbID,
+	).Scan(&total)
+	if err != nil {
+		return nil, 0, fmt.Errorf("DocumentRepository.List count: %w", err)
+	}
+
+	offset := (page - 1) * pageSize
+	rows, err := tx.Query(ctx,
+		`SELECT `+docColumns+`
+		 FROM documents
+		 WHERE org_id = $1 AND knowledge_base_id = $2
+		 ORDER BY created_at DESC
+		 LIMIT $3 OFFSET $4`,
+		orgID, kbID, pageSize, offset,
+	)
+	if err != nil {
+		return nil, 0, fmt.Errorf("DocumentRepository.List query: %w", err)
+	}
+	defer rows.Close()
+
+	var docs []model.Document
+	for rows.Next() {
+		var doc model.Document
+		if err := rows.Scan(
+			&doc.ID, &doc.OrgID, &doc.KnowledgeBaseID, &doc.FileName,
+			&doc.FileType, &doc.FileSizeBytes, &doc.FileHash, &doc.StoragePath,
+			&doc.ProcessingStatus, &doc.ProcessingError, &doc.Title,
+			&doc.PageCount, &doc.Metadata, &doc.UploadedBy,
+			&doc.CreatedAt, &doc.UpdatedAt,
+		); err != nil {
+			return nil, 0, fmt.Errorf("DocumentRepository.List scan: %w", err)
+		}
+		docs = append(docs, doc)
+	}
+	return docs, total, rows.Err()
+}
+
+// Update applies partial updates to a document's metadata fields.
+func (r *DocumentRepository) Update(ctx context.Context, tx pgx.Tx, orgID, docID string, title *string, metadata map[string]any) (*model.Document, error) {
+	row := tx.QueryRow(ctx,
+		`UPDATE documents
+		 SET
+		   title    = COALESCE($3, title),
+		   metadata = CASE WHEN $4::jsonb IS NOT NULL THEN $4::jsonb ELSE metadata END,
+		   updated_at = NOW()
+		 WHERE id = $1 AND org_id = $2
+		 RETURNING `+docColumns,
+		docID, orgID, title, metadata,
+	)
+	doc, err := scanDocument(row)
+	if err != nil {
+		return nil, fmt.Errorf("DocumentRepository.Update: %w", err)
+	}
+	return doc, nil
+}
+
+// Delete hard-deletes a document by ID within an org.
+func (r *DocumentRepository) Delete(ctx context.Context, tx pgx.Tx, orgID, docID string) error {
+	tag, err := tx.Exec(ctx,
+		`DELETE FROM documents WHERE id = $1 AND org_id = $2`,
+		docID, orgID,
+	)
+	if err != nil {
+		return fmt.Errorf("DocumentRepository.Delete: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("DocumentRepository.Delete: document %s not found", docID)
+	}
+	return nil
+}
+
+// UpdateStatus updates the processing status (and optional error message) of a document.
+func (r *DocumentRepository) UpdateStatus(ctx context.Context, tx pgx.Tx, orgID, docID string, status model.ProcessingStatus, errorMsg string) error {
+	tag, err := tx.Exec(ctx,
+		`UPDATE documents
+		 SET processing_status = $3,
+		     processing_error  = NULLIF($4, ''),
+		     updated_at        = NOW()
+		 WHERE id = $1 AND org_id = $2`,
+		docID, orgID, status, errorMsg,
+	)
+	if err != nil {
+		return fmt.Errorf("DocumentRepository.UpdateStatus: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("DocumentRepository.UpdateStatus: document %s not found", docID)
+	}
+	return nil
+}

--- a/internal/repository/document_test.go
+++ b/internal/repository/document_test.go
@@ -1,0 +1,18 @@
+package repository
+
+import (
+	"testing"
+)
+
+func TestDocColumns_NotEmpty(t *testing.T) {
+	if docColumns == "" {
+		t.Error("docColumns constant should not be empty")
+	}
+}
+
+func TestNewDocumentRepository(t *testing.T) {
+	repo := NewDocumentRepository(nil)
+	if repo == nil {
+		t.Error("NewDocumentRepository should return non-nil")
+	}
+}

--- a/internal/service/document.go
+++ b/internal/service/document.go
@@ -1,0 +1,155 @@
+package service
+
+import (
+	"context"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/ravencloak-org/Raven/internal/db"
+	"github.com/ravencloak-org/Raven/internal/model"
+	"github.com/ravencloak-org/Raven/internal/repository"
+	"github.com/ravencloak-org/Raven/pkg/apierror"
+)
+
+// validStatusTransitions maps current status to the set of allowed next statuses.
+var validStatusTransitions = map[model.ProcessingStatus][]model.ProcessingStatus{
+	model.ProcessingStatusQueued:     {model.ProcessingStatusProcessing},
+	model.ProcessingStatusProcessing: {model.ProcessingStatusCompleted, model.ProcessingStatusFailed},
+	model.ProcessingStatusFailed:     {model.ProcessingStatusQueued},
+}
+
+// DocumentService contains business logic for document management.
+type DocumentService struct {
+	repo *repository.DocumentRepository
+	pool *pgxpool.Pool
+}
+
+// NewDocumentService creates a new DocumentService.
+func NewDocumentService(repo *repository.DocumentRepository, pool *pgxpool.Pool) *DocumentService {
+	return &DocumentService{repo: repo, pool: pool}
+}
+
+// GetByID retrieves a document by ID within an org.
+func (s *DocumentService) GetByID(ctx context.Context, orgID, docID string) (*model.Document, error) {
+	var doc *model.Document
+	err := db.WithOrgID(ctx, s.pool, orgID, func(tx pgx.Tx) error {
+		var err error
+		doc, err = s.repo.GetByID(ctx, tx, orgID, docID)
+		return err
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "no rows") {
+			return nil, apierror.NewNotFound("document not found")
+		}
+		return nil, apierror.NewInternal("failed to fetch document: " + err.Error())
+	}
+	return doc, nil
+}
+
+// List returns paginated documents for a knowledge base.
+func (s *DocumentService) List(ctx context.Context, orgID, kbID string, page, pageSize int) (*model.DocumentListResponse, error) {
+	if page < 1 {
+		page = 1
+	}
+	if pageSize < 1 || pageSize > 100 {
+		pageSize = 20
+	}
+
+	var docs []model.Document
+	var total int
+	err := db.WithOrgID(ctx, s.pool, orgID, func(tx pgx.Tx) error {
+		var err error
+		docs, total, err = s.repo.List(ctx, tx, orgID, kbID, page, pageSize)
+		return err
+	})
+	if err != nil {
+		return nil, apierror.NewInternal("failed to list documents: " + err.Error())
+	}
+	if docs == nil {
+		docs = []model.Document{}
+	}
+	return &model.DocumentListResponse{
+		Documents: docs,
+		Total:     total,
+		Page:      page,
+		PageSize:  pageSize,
+	}, nil
+}
+
+// Update applies partial updates to a document's metadata fields.
+func (s *DocumentService) Update(ctx context.Context, orgID, docID string, req model.UpdateDocumentRequest) (*model.Document, error) {
+	var doc *model.Document
+	err := db.WithOrgID(ctx, s.pool, orgID, func(tx pgx.Tx) error {
+		var err error
+		doc, err = s.repo.Update(ctx, tx, orgID, docID, req.Title, req.Metadata)
+		return err
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "no rows") {
+			return nil, apierror.NewNotFound("document not found")
+		}
+		return nil, apierror.NewInternal("failed to update document: " + err.Error())
+	}
+	return doc, nil
+}
+
+// Delete removes a document by ID within an org.
+func (s *DocumentService) Delete(ctx context.Context, orgID, docID string) error {
+	err := db.WithOrgID(ctx, s.pool, orgID, func(tx pgx.Tx) error {
+		return s.repo.Delete(ctx, tx, orgID, docID)
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return apierror.NewNotFound("document not found")
+		}
+		return apierror.NewInternal("failed to delete document: " + err.Error())
+	}
+	return nil
+}
+
+// UpdateStatus transitions a document's processing status with validation.
+func (s *DocumentService) UpdateStatus(ctx context.Context, orgID, docID string, newStatus model.ProcessingStatus, errorMsg string) error {
+	// First, get the current document to check its status.
+	var current *model.Document
+	err := db.WithOrgID(ctx, s.pool, orgID, func(tx pgx.Tx) error {
+		var err error
+		current, err = s.repo.GetByID(ctx, tx, orgID, docID)
+		return err
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "no rows") {
+			return apierror.NewNotFound("document not found")
+		}
+		return apierror.NewInternal("failed to fetch document for status update: " + err.Error())
+	}
+
+	// Validate the transition.
+	allowed, ok := validStatusTransitions[current.ProcessingStatus]
+	if !ok {
+		return apierror.NewBadRequest("no transitions allowed from status: " + string(current.ProcessingStatus))
+	}
+	valid := false
+	for _, s := range allowed {
+		if s == newStatus {
+			valid = true
+			break
+		}
+	}
+	if !valid {
+		return apierror.NewBadRequest(
+			"invalid status transition from " + string(current.ProcessingStatus) + " to " + string(newStatus),
+		)
+	}
+
+	err = db.WithOrgID(ctx, s.pool, orgID, func(tx pgx.Tx) error {
+		return s.repo.UpdateStatus(ctx, tx, orgID, docID, newStatus, errorMsg)
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return apierror.NewNotFound("document not found")
+		}
+		return apierror.NewInternal("failed to update document status: " + err.Error())
+	}
+	return nil
+}

--- a/internal/service/document_test.go
+++ b/internal/service/document_test.go
@@ -1,0 +1,52 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/ravencloak-org/Raven/internal/model"
+)
+
+func TestValidStatusTransitions(t *testing.T) {
+	tests := []struct {
+		name    string
+		from    model.ProcessingStatus
+		to      model.ProcessingStatus
+		allowed bool
+	}{
+		{"queued to processing", model.ProcessingStatusQueued, model.ProcessingStatusProcessing, true},
+		{"queued to completed", model.ProcessingStatusQueued, model.ProcessingStatusCompleted, false},
+		{"queued to failed", model.ProcessingStatusQueued, model.ProcessingStatusFailed, false},
+		{"processing to completed", model.ProcessingStatusProcessing, model.ProcessingStatusCompleted, true},
+		{"processing to failed", model.ProcessingStatusProcessing, model.ProcessingStatusFailed, true},
+		{"processing to queued", model.ProcessingStatusProcessing, model.ProcessingStatusQueued, false},
+		{"completed to any", model.ProcessingStatusCompleted, model.ProcessingStatusQueued, false},
+		{"completed to processing", model.ProcessingStatusCompleted, model.ProcessingStatusProcessing, false},
+		{"failed to queued", model.ProcessingStatusFailed, model.ProcessingStatusQueued, true},
+		{"failed to processing", model.ProcessingStatusFailed, model.ProcessingStatusProcessing, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			allowed := isTransitionAllowed(tt.from, tt.to)
+			if allowed != tt.allowed {
+				t.Errorf("transition %s -> %s: expected allowed=%v, got %v",
+					tt.from, tt.to, tt.allowed, allowed)
+			}
+		})
+	}
+}
+
+// isTransitionAllowed checks if a status transition is valid.
+// This mirrors the logic used in DocumentService.UpdateStatus.
+func isTransitionAllowed(from, to model.ProcessingStatus) bool {
+	allowed, ok := validStatusTransitions[from]
+	if !ok {
+		return false
+	}
+	for _, s := range allowed {
+		if s == to {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- Document model with ProcessingStatus enum and DTOs (UpdateDocumentRequest, DocumentListResponse with pagination)
- Repository layer with Create, GetByID, List (paginated), Update, Delete, UpdateStatus — all using RLS via SET LOCAL app.current_org_id
- Service layer with status transition validation (queued → processing → completed/failed, failed → queued retry)
- Handler layer with Swagger annotations for all endpoints nested under KB routes
- Routes wired in cmd/api/main.go with RBAC: List/Get = viewer, Update = member, Delete = admin

## Test plan
- [x] Handler tests for List, Get, Update, Delete (success + error cases)
- [x] Service tests for status transition validation (10 transition cases)
- [x] Repository unit tests
- [x] `go test ./...` passes
- [x] `go vet ./...` passes

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)