### PR TITLE
feat(mobile): bottom tab bar navigation (#221)

### DIFF
--- a/docs/superpowers/specs/2026-04-10-mobile-first-responsive-redesign.md
+++ b/docs/superpowers/specs/2026-04-10-mobile-first-responsive-redesign.md
@@ -1,0 +1,304 @@
+# Mobile-First Responsive Redesign
+
+**Issue**: #200  
+**Date**: 2026-04-10  
+**Status**: Approved  
+
+## Context
+
+The Vue 3 frontend is built for desktop. The primary WhatsApp use case is mobile-first — operators managing calls on phones. All pages need to be usable on a 390px viewport without horizontal scrolling.
+
+### Current State
+
+- **UI framework**: Tailwind CSS v4.2.2, no component library — all custom
+- **Mobile detection**: `useMobile()` composable exists (768px breakpoint) but is underutilized
+- **Sidebar**: Already has mobile slide-out mode (w-64 fixed, backdrop overlay)
+- **Touch targets**: Most buttons already enforce `min-h-[44px] min-w-[44px]`
+- **Tables**: Most list pages use desktop-only `<table>` elements — no card fallback
+- **Modals**: Fixed `max-w-md` (448px) — don't adapt to mobile screens
+- **E2E tests**: Only Desktop Chrome viewport — no mobile viewport tests
+
+### Breakpoint Strategy
+
+Single breakpoint at `md:` (768px) — matches the existing `useMobile()` composable. Below = mobile layout, above = desktop layout.
+
+---
+
+## Design
+
+### 1. Navigation: Bottom Tab Bar
+
+**Desktop** (≥768px): Keep the existing 64px icon-only sidebar (`w-16`).
+
+**Mobile** (<768px): Replace the slide-out sidebar with a fixed bottom tab bar.
+
+#### Tab mapping (5 tabs)
+
+| Tab | Icon | Route | Priority |
+|-----|------|-------|----------|
+| Home | house | `/dashboard` | Overview |
+| Voice | microphone | `/orgs/:orgId/voice` | Voice sessions |
+| Calls | phone | `/orgs/:orgId/whatsapp/calls` | Primary operator flow |
+| Numbers | smartphone | `/orgs/:orgId/whatsapp/phone-numbers` | Phone management |
+| More | ellipsis-h | bottom sheet | Secondary pages |
+
+#### "More" bottom sheet contents
+
+- Dashboard (if not already on Home)
+- Knowledge Bases
+- Chatbot Config
+- Analytics
+- API Keys
+- LLM Providers
+- Sandbox
+
+#### Implementation
+
+New component: `MobileTabBar.vue`
+
+```
+<template>
+  <!-- Only rendered when isMobile -->
+  <nav class="fixed bottom-0 inset-x-0 z-50 bg-slate-800 border-t border-slate-700
+              flex justify-around items-center pb-[env(safe-area-inset-bottom)] min-h-[56px]">
+    <TabItem v-for="tab in tabs" :key="tab.name" v-bind="tab" />
+  </nav>
+</template>
+```
+
+- Active tab: indigo-500 icon + label color, white icon stroke
+- Inactive: slate-400 icon + label
+- All touch targets: min 56×44px
+- Safe-area padding at bottom for notched phones: `pb-[env(safe-area-inset-bottom)]`
+- FAB (floating action button) for "New Call" on the Calls page — positioned above tab bar
+
+#### Changes to existing components
+
+- `DefaultLayout.vue`: Conditionally render `AppSidebar` (desktop) or `MobileTabBar` (mobile)
+- `AppSidebar.vue`: Add `v-if="!isMobile"` — no longer needed on mobile
+- `AppHeader.vue`: Remove hamburger menu button on mobile (no sidebar to toggle)
+- Main content area: Add `pb-20` on mobile to prevent content hiding behind tab bar
+
+#### "More" bottom sheet
+
+New component: `BottomSheet.vue` — reusable slide-up panel.
+
+```
+Props: { open: boolean, title?: string }
+Emits: ['close']
+```
+
+- Backdrop: `bg-black/50` with fade transition
+- Sheet: slides up from bottom, `rounded-t-2xl`, drag handle at top
+- Menu items: 48px min-height, icon + label, full-width tap area
+
+---
+
+### 2. Table → Card Conversions
+
+All list pages conditionally render a `<table>` (desktop) or stacked cards (mobile) based on `useMobile()`.
+
+#### Card design pattern
+
+Every card follows this consistent structure:
+
+```
+┌─────────────────────────────────┐
+│ Title                   [Badge] │
+│ subtitle • metadata             │
+│                                 │
+│ secondary info / progress       │
+├─────────────────────────────────┤
+│ timestamp              [Action] │  ← optional action row
+└─────────────────────────────────┘
+```
+
+- Background: `bg-slate-800` with `rounded-xl` (12px)
+- Padding: 14px
+- Title: white, font-semibold, 15px
+- Subtitle: slate-400, 12px, bullet-separated
+- Badge: pill-shaped, top-right (status colors: green=active, amber=indexing, red=error, slate=inactive)
+- Action row: separated by `border-t border-slate-700`, only shown when inline actions exist
+- Drill-down cards: chevron `›` icon on the right edge
+- Color-coded left border for status-heavy lists (calls): `border-l-3` with green/blue/slate
+
+#### Pages affected
+
+| Page | Desktop | Mobile Card Content |
+|------|---------|-------------------|
+| `KBListPage.vue` | table | name, model+doc count, status badge, progress bar if indexing |
+| `WorkspaceListPage.vue` | table | initial avatar, name, KB+member count, chevron |
+| `ApiKeyListPage.vue` | table | name, masked key (mono), status, created date, revoke button |
+| `VoiceSessionListPage.vue` | table | session name, state badge, duration, timestamp |
+| `CallsPage.vue` | already has cards | refine: color-coded border, LIVE/RING/END badges |
+| `PhoneNumbersPage.vue` | already has mobile cards | already done — no changes needed |
+| `LlmProviderListPage.vue` | table | provider name, model count, status |
+
+#### Implementation approach
+
+Each page uses conditional rendering:
+
+```vue
+<template>
+  <!-- Desktop table -->
+  <table v-if="!isMobile" class="w-full">...</table>
+
+  <!-- Mobile cards -->
+  <div v-else class="flex flex-col gap-2.5">
+    <div v-for="item in items" class="bg-slate-800 rounded-xl p-3.5">
+      ...card layout...
+    </div>
+  </div>
+</template>
+```
+
+No shared `DataCard` component — each page renders its own card markup inline. The pattern is simple enough that a shared component would add indirection without reducing code.
+
+---
+
+### 3. Modals → Full-Screen / Bottom Sheet
+
+#### Form modals (create/edit flows)
+
+Desktop: Centered overlay modal (`max-w-md`, backdrop blur).
+
+Mobile: Full-screen page with:
+- Top bar: back arrow (←) left, title center, empty right spacer
+- Scrollable form body with larger inputs (min-height 48px, font-size 15px)
+- Sticky bottom CTA: full-width primary button with safe-area padding
+
+Affected modals:
+- `CreateSessionModal.vue` (voice)
+- `InitiateCallModal.vue` (WhatsApp)
+- Create API Key dialog (inline in `ApiKeyListPage.vue`)
+- Add Phone Number form (inline in `PhoneNumbersPage.vue`)
+- Create Workspace form (inline in `WorkspaceListPage.vue`)
+
+#### Confirmation dialogs (destructive actions)
+
+Desktop: Small centered dialog with side-by-side Cancel/Confirm buttons.
+
+Mobile: Bottom sheet with:
+- Drag handle at top
+- Warning icon + title
+- Description text
+- Stacked full-width buttons: destructive action on top (red), cancel below (slate)
+
+Affected dialogs:
+- Revoke API Key
+- Delete Session
+- Delete KB
+
+#### Implementation
+
+Wrap existing modals in a responsive container:
+
+```vue
+<template>
+  <!-- Desktop: centered overlay -->
+  <div v-if="!isMobile" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+    <div class="bg-slate-800 rounded-xl max-w-md w-full mx-4">
+      <slot />
+    </div>
+  </div>
+
+  <!-- Mobile: full-screen -->
+  <div v-else class="fixed inset-0 z-50 bg-slate-900 flex flex-col">
+    <header class="flex items-center h-14 px-4 border-b border-slate-700">
+      <button @click="$emit('close')" class="min-h-[44px] min-w-[44px]">←</button>
+      <span class="flex-1 text-center font-semibold">{{ title }}</span>
+      <div class="w-11" />
+    </header>
+    <div class="flex-1 overflow-y-auto p-4">
+      <slot />
+    </div>
+    <div class="p-4 pb-7 border-t border-slate-700">
+      <slot name="actions" />
+    </div>
+  </div>
+</template>
+```
+
+New shared component: `ResponsiveModal.vue` — wraps any modal content and handles desktop/mobile rendering.
+
+---
+
+### 4. Form Adaptations
+
+Forms already use `w-full` inputs and `space-y-4` vertical stacking — they work on mobile. Minor adjustments:
+
+- Input min-height: `min-h-[48px]` on mobile (vs default ~40px)
+- Font size: `text-[15px]` on mobile inputs for readability and to prevent iOS zoom
+- Labels: keep `text-sm` but add `font-medium` for contrast
+- Button groups: stack vertically on mobile (`flex-col` vs `flex-row`)
+- `ChatbotConfiguratorPage.vue` (434 lines, largest form): sections already stack naturally — just ensure no fixed widths
+
+---
+
+### 5. Playwright Mobile Viewport Tests
+
+Add mobile viewport project to `playwright.config.ts`:
+
+```typescript
+projects: [
+  { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  { name: 'mobile-chrome', use: { ...devices['Pixel 7'] } },
+]
+```
+
+Add 3 mobile E2E tests for critical flows:
+
+1. **Login flow** (`e2e/mobile/login.spec.ts`): navigate to login, verify no horizontal scroll, verify touch targets
+2. **Navigation** (`e2e/mobile/navigation.spec.ts`): verify bottom tab bar renders, tap each tab, open "More" sheet
+3. **Call list** (`e2e/mobile/calls.spec.ts`): verify cards render (not table), tap a call card, verify detail page
+
+---
+
+## Component Inventory
+
+### New components
+
+| Component | Purpose |
+|-----------|---------|
+| `MobileTabBar.vue` | Bottom tab bar navigation (mobile only) |
+| `BottomSheet.vue` | Reusable slide-up panel for "More" menu and confirm dialogs |
+| `ResponsiveModal.vue` | Wrapper that renders centered modal (desktop) or full-screen (mobile) |
+
+### Modified components
+
+| Component | Change |
+|-----------|--------|
+| `DefaultLayout.vue` | Conditional sidebar vs tab bar, mobile bottom padding |
+| `AppSidebar.vue` | Hide on mobile (`v-if="!isMobile"`) |
+| `AppHeader.vue` | Remove hamburger on mobile |
+| `KBListPage.vue` | Add mobile card view |
+| `WorkspaceListPage.vue` | Add mobile card view |
+| `ApiKeyListPage.vue` | Add mobile card view + bottom sheet confirm |
+| `VoiceSessionListPage.vue` | Add mobile card view |
+| `CallsPage.vue` | Refine existing card layout |
+| `LlmProviderListPage.vue` | Add mobile card view |
+| `CreateSessionModal.vue` | Wrap in ResponsiveModal |
+| `InitiateCallModal.vue` | Wrap in ResponsiveModal |
+| `playwright.config.ts` | Add mobile-chrome project |
+
+### Unchanged
+
+- `AuthLayout.vue` — already responsive (max-w-md centered)
+- `DashboardPage.vue` — simple metrics, stacks naturally
+- `PhoneNumbersPage.vue` — already has mobile card view
+- `ChatbotConfiguratorPage.vue` — forms stack naturally, no table
+- `AnalyticsDashboardPage.vue` — charts, out of scope for this pass
+- Legal pages — static content, already readable
+
+---
+
+## Acceptance Criteria
+
+- All pages usable without horizontal scrolling at 390px width
+- Bottom tab bar visible on mobile with all 5 tabs functional
+- All list pages show cards (not tables) on mobile
+- Form modals render full-screen on mobile with sticky CTA
+- Confirm dialogs render as bottom sheets on mobile
+- Touch targets ≥ 44×44px on all interactive elements
+- Playwright mobile viewport tests pass for login, navigation, call list
+- Lighthouse mobile score ≥ 80 for dashboard page

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -1,22 +1,6 @@
 <template>
   <header class="flex h-14 items-center justify-between border-b border-gray-200 bg-white px-4 md:px-6">
     <div class="flex items-center gap-3">
-      <button
-        class="flex h-8 w-8 items-center justify-center rounded-lg text-gray-600 transition-colors hover:bg-gray-100 md:hidden"
-        title="Toggle menu"
-        @click="$emit('toggle-sidebar')"
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          class="h-5 w-5"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          stroke-width="2"
-        >
-          <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-      </button>
       <h2 class="text-sm font-semibold text-gray-700">Raven</h2>
     </div>
 
@@ -35,10 +19,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useAuth } from '../composables/useAuth'
-
-defineEmits<{
-  'toggle-sidebar': []
-}>()
 
 const { user } = useAuth()
 

