### PR TITLE
feat(mobile): table-to-card views for list pages (#222)

### DIFF
--- a/frontend/src/pages/apikeys/ApiKeyListPage.vue
+++ b/frontend/src/pages/apikeys/ApiKeyListPage.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted, computed } from 'vue'
 import { useApiKeysStore } from '../../stores/apikeys'
+import { useMobile } from '../../composables/useMediaQuery'
 import { pipe, split, map, filter, isTruthy } from 'remeda'
 import { useMobile } from '../../composables/useMediaQuery'
 
@@ -110,6 +111,11 @@ function dismissNewKeyBanner() {
   newRawKey.value = ''
   store.clearLastCreatedKey()
 }
+
+function mobileStatusClass(status: string): string {
+  if (status === 'active') return 'bg-green-900 text-green-300'
+  return 'bg-red-900 text-red-300'
+}
 </script>
 
 <template>
@@ -201,8 +207,8 @@ function dismissNewKeyBanner() {
       <p class="text-gray-500">No API keys yet. Create one to get started.</p>
     </div>
 
-    <!-- Keys table -->
-    <div v-else class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+    <!-- Desktop: Keys table -->
+    <div v-else-if="!isMobile" class="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
       <table class="min-w-full divide-y divide-gray-200">
         <thead class="bg-gray-50">
           <tr>
@@ -254,6 +260,41 @@ function dismissNewKeyBanner() {
           </tr>
         </tbody>
       </table>
+    </div>
+
+    <!-- Mobile: card list -->
+    <div v-else class="space-y-3">
+      <div
+        v-for="key in store.keys"
+        :key="key.id"
+        class="bg-slate-800 rounded-xl p-3.5"
+      >
+        <!-- Header: name + status badge -->
+        <div class="flex items-start justify-between gap-2">
+          <span class="text-white font-semibold text-[15px] truncate">{{ key.name }}</span>
+          <span
+            class="shrink-0 inline-block rounded-full px-2 py-0.5 text-xs font-medium"
+            :class="mobileStatusClass(key.status)"
+          >
+            {{ key.status }}
+          </span>
+        </div>
+
+        <!-- Masked key -->
+        <p class="font-mono text-xs text-slate-400 mt-1">{{ key.key_prefix }}••••••••</p>
+
+        <!-- Action row -->
+        <div class="border-t border-slate-700 mt-2.5 pt-2.5 flex items-center justify-between">
+          <span class="text-slate-500 text-xs">{{ formatDate(key.created_at) }}</span>
+          <button
+            v-if="key.status === 'active'"
+            class="border border-red-500 text-red-400 text-xs px-3 py-1 rounded-lg"
+            @click="promptRevoke(key.id, key.name)"
+          >
+            Revoke
+          </button>
+        </div>
+      </div>
     </div>
 
     <!-- Create API Key Dialog (modal overlay) -->

--- a/frontend/src/pages/knowledge-bases/KBListPage.vue
+++ b/frontend/src/pages/knowledge-bases/KBListPage.vue
@@ -48,6 +48,12 @@ function statusColor(status: string): string {
     ? 'bg-green-100 text-green-800'
     : 'bg-gray-100 text-gray-600'
 }
+
+function mobileStatusClass(status: string): string {
+  if (status === 'active') return 'bg-green-900 text-green-300'
+  if (status === 'archived') return 'bg-slate-700 text-slate-300'
+  return 'bg-amber-900 text-amber-300'
+}
 </script>
 
 <template>
@@ -88,8 +94,8 @@ function statusColor(status: string): string {
       No knowledge bases yet. Create one above.
     </div>
 
-    <!-- KB cards grid -->
-    <div v-else class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+    <!-- Desktop: KB cards grid -->
+    <div v-else-if="!isMobile" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
       <div
         v-for="kb in store.knowledgeBases"
         :key="kb.id"
@@ -124,6 +130,50 @@ function statusColor(status: string): string {
         <p class="mt-2 text-xs text-gray-400">
           Updated {{ new Date(kb.updated_at).toLocaleDateString() }}
         </p>
+      </div>
+    </div>
+
+    <!-- Mobile: card list -->
+    <div v-else class="space-y-3">
+      <div
+        v-for="kb in store.knowledgeBases"
+        :key="kb.id"
+        class="bg-slate-800 rounded-xl p-3.5 cursor-pointer"
+        @click="openKB(kb.id)"
+      >
+        <!-- Header row: title + status badge -->
+        <div class="flex items-start justify-between gap-2">
+          <span class="text-white font-semibold text-[15px] truncate">{{ kb.name }}</span>
+          <span
+            class="shrink-0 inline-block rounded-full px-2 py-0.5 text-xs font-medium"
+            :class="mobileStatusClass(kb.status)"
+          >
+            {{ kb.status }}
+          </span>
+        </div>
+
+        <!-- Subtitle: doc count -->
+        <p class="text-slate-400 text-xs mt-1">
+          {{ kb.doc_count }} document{{ kb.doc_count === 1 ? '' : 's' }}
+        </p>
+
+        <!-- Metadata -->
+        <p class="text-slate-500 text-xs mt-2">
+          Updated {{ new Date(kb.updated_at).toLocaleDateString() }}
+        </p>
+
+        <!-- Action row -->
+        <div
+          v-if="kb.status === 'active'"
+          class="border-t border-slate-700 mt-2.5 pt-2.5 flex justify-end"
+        >
+          <button
+            class="text-red-400 text-xs"
+            @click.stop="handleArchive(kb.id)"
+          >
+            Archive
+          </button>
+        </div>
       </div>
     </div>
 

--- a/frontend/src/pages/llm-providers/LlmProviderListPage.vue
+++ b/frontend/src/pages/llm-providers/LlmProviderListPage.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import { useLlmProvidersStore } from '../../stores/llm-providers'
+import { useMobile } from '../../composables/useMediaQuery'
 import { PROVIDER_MODELS, type ProviderType, type CreateLlmProviderRequest } from '../../api/llm-providers'
 
 const store = useLlmProvidersStore()
+const { isMobile } = useMobile()
 const orgId = 'org-456' // TODO: get from auth store / route
 
 const showCreateDialog = ref(false)
@@ -80,6 +82,15 @@ function statusColor(status: string) {
   return status === 'active' ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-600'
 }
 
+function mobileStatusClass(status: string): string {
+  if (status === 'active') return 'bg-green-900 text-green-300'
+  return 'bg-slate-700 text-slate-300'
+}
+
+function modelCountForProvider(providerType: ProviderType): number {
+  return (PROVIDER_MODELS[providerType] ?? []).length
+}
+
 onMounted(() => store.fetchProviders(orgId))
 </script>
 
@@ -99,7 +110,8 @@ onMounted(() => store.fetchProviders(orgId))
       <button class="mt-2 text-sm text-indigo-600 hover:underline" @click="showCreateDialog = true">Add your first provider</button>
     </div>
 
-    <div v-else class="space-y-4">
+    <!-- Desktop: full provider cards -->
+    <div v-else-if="!isMobile" class="space-y-4">
       <div v-for="provider in store.providers" :key="provider.id" class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
         <div class="flex items-start justify-between">
           <div>
@@ -132,6 +144,55 @@ onMounted(() => store.fetchProviders(orgId))
         <div v-if="testResult[provider.id]" class="mt-2 rounded px-3 py-2 text-sm" :class="testResult[provider.id].success ? 'bg-green-50 text-green-800' : 'bg-red-50 text-red-800'">
           {{ testResult[provider.id].message }}
           <span v-if="testResult[provider.id].latency_ms"> ({{ testResult[provider.id].latency_ms }}ms)</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Mobile: compact card list -->
+    <div v-else class="space-y-3">
+      <div
+        v-for="provider in store.providers"
+        :key="provider.id"
+        class="bg-slate-800 rounded-xl p-3.5"
+      >
+        <!-- Header: name + status badge -->
+        <div class="flex items-start justify-between gap-2">
+          <span class="text-white font-semibold text-[15px] truncate">{{ provider.display_name }}</span>
+          <span
+            class="shrink-0 inline-block rounded-full px-2 py-0.5 text-xs font-medium"
+            :class="mobileStatusClass(provider.status)"
+          >
+            {{ provider.status }}
+          </span>
+        </div>
+
+        <!-- Subtitle: model count -->
+        <p class="text-slate-400 text-xs mt-1">
+          {{ modelCountForProvider(provider.provider_type) }} model{{ modelCountForProvider(provider.provider_type) === 1 ? '' : 's' }}
+          &bull; {{ provider.provider_type.toUpperCase() }}
+        </p>
+
+        <!-- Test result (if present) -->
+        <div v-if="testResult[provider.id]" class="mt-2 rounded px-3 py-2 text-xs" :class="testResult[provider.id].success ? 'bg-green-900 text-green-300' : 'bg-red-900 text-red-300'">
+          {{ testResult[provider.id].message }}
+          <span v-if="testResult[provider.id].latency_ms"> ({{ testResult[provider.id].latency_ms }}ms)</span>
+        </div>
+
+        <!-- Action row -->
+        <div class="border-t border-slate-700 mt-2.5 pt-2.5 flex items-center justify-end gap-2">
+          <button
+            class="border border-slate-600 text-slate-300 text-xs px-3 py-1 rounded-lg disabled:opacity-50"
+            :disabled="testingId === provider.id"
+            @click="handleTest(provider.id)"
+          >
+            {{ testingId === provider.id ? 'Testing...' : 'Test' }}
+          </button>
+          <button
+            class="border border-red-500 text-red-400 text-xs px-3 py-1 rounded-lg"
+            @click="confirmDelete(provider.id, provider.display_name)"
+          >
+            Delete
+          </button>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/voice/VoiceSessionListPage.vue
+++ b/frontend/src/pages/voice/VoiceSessionListPage.vue
@@ -2,12 +2,14 @@
 import { onMounted, ref, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useVoiceSessionsStore } from '../../stores/voice-sessions'
+import { useMobile } from '../../composables/useMediaQuery'
 import VoiceStatusBadge from '../../components/voice/VoiceStatusBadge.vue'
 import CreateSessionModal from '../../components/voice/CreateSessionModal.vue'
 
 const route = useRoute()
 const router = useRouter()
 const store = useVoiceSessionsStore()
+const { isMobile } = useMobile()
 
 const orgId = route.params.orgId as string
 const showCreateModal = ref(false)
@@ -49,6 +51,12 @@ function formatDuration(seconds?: number): string {
   const s = seconds % 60
   return `${m}m ${s}s`
 }
+
+function mobileStateClass(state: string): string {
+  if (state === 'active') return 'bg-green-900 text-green-300'
+  if (state === 'created') return 'bg-amber-900 text-amber-300'
+  return 'bg-slate-700 text-slate-300'
+}
 </script>
 
 <template>
@@ -77,8 +85,8 @@ function formatDuration(seconds?: number): string {
       No voice sessions yet. Create one to get started.
     </div>
 
-    <!-- Sessions table -->
-    <div v-else class="overflow-x-auto">
+    <!-- Desktop: Sessions table -->
+    <div v-else-if="!isMobile" class="overflow-x-auto">
       <table class="w-full border-collapse">
         <thead>
           <tr
@@ -114,6 +122,55 @@ function formatDuration(seconds?: number): string {
       </table>
 
       <!-- Pagination -->
+      <div class="mt-4 flex items-center justify-between">
+        <p class="text-sm text-gray-400">
+          {{ store.total }} session{{ store.total === 1 ? '' : 's' }} total
+        </p>
+        <div v-if="totalPages > 1" class="flex gap-1">
+          <button
+            v-for="page in totalPages"
+            :key="page"
+            :disabled="page - 1 === currentPage"
+            :class="[
+              'min-h-[44px] min-w-[44px] rounded-md px-3 py-1 text-sm',
+              page - 1 === currentPage
+                ? 'bg-indigo-600 text-white'
+                : 'bg-gray-100 text-gray-700 hover:bg-gray-200',
+            ]"
+            @click="goToPage(page - 1)"
+          >
+            {{ page }}
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Mobile: card list -->
+    <div v-else class="space-y-3">
+      <div
+        v-for="session in store.sessions"
+        :key="session.id"
+        class="bg-slate-800 rounded-xl p-3.5 cursor-pointer"
+        @click="openSession(session.id)"
+      >
+        <!-- Header: session name + state badge -->
+        <div class="flex items-start justify-between gap-2">
+          <span class="text-white font-semibold text-[15px] truncate">{{ session.livekit_room }}</span>
+          <span
+            class="shrink-0 inline-block rounded-full px-2 py-0.5 text-xs font-medium capitalize"
+            :class="mobileStateClass(session.state)"
+          >
+            {{ session.state }}
+          </span>
+        </div>
+
+        <!-- Metadata -->
+        <p class="text-slate-500 text-xs mt-2">
+          {{ formatDuration(session.call_duration_seconds) }} &bull; {{ formatDate(session.created_at) }}
+        </p>
+      </div>
+
+      <!-- Pagination (mobile) -->
       <div class="mt-4 flex items-center justify-between">
         <p class="text-sm text-gray-400">
           {{ store.total }} session{{ store.total === 1 ? '' : 's' }} total

--- a/frontend/src/pages/whatsapp/CallsPage.vue
+++ b/frontend/src/pages/whatsapp/CallsPage.vue
@@ -56,6 +56,24 @@ function stateClasses(state: string) {
   }
 }
 
+function mobileCardBorderClass(state: string): string {
+  if (state === 'connected' || state === 'active') return 'border-l-4 border-green-500'
+  if (state === 'ringing') return 'border-l-4 border-blue-500'
+  return 'border-l-4 border-slate-600'
+}
+
+function mobileStateBadgeClass(state: string): string {
+  if (state === 'connected' || state === 'active') return 'bg-green-900 text-green-300'
+  if (state === 'ringing') return 'bg-blue-900 text-blue-300'
+  return 'bg-slate-700 text-slate-300'
+}
+
+function mobileStateBadgeLabel(state: string): string {
+  if (state === 'connected' || state === 'active') return 'LIVE'
+  if (state === 'ringing') return 'RING'
+  return 'END'
+}
+
 function handleCallStarted() {
   showCallModal.value = false
 }
@@ -132,7 +150,8 @@ function selectCall(callId: string) {
         <div
           v-for="call in filteredCalls"
           :key="call.id"
-          class="rounded-lg border border-gray-200 p-4 cursor-pointer hover:bg-gray-50"
+          class="rounded-lg border border-gray-200 bg-slate-800 p-4 cursor-pointer hover:bg-slate-700"
+          :class="mobileCardBorderClass(call.state)"
           @click="selectCall(call.id)"
         >
           <div class="flex items-center gap-2 mb-2">
@@ -146,20 +165,20 @@ function selectCall(callId: string) {
             </span>
             <span
               :class="[
-                'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium capitalize',
-                stateClasses(call.state),
+                'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium uppercase',
+                mobileStateBadgeClass(call.state),
               ]"
             >
-              {{ call.state }}
+              {{ mobileStateBadgeLabel(call.state) }}
             </span>
           </div>
-          <p class="text-sm font-medium">
+          <p class="text-sm font-medium text-white">
             {{ call.caller }} &rarr; {{ call.callee }}
           </p>
-          <p class="text-xs text-gray-400 mt-1">
+          <p class="text-xs text-slate-400 mt-1">
             {{ new Date(call.created_at).toLocaleString() }}
           </p>
-          <p v-if="call.duration_seconds != null" class="text-xs text-gray-400">
+          <p v-if="call.duration_seconds != null" class="text-xs text-slate-400">
             Duration: {{ call.duration_seconds }}s
           </p>
         </div>

--- a/frontend/src/pages/workspaces/WorkspaceListPage.vue
+++ b/frontend/src/pages/workspaces/WorkspaceListPage.vue
@@ -81,8 +81,8 @@ async function handleDelete(wsId: string) {
       No workspaces yet. Create one above.
     </div>
 
-    <!-- Workspace table -->
-    <table v-else class="w-full border-collapse">
+    <!-- Desktop: Workspace table -->
+    <table v-else-if="!isMobile" class="w-full border-collapse">
       <thead>
         <tr class="border-b border-gray-200 text-left text-sm font-medium text-gray-500">
           <th class="pb-3 pr-4">Name</th>
@@ -114,6 +114,35 @@ async function handleDelete(wsId: string) {
         </tr>
       </tbody>
     </table>
+
+    <!-- Mobile: card list -->
+    <div v-else class="space-y-3">
+      <div
+        v-for="ws in store.workspaces"
+        :key="ws.id"
+        class="bg-slate-800 rounded-xl p-3.5 cursor-pointer flex items-center gap-3"
+        @click="openWorkspace(ws.id)"
+      >
+        <!-- Colored initial avatar -->
+        <div
+          class="shrink-0 flex items-center justify-center rounded-lg bg-indigo-600 text-white font-semibold text-lg"
+          style="width:40px;height:40px"
+        >
+          {{ ws.name.charAt(0).toUpperCase() }}
+        </div>
+
+        <!-- Content -->
+        <div class="flex-1 min-w-0">
+          <p class="text-white font-semibold text-[15px] truncate">{{ ws.name }}</p>
+          <p class="text-slate-400 text-xs mt-0.5">
+            {{ ws.slug }}
+          </p>
+        </div>
+
+        <!-- Chevron -->
+        <span class="text-slate-500 text-lg shrink-0">›</span>
+      </div>
+    </div>
 
     <!-- Total count -->
     <p v-if="store.workspaces.length > 0" class="mt-4 text-sm text-gray-400">


### PR DESCRIPTION
## Summary

All list pages now conditionally render stacked cards (mobile) or the existing table (desktop) based on \`useMobile()\`.

- **KBListPage**: status badge (active=green, archived=slate), archive action row
- **WorkspaceListPage**: indigo initial avatar, slug subtitle, chevron drill-down; whole card is a link
- **ApiKeyListPage**: monospace masked key subtitle, created date + Revoke button in action row
- **VoiceSessionListPage**: state badge, duration + timestamp metadata, taps navigate to session detail; pagination preserved for mobile
- **CallsPage**: refined existing cards — `border-l-4` color coding (green=LIVE, blue=RING, slate=END), updated LIVE/RING/END badges
- **LlmProviderListPage**: provider name + status badge, model count subtitle, test/delete action row

No shared DataCard component — each page renders its own markup inline per spec.

Closes #222

## Test plan

- [ ] Each list page: desktop shows table, mobile (<768px) shows cards
- [ ] CallsPage: live calls get green left border, ringing get blue, ended get slate
- [ ] ApiKeyListPage: Revoke button in card triggers same handler as desktop table
- [ ] VoiceSessionListPage: tapping a card navigates to session detail
- [ ] WorkspaceListPage: tapping a card navigates to workspace detail
- [ ] All 143 unit tests pass
- [ ] Build clean, ESLint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mobile-first responsive redesign with fixed bottom tab bar navigation for quick access to key sections
  * Mobile-optimized card-based list views across API keys, knowledge bases, LLM providers, voice sessions, calls, and workspace pages
  * Bottom sheet component for mobile modal interactions and menus

* **Refactor**
  * Updated layout and navigation structure to prioritize mobile experience, replacing sidebar with mobile bottom navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->