### PR TITLE
fix(observability): restore OTel log exporter and HTTP structured logging (#235)

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -377,6 +377,7 @@ go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 h1:88Y4s2C8oTui1LGM6bT
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0/go.mod h1:Vl1/iaggsuRlrHf/hfPJPvVag77kKyvrLeD10kpMl+A=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0 h1:RAE+JPfvEmvy+0LzyUA25/SGawPwIUbZ6u0Wug54sLc=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.43.0/go.mod h1:AGmbycVGEsRx9mXMZ75CsOyhSP6MFIcj/6dnG+vhVjk=
+go.opentelemetry.io/otel/log v0.19.0 h1:KUZs/GOsw79TBBMfDWsXS+KZ4g2Ckzksd1ymzsIEbo4=
 go.opentelemetry.io/otel/log v0.19.0/go.mod h1:5DQYeGmxVIr4n0/BcJvF4upsraHjg6vudJJpnkL6Ipk=
 go.opentelemetry.io/otel/metric v1.43.0 h1:d7638QeInOnuwOONPp4JAOGfbCEpYb+K6DVWvdxGzgM=
 go.opentelemetry.io/otel/metric v1.43.0/go.mod h1:RDnPtIxvqlgO8GRW18W6Z/4P462ldprJtfxHxyKd2PY=


### PR DESCRIPTION
## Summary

- Add missing `go.sum` checksum entry for `go.opentelemetry.io/otel/log v0.19.0`, which prevented `go build` from succeeding
- The OTLP log exporter, `logging.go` multi-handler, per-request structured log line in `OTelMiddleware`, OpenObserve gRPC port 5081, and dashboard JSON files were all correctly restored in #209 but the `go.sum` was left incomplete, making the build fail

## Context

Issue #235 reported that several observability components were missing. Investigation showed that PR #209 had already restored all the Go source files, docker-compose config, and dashboards. However, `go.sum` was missing one hash entry for `go.opentelemetry.io/otel/log v0.19.0`, causing build failures with "missing go.sum entry" errors.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/telemetry/...` passes
- [x] `golangci-lint run ./...` passes
- [x] Verified all files mentioned in #235 are present on main

Closes #235