--- a/frontend/src/components/BottomSheet.vue
+++ b/frontend/src/components/BottomSheet.vue
@@ -1,0 +1,61 @@
+<template>
+  <Teleport to="body">
+    <Transition name="backdrop">
+      <div
+        v-if="open"
+        class="fixed inset-0 z-50 bg-black/50"
+        @click="$emit('close')"
+      />
+    </Transition>
+
+    <Transition name="sheet">
+      <div
+        v-if="open"
+        class="fixed inset-x-0 bottom-0 z-50 rounded-t-2xl bg-slate-800"
+        :style="{ paddingBottom: 'env(safe-area-inset-bottom)' }"
+      >
+        <!-- Drag handle -->
+        <div class="flex justify-center pt-2 pb-1">
+          <div class="h-1 w-9 rounded-full bg-slate-600" />
+        </div>
+
+        <div v-if="title" class="px-4 pb-3">
+          <h3 class="text-center text-sm font-semibold text-slate-300">{{ title }}</h3>
+        </div>
+
+        <slot />
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  open: boolean
+  title?: string
+}>()
+
+defineEmits<{
+  close: []
+}>()
+</script>
+
+<style scoped>
+.backdrop-enter-active,
+.backdrop-leave-active {
+  transition: opacity 0.25s ease;
+}
+.backdrop-enter-from,
+.backdrop-leave-to {
+  opacity: 0;
+}
+
+.sheet-enter-active,
+.sheet-leave-active {
+  transition: transform 0.3s ease;
+}
+.sheet-enter-from,
+.sheet-leave-to {
+  transform: translateY(100%);
+}
+</style>

