### PR TITLE
fix(frontend): remove duplicate useMobile import in ApiKeyListPage

### DIFF
--- a/frontend/src/pages/apikeys/ApiKeyListPage.vue
+++ b/frontend/src/pages/apikeys/ApiKeyListPage.vue
@@ -3,7 +3,6 @@ import { ref, onMounted, computed } from 'vue'
 import { useApiKeysStore } from '../../stores/apikeys'
 import { useMobile } from '../../composables/useMediaQuery'
 import { pipe, split, map, filter, isTruthy } from 'remeda'
-import { useMobile } from '../../composables/useMediaQuery'
 
 const store = useApiKeysStore()
 const { isMobile } = useMobile()


### PR DESCRIPTION
Removes duplicate `useMobile` import introduced when PRs #228 (mobile cards) and #229 (form adaptations) both added the import to ApiKeyListPage.vue independently.