### PR TITLE
chore: add ChartDB docker-compose overlay and schema export script

### DIFF
--- a/docker-compose.chartdb.yml
+++ b/docker-compose.chartdb.yml
@@ -1,0 +1,22 @@
+# ChartDB overlay — add to the main stack:
+#   docker compose -f docker-compose.yml -f docker-compose.chartdb.yml up -d chartdb
+#
+# Then open http://localhost:3000, pick PostgreSQL, paste the output of:
+#   scripts/chartdb-query.sh
+services:
+  chartdb:
+    image: ghcr.io/chartdb/chartdb:latest
+    ports:
+      - "127.0.0.1:3000:80"
+    environment:
+      # Optional — enables AI-powered DDL export.
+      # Leave empty to use ChartDB without AI features.
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+    networks:
+      - raven-internal
+    restart: unless-stopped
+
+networks:
+  raven-internal:
+    external: true
+    name: raven_raven-internal

--- a/docs/schema/chartdb-raven.json
+++ b/docs/schema/chartdb-raven.json
@@ -1,0 +1,9689 @@
+{
+  "id": "0",
+  "name": "raven",
+  "createdAt": "2026-04-09T10:05:53.146Z",
+  "updatedAt": "2026-04-09T10:05:53.146Z",
+  "databaseType": "postgresql",
+  "tables": [
+    {
+      "id": "1",
+      "name": "whatsapp_calls",
+      "schema": "public",
+      "x": -979.3830218564448,
+      "y": 915.312686866809,
+      "fields": [
+        {
+          "id": "2",
+          "name": "id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "default": "uuid_generate_v4()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "3",
+          "name": "org_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "4",
+          "name": "call_id",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "characterMaximumLength": "128",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "5",
+          "name": "phone_number_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "6",
+          "name": "direction",
+          "type": {
+            "id": "whatsapp_call_direction",
+            "name": "whatsapp_call_direction"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "7",
+          "name": "state",
+          "type": {
+            "id": "whatsapp_call_state",
+            "name": "whatsapp_call_state"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "'ringing'::whatsapp_call_state",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "8",
+          "name": "caller",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "20",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "9",
+          "name": "callee",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "20",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "10",
+          "name": "started_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "11",
+          "name": "ended_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "12",
+          "name": "duration_seconds",
+          "type": {
+            "id": "int",
+            "name": "int"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "13",
+          "name": "created_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "14",
+          "name": "updated_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "15",
+          "name": "idx_whatsapp_calls_org_created",
+          "unique": false,
+          "fieldIds": [
+            "3",
+            "13"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "16",
+          "name": "idx_whatsapp_calls_phone",
+          "unique": false,
+          "fieldIds": [
+            "5"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "17",
+          "name": "idx_whatsapp_calls_org",
+          "unique": false,
+          "fieldIds": [
+            "3"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "18",
+          "name": "uq_whatsapp_call_id",
+          "unique": true,
+          "fieldIds": [
+            "4"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "19",
+          "name": "idx_whatsapp_calls_org_state",
+          "unique": false,
+          "fieldIds": [
+            "3",
+            "7"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "20",
+          "name": "whatsapp_calls_pkey",
+          "unique": true,
+          "fieldIds": [
+            "2"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "21",
+          "name": "idx_whatsapp_calls_call_id",
+          "unique": false,
+          "fieldIds": [
+            "4"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        }
+      ],
+      "checkConstraints": [
+        {
+          "id": "o30q4rib8rk45e3pwpe66l3j0",
+          "expression": "",
+          "createdAt": 1775729153141
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153141,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "22",
+      "name": "llm_provider_configs",
+      "schema": "public",
+      "x": 627.410728203126,
+      "y": 622.4427331715674,
+      "fields": [
+        {
+          "id": "23",
+          "name": "id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "default": "uuid_generate_v4()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "24",
+          "name": "org_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "25",
+          "name": "provider",
+          "type": {
+            "id": "llm_provider",
+            "name": "llm_provider"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "26",
+          "name": "display_name",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "255",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "27",
+          "name": "api_key_encrypted",
+          "type": {
+            "id": "bytea",
+            "name": "bytea"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "28",
+          "name": "api_key_iv",
+          "type": {
+            "id": "bytea",
+            "name": "bytea"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "29",
+          "name": "api_key_hint",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "characterMaximumLength": "20",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "30",
+          "name": "base_url",
+          "type": {
+            "id": "text",
+            "name": "text"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "31",
+          "name": "config",
+          "type": {
+            "id": "jsonb",
+            "name": "jsonb"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "default": "'{}'::jsonb",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "32",
+          "name": "is_default",
+          "type": {
+            "id": "boolean",
+            "name": "boolean"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "false",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "33",
+          "name": "status",
+          "type": {
+            "id": "provider_status",
+            "name": "provider_status"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "'active'::provider_status",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "34",
+          "name": "created_by",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "35",
+          "name": "created_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "36",
+          "name": "updated_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "37",
+          "name": "llm_provider_configs_pkey",
+          "unique": true,
+          "fieldIds": [
+            "23"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "38",
+          "name": "idx_llm_provider_configs_org_id",
+          "unique": false,
+          "fieldIds": [
+            "24"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153140,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "39",
+      "name": "airbyte_sync_history",
+      "schema": "public",
+      "x": 1291.093703334389,
+      "y": 1188.0685994495716,
+      "fields": [
+        {
+          "id": "40",
+          "name": "id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "default": "uuid_generate_v4()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "41",
+          "name": "connector_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "42",
+          "name": "org_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "43",
+          "name": "status",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "50",
+          "default": "'running'::character varying",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "44",
+          "name": "records_synced",
+          "type": {
+            "id": "int",
+            "name": "int"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "default": "0",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "45",
+          "name": "records_failed",
+          "type": {
+            "id": "int",
+            "name": "int"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "default": "0",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "46",
+          "name": "bytes_synced",
+          "type": {
+            "id": "bigint",
+            "name": "bigint"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "default": "0",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "47",
+          "name": "started_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "48",
+          "name": "completed_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "49",
+          "name": "error_message",
+          "type": {
+            "id": "text",
+            "name": "text"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "50",
+          "name": "airbyte_sync_history_pkey",
+          "unique": true,
+          "fieldIds": [
+            "40"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "51",
+          "name": "idx_sync_history_connector",
+          "unique": false,
+          "fieldIds": [
+            "41"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153140,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "52",
+      "name": "api_keys",
+      "schema": "public",
+      "x": 2152.6914979204207,
+      "y": 609.4903924893354,
+      "fields": [
+        {
+          "id": "53",
+          "name": "id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "default": "uuid_generate_v4()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "54",
+          "name": "org_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "55",
+          "name": "knowledge_base_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "56",
+          "name": "key_hash",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "128",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "57",
+          "name": "key_prefix",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "20",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "58",
+          "name": "name",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "255",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "59",
+          "name": "allowed_domains",
+          "type": {
+            "id": "text",
+            "name": "text"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": true,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "60",
+          "name": "rate_limit",
+          "type": {
+            "id": "int",
+            "name": "int"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "default": "60",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "61",
+          "name": "status",
+          "type": {
+            "id": "api_key_status",
+            "name": "api_key_status"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "'active'::api_key_status",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "62",
+          "name": "created_by",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "63",
+          "name": "created_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "64",
+          "name": "expires_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "65",
+          "name": "workspace_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "66",
+          "name": "idx_api_keys_org_id",
+          "unique": false,
+          "fieldIds": [
+            "54"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "67",
+          "name": "idx_api_keys_key_hash",
+          "unique": false,
+          "fieldIds": [
+            "56"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "68",
+          "name": "api_keys_pkey",
+          "unique": true,
+          "fieldIds": [
+            "53"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "69",
+          "name": "idx_api_keys_knowledge_base_id",
+          "unique": false,
+          "fieldIds": [
+            "55"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "70",
+          "name": "idx_api_keys_workspace_id",
+          "unique": false,
+          "fieldIds": [
+            "65"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153140,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "71",
+      "name": "voice_usage_summaries",
+      "schema": "public",
+      "x": -433.0670361787382,
+      "y": -421.68551684265674,
+      "fields": [
+        {
+          "id": "72",
+          "name": "id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "default": "uuid_generate_v4()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "73",
+          "name": "org_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "74",
+          "name": "period_start",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "75",
+          "name": "total_sessions",
+          "type": {
+            "id": "int",
+            "name": "int"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "0",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "76",
+          "name": "total_duration_seconds",
+          "type": {
+            "id": "int",
+            "name": "int"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "0",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "77",
+          "name": "created_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "78",
+          "name": "updated_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "79",
+          "name": "idx_voice_usage_period",
+          "unique": false,
+          "fieldIds": [
+            "73",
+            "74"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "80",
+          "name": "uq_voice_usage_org_period",
+          "unique": true,
+          "fieldIds": [
+            "73",
+            "74"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "81",
+          "name": "voice_usage_summaries_pkey",
+          "unique": true,
+          "fieldIds": [
+            "72"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "82",
+          "name": "idx_voice_usage_org",
+          "unique": false,
+          "fieldIds": [
+            "73"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153141,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "83",
+      "name": "knowledge_bases",
+      "schema": "public",
+      "x": 1796,
+      "y": 100,
+      "fields": [
+        {
+          "id": "84",
+          "name": "id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "default": "uuid_generate_v4()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "85",
+          "name": "org_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "86",
+          "name": "workspace_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "87",
+          "name": "name",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "255",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "88",
+          "name": "slug",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "100",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "89",
+          "name": "description",
+          "type": {
+            "id": "text",
+            "name": "text"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "90",
+          "name": "settings",
+          "type": {
+            "id": "jsonb",
+            "name": "jsonb"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "default": "'{}'::jsonb",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "91",
+          "name": "status",
+          "type": {
+            "id": "kb_status",
+            "name": "kb_status"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "'active'::kb_status",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "92",
+          "name": "created_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "93",
+          "name": "updated_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "94",
+          "name": "knowledge_bases_workspace_id_slug_key",
+          "unique": true,
+          "fieldIds": [
+            "86",
+            "88"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        },
+        {
+          "id": "95",
+          "name": "knowledge_bases_pkey",
+          "unique": true,
+          "fieldIds": [
+            "84"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        },
+        {
+          "id": "96",
+          "name": "idx_knowledge_bases_org_id",
+          "unique": false,
+          "fieldIds": [
+            "85"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        },
+        {
+          "id": "97",
+          "name": "idx_knowledge_bases_workspace_id",
+          "unique": false,
+          "fieldIds": [
+            "86"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153139,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "98",
+      "name": "stranger_users",
+      "schema": "public",
+      "x": -161.3488759974773,
+      "y": 647.909486646185,
+      "fields": [
+        {
+          "id": "99",
+          "name": "id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "default": "uuid_generate_v4()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "100",
+          "name": "org_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "101",
+          "name": "session_id",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "255",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "102",
+          "name": "ip_address",
+          "type": {
+            "id": "inet",
+            "name": "inet"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "103",
+          "name": "user_agent",
+          "type": {
+            "id": "text",
+            "name": "text"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "104",
+          "name": "status",
+          "type": {
+            "id": "stranger_status",
+            "name": "stranger_status"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "'active'::stranger_status",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "105",
+          "name": "block_reason",
+          "type": {
+            "id": "text",
+            "name": "text"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "106",
+          "name": "message_count",
+          "type": {
+            "id": "int",
+            "name": "int"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "0",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "107",
+          "name": "rate_limit_rpm",
+          "type": {
+            "id": "int",
+            "name": "int"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "108",
+          "name": "last_active_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "109",
+          "name": "blocked_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "110",
+          "name": "blocked_by",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "111",
+          "name": "created_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "112",
+          "name": "updated_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "113",
+          "name": "idx_stranger_users_last_active",
+          "unique": false,
+          "fieldIds": [
+            "100",
+            "108"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "114",
+          "name": "stranger_users_org_id_session_id_key",
+          "unique": true,
+          "fieldIds": [
+            "100",
+            "101"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "115",
+          "name": "idx_stranger_users_org",
+          "unique": false,
+          "fieldIds": [
+            "100"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "116",
+          "name": "idx_stranger_users_org_status",
+          "unique": false,
+          "fieldIds": [
+            "100",
+            "104"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "117",
+          "name": "idx_stranger_users_ip",
+          "unique": false,
+          "fieldIds": [
+            "100",
+            "102"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "118",
+          "name": "stranger_users_pkey",
+          "unique": true,
+          "fieldIds": [
+            "99"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        }
+      ],
+      "checkConstraints": [
+        {
+          "id": "d1epw2mwpwlgcpv20w17qbphv",
+          "expression": "",
+          "createdAt": 1775729153141
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153141,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "119",
+      "name": "organizations",
+      "schema": "public",
+      "x": 100,
+      "y": 100,
+      "fields": [
+        {
+          "id": "120",
+          "name": "id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "default": "uuid_generate_v4()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "121",
+          "name": "name",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "255",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "122",
+          "name": "slug",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "characterMaximumLength": "100",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "123",
+          "name": "status",
+          "type": {
+            "id": "org_status",
+            "name": "org_status"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "'active'::org_status",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "124",
+          "name": "settings",
+          "type": {
+            "id": "jsonb",
+            "name": "jsonb"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "default": "'{}'::jsonb",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "125",
+          "name": "keycloak_realm",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "characterMaximumLength": "255",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "126",
+          "name": "created_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "127",
+          "name": "updated_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "128",
+          "name": "organizations_pkey",
+          "unique": true,
+          "fieldIds": [
+            "120"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        },
+        {
+          "id": "129",
+          "name": "idx_organizations_slug",
+          "unique": false,
+          "fieldIds": [
+            "122"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        },
+        {
+          "id": "130",
+          "name": "organizations_slug_key",
+          "unique": true,
+          "fieldIds": [
+            "122"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        },
+        {
+          "id": "131",
+          "name": "idx_organizations_status",
+          "unique": false,
+          "fieldIds": [
+            "123"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153139,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "132",
+      "name": "workspace_members",
+      "schema": "public",
+      "x": 948,
+      "y": 100,
+      "fields": [
+        {
+          "id": "133",
+          "name": "id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "default": "uuid_generate_v4()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "134",
+          "name": "workspace_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "135",
+          "name": "user_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "136",
+          "name": "role",
+          "type": {
+            "id": "workspace_role",
+            "name": "workspace_role"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "'member'::workspace_role",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "137",
+          "name": "org_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "138",
+          "name": "created_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "139",
+          "name": "workspace_members_workspace_id_user_id_key",
+          "unique": true,
+          "fieldIds": [
+            "134",
+            "135"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        },
+        {
+          "id": "140",
+          "name": "idx_workspace_members_workspace_id",
+          "unique": false,
+          "fieldIds": [
+            "134"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        },
+        {
+          "id": "141",
+          "name": "idx_workspace_members_user_id",
+          "unique": false,
+          "fieldIds": [
+            "135"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        },
+        {
+          "id": "142",
+          "name": "workspace_members_pkey",
+          "unique": true,
+          "fieldIds": [
+            "133"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        },
+        {
+          "id": "143",
+          "name": "idx_workspace_members_org_id",
+          "unique": false,
+          "fieldIds": [
+            "137"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153139,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "144",
+      "name": "voice_sessions",
+      "schema": "public",
+      "x": -294.5490195724767,
+      "y": 1205.1096302211845,
+      "fields": [
+        {
+          "id": "145",
+          "name": "id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "default": "uuid_generate_v4()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "146",
+          "name": "org_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "147",
+          "name": "user_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "148",
+          "name": "stranger_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "149",
+          "name": "livekit_room",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "255",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "150",
+          "name": "state",
+          "type": {
+            "id": "voice_session_state",
+            "name": "voice_session_state"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "'created'::voice_session_state",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "151",
+          "name": "started_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "152",
+          "name": "ended_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "153",
+          "name": "created_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "154",
+          "name": "updated_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "155",
+          "name": "call_duration_seconds",
+          "type": {
+            "id": "int",
+            "name": "int"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "156",
+          "name": "idx_voice_sessions_org",
+          "unique": false,
+          "fieldIds": [
+            "146"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "157",
+          "name": "idx_voice_sessions_org_created",
+          "unique": false,
+          "fieldIds": [
+            "146",
+            "153"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "158",
+          "name": "idx_voice_sessions_user",
+          "unique": false,
+          "fieldIds": [
+            "146",
+            "147"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "159",
+          "name": "idx_voice_sessions_org_state",
+          "unique": false,
+          "fieldIds": [
+            "146",
+            "150"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "160",
+          "name": "idx_voice_sessions_stranger",
+          "unique": false,
+          "fieldIds": [
+            "146",
+            "148"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "161",
+          "name": "voice_sessions_pkey",
+          "unique": true,
+          "fieldIds": [
+            "145"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        }
+      ],
+      "checkConstraints": [
+        {
+          "id": "vf4nc52sdkjz9vcvy1kqk7ezp",
+          "expression": "",
+          "createdAt": 1775729153141
+        },
+        {
+          "id": "bcnx884b4bmueshy6ds3q3prk",
+          "expression": "",
+          "createdAt": 1775729153141
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153141,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "162",
+      "name": "whatsapp_phone_numbers",
+      "schema": "public",
+      "x": -985.4829141751952,
+      "y": 497.4125791855594,
+      "fields": [
+        {
+          "id": "163",
+          "name": "id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "default": "uuid_generate_v4()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "164",
+          "name": "org_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "165",
+          "name": "phone_number",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "20",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "166",
+          "name": "display_name",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "255",
+          "default": "''::character varying",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "167",
+          "name": "waba_id",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "64",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "168",
+          "name": "verified",
+          "type": {
+            "id": "boolean",
+            "name": "boolean"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "false",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "169",
+          "name": "created_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "170",
+          "name": "updated_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "171",
+          "name": "idx_whatsapp_phones_org",
+          "unique": false,
+          "fieldIds": [
+            "164"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "172",
+          "name": "idx_whatsapp_phones_waba",
+          "unique": false,
+          "fieldIds": [
+            "167"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "173",
+          "name": "uq_whatsapp_phone_org",
+          "unique": true,
+          "fieldIds": [
+            "164",
+            "165"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "174",
+          "name": "whatsapp_phone_numbers_pkey",
+          "unique": true,
+          "fieldIds": [
+            "163"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153141,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "175",
+      "name": "user_identities",
+      "schema": "public",
+      "x": -528.3596759881029,
+      "y": 539.3892931470328,
+      "fields": [
+        {
+          "id": "176",
+          "name": "id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "default": "uuid_generate_v4()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "177",
+          "name": "org_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "178",
+          "name": "anonymous_id",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "255",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "179",
+          "name": "user_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "180",
+          "name": "posthog_distinct_id",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "characterMaximumLength": "255",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "181",
+          "name": "channel",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "50",
+          "default": "'chat'::character varying",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "182",
+          "name": "first_seen_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "183",
+          "name": "last_seen_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "184",
+          "name": "session_count",
+          "type": {
+            "id": "int",
+            "name": "int"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "1",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "185",
+          "name": "metadata",
+          "type": {
+            "id": "jsonb",
+            "name": "jsonb"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "default": "'{}'::jsonb",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "186",
+          "name": "created_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "187",
+          "name": "updated_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "188",
+          "name": "idx_user_identities_last_seen",
+          "unique": false,
+          "fieldIds": [
+            "177",
+            "183"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "189",
+          "name": "idx_user_identities_channel",
+          "unique": false,
+          "fieldIds": [
+            "177",
+            "181"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "190",
+          "name": "idx_user_identities_org",
+          "unique": false,
+          "fieldIds": [
+            "177"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "191",
+          "name": "idx_user_identities_user",
+          "unique": false,
+          "fieldIds": [
+            "179"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "192",
+          "name": "user_identities_org_id_anonymous_id_channel_key",
+          "unique": true,
+          "fieldIds": [
+            "177",
+            "178",
+            "181"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "193",
+          "name": "idx_user_identities_anonymous",
+          "unique": false,
+          "fieldIds": [
+            "177",
+            "178"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "194",
+          "name": "user_identities_pkey",
+          "unique": true,
+          "fieldIds": [
+            "176"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153141,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "195",
+      "name": "documents",
+      "schema": "public",
+      "x": 2220,
+      "y": 100,
+      "fields": [
+        {
+          "id": "196",
+          "name": "id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "default": "uuid_generate_v4()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "197",
+          "name": "org_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "198",
+          "name": "knowledge_base_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "199",
+          "name": "file_name",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "500",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "200",
+          "name": "file_type",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "characterMaximumLength": "50",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "201",
+          "name": "file_size_bytes",
+          "type": {
+            "id": "bigint",
+            "name": "bigint"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "202",
+          "name": "file_hash",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "characterMaximumLength": "128",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "203",
+          "name": "storage_path",
+          "type": {
+            "id": "text",
+            "name": "text"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "204",
+          "name": "processing_status",
+          "type": {
+            "id": "processing_status",
+            "name": "processing_status"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "'queued'::processing_status",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "205",
+          "name": "processing_error",
+          "type": {
+            "id": "text",
+            "name": "text"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "206",
+          "name": "title",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "characterMaximumLength": "500",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "207",
+          "name": "page_count",
+          "type": {
+            "id": "int",
+            "name": "int"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "208",
+          "name": "metadata",
+          "type": {
+            "id": "jsonb",
+            "name": "jsonb"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "default": "'{}'::jsonb",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "209",
+          "name": "uploaded_by",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "210",
+          "name": "created_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "211",
+          "name": "updated_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "212",
+          "name": "documents_pkey",
+          "unique": true,
+          "fieldIds": [
+            "196"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        },
+        {
+          "id": "213",
+          "name": "idx_documents_knowledge_base_id",
+          "unique": false,
+          "fieldIds": [
+            "198"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        },
+        {
+          "id": "214",
+          "name": "idx_documents_file_hash",
+          "unique": false,
+          "fieldIds": [
+            "202"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        },
+        {
+          "id": "215",
+          "name": "idx_documents_org_id",
+          "unique": false,
+          "fieldIds": [
+            "197"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        },
+        {
+          "id": "216",
+          "name": "idx_documents_processing_status",
+          "unique": false,
+          "fieldIds": [
+            "204"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153139,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "217",
+      "name": "lead_profiles",
+      "schema": "public",
+      "x": 971.2748715062036,
+      "y": 680.7415255355959,
+      "fields": [
+        {
+          "id": "218",
+          "name": "id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "default": "uuid_generate_v4()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "219",
+          "name": "org_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "220",
+          "name": "knowledge_base_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "221",
+          "name": "session_ids",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "default": "'{}'::uuid[]",
+          "increment": false,
+          "isArray": true,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "222",
+          "name": "email",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "characterMaximumLength": "255",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "223",
+          "name": "name",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "characterMaximumLength": "255",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "224",
+          "name": "phone",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "characterMaximumLength": "50",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "225",
+          "name": "company",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "characterMaximumLength": "255",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "226",
+          "name": "metadata",
+          "type": {
+            "id": "jsonb",
+            "name": "jsonb"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "default": "'{}'::jsonb",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "227",
+          "name": "engagement_score",
+          "type": {
+            "id": "real",
+            "name": "real"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "0.0",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "228",
+          "name": "total_messages",
+          "type": {
+            "id": "int",
+            "name": "int"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "0",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "229",
+          "name": "total_sessions",
+          "type": {
+            "id": "int",
+            "name": "int"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "1",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "230",
+          "name": "first_seen_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "231",
+          "name": "last_seen_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "232",
+          "name": "created_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "233",
+          "name": "updated_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "234",
+          "name": "uq_lead_profiles_org_email",
+          "unique": true,
+          "fieldIds": [
+            "219",
+            "222"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "235",
+          "name": "idx_lead_profiles_org_score",
+          "unique": false,
+          "fieldIds": [
+            "219",
+            "227"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "236",
+          "name": "lead_profiles_pkey",
+          "unique": true,
+          "fieldIds": [
+            "218"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153140,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "237",
+      "name": "security_events",
+      "schema": "public",
+      "x": 621.359675988103,
+      "y": 1130.3892931470327,
+      "fields": [
+        {
+          "id": "238",
+          "name": "id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "default": "uuid_generate_v4()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "239",
+          "name": "org_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "240",
+          "name": "rule_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "241",
+          "name": "event_type",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "50",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "242",
+          "name": "ip_address",
+          "type": {
+            "id": "inet",
+            "name": "inet"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "243",
+          "name": "country_code",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "characterMaximumLength": "2",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "244",
+          "name": "request_path",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "characterMaximumLength": "1000",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "245",
+          "name": "request_method",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "characterMaximumLength": "10",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "246",
+          "name": "user_agent",
+          "type": {
+            "id": "text",
+            "name": "text"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "247",
+          "name": "details",
+          "type": {
+            "id": "jsonb",
+            "name": "jsonb"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "default": "'{}'::jsonb",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "248",
+          "name": "created_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "249",
+          "name": "idx_security_events_time",
+          "unique": false,
+          "fieldIds": [
+            "239",
+            "248"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "250",
+          "name": "security_events_pkey",
+          "unique": true,
+          "fieldIds": [
+            "238"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "251",
+          "name": "idx_security_events_ip",
+          "unique": false,
+          "fieldIds": [
+            "242"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "252",
+          "name": "idx_security_events_org",
+          "unique": false,
+          "fieldIds": [
+            "239"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153140,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "253",
+      "name": "chat_sessions",
+      "schema": "public",
+      "x": 1823.1359655127999,
+      "y": 582.1049575378947,
+      "fields": [
+        {
+          "id": "254",
+          "name": "id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "default": "uuid_generate_v4()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "255",
+          "name": "org_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "256",
+          "name": "knowledge_base_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "257",
+          "name": "user_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "258",
+          "name": "session_token",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "255",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "259",
+          "name": "metadata",
+          "type": {
+            "id": "jsonb",
+            "name": "jsonb"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "default": "'{}'::jsonb",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "260",
+          "name": "created_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "261",
+          "name": "expires_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "262",
+          "name": "idx_chat_sessions_knowledge_base_id",
+          "unique": false,
+          "fieldIds": [
+            "256"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "263",
+          "name": "chat_sessions_pkey",
+          "unique": true,
+          "fieldIds": [
+            "254"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "264",
+          "name": "idx_chat_sessions_org_id",
+          "unique": false,
+          "fieldIds": [
+            "255"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "265",
+          "name": "idx_chat_sessions_session_token",
+          "unique": false,
+          "fieldIds": [
+            "258"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153140,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "266",
+      "name": "subscriptions",
+      "schema": "public",
+      "x": 516.7805942659742,
+      "y": -404.492740127348,
+      "fields": [
+        {
+          "id": "267",
+          "name": "id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "default": "gen_random_uuid()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "268",
+          "name": "org_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "269",
+          "name": "plan_id",
+          "type": {
+            "id": "text",
+            "name": "text"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "270",
+          "name": "status",
+          "type": {
+            "id": "text",
+            "name": "text"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "'active'::text",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "271",
+          "name": "hyperswitch_subscription_id",
+          "type": {
+            "id": "text",
+            "name": "text"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "272",
+          "name": "current_period_start",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "273",
+          "name": "current_period_end",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "(now() + '1 mon'::interval)",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "274",
+          "name": "created_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "275",
+          "name": "idx_subscriptions_org_active",
+          "unique": true,
+          "fieldIds": [
+            "268"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "276",
+          "name": "subscriptions_pkey",
+          "unique": true,
+          "fieldIds": [
+            "267"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "277",
+          "name": "idx_subscriptions_hyperswitch_id",
+          "unique": false,
+          "fieldIds": [
+            "271"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        }
+      ],
+      "checkConstraints": [
+        {
+          "id": "7w8p0jnf9atcqqbw6tz90iht4",
+          "expression": "",
+          "createdAt": 1775729153140
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153140,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "278",
+      "name": "webhook_deliveries",
+      "schema": "public",
+      "x": 624.4487683162278,
+      "y": 1656.8095943274345,
+      "fields": [
+        {
+          "id": "279",
+          "name": "id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "default": "uuid_generate_v4()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "280",
+          "name": "webhook_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "281",
+          "name": "org_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "282",
+          "name": "event_type",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "100",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "283",
+          "name": "payload",
+          "type": {
+            "id": "jsonb",
+            "name": "jsonb"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "284",
+          "name": "status",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "50",
+          "default": "'pending'::character varying",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "285",
+          "name": "attempt",
+          "type": {
+            "id": "int",
+            "name": "int"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "0",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "286",
+          "name": "response_status",
+          "type": {
+            "id": "int",
+            "name": "int"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "287",
+          "name": "response_body",
+          "type": {
+            "id": "text",
+            "name": "text"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "288",
+          "name": "next_retry_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "289",
+          "name": "created_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "290",
+          "name": "completed_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "291",
+          "name": "idx_webhook_deliveries_retry",
+          "unique": false,
+          "fieldIds": [
+            "288"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "292",
+          "name": "idx_webhook_deliveries_status",
+          "unique": false,
+          "fieldIds": [
+            "280",
+            "284"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "293",
+          "name": "idx_webhook_deliveries_webhook",
+          "unique": false,
+          "fieldIds": [
+            "280"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "294",
+          "name": "idx_webhook_deliveries_org",
+          "unique": false,
+          "fieldIds": [
+            "281"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "295",
+          "name": "webhook_deliveries_pkey",
+          "unique": true,
+          "fieldIds": [
+            "279"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153140,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "296",
+      "name": "workspaces",
+      "schema": "public",
+      "x": 1372,
+      "y": 100,
+      "fields": [
+        {
+          "id": "297",
+          "name": "id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "default": "uuid_generate_v4()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "298",
+          "name": "org_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "299",
+          "name": "name",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "255",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "300",
+          "name": "slug",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "100",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "301",
+          "name": "settings",
+          "type": {
+            "id": "jsonb",
+            "name": "jsonb"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "default": "'{}'::jsonb",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "302",
+          "name": "created_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "303",
+          "name": "updated_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "304",
+          "name": "workspaces_pkey",
+          "unique": true,
+          "fieldIds": [
+            "297"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        },
+        {
+          "id": "305",
+          "name": "workspaces_org_id_slug_key",
+          "unique": true,
+          "fieldIds": [
+            "298",
+            "300"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        },
+        {
+          "id": "306",
+          "name": "idx_workspaces_org_id",
+          "unique": false,
+          "fieldIds": [
+            "298"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153139,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "307",
+      "name": "webhook_configs",
+      "schema": "public",
+      "x": 200.44876831622776,
+      "y": 1065.8095943274345,
+      "fields": [
+        {
+          "id": "308",
+          "name": "id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "default": "uuid_generate_v4()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "309",
+          "name": "org_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "310",
+          "name": "name",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "255",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "311",
+          "name": "url",
+          "type": {
+            "id": "text",
+            "name": "text"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "312",
+          "name": "secret",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "255",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "313",
+          "name": "events",
+          "type": {
+            "id": "text",
+            "name": "text"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": true,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "314",
+          "name": "headers",
+          "type": {
+            "id": "jsonb",
+            "name": "jsonb"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "default": "'{}'::jsonb",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "315",
+          "name": "status",
+          "type": {
+            "id": "webhook_status",
+            "name": "webhook_status"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "'active'::webhook_status",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "316",
+          "name": "max_retries",
+          "type": {
+            "id": "int",
+            "name": "int"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "5",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "317",
+          "name": "last_triggered_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "318",
+          "name": "failure_count",
+          "type": {
+            "id": "int",
+            "name": "int"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "0",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "319",
+          "name": "created_by",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "320",
+          "name": "created_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "321",
+          "name": "updated_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "322",
+          "name": "idx_webhook_configs_org",
+          "unique": false,
+          "fieldIds": [
+            "309"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "323",
+          "name": "webhook_configs_pkey",
+          "unique": true,
+          "fieldIds": [
+            "308"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "324",
+          "name": "idx_webhook_configs_events",
+          "unique": false,
+          "fieldIds": [
+            "313"
+          ],
+          "createdAt": 1775729153140,
+          "type": "gin"
+        },
+        {
+          "id": "325",
+          "name": "idx_webhook_configs_id_org",
+          "unique": true,
+          "fieldIds": [
+            "308",
+            "309"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "326",
+          "name": "idx_webhook_configs_status",
+          "unique": false,
+          "fieldIds": [
+            "309",
+            "315"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153140,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "327",
+      "name": "catalog_metadata",
+      "schema": "public",
+      "x": -83.75222852433569,
+      "y": -310.78183734856907,
+      "fields": [
+        {
+          "id": "328",
+          "name": "id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "default": "uuid_generate_v4()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "329",
+          "name": "org_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "330",
+          "name": "catalog_type",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "100",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "331",
+          "name": "resource_path",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "1000",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "332",
+          "name": "labels",
+          "type": {
+            "id": "jsonb",
+            "name": "jsonb"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "default": "'{}'::jsonb",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "333",
+          "name": "discovered_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "334",
+          "name": "catalog_metadata_org_id_catalog_type_resource_path_key",
+          "unique": true,
+          "fieldIds": [
+            "329",
+            "330",
+            "331"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "335",
+          "name": "catalog_metadata_pkey",
+          "unique": true,
+          "fieldIds": [
+            "328"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153140,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "336",
+      "name": "security_rules",
+      "schema": "public",
+      "x": 197.35967598810305,
+      "y": 539.3892931470328,
+      "fields": [
+        {
+          "id": "337",
+          "name": "id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "default": "uuid_generate_v4()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "338",
+          "name": "org_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "339",
+          "name": "name",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "255",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "340",
+          "name": "description",
+          "type": {
+            "id": "text",
+            "name": "text"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "341",
+          "name": "rule_type",
+          "type": {
+            "id": "security_rule_type",
+            "name": "security_rule_type"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "342",
+          "name": "action",
+          "type": {
+            "id": "security_action",
+            "name": "security_action"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "'block'::security_action",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "343",
+          "name": "ip_cidrs",
+          "type": {
+            "id": "text",
+            "name": "text"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": true,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "344",
+          "name": "country_codes",
+          "type": {
+            "id": "text",
+            "name": "text"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": true,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "345",
+          "name": "pattern_config",
+          "type": {
+            "id": "jsonb",
+            "name": "jsonb"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "default": "'{}'::jsonb",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "346",
+          "name": "rate_limit",
+          "type": {
+            "id": "int",
+            "name": "int"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "347",
+          "name": "rate_window_seconds",
+          "type": {
+            "id": "int",
+            "name": "int"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "348",
+          "name": "priority",
+          "type": {
+            "id": "int",
+            "name": "int"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "0",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "349",
+          "name": "is_active",
+          "type": {
+            "id": "boolean",
+            "name": "boolean"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "true",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "350",
+          "name": "hits_count",
+          "type": {
+            "id": "bigint",
+            "name": "bigint"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "0",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "351",
+          "name": "last_hit_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "352",
+          "name": "created_by",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "353",
+          "name": "created_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "354",
+          "name": "updated_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "355",
+          "name": "idx_security_rules_org",
+          "unique": false,
+          "fieldIds": [
+            "338"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "356",
+          "name": "idx_security_rules_type",
+          "unique": false,
+          "fieldIds": [
+            "338",
+            "341"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "357",
+          "name": "security_rules_pkey",
+          "unique": true,
+          "fieldIds": [
+            "337"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153140,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "358",
+      "name": "payment_intents",
+      "schema": "public",
+      "x": -734.8975563088684,
+      "y": 1598.327163576304,
+      "fields": [
+        {
+          "id": "359",
+          "name": "id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "default": "gen_random_uuid()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "360",
+          "name": "org_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "361",
+          "name": "amount",
+          "type": {
+            "id": "bigint",
+            "name": "bigint"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "362",
+          "name": "currency",
+          "type": {
+            "id": "text",
+            "name": "text"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "'INR'::text",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "363",
+          "name": "status",
+          "type": {
+            "id": "text",
+            "name": "text"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "'requires_payment_method'::text",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "364",
+          "name": "hyperswitch_payment_id",
+          "type": {
+            "id": "text",
+            "name": "text"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "365",
+          "name": "client_secret",
+          "type": {
+            "id": "text",
+            "name": "text"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "366",
+          "name": "idempotency_key",
+          "type": {
+            "id": "text",
+            "name": "text"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "367",
+          "name": "created_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "368",
+          "name": "updated_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "369",
+          "name": "payment_intents_pkey",
+          "unique": true,
+          "fieldIds": [
+            "359"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "370",
+          "name": "idx_payment_intents_hs_payment_id",
+          "unique": true,
+          "fieldIds": [
+            "364"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "371",
+          "name": "idx_payment_intents_org_id",
+          "unique": false,
+          "fieldIds": [
+            "360"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        }
+      ],
+      "checkConstraints": [
+        {
+          "id": "mj9utw2on4xbqq1r3aqsknewx",
+          "expression": "",
+          "createdAt": 1775729153141
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153141,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "372",
+      "name": "routing_rules",
+      "schema": "public",
+      "x": 1735.6585085721272,
+      "y": 1066.116793407179,
+      "fields": [
+        {
+          "id": "373",
+          "name": "id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "default": "uuid_generate_v4()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "374",
+          "name": "org_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "375",
+          "name": "name",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "255",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "376",
+          "name": "description",
+          "type": {
+            "id": "text",
+            "name": "text"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "377",
+          "name": "source_type",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "100",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "378",
+          "name": "source_identifier",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "characterMaximumLength": "500",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "379",
+          "name": "routing_mode",
+          "type": {
+            "id": "routing_mode",
+            "name": "routing_mode"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "'static'::routing_mode",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "380",
+          "name": "target_kb_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "381",
+          "name": "discriminator_column",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "characterMaximumLength": "255",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "382",
+          "name": "column_mappings",
+          "type": {
+            "id": "jsonb",
+            "name": "jsonb"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "default": "'{}'::jsonb",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "383",
+          "name": "classification_prompt",
+          "type": {
+            "id": "text",
+            "name": "text"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "384",
+          "name": "classification_model",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "characterMaximumLength": "100",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "385",
+          "name": "classification_provider",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "characterMaximumLength": "50",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "386",
+          "name": "priority",
+          "type": {
+            "id": "int",
+            "name": "int"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "0",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "387",
+          "name": "is_active",
+          "type": {
+            "id": "boolean",
+            "name": "boolean"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "true",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "388",
+          "name": "created_by",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "389",
+          "name": "created_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "390",
+          "name": "updated_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "391",
+          "name": "idx_routing_rules_org",
+          "unique": false,
+          "fieldIds": [
+            "374"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "392",
+          "name": "idx_routing_rules_source",
+          "unique": false,
+          "fieldIds": [
+            "374",
+            "377",
+            "378"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "393",
+          "name": "routing_rules_pkey",
+          "unique": true,
+          "fieldIds": [
+            "373"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153140,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "394",
+      "name": "chat_messages",
+      "schema": "public",
+      "x": 2247.1359655128,
+      "y": 1125.1049575378947,
+      "fields": [
+        {
+          "id": "395",
+          "name": "id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "default": "uuid_generate_v4()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "396",
+          "name": "session_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "397",
+          "name": "org_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "398",
+          "name": "role",
+          "type": {
+            "id": "message_role",
+            "name": "message_role"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "399",
+          "name": "content",
+          "type": {
+            "id": "text",
+            "name": "text"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "400",
+          "name": "token_count",
+          "type": {
+            "id": "int",
+            "name": "int"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "401",
+          "name": "chunk_ids",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": true,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "402",
+          "name": "model_name",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "characterMaximumLength": "100",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "403",
+          "name": "latency_ms",
+          "type": {
+            "id": "int",
+            "name": "int"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "404",
+          "name": "created_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "405",
+          "name": "idx_chat_messages_org_id",
+          "unique": false,
+          "fieldIds": [
+            "397"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "406",
+          "name": "chat_messages_pkey",
+          "unique": true,
+          "fieldIds": [
+            "395"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "407",
+          "name": "idx_chat_messages_session_id",
+          "unique": false,
+          "fieldIds": [
+            "396"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153140,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "408",
+      "name": "sources",
+      "schema": "public",
+      "x": 3068,
+      "y": 100,
+      "fields": [
+        {
+          "id": "409",
+          "name": "id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "default": "uuid_generate_v4()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "410",
+          "name": "org_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "411",
+          "name": "knowledge_base_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "412",
+          "name": "source_type",
+          "type": {
+            "id": "source_type",
+            "name": "source_type"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "413",
+          "name": "url",
+          "type": {
+            "id": "text",
+            "name": "text"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "414",
+          "name": "crawl_depth",
+          "type": {
+            "id": "int",
+            "name": "int"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "default": "1",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "415",
+          "name": "crawl_frequency",
+          "type": {
+            "id": "crawl_frequency",
+            "name": "crawl_frequency"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "'manual'::crawl_frequency",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "416",
+          "name": "processing_status",
+          "type": {
+            "id": "processing_status",
+            "name": "processing_status"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "'queued'::processing_status",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "417",
+          "name": "processing_error",
+          "type": {
+            "id": "text",
+            "name": "text"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "418",
+          "name": "title",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "characterMaximumLength": "500",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "419",
+          "name": "pages_crawled",
+          "type": {
+            "id": "int",
+            "name": "int"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "default": "0",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "420",
+          "name": "metadata",
+          "type": {
+            "id": "jsonb",
+            "name": "jsonb"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "default": "'{}'::jsonb",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "421",
+          "name": "created_by",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "422",
+          "name": "created_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "423",
+          "name": "updated_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "424",
+          "name": "idx_sources_org_id",
+          "unique": false,
+          "fieldIds": [
+            "410"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        },
+        {
+          "id": "425",
+          "name": "idx_sources_processing_status",
+          "unique": false,
+          "fieldIds": [
+            "416"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        },
+        {
+          "id": "426",
+          "name": "idx_sources_knowledge_base_id",
+          "unique": false,
+          "fieldIds": [
+            "411"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        },
+        {
+          "id": "427",
+          "name": "sources_pkey",
+          "unique": true,
+          "fieldIds": [
+            "409"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153139,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "428",
+      "name": "chunks",
+      "schema": "public",
+      "x": 2644,
+      "y": 100,
+      "fields": [
+        {
+          "id": "429",
+          "name": "id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "default": "uuid_generate_v4()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "430",
+          "name": "org_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "431",
+          "name": "knowledge_base_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "432",
+          "name": "document_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "433",
+          "name": "source_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "434",
+          "name": "content",
+          "type": {
+            "id": "text",
+            "name": "text"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "435",
+          "name": "chunk_index",
+          "type": {
+            "id": "int",
+            "name": "int"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "436",
+          "name": "token_count",
+          "type": {
+            "id": "int",
+            "name": "int"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "437",
+          "name": "page_number",
+          "type": {
+            "id": "int",
+            "name": "int"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "438",
+          "name": "heading",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "characterMaximumLength": "500",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "439",
+          "name": "chunk_type",
+          "type": {
+            "id": "chunk_type",
+            "name": "chunk_type"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "'text'::chunk_type",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "440",
+          "name": "metadata",
+          "type": {
+            "id": "jsonb",
+            "name": "jsonb"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "default": "'{}'::jsonb",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "441",
+          "name": "created_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "442",
+          "name": "chunk_hash",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "characterMaximumLength": "64",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "443",
+          "name": "idx_chunks_dedup",
+          "unique": true,
+          "fieldIds": [
+            "430",
+            "431",
+            "433",
+            "442"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        },
+        {
+          "id": "444",
+          "name": "idx_chunks_knowledge_base_id",
+          "unique": false,
+          "fieldIds": [
+            "431"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        },
+        {
+          "id": "445",
+          "name": "idx_chunks_source_id",
+          "unique": false,
+          "fieldIds": [
+            "433"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        },
+        {
+          "id": "446",
+          "name": "idx_chunks_document_id",
+          "unique": false,
+          "fieldIds": [
+            "432"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        },
+        {
+          "id": "447",
+          "name": "chunks_pkey",
+          "unique": true,
+          "fieldIds": [
+            "429"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        },
+        {
+          "id": "448",
+          "name": "idx_chunks_org_id",
+          "unique": false,
+          "fieldIds": [
+            "430"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        }
+      ],
+      "checkConstraints": [
+        {
+          "id": "tovra18zrjbig1zemfrxdt0b6",
+          "expression": "",
+          "createdAt": 1775729153139
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153139,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "449",
+      "name": "embeddings",
+      "schema": "public",
+      "x": 2775.0232056149775,
+      "y": 619.2768578971538,
+      "fields": [
+        {
+          "id": "450",
+          "name": "id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "default": "uuid_generate_v4()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "451",
+          "name": "org_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "452",
+          "name": "chunk_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "453",
+          "name": "embedding",
+          "type": {
+            "id": "vector",
+            "name": "vector"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "454",
+          "name": "model_name",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "100",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "455",
+          "name": "model_version",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "characterMaximumLength": "50",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "456",
+          "name": "dimensions",
+          "type": {
+            "id": "int",
+            "name": "int"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "457",
+          "name": "created_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "458",
+          "name": "embeddings_chunk_id_model_name_key",
+          "unique": true,
+          "fieldIds": [
+            "452",
+            "454"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        },
+        {
+          "id": "459",
+          "name": "idx_embeddings_org_id",
+          "unique": false,
+          "fieldIds": [
+            "451"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        },
+        {
+          "id": "460",
+          "name": "embeddings_pkey",
+          "unique": true,
+          "fieldIds": [
+            "450"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        },
+        {
+          "id": "461",
+          "name": "idx_embeddings_chunk_id",
+          "unique": false,
+          "fieldIds": [
+            "452"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        },
+        {
+          "id": "462",
+          "name": "idx_embeddings_hnsw",
+          "unique": false,
+          "fieldIds": [
+            "453"
+          ],
+          "createdAt": 1775729153139,
+          "type": "hnsw"
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153139,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "463",
+      "name": "voice_turns",
+      "schema": "public",
+      "x": 129.45098042752332,
+      "y": 1652.1096302211845,
+      "fields": [
+        {
+          "id": "464",
+          "name": "id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "default": "uuid_generate_v4()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "465",
+          "name": "session_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "466",
+          "name": "org_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "467",
+          "name": "speaker",
+          "type": {
+            "id": "voice_speaker",
+            "name": "voice_speaker"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "468",
+          "name": "transcript",
+          "type": {
+            "id": "text",
+            "name": "text"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "469",
+          "name": "started_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "470",
+          "name": "ended_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "471",
+          "name": "created_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "472",
+          "name": "voice_turns_pkey",
+          "unique": true,
+          "fieldIds": [
+            "464"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "473",
+          "name": "idx_voice_turns_session",
+          "unique": false,
+          "fieldIds": [
+            "465"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "474",
+          "name": "idx_voice_turns_session_started",
+          "unique": false,
+          "fieldIds": [
+            "465",
+            "469"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "475",
+          "name": "idx_voice_turns_org",
+          "unique": false,
+          "fieldIds": [
+            "466"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        }
+      ],
+      "checkConstraints": [
+        {
+          "id": "wn1qiwi2jkziyopx45pz2g46x",
+          "expression": "",
+          "createdAt": 1775729153141
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153141,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "476",
+      "name": "airbyte_connectors",
+      "schema": "public",
+      "x": 1379.0390129134494,
+      "y": 676.1232898705111,
+      "fields": [
+        {
+          "id": "477",
+          "name": "id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "default": "uuid_generate_v4()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "478",
+          "name": "org_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "479",
+          "name": "knowledge_base_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "480",
+          "name": "name",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "255",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "481",
+          "name": "connector_type",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "100",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "482",
+          "name": "config",
+          "type": {
+            "id": "jsonb",
+            "name": "jsonb"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "'{}'::jsonb",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "483",
+          "name": "sync_mode",
+          "type": {
+            "id": "sync_mode",
+            "name": "sync_mode"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "'full_refresh'::sync_mode",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "484",
+          "name": "schedule_cron",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "characterMaximumLength": "100",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "485",
+          "name": "status",
+          "type": {
+            "id": "connector_status",
+            "name": "connector_status"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "'active'::connector_status",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "486",
+          "name": "last_sync_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "487",
+          "name": "last_sync_status",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "characterMaximumLength": "50",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "488",
+          "name": "last_sync_records",
+          "type": {
+            "id": "int",
+            "name": "int"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "default": "0",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "489",
+          "name": "created_by",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "490",
+          "name": "created_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "491",
+          "name": "updated_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "492",
+          "name": "idx_airbyte_connectors_kb",
+          "unique": false,
+          "fieldIds": [
+            "479"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "493",
+          "name": "idx_airbyte_connectors_org",
+          "unique": false,
+          "fieldIds": [
+            "478"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "494",
+          "name": "airbyte_connectors_pkey",
+          "unique": true,
+          "fieldIds": [
+            "477"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153140,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "495",
+      "name": "response_cache",
+      "schema": "public",
+      "x": 1110.5749073999532,
+      "y": -341.44148964184615,
+      "fields": [
+        {
+          "id": "496",
+          "name": "id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "default": "uuid_generate_v4()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "497",
+          "name": "org_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "498",
+          "name": "kb_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "499",
+          "name": "query_text",
+          "type": {
+            "id": "text",
+            "name": "text"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "500",
+          "name": "query_embedding",
+          "type": {
+            "id": "vector",
+            "name": "vector"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "501",
+          "name": "response_text",
+          "type": {
+            "id": "text",
+            "name": "text"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "502",
+          "name": "sources",
+          "type": {
+            "id": "jsonb",
+            "name": "jsonb"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "default": "'[]'::jsonb",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "503",
+          "name": "model_name",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "characterMaximumLength": "100",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "504",
+          "name": "hit_count",
+          "type": {
+            "id": "int",
+            "name": "int"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "0",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "505",
+          "name": "created_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "506",
+          "name": "expires_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "(now() + '01:00:00'::interval)",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "507",
+          "name": "idx_response_cache_org_kb",
+          "unique": false,
+          "fieldIds": [
+            "497",
+            "498"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "508",
+          "name": "idx_response_cache_expires",
+          "unique": false,
+          "fieldIds": [
+            "506"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "509",
+          "name": "idx_response_cache_embedding",
+          "unique": false,
+          "fieldIds": [
+            "500"
+          ],
+          "createdAt": 1775729153141,
+          "type": "hnsw"
+        },
+        {
+          "id": "510",
+          "name": "response_cache_pkey",
+          "unique": true,
+          "fieldIds": [
+            "496"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153141,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "511",
+      "name": "notification_configs",
+      "schema": "public",
+      "x": 460.4920655493562,
+      "y": -829.8367828870769,
+      "fields": [
+        {
+          "id": "512",
+          "name": "id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "default": "uuid_generate_v4()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "513",
+          "name": "org_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "514",
+          "name": "notification_type",
+          "type": {
+            "id": "notification_type",
+            "name": "notification_type"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "515",
+          "name": "recipients",
+          "type": {
+            "id": "text",
+            "name": "text"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": true,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "516",
+          "name": "enabled",
+          "type": {
+            "id": "boolean",
+            "name": "boolean"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "true",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "517",
+          "name": "config",
+          "type": {
+            "id": "jsonb",
+            "name": "jsonb"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "default": "'{}'::jsonb",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "518",
+          "name": "created_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "519",
+          "name": "updated_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "520",
+          "name": "uniq_notification_configs_org_type",
+          "unique": true,
+          "fieldIds": [
+            "513",
+            "514"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "521",
+          "name": "idx_notification_configs_org",
+          "unique": false,
+          "fieldIds": [
+            "513"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "522",
+          "name": "notification_configs_pkey",
+          "unique": true,
+          "fieldIds": [
+            "512"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "523",
+          "name": "idx_notification_configs_type",
+          "unique": false,
+          "fieldIds": [
+            "513",
+            "514"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        }
+      ],
+      "checkConstraints": [
+        {
+          "id": "b6nvxa0b08eewlchg4cffoahz",
+          "expression": "",
+          "createdAt": 1775729153141
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153141,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "524",
+      "name": "processing_events",
+      "schema": "public",
+      "x": 3492,
+      "y": 100,
+      "fields": [
+        {
+          "id": "525",
+          "name": "id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "default": "uuid_generate_v4()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "526",
+          "name": "org_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "527",
+          "name": "document_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "528",
+          "name": "source_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "529",
+          "name": "from_status",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "characterMaximumLength": "20",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "530",
+          "name": "to_status",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "20",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "531",
+          "name": "error_message",
+          "type": {
+            "id": "text",
+            "name": "text"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "532",
+          "name": "duration_ms",
+          "type": {
+            "id": "int",
+            "name": "int"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        },
+        {
+          "id": "533",
+          "name": "created_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153140,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "534",
+          "name": "idx_processing_events_doc_timeline",
+          "unique": false,
+          "fieldIds": [
+            "527",
+            "533"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "535",
+          "name": "idx_processing_events_source_timeline",
+          "unique": false,
+          "fieldIds": [
+            "528",
+            "533"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "536",
+          "name": "idx_processing_events_org_id",
+          "unique": false,
+          "fieldIds": [
+            "526"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "537",
+          "name": "idx_processing_events_source_id",
+          "unique": false,
+          "fieldIds": [
+            "528"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "538",
+          "name": "idx_processing_events_document_id",
+          "unique": false,
+          "fieldIds": [
+            "527"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        },
+        {
+          "id": "539",
+          "name": "processing_events_pkey",
+          "unique": true,
+          "fieldIds": [
+            "525"
+          ],
+          "createdAt": 1775729153140,
+          "type": "btree"
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153140,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "540",
+      "name": "goose_db_version",
+      "schema": "public",
+      "x": 100,
+      "y": 2250.8095943274348,
+      "fields": [
+        {
+          "id": "541",
+          "name": "id",
+          "type": {
+            "id": "int",
+            "name": "int"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "increment": true,
+          "isArray": false,
+          "createdAt": 1775729153138,
+          "comments": "null"
+        },
+        {
+          "id": "542",
+          "name": "version_id",
+          "type": {
+            "id": "bigint",
+            "name": "bigint"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153138,
+          "comments": "null"
+        },
+        {
+          "id": "543",
+          "name": "is_applied",
+          "type": {
+            "id": "boolean",
+            "name": "boolean"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153138,
+          "comments": "null"
+        },
+        {
+          "id": "544",
+          "name": "tstamp",
+          "type": {
+            "id": "timestamp",
+            "name": "timestamp"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153138,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "545",
+          "name": "goose_db_version_pkey",
+          "unique": true,
+          "fieldIds": [
+            "541"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153139,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "546",
+      "name": "users",
+      "schema": "public",
+      "x": 524,
+      "y": 100,
+      "fields": [
+        {
+          "id": "547",
+          "name": "id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "default": "uuid_generate_v4()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "548",
+          "name": "org_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "549",
+          "name": "email",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "255",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "550",
+          "name": "display_name",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "characterMaximumLength": "255",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "551",
+          "name": "keycloak_sub",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": true,
+          "characterMaximumLength": "255",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "552",
+          "name": "status",
+          "type": {
+            "id": "user_status",
+            "name": "user_status"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "'active'::user_status",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "553",
+          "name": "last_login_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "554",
+          "name": "created_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        },
+        {
+          "id": "555",
+          "name": "updated_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153139,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "556",
+          "name": "users_org_id_email_key",
+          "unique": true,
+          "fieldIds": [
+            "548",
+            "549"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        },
+        {
+          "id": "557",
+          "name": "users_keycloak_sub_key",
+          "unique": true,
+          "fieldIds": [
+            "551"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        },
+        {
+          "id": "558",
+          "name": "idx_users_email",
+          "unique": false,
+          "fieldIds": [
+            "549"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        },
+        {
+          "id": "559",
+          "name": "users_pkey",
+          "unique": true,
+          "fieldIds": [
+            "547"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        },
+        {
+          "id": "560",
+          "name": "idx_users_org_id",
+          "unique": false,
+          "fieldIds": [
+            "548"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        },
+        {
+          "id": "561",
+          "name": "idx_users_keycloak_sub",
+          "unique": false,
+          "fieldIds": [
+            "551"
+          ],
+          "createdAt": 1775729153139,
+          "type": "btree"
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153139,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "562",
+      "name": "notification_log",
+      "schema": "public",
+      "x": 884.4920655493562,
+      "y": -1010.8367828870769,
+      "fields": [
+        {
+          "id": "563",
+          "name": "id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": true,
+          "nullable": false,
+          "default": "uuid_generate_v4()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "564",
+          "name": "org_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "565",
+          "name": "config_id",
+          "type": {
+            "id": "uuid",
+            "name": "uuid"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "566",
+          "name": "notification_type",
+          "type": {
+            "id": "notification_type",
+            "name": "notification_type"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "567",
+          "name": "recipient",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "255",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "568",
+          "name": "subject",
+          "type": {
+            "id": "varchar",
+            "name": "varchar"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "characterMaximumLength": "500",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "569",
+          "name": "status",
+          "type": {
+            "id": "notification_status",
+            "name": "notification_status"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "'pending'::notification_status",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "570",
+          "name": "error_message",
+          "type": {
+            "id": "text",
+            "name": "text"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "571",
+          "name": "sent_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": true,
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        },
+        {
+          "id": "572",
+          "name": "created_at",
+          "type": {
+            "id": "timestamptz",
+            "name": "timestamptz"
+          },
+          "primaryKey": false,
+          "unique": false,
+          "nullable": false,
+          "default": "now()",
+          "increment": false,
+          "isArray": false,
+          "createdAt": 1775729153141,
+          "comments": "null"
+        }
+      ],
+      "indexes": [
+        {
+          "id": "573",
+          "name": "idx_notification_log_status",
+          "unique": false,
+          "fieldIds": [
+            "564",
+            "569"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "574",
+          "name": "idx_notification_log_time",
+          "unique": false,
+          "fieldIds": [
+            "564",
+            "572"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "575",
+          "name": "idx_notification_log_org",
+          "unique": false,
+          "fieldIds": [
+            "564"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        },
+        {
+          "id": "576",
+          "name": "notification_log_pkey",
+          "unique": true,
+          "fieldIds": [
+            "563"
+          ],
+          "createdAt": 1775729153141,
+          "type": "btree"
+        }
+      ],
+      "color": "#8eb7ff",
+      "isView": false,
+      "isMaterializedView": false,
+      "createdAt": 1775729153141,
+      "comments": "null",
+      "diagramId": "j1zlxi53zsbf"
+    }
+  ],
+  "relationships": [
+    {
+      "id": "577",
+      "name": "airbyte_connectors_created_by_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "546",
+      "targetTableId": "476",
+      "sourceFieldId": "547",
+      "targetFieldId": "489",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "578",
+      "name": "airbyte_connectors_knowledge_base_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "83",
+      "targetTableId": "476",
+      "sourceFieldId": "84",
+      "targetFieldId": "479",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "579",
+      "name": "airbyte_connectors_org_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "119",
+      "targetTableId": "476",
+      "sourceFieldId": "120",
+      "targetFieldId": "478",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "580",
+      "name": "airbyte_sync_history_connector_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "476",
+      "targetTableId": "39",
+      "sourceFieldId": "477",
+      "targetFieldId": "41",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "581",
+      "name": "airbyte_sync_history_org_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "119",
+      "targetTableId": "39",
+      "sourceFieldId": "120",
+      "targetFieldId": "42",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "582",
+      "name": "api_keys_created_by_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "546",
+      "targetTableId": "52",
+      "sourceFieldId": "547",
+      "targetFieldId": "62",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "583",
+      "name": "api_keys_knowledge_base_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "83",
+      "targetTableId": "52",
+      "sourceFieldId": "84",
+      "targetFieldId": "55",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "584",
+      "name": "api_keys_org_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "119",
+      "targetTableId": "52",
+      "sourceFieldId": "120",
+      "targetFieldId": "54",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "585",
+      "name": "api_keys_workspace_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "296",
+      "targetTableId": "52",
+      "sourceFieldId": "297",
+      "targetFieldId": "65",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "586",
+      "name": "catalog_metadata_org_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "119",
+      "targetTableId": "327",
+      "sourceFieldId": "120",
+      "targetFieldId": "329",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "587",
+      "name": "chat_messages_org_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "119",
+      "targetTableId": "394",
+      "sourceFieldId": "120",
+      "targetFieldId": "397",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "588",
+      "name": "chat_messages_session_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "253",
+      "targetTableId": "394",
+      "sourceFieldId": "254",
+      "targetFieldId": "396",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "589",
+      "name": "chat_sessions_knowledge_base_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "83",
+      "targetTableId": "253",
+      "sourceFieldId": "84",
+      "targetFieldId": "256",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "590",
+      "name": "chat_sessions_org_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "119",
+      "targetTableId": "253",
+      "sourceFieldId": "120",
+      "targetFieldId": "255",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "591",
+      "name": "chat_sessions_user_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "546",
+      "targetTableId": "253",
+      "sourceFieldId": "547",
+      "targetFieldId": "257",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "592",
+      "name": "chunks_document_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "195",
+      "targetTableId": "428",
+      "sourceFieldId": "196",
+      "targetFieldId": "432",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "593",
+      "name": "chunks_knowledge_base_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "83",
+      "targetTableId": "428",
+      "sourceFieldId": "84",
+      "targetFieldId": "431",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "594",
+      "name": "chunks_org_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "119",
+      "targetTableId": "428",
+      "sourceFieldId": "120",
+      "targetFieldId": "430",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "595",
+      "name": "chunks_source_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "408",
+      "targetTableId": "428",
+      "sourceFieldId": "409",
+      "targetFieldId": "433",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "596",
+      "name": "documents_knowledge_base_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "83",
+      "targetTableId": "195",
+      "sourceFieldId": "84",
+      "targetFieldId": "198",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "597",
+      "name": "documents_org_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "119",
+      "targetTableId": "195",
+      "sourceFieldId": "120",
+      "targetFieldId": "197",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "598",
+      "name": "documents_uploaded_by_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "546",
+      "targetTableId": "195",
+      "sourceFieldId": "547",
+      "targetFieldId": "209",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "599",
+      "name": "embeddings_chunk_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "428",
+      "targetTableId": "449",
+      "sourceFieldId": "429",
+      "targetFieldId": "452",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "600",
+      "name": "embeddings_org_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "119",
+      "targetTableId": "449",
+      "sourceFieldId": "120",
+      "targetFieldId": "451",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "601",
+      "name": "fk_webhook_deliveries_config",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "307",
+      "targetTableId": "278",
+      "sourceFieldId": "309",
+      "targetFieldId": "280",
+      "sourceCardinality": "many",
+      "targetCardinality": "many",
+      "createdAt": 1775729153142,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "602",
+      "name": "fk_webhook_deliveries_config",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "307",
+      "targetTableId": "278",
+      "sourceFieldId": "309",
+      "targetFieldId": "281",
+      "sourceCardinality": "many",
+      "targetCardinality": "many",
+      "createdAt": 1775729153142,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "603",
+      "name": "fk_webhook_deliveries_config",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "307",
+      "targetTableId": "278",
+      "sourceFieldId": "308",
+      "targetFieldId": "281",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153142,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "604",
+      "name": "fk_webhook_deliveries_config",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "307",
+      "targetTableId": "278",
+      "sourceFieldId": "308",
+      "targetFieldId": "280",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153142,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "605",
+      "name": "knowledge_bases_org_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "119",
+      "targetTableId": "83",
+      "sourceFieldId": "120",
+      "targetFieldId": "85",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "606",
+      "name": "knowledge_bases_workspace_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "296",
+      "targetTableId": "83",
+      "sourceFieldId": "297",
+      "targetFieldId": "86",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "607",
+      "name": "lead_profiles_knowledge_base_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "83",
+      "targetTableId": "217",
+      "sourceFieldId": "84",
+      "targetFieldId": "220",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153142,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "608",
+      "name": "lead_profiles_org_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "119",
+      "targetTableId": "217",
+      "sourceFieldId": "120",
+      "targetFieldId": "219",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153142,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "609",
+      "name": "llm_provider_configs_created_by_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "546",
+      "targetTableId": "22",
+      "sourceFieldId": "547",
+      "targetFieldId": "34",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "610",
+      "name": "llm_provider_configs_org_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "119",
+      "targetTableId": "22",
+      "sourceFieldId": "120",
+      "targetFieldId": "24",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "611",
+      "name": "notification_configs_org_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "119",
+      "targetTableId": "511",
+      "sourceFieldId": "120",
+      "targetFieldId": "513",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153142,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "612",
+      "name": "notification_log_config_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "511",
+      "targetTableId": "562",
+      "sourceFieldId": "512",
+      "targetFieldId": "565",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153142,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "613",
+      "name": "notification_log_org_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "119",
+      "targetTableId": "562",
+      "sourceFieldId": "120",
+      "targetFieldId": "564",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153142,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "614",
+      "name": "payment_intents_org_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "119",
+      "targetTableId": "358",
+      "sourceFieldId": "120",
+      "targetFieldId": "360",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153142,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "615",
+      "name": "processing_events_document_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "195",
+      "targetTableId": "524",
+      "sourceFieldId": "196",
+      "targetFieldId": "527",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "616",
+      "name": "processing_events_org_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "119",
+      "targetTableId": "524",
+      "sourceFieldId": "120",
+      "targetFieldId": "526",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "617",
+      "name": "processing_events_source_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "408",
+      "targetTableId": "524",
+      "sourceFieldId": "409",
+      "targetFieldId": "528",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "618",
+      "name": "response_cache_kb_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "83",
+      "targetTableId": "495",
+      "sourceFieldId": "84",
+      "targetFieldId": "498",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153142,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "619",
+      "name": "response_cache_org_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "119",
+      "targetTableId": "495",
+      "sourceFieldId": "120",
+      "targetFieldId": "497",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153142,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "620",
+      "name": "routing_rules_created_by_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "546",
+      "targetTableId": "372",
+      "sourceFieldId": "547",
+      "targetFieldId": "388",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "621",
+      "name": "routing_rules_org_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "119",
+      "targetTableId": "372",
+      "sourceFieldId": "120",
+      "targetFieldId": "374",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "622",
+      "name": "routing_rules_target_kb_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "83",
+      "targetTableId": "372",
+      "sourceFieldId": "84",
+      "targetFieldId": "380",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "623",
+      "name": "security_events_org_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "119",
+      "targetTableId": "237",
+      "sourceFieldId": "120",
+      "targetFieldId": "239",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153142,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "624",
+      "name": "security_events_rule_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "336",
+      "targetTableId": "237",
+      "sourceFieldId": "337",
+      "targetFieldId": "240",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153142,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "625",
+      "name": "security_rules_created_by_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "546",
+      "targetTableId": "336",
+      "sourceFieldId": "547",
+      "targetFieldId": "352",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153142,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "626",
+      "name": "security_rules_org_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "119",
+      "targetTableId": "336",
+      "sourceFieldId": "120",
+      "targetFieldId": "338",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153142,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "627",
+      "name": "sources_created_by_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "546",
+      "targetTableId": "408",
+      "sourceFieldId": "547",
+      "targetFieldId": "421",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "628",
+      "name": "sources_knowledge_base_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "83",
+      "targetTableId": "408",
+      "sourceFieldId": "84",
+      "targetFieldId": "411",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "629",
+      "name": "sources_org_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "119",
+      "targetTableId": "408",
+      "sourceFieldId": "120",
+      "targetFieldId": "410",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "630",
+      "name": "stranger_users_blocked_by_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "546",
+      "targetTableId": "98",
+      "sourceFieldId": "547",
+      "targetFieldId": "110",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153142,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "631",
+      "name": "stranger_users_org_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "119",
+      "targetTableId": "98",
+      "sourceFieldId": "120",
+      "targetFieldId": "100",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153142,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "632",
+      "name": "subscriptions_org_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "119",
+      "targetTableId": "266",
+      "sourceFieldId": "120",
+      "targetFieldId": "268",
+      "sourceCardinality": "one",
+      "targetCardinality": "one",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "633",
+      "name": "user_identities_org_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "119",
+      "targetTableId": "175",
+      "sourceFieldId": "120",
+      "targetFieldId": "177",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153142,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "634",
+      "name": "user_identities_user_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "546",
+      "targetTableId": "175",
+      "sourceFieldId": "547",
+      "targetFieldId": "179",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153142,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "635",
+      "name": "users_org_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "119",
+      "targetTableId": "546",
+      "sourceFieldId": "120",
+      "targetFieldId": "548",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "636",
+      "name": "voice_sessions_org_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "119",
+      "targetTableId": "144",
+      "sourceFieldId": "120",
+      "targetFieldId": "146",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153142,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "637",
+      "name": "voice_sessions_stranger_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "98",
+      "targetTableId": "144",
+      "sourceFieldId": "99",
+      "targetFieldId": "148",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153142,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "638",
+      "name": "voice_sessions_user_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "546",
+      "targetTableId": "144",
+      "sourceFieldId": "547",
+      "targetFieldId": "147",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153142,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "639",
+      "name": "voice_turns_org_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "119",
+      "targetTableId": "463",
+      "sourceFieldId": "120",
+      "targetFieldId": "466",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153142,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "640",
+      "name": "voice_turns_session_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "144",
+      "targetTableId": "463",
+      "sourceFieldId": "145",
+      "targetFieldId": "465",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153142,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "641",
+      "name": "voice_usage_summaries_org_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "119",
+      "targetTableId": "71",
+      "sourceFieldId": "120",
+      "targetFieldId": "73",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153142,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "642",
+      "name": "webhook_configs_created_by_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "546",
+      "targetTableId": "307",
+      "sourceFieldId": "547",
+      "targetFieldId": "319",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153142,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "643",
+      "name": "webhook_configs_org_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "119",
+      "targetTableId": "307",
+      "sourceFieldId": "120",
+      "targetFieldId": "309",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153142,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "644",
+      "name": "webhook_deliveries_org_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "119",
+      "targetTableId": "278",
+      "sourceFieldId": "120",
+      "targetFieldId": "281",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153142,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "645",
+      "name": "whatsapp_calls_org_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "119",
+      "targetTableId": "1",
+      "sourceFieldId": "120",
+      "targetFieldId": "3",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153142,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "646",
+      "name": "whatsapp_calls_phone_number_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "162",
+      "targetTableId": "1",
+      "sourceFieldId": "163",
+      "targetFieldId": "5",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153142,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "647",
+      "name": "whatsapp_phone_numbers_org_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "119",
+      "targetTableId": "162",
+      "sourceFieldId": "120",
+      "targetFieldId": "164",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153142,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "648",
+      "name": "workspace_members_org_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "119",
+      "targetTableId": "132",
+      "sourceFieldId": "120",
+      "targetFieldId": "137",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "649",
+      "name": "workspace_members_user_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "546",
+      "targetTableId": "132",
+      "sourceFieldId": "547",
+      "targetFieldId": "135",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "650",
+      "name": "workspace_members_workspace_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "296",
+      "targetTableId": "132",
+      "sourceFieldId": "297",
+      "targetFieldId": "134",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "651",
+      "name": "workspaces_org_id_fkey",
+      "sourceSchema": "public",
+      "targetSchema": "public",
+      "sourceTableId": "119",
+      "targetTableId": "296",
+      "sourceFieldId": "120",
+      "targetFieldId": "298",
+      "sourceCardinality": "one",
+      "targetCardinality": "many",
+      "createdAt": 1775729153141,
+      "diagramId": "j1zlxi53zsbf"
+    }
+  ],
+  "dependencies": [],
+  "areas": [],
+  "customTypes": [
+    {
+      "id": "652",
+      "schema": "public",
+      "name": "api_key_status",
+      "kind": "enum",
+      "values": [
+        "active",
+        "revoked"
+      ],
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "653",
+      "schema": "public",
+      "name": "chunk_type",
+      "kind": "enum",
+      "values": [
+        "text",
+        "table",
+        "image_caption",
+        "code"
+      ],
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "654",
+      "schema": "public",
+      "name": "connector_status",
+      "kind": "enum",
+      "values": [
+        "active",
+        "paused",
+        "error",
+        "deleted"
+      ],
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "655",
+      "schema": "public",
+      "name": "crawl_frequency",
+      "kind": "enum",
+      "values": [
+        "manual",
+        "daily",
+        "weekly",
+        "monthly"
+      ],
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "656",
+      "schema": "public",
+      "name": "kb_status",
+      "kind": "enum",
+      "values": [
+        "active",
+        "archived"
+      ],
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "657",
+      "schema": "public",
+      "name": "llm_provider",
+      "kind": "enum",
+      "values": [
+        "openai",
+        "anthropic",
+        "cohere",
+        "google",
+        "azure_openai",
+        "custom"
+      ],
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "658",
+      "schema": "public",
+      "name": "message_role",
+      "kind": "enum",
+      "values": [
+        "user",
+        "assistant",
+        "system"
+      ],
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "659",
+      "schema": "public",
+      "name": "notification_status",
+      "kind": "enum",
+      "values": [
+        "pending",
+        "sent",
+        "failed"
+      ],
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "660",
+      "schema": "public",
+      "name": "notification_type",
+      "kind": "enum",
+      "values": [
+        "conversation_summary",
+        "admin_digest",
+        "custom"
+      ],
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "661",
+      "schema": "public",
+      "name": "org_status",
+      "kind": "enum",
+      "values": [
+        "active",
+        "suspended",
+        "deactivated"
+      ],
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "662",
+      "schema": "public",
+      "name": "processing_status",
+      "kind": "enum",
+      "values": [
+        "queued",
+        "crawling",
+        "parsing",
+        "chunking",
+        "embedding",
+        "ready",
+        "failed",
+        "reprocessing"
+      ],
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "663",
+      "schema": "public",
+      "name": "provider_status",
+      "kind": "enum",
+      "values": [
+        "active",
+        "revoked",
+        "expired"
+      ],
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "664",
+      "schema": "public",
+      "name": "routing_mode",
+      "kind": "enum",
+      "values": [
+        "static",
+        "column_based",
+        "auto"
+      ],
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "665",
+      "schema": "public",
+      "name": "security_action",
+      "kind": "enum",
+      "values": [
+        "allow",
+        "block",
+        "throttle",
+        "log",
+        "alert"
+      ],
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "666",
+      "schema": "public",
+      "name": "security_rule_type",
+      "kind": "enum",
+      "values": [
+        "ip_allowlist",
+        "ip_denylist",
+        "geo_block",
+        "pattern_match",
+        "rate_override"
+      ],
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "667",
+      "schema": "public",
+      "name": "source_type",
+      "kind": "enum",
+      "values": [
+        "url",
+        "sitemap",
+        "rss_feed"
+      ],
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "668",
+      "schema": "public",
+      "name": "stranger_status",
+      "kind": "enum",
+      "values": [
+        "active",
+        "throttled",
+        "blocked",
+        "banned"
+      ],
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "669",
+      "schema": "public",
+      "name": "sync_mode",
+      "kind": "enum",
+      "values": [
+        "full_refresh",
+        "incremental",
+        "cdc"
+      ],
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "670",
+      "schema": "public",
+      "name": "user_status",
+      "kind": "enum",
+      "values": [
+        "active",
+        "disabled"
+      ],
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "671",
+      "schema": "public",
+      "name": "voice_session_state",
+      "kind": "enum",
+      "values": [
+        "created",
+        "active",
+        "ended"
+      ],
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "672",
+      "schema": "public",
+      "name": "voice_speaker",
+      "kind": "enum",
+      "values": [
+        "agent",
+        "user"
+      ],
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "673",
+      "schema": "public",
+      "name": "webhook_status",
+      "kind": "enum",
+      "values": [
+        "active",
+        "paused",
+        "failed"
+      ],
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "674",
+      "schema": "public",
+      "name": "whatsapp_call_direction",
+      "kind": "enum",
+      "values": [
+        "inbound",
+        "outbound"
+      ],
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "675",
+      "schema": "public",
+      "name": "whatsapp_call_state",
+      "kind": "enum",
+      "values": [
+        "ringing",
+        "connected",
+        "ended"
+      ],
+      "diagramId": "j1zlxi53zsbf"
+    },
+    {
+      "id": "676",
+      "schema": "public",
+      "name": "workspace_role",
+      "kind": "enum",
+      "values": [
+        "owner",
+        "admin",
+        "member",
+        "viewer"
+      ],
+      "diagramId": "j1zlxi53zsbf"
+    }
+  ],
+  "notes": []
+}

--- a/scripts/chartdb-query.sh
+++ b/scripts/chartdb-query.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Emit the ChartDB PostgreSQL smart-query result as JSON.
+#
+# Usage:
+#   ./scripts/chartdb-query.sh
+#   ./scripts/chartdb-query.sh | pbcopy     # copy to clipboard (macOS)
+#
+# The script reads DATABASE_URL from the environment (or .env if present).
+# Then paste the JSON into the ChartDB UI at http://localhost:3000.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Load .env if DATABASE_URL is not already set
+if [[ -z "${DATABASE_URL:-}" && -f "$ROOT_DIR/.env" ]]; then
+  # shellcheck disable=SC1090
+  set -o allexport
+  source "$ROOT_DIR/.env"
+  set +o allexport
+fi
+
+if [[ -z "${DATABASE_URL:-}" ]]; then
+  echo "Error: DATABASE_URL is not set." >&2
+  echo "Either export it or create a .env file with DATABASE_URL=postgresql://..." >&2
+  exit 1
+fi
+
+SQL_FILE="$SCRIPT_DIR/chartdb-query.sql"
+
+psql "$DATABASE_URL" \
+  --no-psqlrc \
+  --tuples-only \
+  --no-align \
+  --quiet \
+  --file="$SQL_FILE"

--- a/scripts/chartdb-query.sql
+++ b/scripts/chartdb-query.sql
@@ -1,0 +1,276 @@
+/* ChartDB PostgreSQL Smart Query
+ * Source: https://github.com/chartdb/chartdb
+ *
+ * Run against the Raven database to generate the JSON schema blob,
+ * then paste it into the ChartDB UI (http://localhost:3000).
+ *
+ * Quick usage:
+ *   psql $DATABASE_URL -f scripts/chartdb-query.sql
+ *   ./scripts/chartdb-query.sh | pbcopy     # copy to clipboard
+ */
+
+WITH fk_info AS (
+    SELECT array_to_string(array_agg(CONCAT('{"schema":"', replace(schema_name, '"', ''), '"',
+                                            ',"table":"', replace(table_name::text, '"', ''), '"',
+                                            ',"column":"', replace(fk_column::text, '"', ''), '"',
+                                            ',"foreign_key_name":"', foreign_key_name, '"',
+                                            ',"reference_schema":"', COALESCE(replace(reference_schema, '"', ''), 'public'), '"',
+                                            ',"reference_table":"', replace(reference_table, '"', ''), '"',
+                                            ',"reference_column":"', replace(reference_column, '"', ''), '"',
+                                            ',"fk_def":"', replace(fk_def, '"', ''),
+                                            '"}')), ',') as fk_metadata
+    FROM (
+            SELECT c.conname AS foreign_key_name,
+                    n.nspname AS schema_name,
+                    CASE
+                        WHEN position('.' in conrelid::regclass::text) > 0
+                        THEN split_part(conrelid::regclass::text, '.', 2)
+                        ELSE conrelid::regclass::text
+                    END AS table_name,
+                    a.attname AS fk_column,
+                    nr.nspname AS reference_schema,
+                    CASE
+                        WHEN position('.' in confrelid::regclass::text) > 0
+                        THEN split_part(confrelid::regclass::text, '.', 2)
+                        ELSE confrelid::regclass::text
+                    END AS reference_table,
+                    af.attname AS reference_column,
+                    pg_get_constraintdef(c.oid) as fk_def
+                FROM
+                    pg_constraint AS c
+                JOIN
+                    pg_attribute AS a ON a.attnum = ANY(c.conkey) AND a.attrelid = c.conrelid
+                JOIN
+                    pg_class AS cl ON cl.oid = c.conrelid
+                JOIN
+                    pg_namespace AS n ON n.oid = cl.relnamespace
+                JOIN
+                    pg_attribute AS af ON af.attnum = ANY(c.confkey) AND af.attrelid = c.confrelid
+                JOIN
+                    pg_class AS clf ON clf.oid = c.confrelid
+                JOIN
+                    pg_namespace AS nr ON nr.oid = clf.relnamespace
+                WHERE
+                    c.contype = 'f'
+                    AND connamespace::regnamespace::text NOT IN ('information_schema', 'pg_catalog')
+    ) AS x
+), pk_info AS (
+    SELECT array_to_string(array_agg(CONCAT('{"schema":"', replace(schema_name, '"', ''), '"',
+                                            ',"table":"', replace(pk_table, '"', ''), '"',
+                                            ',"column":"', replace(pk_column, '"', ''), '"',
+                                            ',"pk_def":"', replace(pk_def, '"', ''),
+                                            '"}')), ',') AS pk_metadata
+    FROM (
+            SELECT connamespace::regnamespace::text AS schema_name,
+                CASE
+                    WHEN strpos(conrelid::regclass::text, '.') > 0
+                    THEN split_part(conrelid::regclass::text, '.', 2)
+                    ELSE conrelid::regclass::text
+                END AS pk_table,
+                unnest(string_to_array(substring(pg_get_constraintdef(oid) FROM '\\((.*?)\\)'), ',')) AS pk_column,
+                pg_get_constraintdef(oid) as pk_def
+            FROM
+              pg_constraint
+            WHERE
+              contype = 'p'
+              AND connamespace::regnamespace::text NOT IN ('information_schema', 'pg_catalog')
+    ) AS y
+),
+indexes_cols AS (
+    SELECT  tnsp.nspname                                                                AS schema_name,
+        trel.relname                                                                    AS table_name,
+            pg_relation_size('"' || tnsp.nspname || '".' || '"' || irel.relname || '"') AS index_size,
+            irel.relname                                                                AS index_name,
+            am.amname                                                                   AS index_type,
+            a.attname                                                                   AS col_name,
+            (CASE WHEN i.indisunique = TRUE THEN 'true' ELSE 'false' END)               AS is_unique,
+            irel.reltuples                                                              AS cardinality,
+            1 + Array_position(i.indkey, a.attnum)                                      AS column_position,
+            CASE o.OPTION & 1 WHEN 1 THEN 'DESC' ELSE 'ASC' END                         AS direction
+    FROM pg_index AS i
+        JOIN pg_class AS trel ON trel.oid = i.indrelid
+        JOIN pg_namespace AS tnsp ON trel.relnamespace = tnsp.oid
+        JOIN pg_class AS irel ON irel.oid = i.indexrelid
+        JOIN pg_am AS am ON irel.relam = am.oid
+        CROSS JOIN LATERAL unnest (i.indkey)
+        WITH ORDINALITY AS c (colnum, ordinality) LEFT JOIN LATERAL unnest (i.indoption)
+        WITH ORDINALITY AS o (option, ordinality)
+        ON c.ordinality = o.ordinality JOIN pg_attribute AS a ON trel.oid = a.attrelid AND a.attnum = c.colnum
+    WHERE tnsp.nspname NOT LIKE 'pg_%'
+    GROUP BY tnsp.nspname, trel.relname, irel.relname, am.amname, i.indisunique, i.indexrelid, irel.reltuples, a.attname, Array_position(i.indkey, a.attnum), o.OPTION, i.indpred
+),
+cols AS (
+    SELECT array_to_string(array_agg(CONCAT('{"schema":"', cols.table_schema,
+                                            '","table":"', cols.table_name,
+                                            '","name":"', cols.column_name,
+                                            '","ordinal_position":', cols.ordinal_position,
+                                            ',"type":"', CASE WHEN cols.column_default IS NOT NULL AND cols.column_default LIKE 'nextval(%' THEN
+                                                                CASE
+                                                                    WHEN LOWER(replace(cols.data_type, '"', '')) = 'smallint' THEN 'smallserial'
+                                                                    WHEN LOWER(replace(cols.data_type, '"', '')) = 'integer' THEN 'serial'
+                                                                    WHEN LOWER(replace(cols.data_type, '"', '')) = 'bigint' THEN 'bigserial'
+                                                                    ELSE LOWER(replace(cols.data_type, '"', ''))
+                                                                END
+                                                            WHEN cols.data_type = 'ARRAY' THEN
+                                                                format_type(pg_type.typelem, NULL)
+                                                            WHEN LOWER(replace(cols.data_type, '"', '')) = 'user-defined' THEN
+                                                                format_type(pg_type.oid, NULL)
+                                                            ELSE
+                                                                LOWER(replace(cols.data_type, '"', ''))
+                                                        END,
+                                            '","character_maximum_length":"', COALESCE(cols.character_maximum_length::text, 'null'),
+                                            '","precision":',
+                                                CASE
+                                                    WHEN cols.data_type = 'numeric' OR cols.data_type = 'decimal'
+                                                    THEN CONCAT('{"precision":', COALESCE(cols.numeric_precision::text, 'null'),
+                                                                ',"scale":', COALESCE(cols.numeric_scale::text, 'null'), '}')
+                                                    ELSE 'null'
+                                                END,
+                                            ',"nullable":', CASE WHEN (cols.IS_NULLABLE = 'YES') THEN 'true' ELSE 'false' END,
+                                            ',"default":"', CASE WHEN cols.column_default IS NOT NULL AND cols.column_default LIKE 'nextval(%' THEN '' ELSE COALESCE(replace(replace(cols.column_default, '"', '\\"'), '\\x', '\\\\x'), '') END,
+                                            '","collation":"', COALESCE(cols.COLLATION_NAME, ''),
+                                            '","comment":"', 'null',
+                                            '","is_identity":', CASE
+                                                WHEN cols.is_identity = 'YES' THEN 'true'
+                                                WHEN cols.column_default IS NOT NULL AND cols.column_default LIKE 'nextval(%' THEN 'true'
+                                                ELSE 'false'
+                                            END,
+                                            ',"is_array":', CASE
+                                                WHEN cols.data_type = 'ARRAY' OR pg_type.typelem > 0 THEN 'true'
+                                                ELSE 'false'
+                                            END,
+                                            '}')), ',') AS cols_metadata
+    FROM information_schema.columns cols
+    LEFT JOIN pg_catalog.pg_class c
+        ON c.relname = cols.table_name
+    JOIN pg_catalog.pg_namespace n
+        ON n.oid = c.relnamespace AND n.nspname = cols.table_schema
+    LEFT JOIN pg_catalog.pg_description dsc
+        ON dsc.objoid = c.oid AND dsc.objsubid = cols.ordinal_position
+    LEFT JOIN pg_catalog.pg_attribute attr
+        ON attr.attrelid = c.oid AND attr.attname = cols.column_name
+    LEFT JOIN pg_catalog.pg_type
+        ON pg_type.oid = attr.atttypid
+    LEFT JOIN pg_catalog.pg_type AS elem_type
+        ON elem_type.oid = pg_type.typelem
+    WHERE cols.table_schema NOT IN ('information_schema', 'pg_catalog')
+), indexes_metadata AS (
+    SELECT array_to_string(array_agg(CONCAT('{"schema":"', schema_name,
+                                            '","table":"', table_name,
+                                            '","name":"', index_name,
+                                            '","column":"', replace(col_name :: TEXT, '"', E'"'),
+                                            '","index_type":"', index_type,
+                                            '","cardinality":', cardinality,
+                                            ',"size":', index_size,
+                                            ',"unique":', is_unique,
+                                            ',"column_position":', column_position,
+                                            ',"direction":"', LOWER(direction),
+                                            '"}')), ',') AS indexes_metadata
+    FROM indexes_cols x
+), tbls AS (
+    SELECT array_to_string(array_agg(CONCAT('{',
+                        '"schema":"', tbls.TABLE_SCHEMA, '",',
+                        '"table":"', tbls.TABLE_NAME, '",',
+                        '"rows":', COALESCE((SELECT s.n_live_tup
+                                                FROM pg_stat_user_tables s
+                                                WHERE tbls.TABLE_SCHEMA = s.schemaname AND tbls.TABLE_NAME = s.relname),
+                                                0), ', "type":"', tbls.TABLE_TYPE, '",', '"engine":"",', '"collation":"",',
+                        '"comment":"', 'null',
+                        '"}'
+                )),
+                ',') AS tbls_metadata
+        FROM information_schema.tables tbls
+        LEFT JOIN pg_catalog.pg_class c ON c.relname = tbls.TABLE_NAME
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+                                            AND n.nspname = tbls.TABLE_SCHEMA
+        LEFT JOIN pg_catalog.pg_description dsc ON dsc.objoid = c.oid
+                                                AND dsc.objsubid = 0
+        WHERE tbls.TABLE_SCHEMA NOT IN ('information_schema', 'pg_catalog')
+), config AS (
+    SELECT array_to_string(
+                      array_agg(CONCAT('{"name":"', conf.name, '","value":"', replace(conf.setting, '"', E'"'), '"}')),
+                      ',') AS config_metadata
+    FROM pg_settings conf
+), views AS (
+    SELECT array_to_string(array_agg(CONCAT('{"schema":"', views.schemaname,
+                      '","view_name":"', viewname,
+                      '","view_definition":""}')),
+                      ',') AS views_metadata
+    FROM pg_views views
+    WHERE views.schemaname NOT IN ('information_schema', 'pg_catalog')
+), custom_types AS (
+    SELECT array_to_string(array_agg(type_json), ',') AS custom_types_metadata
+    FROM (
+        -- ENUM types
+        SELECT CONCAT(
+            '{"schema":"', n.nspname,
+            '","type":"', t.typname,
+            '","kind":"enum"',
+            ',"values":[', string_agg('"' || e.enumlabel || '"', ',' ORDER BY e.enumsortorder), ']}'
+        ) AS type_json
+        FROM pg_type t
+        JOIN pg_enum e ON t.oid = e.enumtypid
+        JOIN pg_namespace n ON n.oid = t.typnamespace
+        WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+        GROUP BY n.nspname, t.typname
+
+        UNION ALL
+
+        -- COMPOSITE types
+        SELECT CONCAT(
+            '{"schema":"', schema_name,
+            '","type":"', type_name,
+            '","kind":"composite"',
+            ',"fields":[', fields_json, ']}'
+        ) AS type_json
+        FROM (
+            SELECT
+                n.nspname AS schema_name,
+                t.typname AS type_name,
+                string_agg(
+                    CONCAT('{"field":"', a.attname, '","type":"', format_type(a.atttypid, a.atttypmod), '"}'),
+                    ',' ORDER BY a.attnum
+                ) AS fields_json
+            FROM pg_type t
+            JOIN pg_namespace n ON n.oid = t.typnamespace
+            JOIN pg_class c ON c.oid = t.typrelid
+            JOIN pg_attribute a ON a.attrelid = c.oid
+            WHERE t.typtype = 'c'
+              AND c.relkind = 'c'
+              AND a.attnum > 0 AND NOT a.attisdropped
+              AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+            GROUP BY n.nspname, t.typname
+        ) AS comp
+    ) AS all_types
+), check_constraints AS (
+    SELECT array_to_string(array_agg(CONCAT('{"schema":"', replace(schema_name, '"', ''), '"',
+                                            ',"table":"', replace(table_name, '"', ''), '"',
+                                            ',"expression":"', replace(replace(check_expr, '"', '\\"'), E'\\n', ' '),
+                                            '"}')), ',') AS check_constraints_metadata
+    FROM (
+        SELECT
+            n.nspname AS schema_name,
+            CASE
+                WHEN position('.' in c.conrelid::regclass::text) > 0
+                THEN split_part(c.conrelid::regclass::text, '.', 2)
+                ELSE c.conrelid::regclass::text
+            END AS table_name,
+            substring(pg_get_constraintdef(c.oid) FROM 'CHECK \\((.*)\\)') AS check_expr
+        FROM pg_constraint c
+        JOIN pg_class cl ON cl.oid = c.conrelid
+        JOIN pg_namespace n ON n.oid = cl.relnamespace
+        WHERE c.contype = 'c'
+          AND n.nspname NOT IN ('information_schema', 'pg_catalog')
+    ) AS chk
+)
+SELECT CONCAT('{    "fk_info": [', COALESCE(fk_metadata, ''),
+                    '], "pk_info": [', COALESCE(pk_metadata, ''),
+                    '], "columns": [', COALESCE(cols_metadata, ''),
+                    '], "indexes": [', COALESCE(indexes_metadata, ''),
+                    '], "tables":[', COALESCE(tbls_metadata, ''),
+                    '], "views":[', COALESCE(views_metadata, ''),
+                    '], "check_constraints": [', COALESCE(check_constraints_metadata, ''),
+                    '], "custom_types": [', COALESCE(custom_types_metadata, ''),
+                    '], "database_name": "', CURRENT_DATABASE(), '', '", "version": "', '',
+              '"}') AS metadata_json_to_import
+FROM fk_info, pk_info, cols, indexes_metadata, tbls, config, views, check_constraints, custom_types;


### PR DESCRIPTION
## Summary

- Adds `docker-compose.chartdb.yml` overlay to run [ChartDB](https://github.com/chartdb/chartdb) (self-hosted database schema visualiser) alongside the existing stack
- Adds `scripts/chartdb-query.sql` — the official ChartDB PostgreSQL smart query that extracts the full Raven schema as JSON
- Adds `scripts/chartdb-query.sh` — convenience wrapper that reads `DATABASE_URL` from `.env` and runs the query

## Usage

```bash
# 1. Start ChartDB alongside the stack
docker compose -f docker-compose.yml -f docker-compose.chartdb.yml up -d chartdb

# 2. Dump schema JSON (copy to clipboard on macOS)
./scripts/chartdb-query.sh | pbcopy

# 3. Open http://localhost:3000 → New diagram → PostgreSQL → paste JSON
```

No database password is ever sent to ChartDB — the query runs locally and only the schema metadata JSON is imported into the UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ChartDB service for database visualization and management, accessible on port 3000
  * Introduced database introspection capability to extract and export schema metadata including tables, columns, indexes, views, and constraints
<!-- end of auto-generated comment: release notes by coderabbit.ai -->