--- a/frontend/src/components/MobileTabBar.vue
+++ b/frontend/src/components/MobileTabBar.vue
@@ -1,0 +1,133 @@
+<template>
+  <nav
+    class="fixed bottom-0 inset-x-0 z-40 flex justify-around items-center bg-slate-800 border-t border-slate-700"
+    style="min-height: 56px; padding-bottom: env(safe-area-inset-bottom);"
+  >
+    <!-- Home -->
+    <RouterLink
+      to="/dashboard"
+      class="flex flex-col items-center justify-center gap-0.5 min-w-[56px] min-h-[44px] px-2 transition-colors"
+      :class="route.name === 'dashboard' ? 'text-indigo-400' : 'text-slate-400'"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 shrink-0" viewBox="0 0 20 20" fill="currentColor">
+        <path d="M10.707 2.293a1 1 0 00-1.414 0l-7 7a1 1 0 001.414 1.414L4 10.414V17a1 1 0 001 1h2a1 1 0 001-1v-2a1 1 0 011-1h2a1 1 0 011 1v2a1 1 0 001 1h2a1 1 0 001-1v-6.586l.293.293a1 1 0 001.414-1.414l-7-7z" />
+      </svg>
+      <span class="text-[10px] font-medium">Home</span>
+    </RouterLink>
+
+    <!-- Voice -->
+    <RouterLink
+      :to="`/orgs/${currentOrgId}/voice`"
+      class="flex flex-col items-center justify-center gap-0.5 min-w-[56px] min-h-[44px] px-2 transition-colors"
+      :class="route.name === 'voice-session-list' ? 'text-indigo-400' : 'text-slate-400'"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 shrink-0" viewBox="0 0 20 20" fill="currentColor">
+        <path fill-rule="evenodd" d="M7 4a3 3 0 016 0v4a3 3 0 11-6 0V4zm4 10.93A7.001 7.001 0 0017 8a1 1 0 10-2 0A5 5 0 015 8a1 1 0 00-2 0 7.001 7.001 0 006 6.93V17H6a1 1 0 100 2h8a1 1 0 100-2h-3v-2.07z" clip-rule="evenodd" />
+      </svg>
+      <span class="text-[10px] font-medium">Voice</span>
+    </RouterLink>
+
+    <!-- Calls -->
+    <RouterLink
+      :to="`/orgs/${currentOrgId}/whatsapp/calls`"
+      class="flex flex-col items-center justify-center gap-0.5 min-w-[56px] min-h-[44px] px-2 transition-colors"
+      :class="route.name === 'whatsapp-calls' ? 'text-indigo-400' : 'text-slate-400'"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 shrink-0" viewBox="0 0 20 20" fill="currentColor">
+        <path d="M2 3a1 1 0 011-1h2.153a1 1 0 01.986.836l.74 4.435a1 1 0 01-.54 1.06l-1.548.773a11.037 11.037 0 006.105 6.105l.774-1.548a1 1 0 011.059-.54l4.435.74a1 1 0 01.836.986V17a1 1 0 01-1 1h-2C7.82 18 2 12.18 2 5V3z" />
+      </svg>
+      <span class="text-[10px] font-medium">Calls</span>
+    </RouterLink>
+
+    <!-- Numbers -->
+    <RouterLink
+      :to="`/orgs/${currentOrgId}/whatsapp/phone-numbers`"
+      class="flex flex-col items-center justify-center gap-0.5 min-w-[56px] min-h-[44px] px-2 transition-colors"
+      :class="route.name === 'whatsapp-phone-numbers' ? 'text-indigo-400' : 'text-slate-400'"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 shrink-0" viewBox="0 0 20 20" fill="currentColor">
+        <path d="M17.924 2.617a.997.997 0 00-.215-.322l-.004-.004A.997.997 0 0017 2h-4a1 1 0 100 2h1.586l-3.293 3.293a1 1 0 001.414 1.414L16 5.414V7a1 1 0 102 0V3a.997.997 0 00-.076-.383zM2 3a1 1 0 011-1h2.153a1 1 0 01.986.836l.74 4.435a1 1 0 01-.54 1.06l-1.548.773a11.037 11.037 0 006.105 6.105l.774-1.548a1 1 0 011.059-.54l4.435.74a1 1 0 01.836.986V17a1 1 0 01-1 1h-2C7.82 18 2 12.18 2 5V3z" />
+      </svg>
+      <span class="text-[10px] font-medium">Numbers</span>
+    </RouterLink>
+
+    <!-- More -->
+    <button
+      class="flex flex-col items-center justify-center gap-0.5 min-w-[56px] min-h-[44px] px-2 transition-colors"
+      :class="moreSheetOpen ? 'text-indigo-400' : 'text-slate-400'"
+      @click="moreSheetOpen = true"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 shrink-0" viewBox="0 0 20 20" fill="currentColor">
+        <path d="M6 10a2 2 0 11-4 0 2 2 0 014 0zM12 10a2 2 0 11-4 0 2 2 0 014 0zM16 12a2 2 0 100-4 2 2 0 000 4z" />
+      </svg>
+      <span class="text-[10px] font-medium">More</span>
+    </button>
+  </nav>
+
+  <BottomSheet :open="moreSheetOpen" title="Menu" @close="moreSheetOpen = false">
+    <div class="px-2 pb-4">
+      <RouterLink
+        v-for="item in moreItems"
+        :key="item.name"
+        :to="item.to"
+        class="flex items-center gap-3 w-full min-h-[48px] px-4 rounded-xl text-slate-300 hover:bg-slate-700 transition-colors"
+        @click="moreSheetOpen = false"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-slate-400 shrink-0" viewBox="0 0 20 20" fill="currentColor">
+          <path :d="item.iconPath" />
+        </svg>
+        <span class="text-sm font-medium">{{ item.label }}</span>
+      </RouterLink>
+    </div>
+  </BottomSheet>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { RouterLink, useRoute } from 'vue-router'
+import BottomSheet from './BottomSheet.vue'
+
+const route = useRoute()
+const moreSheetOpen = ref(false)
+
+const currentOrgId = computed(() => (route.params.orgId as string) || '_')
+
+const moreItems = computed(() => [
+  {
+    name: 'knowledge-bases',
+    label: 'Knowledge Bases',
+    to: `/orgs/${currentOrgId.value}/workspaces`,
+    iconPath: 'M9 4.804A7.968 7.968 0 005.5 4c-1.255 0-2.443.29-3.5.804v10A7.969 7.969 0 015.5 14c1.669 0 3.218.51 4.5 1.385A7.962 7.962 0 0114.5 14c1.255 0 2.443.29 3.5.804v-10A7.968 7.968 0 0014.5 4c-1.255 0-2.443.29-3.5.804V12a1 1 0 11-2 0V4.804z',
+  },
+  {
+    name: 'chatbot-config',
+    label: 'Chatbot Config',
+    to: '/chatbot-config',
+    iconPath: 'M2 5a2 2 0 012-2h7a2 2 0 012 2v4a2 2 0 01-2 2H9l-3 3v-3H4a2 2 0 01-2-2V5z',
+  },
+  {
+    name: 'analytics',
+    label: 'Analytics',
+    to: '/analytics',
+    iconPath: 'M2 11a1 1 0 011-1h2a1 1 0 011 1v5a1 1 0 01-1 1H3a1 1 0 01-1-1v-5zM8 7a1 1 0 011-1h2a1 1 0 011 1v9a1 1 0 01-1 1H9a1 1 0 01-1-1V7zM14 4a1 1 0 011-1h2a1 1 0 011 1v12a1 1 0 01-1 1h-2a1 1 0 01-1-1V4z',
+  },
+  {
+    name: 'api-keys',
+    label: 'API Keys',
+    to: '/api-keys',
+    iconPath: 'M15 7a1 1 0 011 1v4a1 1 0 01-2 0V9.414l-4.293 4.293a1 1 0 01-1.414 0L7 12.414V13a1 1 0 01-2 0V9a1 1 0 01.293-.707l2-2a1 1 0 011.414 1.414L7.414 9H8a1 1 0 010 2h-.586l4.293 4.293 2.293-2.293A1 1 0 0115 7z',
+  },
+  {
+    name: 'llm-providers',
+    label: 'LLM Providers',
+    to: '/llm-providers',
+    iconPath: 'M10 18a8 8 0 100-16 8 8 0 000 16zM9.555 7.168A1 1 0 008 8v4a1 1 0 001.555.832l3-2a1 1 0 000-1.664l-3-2z',
+  },
+  {
+    name: 'sandbox',
+    label: 'Sandbox',
+    to: '/sandbox',
+    iconPath: 'M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z',
+  },
+])
+</script>

