### PR TITLE
test(e2e): Playwright mobile viewport tests for critical flows (#225)

### DIFF
--- a/frontend/e2e/mobile/calls.spec.ts
+++ b/frontend/e2e/mobile/calls.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '../fixtures'
+
+test.describe('Mobile: Call list renders cards', () => {
+  test('Calls tab navigates to the calls URL', async ({ adminPage: page }) => {
+    await page.goto('/dashboard')
+    await page.getByRole('link', { name: 'Calls' }).click()
+    await expect(page).toHaveURL(/\/whatsapp\/calls/, { timeout: 10000 })
+  })
+
+  test('calls page shows cards not table on mobile', async ({ adminPage: page }) => {
+    await page.goto('/dashboard')
+    await page.getByRole('link', { name: 'Calls' }).click()
+    await page.waitForURL(/\/whatsapp\/calls/, { timeout: 10000 })
+
+    // Mobile layout must NOT render a <table>
+    await expect(page.locator('table')).not.toBeVisible()
+  })
+
+  test('call card is tappable', async ({ adminPage: page }) => {
+    await page.goto('/dashboard')
+    await page.getByRole('link', { name: 'Calls' }).click()
+    await page.waitForURL(/\/whatsapp\/calls/, { timeout: 10000 })
+
+    const firstCard = page.locator('[data-testid="call-card"]').first()
+    if (await firstCard.isVisible()) {
+      const box = await firstCard.boundingBox()
+      expect(box).not.toBeNull()
+      expect(box!.height).toBeGreaterThanOrEqual(44)
+    }
+  })
+})

--- a/frontend/e2e/mobile/login.spec.ts
+++ b/frontend/e2e/mobile/login.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test'
+
+// Abort Keycloak requests so keycloak.init() resolves as unauthenticated
+test.beforeEach(async ({ page }) => {
+  await page.route('**/realms/**', (route) => route.abort())
+})
+
+test.describe('Mobile: Login page', () => {
+  test('renders without horizontal scroll at 390px', async ({ page }) => {
+    await page.goto('/login')
+    await expect(page.getByRole('button', { name: 'Login' })).toBeVisible({ timeout: 15000 })
+
+    const scrollWidth = await page.evaluate(() => document.documentElement.scrollWidth)
+    const clientWidth = await page.evaluate(() => document.documentElement.clientWidth)
+    expect(scrollWidth).toBeLessThanOrEqual(clientWidth)
+  })
+
+  test('login button meets 44px touch target', async ({ page }) => {
+    await page.goto('/login')
+    const btn = page.getByRole('button', { name: 'Login' })
+    await expect(btn).toBeVisible({ timeout: 15000 })
+
+    const box = await btn.boundingBox()
+    expect(box).not.toBeNull()
+    expect(box!.height).toBeGreaterThanOrEqual(44)
+    expect(box!.width).toBeGreaterThanOrEqual(44)
+  })
+})

--- a/frontend/e2e/mobile/navigation.spec.ts
+++ b/frontend/e2e/mobile/navigation.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '../fixtures'
+
+test.describe('Mobile: Bottom tab bar navigation', () => {
+  test('tab bar renders on mobile dashboard', async ({ adminPage: page }) => {
+    await page.goto('/dashboard')
+    // Tab bar nav contains tab labels
+    const tabBar = page.locator('nav').filter({ hasText: 'Home' })
+    await expect(tabBar).toBeVisible({ timeout: 10000 })
+  })
+
+  test('each primary tab meets 44px touch target', async ({ adminPage: page }) => {
+    await page.goto('/dashboard')
+    const tabs = [
+      page.getByRole('link', { name: 'Home' }),
+      page.getByRole('link', { name: 'Voice' }),
+      page.getByRole('link', { name: 'Calls' }),
+      page.getByRole('link', { name: 'Numbers' }),
+      page.getByRole('button', { name: 'More' }),
+    ]
+    for (const tab of tabs) {
+      const box = await tab.first().boundingBox()
+      expect(box, `tab "${await tab.first().textContent()}" bounding box`).not.toBeNull()
+      expect(box!.height).toBeGreaterThanOrEqual(44)
+    }
+  })
+
+  test('"More" button opens bottom sheet with secondary nav items', async ({ adminPage: page }) => {
+    await page.goto('/dashboard')
+    await page.getByRole('button', { name: 'More' }).click()
+    await expect(page.getByText('Knowledge Bases')).toBeVisible({ timeout: 5000 })
+    await expect(page.getByText('API Keys')).toBeVisible()
+  })
+})

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -11,7 +11,16 @@ export default defineConfig({
     trace: 'on-first-retry',
   },
   projects: [
-    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+      testIgnore: 'e2e/mobile/**',
+    },
+    {
+      name: 'mobile-chrome',
+      use: { ...devices['Pixel 7'] },
+      testMatch: 'e2e/mobile/**/*.spec.ts',
+    },
   ],
   webServer: {
     command: process.env.CI ? 'npx vite preview' : 'npm run dev',


### PR DESCRIPTION
Closes #225

Adds Playwright mobile viewport tests using the `Pixel 7` device profile:

- **`e2e/mobile/login.spec.ts`** — runs in CI without auth: no horizontal scroll at 390px, login button meets 44px touch target
- **`e2e/mobile/navigation.spec.ts`** — bottom tab bar renders, each tab meets 44px target, More sheet opens (skips without E2E_ADMIN)
- **`e2e/mobile/calls.spec.ts`** — Calls tab navigates correctly, cards render (not table) on mobile (skips without E2E_ADMIN)

Updated `playwright.config.ts` to add `mobile-chrome` project (Pixel 7). Existing tests remain chromium-only; mobile tests are scoped to `e2e/mobile/**`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added end-to-end mobile browser tests for call list display, login page, and bottom tab navigation to verify mobile-friendly layouts, responsive design, and proper touch target sizing for accessibility and usability.
  * Updated the testing framework configuration to support dedicated mobile device profiles in addition to desktop browser testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->