### PR TITLE
feat(mobile): responsive modals and bottom-sheet confirms (#223)

### DIFF
--- a/docs/superpowers/specs/2026-04-10-mobile-first-responsive-redesign.md
+++ b/docs/superpowers/specs/2026-04-10-mobile-first-responsive-redesign.md
@@ -56,7 +56,7 @@ Single breakpoint at `md:` (768px) — matches the existing `useMobile()` compos
 
 New component: `MobileTabBar.vue`
 
-```
+```vue
 <template>
   <!-- Only rendered when isMobile -->
   <nav class="fixed bottom-0 inset-x-0 z-50 bg-slate-800 border-t border-slate-700
@@ -83,7 +83,7 @@ New component: `MobileTabBar.vue`
 
 New component: `BottomSheet.vue` — reusable slide-up panel.
 
-```
+```ts
 Props: { open: boolean, title?: string }
 Emits: ['close']
 ```
@@ -102,7 +102,7 @@ All list pages conditionally render a `<table>` (desktop) or stacked cards (mobi
 
 Every card follows this consistent structure:
 
-```
+```text
 ┌─────────────────────────────────┐
 │ Title                   [Badge] │
 │ subtitle • metadata             │

--- a/frontend/src/components/BottomSheet.vue
+++ b/frontend/src/components/BottomSheet.vue
@@ -11,8 +11,12 @@
     <Transition name="sheet">
       <div
         v-if="open"
+        role="dialog"
+        aria-modal="true"
+        :aria-labelledby="title ? 'bottom-sheet-title' : undefined"
         class="fixed inset-x-0 bottom-0 z-50 rounded-t-2xl bg-slate-800"
         :style="{ paddingBottom: 'env(safe-area-inset-bottom)' }"
+        @keydown.escape="$emit('close')"
       >
         <!-- Drag handle -->
         <div class="flex justify-center pt-2 pb-1">
@@ -20,7 +24,7 @@
         </div>
 
         <div v-if="title" class="px-4 pb-3">
-          <h3 class="text-center text-sm font-semibold text-slate-300">{{ title }}</h3>
+          <h3 id="bottom-sheet-title" class="text-center text-sm font-semibold text-slate-300">{{ title }}</h3>
         </div>
 
         <slot />

--- a/frontend/src/components/MobileTabBar.vue
+++ b/frontend/src/components/MobileTabBar.vue
@@ -1,5 +1,6 @@
 <template>
   <nav
+    aria-label="Primary navigation"
     class="fixed bottom-0 inset-x-0 z-40 flex justify-around items-center bg-slate-800 border-t border-slate-700"
     style="min-height: 56px; padding-bottom: env(safe-area-inset-bottom);"
   >
@@ -15,8 +16,9 @@
       <span class="text-[10px] font-medium">Home</span>
     </RouterLink>
 
-    <!-- Voice -->
+    <!-- Voice — only active when orgId is known -->
     <RouterLink
+      v-if="currentOrgId"
       :to="`/orgs/${currentOrgId}/voice`"
       class="flex flex-col items-center justify-center gap-0.5 min-w-[56px] min-h-[44px] px-2 transition-colors"
       :class="route.name === 'voice-session-list' ? 'text-indigo-400' : 'text-slate-400'"
@@ -26,9 +28,20 @@
       </svg>
       <span class="text-[10px] font-medium">Voice</span>
     </RouterLink>
+    <span
+      v-else
+      class="flex flex-col items-center justify-center gap-0.5 min-w-[56px] min-h-[44px] px-2 text-slate-600"
+      aria-disabled="true"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 shrink-0" viewBox="0 0 20 20" fill="currentColor">
+        <path fill-rule="evenodd" d="M7 4a3 3 0 016 0v4a3 3 0 11-6 0V4zm4 10.93A7.001 7.001 0 0017 8a1 1 0 10-2 0A5 5 0 015 8a1 1 0 00-2 0 7.001 7.001 0 006 6.93V17H6a1 1 0 100 2h8a1 1 0 100-2h-3v-2.07z" clip-rule="evenodd" />
+      </svg>
+      <span class="text-[10px] font-medium">Voice</span>
+    </span>
 
     <!-- Calls -->
     <RouterLink
+      v-if="currentOrgId"
       :to="`/orgs/${currentOrgId}/whatsapp/calls`"
       class="flex flex-col items-center justify-center gap-0.5 min-w-[56px] min-h-[44px] px-2 transition-colors"
       :class="route.name === 'whatsapp-calls' ? 'text-indigo-400' : 'text-slate-400'"
@@ -38,9 +51,20 @@
       </svg>
       <span class="text-[10px] font-medium">Calls</span>
     </RouterLink>
+    <span
+      v-else
+      class="flex flex-col items-center justify-center gap-0.5 min-w-[56px] min-h-[44px] px-2 text-slate-600"
+      aria-disabled="true"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 shrink-0" viewBox="0 0 20 20" fill="currentColor">
+        <path d="M2 3a1 1 0 011-1h2.153a1 1 0 01.986.836l.74 4.435a1 1 0 01-.54 1.06l-1.548.773a11.037 11.037 0 006.105 6.105l.774-1.548a1 1 0 011.059-.54l4.435.74a1 1 0 01.836.986V17a1 1 0 01-1 1h-2C7.82 18 2 12.18 2 5V3z" />
+      </svg>
+      <span class="text-[10px] font-medium">Calls</span>
+    </span>
 
     <!-- Numbers -->
     <RouterLink
+      v-if="currentOrgId"
       :to="`/orgs/${currentOrgId}/whatsapp/phone-numbers`"
       class="flex flex-col items-center justify-center gap-0.5 min-w-[56px] min-h-[44px] px-2 transition-colors"
       :class="route.name === 'whatsapp-phone-numbers' ? 'text-indigo-400' : 'text-slate-400'"
@@ -50,11 +74,22 @@
       </svg>
       <span class="text-[10px] font-medium">Numbers</span>
     </RouterLink>
+    <span
+      v-else
+      class="flex flex-col items-center justify-center gap-0.5 min-w-[56px] min-h-[44px] px-2 text-slate-600"
+      aria-disabled="true"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 shrink-0" viewBox="0 0 20 20" fill="currentColor">
+        <path d="M17.924 2.617a.997.997 0 00-.215-.322l-.004-.004A.997.997 0 0017 2h-4a1 1 0 100 2h1.586l-3.293 3.293a1 1 0 001.414 1.414L16 5.414V7a1 1 0 102 0V3a.997.997 0 00-.076-.383zM2 3a1 1 0 011-1h2.153a1 1 0 01.986.836l.74 4.435a1 1 0 01-.54 1.06l-1.548.773a11.037 11.037 0 006.105 6.105l.774-1.548a1 1 0 011.059-.54l4.435.74a1 1 0 01.836.986V17a1 1 0 01-1 1h-2C7.82 18 2 12.18 2 5V3z" />
+      </svg>
+      <span class="text-[10px] font-medium">Numbers</span>
+    </span>
 
     <!-- More -->
     <button
       class="flex flex-col items-center justify-center gap-0.5 min-w-[56px] min-h-[44px] px-2 transition-colors"
       :class="moreSheetOpen ? 'text-indigo-400' : 'text-slate-400'"
+      aria-label="More navigation options"
       @click="moreSheetOpen = true"
     >
       <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 shrink-0" viewBox="0 0 20 20" fill="currentColor">
@@ -90,13 +125,13 @@ import BottomSheet from './BottomSheet.vue'
 const route = useRoute()
 const moreSheetOpen = ref(false)
 
-const currentOrgId = computed(() => (route.params.orgId as string) || '_')
+const currentOrgId = computed(() => route.params.orgId as string | undefined)
 
 const moreItems = computed(() => [
   {
     name: 'knowledge-bases',
     label: 'Knowledge Bases',
-    to: `/orgs/${currentOrgId.value}/workspaces`,
+    to: currentOrgId.value ? `/orgs/${currentOrgId.value}/workspaces` : '/dashboard',
     iconPath: 'M9 4.804A7.968 7.968 0 005.5 4c-1.255 0-2.443.29-3.5.804v10A7.969 7.969 0 015.5 14c1.669 0 3.218.51 4.5 1.385A7.962 7.962 0 0114.5 14c1.255 0 2.443.29 3.5.804v-10A7.968 7.968 0 0014.5 4c-1.255 0-2.443.29-3.5.804V12a1 1 0 11-2 0V4.804z',
   },
   {

--- a/frontend/src/components/ResponsiveModal.vue
+++ b/frontend/src/components/ResponsiveModal.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import { useMobile } from '../composables/useMediaQuery'
+
+defineProps<{
+  open: boolean
+  title: string
+}>()
+
+defineEmits<{
+  close: []
+}>()
+
+const { isMobile } = useMobile()
+</script>
+
+<template>
+  <Teleport to="body">
+    <!-- Mobile: full-screen page -->
+    <div
+      v-if="open && isMobile"
+      class="fixed inset-0 z-50 flex flex-col bg-slate-900"
+    >
+      <!-- Header -->
+      <div class="flex h-14 items-center border-b border-slate-700 px-4">
+        <button
+          class="flex min-h-[44px] min-w-[44px] items-center justify-center text-slate-300 hover:text-white"
+          @click="$emit('close')"
+        >
+          <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+            <path d="M19 12H5M12 19l-7-7 7-7" />
+          </svg>
+        </button>
+        <span class="flex-1 text-center text-[15px] font-semibold text-white">{{ title }}</span>
+        <!-- Spacer to keep title centered -->
+        <div class="w-11" />
+      </div>
+
+      <!-- Body -->
+      <div class="flex-1 overflow-y-auto p-4">
+        <slot />
+      </div>
+
+      <!-- Footer / Actions -->
+      <div
+        class="border-t border-slate-700 p-4"
+        :style="{ paddingBottom: 'max(env(safe-area-inset-bottom), 1rem)' }"
+      >
+        <slot name="actions" />
+      </div>
+    </div>
+
+    <!-- Desktop: centered overlay -->
+    <div
+      v-else-if="open && !isMobile"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      @click.self="$emit('close')"
+    >
+      <div class="w-full max-w-md rounded-xl bg-slate-800 mx-4">
+        <slot />
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/frontend/src/components/ResponsiveModal.vue
+++ b/frontend/src/components/ResponsiveModal.vue
@@ -18,12 +18,17 @@ const { isMobile } = useMobile()
     <!-- Mobile: full-screen page -->
     <div
       v-if="open && isMobile"
+      role="dialog"
+      aria-modal="true"
+      :aria-label="title"
       class="fixed inset-0 z-50 flex flex-col bg-slate-900"
+      @keydown.escape="$emit('close')"
     >
       <!-- Header -->
       <div class="flex h-14 items-center border-b border-slate-700 px-4">
         <button
           class="flex min-h-[44px] min-w-[44px] items-center justify-center text-slate-300 hover:text-white"
+          :aria-label="`Close ${title}`"
           @click="$emit('close')"
         >
           <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
@@ -52,8 +57,12 @@ const { isMobile } = useMobile()
     <!-- Desktop: centered overlay -->
     <div
       v-else-if="open && !isMobile"
+      role="dialog"
+      aria-modal="true"
+      :aria-label="title"
       class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
       @click.self="$emit('close')"
+      @keydown.escape="$emit('close')"
     >
       <div class="w-full max-w-md rounded-xl bg-slate-800 mx-4">
         <slot />

--- a/frontend/src/components/voice/CreateSessionModal.vue
+++ b/frontend/src/components/voice/CreateSessionModal.vue
@@ -1,5 +1,10 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+import ResponsiveModal from '../ResponsiveModal.vue'
+
+const props = defineProps<{
+  open?: boolean
+}>()
 
 const emit = defineEmits<{
   create: [roomName: string]
@@ -20,48 +25,58 @@ async function handleSubmit() {
 </script>
 
 <template>
-  <div class="fixed inset-0 z-50 flex items-center justify-center">
-    <div
-      class="fixed inset-0 bg-black/50"
-      data-testid="modal-backdrop"
-      @click="$emit('close')"
-    />
-    <div
-      class="relative z-10 w-full max-w-md rounded-lg bg-white p-6 shadow-xl"
-    >
-      <h2 class="mb-4 text-lg font-semibold">Create Voice Session</h2>
-      <form @submit.prevent="handleSubmit">
-        <label
-          for="room-name"
-          class="mb-1 block text-sm font-medium text-gray-700"
+  <ResponsiveModal :open="props.open ?? true" title="Create Voice Session" @close="$emit('close')">
+    <form class="p-6" @submit.prevent="handleSubmit">
+      <h2 class="mb-4 text-lg font-semibold text-white">Create Voice Session</h2>
+      <label
+        for="room-name"
+        class="mb-1 block text-sm font-medium text-slate-300"
+      >
+        LiveKit Room Name
+        <span class="text-slate-400">(optional)</span>
+      </label>
+      <input
+        id="room-name"
+        v-model="roomName"
+        type="text"
+        placeholder="Auto-generated if blank"
+        class="mb-4 w-full rounded-md border border-slate-600 bg-slate-700 px-3 py-2 text-sm text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+      />
+      <div class="hidden sm:flex justify-end gap-3">
+        <button
+          type="button"
+          class="min-h-[44px] min-w-[44px] rounded-md border border-slate-600 px-4 py-2 text-sm font-medium text-slate-300 hover:bg-slate-700"
+          @click="$emit('close')"
         >
-          LiveKit Room Name
-          <span class="text-gray-400">(optional)</span>
-        </label>
-        <input
-          id="room-name"
-          v-model="roomName"
-          type="text"
-          placeholder="Auto-generated if blank"
-          class="mb-4 w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-        />
-        <div class="flex justify-end gap-3">
-          <button
-            type="button"
-            class="min-h-[44px] min-w-[44px] rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
-            @click="$emit('close')"
-          >
-            Cancel
-          </button>
-          <button
-            type="submit"
-            :disabled="submitting"
-            class="min-h-[44px] min-w-[44px] rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {{ submitting ? 'Creating...' : 'Create Session' }}
-          </button>
-        </div>
-      </form>
-    </div>
-  </div>
+          Cancel
+        </button>
+        <button
+          type="submit"
+          :disabled="submitting"
+          class="min-h-[44px] min-w-[44px] rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {{ submitting ? 'Creating...' : 'Create Session' }}
+        </button>
+      </div>
+    </form>
+    <template #actions>
+      <div class="flex flex-col gap-2 sm:hidden">
+        <button
+          type="button"
+          class="w-full min-h-[48px] rounded-xl bg-indigo-600 text-sm font-semibold text-white"
+          :disabled="submitting"
+          @click="handleSubmit"
+        >
+          {{ submitting ? 'Creating...' : 'Create Session' }}
+        </button>
+        <button
+          type="button"
+          class="w-full min-h-[48px] rounded-xl bg-slate-700 text-sm text-slate-200"
+          @click="$emit('close')"
+        >
+          Cancel
+        </button>
+      </div>
+    </template>
+  </ResponsiveModal>
 </template>

--- a/frontend/src/components/voice/CreateSessionModal.vue
+++ b/frontend/src/components/voice/CreateSessionModal.vue
@@ -40,7 +40,7 @@ async function handleSubmit() {
         v-model="roomName"
         type="text"
         placeholder="Auto-generated if blank"
-        class="mb-4 w-full rounded-md border border-slate-600 bg-slate-700 px-3 py-2 text-sm text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        class="mb-4 w-full min-h-[48px] rounded-md border border-slate-600 bg-slate-700 px-3 py-2 text-[15px] text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-indigo-500"
       />
       <div class="hidden sm:flex justify-end gap-3">
         <button

--- a/frontend/src/components/voice/CreateSessionModal.vue
+++ b/frontend/src/components/voice/CreateSessionModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import ResponsiveModal from '../ResponsiveModal.vue'
 
 const props = defineProps<{
@@ -13,6 +13,13 @@ const emit = defineEmits<{
 
 const roomName = ref('')
 const submitting = ref(false)
+
+watch(() => props.open, (open) => {
+  if (open) {
+    roomName.value = ''
+    submitting.value = false
+  }
+})
 
 async function handleSubmit() {
   submitting.value = true

--- a/frontend/src/components/whatsapp/InitiateCallModal.vue
+++ b/frontend/src/components/whatsapp/InitiateCallModal.vue
@@ -123,9 +123,10 @@ async function handleSubmit() {
     <template #actions>
       <div class="flex flex-col gap-2 sm:hidden">
         <button
-          type="submit"
+          type="button"
           class="w-full min-h-[48px] rounded-xl bg-indigo-600 text-sm font-semibold text-white disabled:opacity-50 disabled:cursor-not-allowed"
           :disabled="submitting || !selectedPhoneId || !callee.trim()"
+          @click="handleSubmit"
         >
           {{ submitting ? 'Calling...' : 'Call' }}
         </button>

--- a/frontend/src/components/whatsapp/InitiateCallModal.vue
+++ b/frontend/src/components/whatsapp/InitiateCallModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import { useWhatsAppStore } from '../../stores/whatsapp'
 import type { WhatsAppPhoneNumber } from '../../api/whatsapp'
 import ResponsiveModal from '../ResponsiveModal.vue'
@@ -21,6 +21,15 @@ const selectedPhoneId = ref(props.phoneNumbers.length > 0 ? props.phoneNumbers[0
 const callee = ref('')
 const submitting = ref(false)
 const submitError = ref<string | null>(null)
+
+watch(() => props.open, (open) => {
+  if (open) {
+    selectedPhoneId.value = props.phoneNumbers.length > 0 ? props.phoneNumbers[0].id : ''
+    callee.value = ''
+    submitting.value = false
+    submitError.value = null
+  }
+})
 
 async function handleSubmit() {
   const num = callee.value.trim()

--- a/frontend/src/components/whatsapp/InitiateCallModal.vue
+++ b/frontend/src/components/whatsapp/InitiateCallModal.vue
@@ -2,10 +2,12 @@
 import { ref } from 'vue'
 import { useWhatsAppStore } from '../../stores/whatsapp'
 import type { WhatsAppPhoneNumber } from '../../api/whatsapp'
+import ResponsiveModal from '../ResponsiveModal.vue'
 
 const props = defineProps<{
   orgId: string
   phoneNumbers: WhatsAppPhoneNumber[]
+  open?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -41,16 +43,12 @@ async function handleSubmit() {
 </script>
 
 <template>
-  <div class="fixed inset-0 z-50 flex items-center justify-center">
-    <!-- Backdrop -->
-    <div class="absolute inset-0 bg-black/50" @click="emit('close')" />
-
-    <!-- Modal -->
-    <div class="relative z-10 w-full max-w-md mx-4 rounded-lg bg-white p-6 shadow-xl">
-      <div class="flex items-center justify-between mb-4">
-        <h2 class="text-lg font-bold">New Call</h2>
+  <ResponsiveModal :open="props.open ?? true" title="New Call" @close="emit('close')">
+    <div class="p-6">
+      <div class="hidden sm:flex items-center justify-between mb-4">
+        <h2 class="text-lg font-bold text-white">New Call</h2>
         <button
-          class="flex h-11 w-11 items-center justify-center rounded-lg text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+          class="flex h-11 w-11 items-center justify-center rounded-lg text-slate-400 hover:bg-slate-700 hover:text-slate-200"
           @click="emit('close')"
         >
           <svg
@@ -68,13 +66,13 @@ async function handleSubmit() {
 
       <form class="space-y-4" @submit.prevent="handleSubmit">
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1" for="from-phone"
+          <label class="block text-sm font-medium text-slate-300 mb-1" for="from-phone"
             >From Number</label
           >
           <select
             id="from-phone"
             v-model="selectedPhoneId"
-            class="min-h-[44px] w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            class="min-h-[44px] w-full rounded-md border border-slate-600 bg-slate-700 px-3 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
             required
           >
             <option v-if="phoneNumbers.length === 0" value="" disabled>
@@ -88,7 +86,7 @@ async function handleSubmit() {
         </div>
 
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1" for="callee-number"
+          <label class="block text-sm font-medium text-slate-300 mb-1" for="callee-number"
             >Callee Number</label
           >
           <input
@@ -96,17 +94,17 @@ async function handleSubmit() {
             v-model="callee"
             type="text"
             placeholder="+1234567890"
-            class="min-h-[44px] w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            class="min-h-[44px] w-full rounded-md border border-slate-600 bg-slate-700 px-3 py-2 text-sm text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-indigo-500"
             required
           />
         </div>
 
-        <div v-if="submitError" class="text-sm text-red-600">{{ submitError }}</div>
+        <div v-if="submitError" class="text-sm text-red-400">{{ submitError }}</div>
 
-        <div class="flex gap-3 pt-2">
+        <div class="hidden sm:flex gap-3 pt-2">
           <button
             type="button"
-            class="min-h-[44px] flex-1 rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+            class="min-h-[44px] flex-1 rounded-md border border-slate-600 px-4 py-2 text-sm font-medium text-slate-300 hover:bg-slate-700"
             @click="emit('close')"
           >
             Cancel
@@ -121,5 +119,25 @@ async function handleSubmit() {
         </div>
       </form>
     </div>
-  </div>
+
+    <template #actions>
+      <div class="flex flex-col gap-2 sm:hidden">
+        <button
+          type="button"
+          class="w-full min-h-[48px] rounded-xl bg-indigo-600 text-sm font-semibold text-white disabled:opacity-50 disabled:cursor-not-allowed"
+          :disabled="submitting || !selectedPhoneId || !callee.trim()"
+          @click="handleSubmit"
+        >
+          {{ submitting ? 'Calling...' : 'Call' }}
+        </button>
+        <button
+          type="button"
+          class="w-full min-h-[48px] rounded-xl bg-slate-700 text-sm text-slate-200"
+          @click="emit('close')"
+        >
+          Cancel
+        </button>
+      </div>
+    </template>
+  </ResponsiveModal>
 </template>

--- a/frontend/src/components/whatsapp/InitiateCallModal.vue
+++ b/frontend/src/components/whatsapp/InitiateCallModal.vue
@@ -123,10 +123,9 @@ async function handleSubmit() {
     <template #actions>
       <div class="flex flex-col gap-2 sm:hidden">
         <button
-          type="button"
+          type="submit"
           class="w-full min-h-[48px] rounded-xl bg-indigo-600 text-sm font-semibold text-white disabled:opacity-50 disabled:cursor-not-allowed"
           :disabled="submitting || !selectedPhoneId || !callee.trim()"
-          @click="handleSubmit"
         >
           {{ submitting ? 'Calling...' : 'Call' }}
         </button>

--- a/frontend/src/pages/apikeys/ApiKeyListPage.vue
+++ b/frontend/src/pages/apikeys/ApiKeyListPage.vue
@@ -419,8 +419,8 @@ function mobileStatusClass(status: string): string {
 
     <!-- Revoke Confirmation: Mobile bottom sheet -->
     <BottomSheet
-      v-else-if="isMobile && showRevokeDialog"
-      :open="showRevokeDialog"
+      v-if="isMobile && showRevokeDialog"
+      :open="true"
       @close="showRevokeDialog = false"
     >
       <div class="px-4 pb-6 flex flex-col gap-3">

--- a/frontend/src/pages/apikeys/ApiKeyListPage.vue
+++ b/frontend/src/pages/apikeys/ApiKeyListPage.vue
@@ -386,8 +386,13 @@ function mobileStatusClass(status: string): string {
       class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
       @click.self="showRevokeDialog = false"
     >
-      <div class="w-full max-w-sm rounded-xl bg-white p-6 shadow-xl">
-        <h2 class="text-lg font-semibold text-gray-900">Revoke API Key</h2>
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="revoke-dialog-title"
+        class="w-full max-w-sm rounded-xl bg-white p-6 shadow-xl"
+      >
+        <h2 id="revoke-dialog-title" class="text-lg font-semibold text-gray-900">Revoke API Key</h2>
         <p class="mt-2 text-sm text-gray-600">
           Are you sure you want to revoke <strong>{{ keyToRevokeName }}</strong>? This action cannot
           be undone. Any integrations using this key will stop working immediately.
@@ -419,8 +424,8 @@ function mobileStatusClass(status: string): string {
 
     <!-- Revoke Confirmation: Mobile bottom sheet -->
     <BottomSheet
-      v-if="isMobile && showRevokeDialog"
-      :open="true"
+      v-if="isMobile"
+      :open="showRevokeDialog"
       @close="showRevokeDialog = false"
     >
       <div class="px-4 pb-6 flex flex-col gap-3">

--- a/frontend/src/pages/apikeys/ApiKeyListPage.vue
+++ b/frontend/src/pages/apikeys/ApiKeyListPage.vue
@@ -3,6 +3,7 @@ import { ref, onMounted, computed } from 'vue'
 import { useApiKeysStore } from '../../stores/apikeys'
 import { useMobile } from '../../composables/useMediaQuery'
 import { pipe, split, map, filter, isTruthy } from 'remeda'
+import BottomSheet from '../../components/BottomSheet.vue'
 
 const store = useApiKeysStore()
 const { isMobile } = useMobile()
@@ -379,9 +380,9 @@ function mobileStatusClass(status: string): string {
       </div>
     </div>
 
-    <!-- Revoke Confirmation Dialog -->
+    <!-- Revoke Confirmation Dialog: Desktop -->
     <div
-      v-if="showRevokeDialog"
+      v-if="!isMobile && showRevokeDialog"
       class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
       @click.self="showRevokeDialog = false"
     >
@@ -415,5 +416,41 @@ function mobileStatusClass(status: string): string {
         </div>
       </div>
     </div>
+
+    <!-- Revoke Confirmation: Mobile bottom sheet -->
+    <BottomSheet
+      v-else-if="isMobile && showRevokeDialog"
+      :open="showRevokeDialog"
+      @close="showRevokeDialog = false"
+    >
+      <div class="px-4 pb-6 flex flex-col gap-3">
+        <div class="flex flex-col items-center gap-2 py-2">
+          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-red-100">
+            <svg class="h-6 w-6 text-red-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+            </svg>
+          </div>
+          <h2 class="text-base font-semibold text-white">Revoke API Key</h2>
+          <p class="text-center text-sm text-slate-400">
+            Are you sure you want to revoke <strong class="text-slate-200">{{ keyToRevokeName }}</strong>? This action cannot be undone.
+          </p>
+        </div>
+        <button
+          type="button"
+          :disabled="revoking"
+          class="w-full min-h-[48px] rounded-xl bg-red-600 text-sm font-semibold text-white disabled:opacity-50"
+          @click="confirmRevoke"
+        >
+          {{ revoking ? 'Revoking...' : 'Revoke Key' }}
+        </button>
+        <button
+          type="button"
+          class="w-full min-h-[48px] rounded-xl bg-slate-700 text-sm text-slate-200"
+          @click="showRevokeDialog = false"
+        >
+          Cancel
+        </button>
+      </div>
+    </BottomSheet>
   </div>
 </template>

--- a/frontend/src/pages/knowledge-bases/KBListPage.vue
+++ b/frontend/src/pages/knowledge-bases/KBListPage.vue
@@ -20,6 +20,7 @@ const showArchiveDialog = ref(false)
 const kbToArchiveId = ref<string | null>(null)
 const kbToArchiveName = ref('')
 const archiving = ref(false)
+const archiveError = ref<string | null>(null)
 
 onMounted(() => store.fetchKnowledgeBases(orgId, wsId))
 
@@ -51,11 +52,12 @@ function promptArchive(kbId: string, kbName: string) {
 async function confirmArchive() {
   if (!kbToArchiveId.value) return
   archiving.value = true
+  archiveError.value = null
   try {
     await store.archive(orgId, wsId, kbToArchiveId.value)
     showArchiveDialog.value = false
-  } catch {
-    /* error surfaced via store.error */
+  } catch (e) {
+    archiveError.value = (e as Error).message ?? 'Failed to archive. Please try again.'
   } finally {
     archiving.value = false
   }
@@ -206,11 +208,17 @@ function mobileStatusClass(status: string): string {
       class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
       @click.self="showArchiveDialog = false"
     >
-      <div class="w-full max-w-sm rounded-xl bg-white p-6 shadow-xl">
-        <h2 class="text-lg font-semibold text-gray-900">Archive Knowledge Base</h2>
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="archive-kb-title"
+        class="w-full max-w-sm rounded-xl bg-white p-6 shadow-xl"
+      >
+        <h2 id="archive-kb-title" class="text-lg font-semibold text-gray-900">Archive Knowledge Base</h2>
         <p class="mt-2 text-sm text-gray-600">
           Are you sure you want to archive <strong>{{ kbToArchiveName }}</strong>? It will be removed from active use.
         </p>
+        <p v-if="archiveError" class="mt-2 text-sm text-red-600">{{ archiveError }}</p>
         <div class="mt-6 flex justify-end gap-3">
           <button
             type="button"
@@ -248,6 +256,7 @@ function mobileStatusClass(status: string): string {
           <p class="text-center text-sm text-slate-400">
             Are you sure you want to archive <strong class="text-slate-200">{{ kbToArchiveName }}</strong>? It will be removed from active use.
           </p>
+          <p v-if="archiveError" class="text-center text-sm text-red-400">{{ archiveError }}</p>
         </div>
         <button
           type="button"

--- a/frontend/src/pages/knowledge-bases/KBListPage.vue
+++ b/frontend/src/pages/knowledge-bases/KBListPage.vue
@@ -3,6 +3,7 @@ import { onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useKnowledgeBasesStore } from '../../stores/knowledge-bases'
 import { useMobile } from '../../composables/useMediaQuery'
+import BottomSheet from '../../components/BottomSheet.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -13,6 +14,12 @@ const orgId = route.params.orgId as string
 const wsId = route.params.wsId as string
 const newName = ref('')
 const creating = ref(false)
+
+// Archive confirmation state
+const showArchiveDialog = ref(false)
+const kbToArchiveId = ref<string | null>(null)
+const kbToArchiveName = ref('')
+const archiving = ref(false)
 
 onMounted(() => store.fetchKnowledgeBases(orgId, wsId))
 
@@ -35,11 +42,22 @@ function openKB(kbId: string) {
   router.push(`/orgs/${orgId}/workspaces/${wsId}/knowledge-bases/${kbId}`)
 }
 
-async function handleArchive(kbId: string) {
+function promptArchive(kbId: string, kbName: string) {
+  kbToArchiveId.value = kbId
+  kbToArchiveName.value = kbName
+  showArchiveDialog.value = true
+}
+
+async function confirmArchive() {
+  if (!kbToArchiveId.value) return
+  archiving.value = true
   try {
-    await store.archive(orgId, wsId, kbId)
+    await store.archive(orgId, wsId, kbToArchiveId.value)
+    showArchiveDialog.value = false
   } catch {
     /* error surfaced via store.error */
+  } finally {
+    archiving.value = false
   }
 }
 
@@ -121,7 +139,7 @@ function mobileStatusClass(status: string): string {
           <button
             v-if="kb.status === 'active'"
             class="text-red-600 hover:text-red-800 text-xs min-h-[44px] min-w-[44px]"
-            @click.stop="handleArchive(kb.id)"
+            @click.stop="promptArchive(kb.id, kb.name)"
           >
             Archive
           </button>
@@ -168,8 +186,8 @@ function mobileStatusClass(status: string): string {
           class="border-t border-slate-700 mt-2.5 pt-2.5 flex justify-end"
         >
           <button
-            class="text-red-400 text-xs"
-            @click.stop="handleArchive(kb.id)"
+            class="text-red-400 text-xs min-h-[44px] min-w-[44px]"
+            @click.stop="promptArchive(kb.id, kb.name)"
           >
             Archive
           </button>
@@ -181,5 +199,72 @@ function mobileStatusClass(status: string): string {
     <p v-if="store.knowledgeBases.length > 0" class="mt-4 text-sm text-gray-400">
       {{ store.total }} knowledge base{{ store.total === 1 ? '' : 's' }} total
     </p>
+
+    <!-- Archive Confirmation Dialog: Desktop -->
+    <div
+      v-if="!isMobile && showArchiveDialog"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      @click.self="showArchiveDialog = false"
+    >
+      <div class="w-full max-w-sm rounded-xl bg-white p-6 shadow-xl">
+        <h2 class="text-lg font-semibold text-gray-900">Archive Knowledge Base</h2>
+        <p class="mt-2 text-sm text-gray-600">
+          Are you sure you want to archive <strong>{{ kbToArchiveName }}</strong>? It will be removed from active use.
+        </p>
+        <div class="mt-6 flex justify-end gap-3">
+          <button
+            type="button"
+            class="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+            @click="showArchiveDialog = false"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            :disabled="archiving"
+            class="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 disabled:opacity-50"
+            @click="confirmArchive"
+          >
+            {{ archiving ? 'Archiving...' : 'Archive' }}
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Archive Confirmation: Mobile bottom sheet -->
+    <BottomSheet
+      v-else-if="isMobile && showArchiveDialog"
+      :open="showArchiveDialog"
+      @close="showArchiveDialog = false"
+    >
+      <div class="px-4 pb-6 flex flex-col gap-3">
+        <div class="flex flex-col items-center gap-2 py-2">
+          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-red-100">
+            <svg class="h-6 w-6 text-red-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+            </svg>
+          </div>
+          <h2 class="text-base font-semibold text-white">Archive Knowledge Base</h2>
+          <p class="text-center text-sm text-slate-400">
+            Are you sure you want to archive <strong class="text-slate-200">{{ kbToArchiveName }}</strong>? It will be removed from active use.
+          </p>
+        </div>
+        <button
+          type="button"
+          :disabled="archiving"
+          class="w-full min-h-[48px] rounded-xl bg-red-600 text-sm font-semibold text-white disabled:opacity-50"
+          @click="confirmArchive"
+        >
+          {{ archiving ? 'Archiving...' : 'Archive' }}
+        </button>
+        <button
+          type="button"
+          class="w-full min-h-[48px] rounded-xl bg-slate-700 text-sm text-slate-200"
+          @click="showArchiveDialog = false"
+        >
+          Cancel
+        </button>
+      </div>
+    </BottomSheet>
   </div>
 </template>

--- a/frontend/src/pages/voice/VoiceSessionListPage.vue
+++ b/frontend/src/pages/voice/VoiceSessionListPage.vue
@@ -196,7 +196,7 @@ function mobileStateClass(state: string): string {
 
     <!-- Create session modal -->
     <CreateSessionModal
-      v-if="showCreateModal"
+      :open="showCreateModal"
       @create="handleCreate"
       @close="showCreateModal = false"
     />

--- a/frontend/src/pages/whatsapp/CallsPage.vue
+++ b/frontend/src/pages/whatsapp/CallsPage.vue
@@ -242,7 +242,7 @@ function selectCall(callId: string) {
 
     <!-- Initiate call modal -->
     <InitiateCallModal
-      v-if="showCallModal"
+      :open="showCallModal"
       :org-id="orgId"
       :phone-numbers="store.phoneNumbers"
       @close="showCallModal = false"


### PR DESCRIPTION
## Summary

- Adds `ResponsiveModal.vue`: shared wrapper that renders a centered overlay on desktop (≥768px) and a full-screen page with back-arrow header + sticky CTA footer on mobile
- Wraps `CreateSessionModal.vue` (voice) and `InitiateCallModal.vue` (WhatsApp) in `ResponsiveModal` — adds `open` prop to each
- Updates `VoiceSessionListPage.vue` and `CallsPage.vue` to pass `:open` prop to their modals
- `ApiKeyListPage.vue`: revoke confirmation renders as `BottomSheet` on mobile, desktop centered dialog unchanged
- `KBListPage.vue`: archive/delete confirmation renders as `BottomSheet` on mobile

Closes #223

## Test plan

- [ ] Desktop: form modals open as centered overlays, confirm dialogs unchanged
- [ ] Mobile: form modals open full-screen with back arrow and sticky CTA
- [ ] Mobile: revoke/archive confirmations slide up as bottom sheets
- [ ] Bottom sheet: destructive action on top (red), cancel below (slate)
- [ ] All 143 unit tests pass
- [ ] Build clean, ESLint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added responsive modal component that automatically adapts between desktop and mobile layouts.
  * Mobile users now see full-screen modals and bottom sheets for confirmations, providing better mobile experience.

* **Refactor**
  * Updated voice session, WhatsApp call, API key, and knowledge base modals to use new responsive patterns for improved consistency across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->