--- a/frontend/src/layouts/DefaultLayout.vue
+++ b/frontend/src/layouts/DefaultLayout.vue
@@ -1,38 +1,22 @@
 <template>
   <div class="flex h-screen bg-gray-100">
-    <AppSidebar
-      :mobile="isMobile"
-      :open="sidebarOpen"
-      @close="sidebarOpen = false"
-    />
+    <AppSidebar v-if="!isMobile" :mobile="false" :open="false" />
     <div class="flex flex-1 flex-col overflow-hidden">
-      <AppHeader @toggle-sidebar="sidebarOpen = !sidebarOpen" />
-      <main class="flex-1 overflow-y-auto p-4 md:p-6">
+      <AppHeader />
+      <main class="flex-1 overflow-y-auto p-4 md:p-6" :class="isMobile ? 'pb-24' : ''">
         <RouterView />
       </main>
     </div>
+    <MobileTabBar v-if="isMobile" />
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue'
 import { RouterView } from 'vue-router'
-import { useRoute } from 'vue-router'
 import AppSidebar from '../components/AppSidebar.vue'
 import AppHeader from '../components/AppHeader.vue'
+import MobileTabBar from '../components/MobileTabBar.vue'
 import { useMobile } from '../composables/useMediaQuery'
 
 const { isMobile } = useMobile()
-const sidebarOpen = ref(false)
-const route = useRoute()
-
-// Close sidebar on route change (mobile)
-watch(
-  () => route.path,
-  () => {
-    if (isMobile.value) {
-      sidebarOpen.value = false
-    }
-  },
-)
 </script>


### PR DESCRIPTION
## Summary

- Adds `MobileTabBar.vue`: fixed bottom nav bar with 5 tabs (Home, Voice, Calls, Numbers, More) — only rendered on mobile (<768px)
- Adds `BottomSheet.vue`: reusable slide-up panel with backdrop, drag handle, and slide transition — used for the "More" menu (secondary pages: Knowledge Bases, Chatbot Config, Analytics, API Keys, LLM Providers, Sandbox)
- Updates `DefaultLayout.vue`: sidebar shown on desktop only; tab bar shown on mobile; `pb-24` on main content prevents content hiding behind tab bar
- Updates `AppHeader.vue`: removes hamburger button (redundant now that mobile uses bottom tab nav)

Closes #221

## Test plan

- [ ] Desktop (≥768px): sidebar visible, no tab bar
- [ ] Mobile (<768px): tab bar visible at bottom, no sidebar
- [ ] All 5 tabs navigate correctly; active tab highlights in indigo
- [ ] "More" tab opens bottom sheet with secondary nav items
- [ ] Content area does not scroll behind tab bar on mobile
- [ ] Safe-area inset padding works on notched phones (iPhone with notch)
- [ ] All 143 unit tests pass (`npm run test:unit`)
- [ ] Build clean, no TypeScript errors (`npm run build`)
- [ ] ESLint clean (`npm run lint`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile-first responsive redesign with bottom tab navigation, mobile-optimized card layouts, and full-screen modals for mobile devices.
  * Introduced voice sessions management functionality for organizing voice calls with session state tracking and turn management.
  * Added support for India payments integration through Hyperswitch and Razorpay payment processing.

* **Bug Fixes**
  * Improved error handling and null-safety checks across API services.

* **Documentation**
  * Enhanced project documentation with expanded repository structure and improved CI workflow documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->