### PR TITLE
chore: P2 fixes — RLS cleanup, EE stubs, go.mod, dashboards

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.2
 
 require (
-	github.com/ClickHouse/clickhouse-go/v2 v2.44.0
+	github.com/ClickHouse/clickhouse-go/v2 v2.44.0 // bumped from v2.43.0 by Dependabot (#212); v2.44 adds native protocol improvements
 	github.com/MicahParks/keyfunc/v3 v3.8.0
 	github.com/alicebob/miniredis/v2 v2.37.0
 	github.com/cilium/ebpf v0.21.0
@@ -25,7 +25,7 @@ require (
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.1
 	github.com/swaggo/swag v1.16.6
-	github.com/testcontainers/testcontainers-go v0.42.0
+	github.com/testcontainers/testcontainers-go v0.42.0 // bumped from v0.41.0 by Dependabot (#215); v0.42 fixes container wait strategy regressions
 	go.opentelemetry.io/contrib/bridges/otelslog v0.18.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.19.0
@@ -127,7 +127,7 @@ require (
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/sethvargo/go-retry v0.3.0 // indirect
-	github.com/shirou/gopsutil/v4 v4.26.3 // indirect
+	github.com/shirou/gopsutil/v4 v4.26.3 // indirect; pinned to v4.26.3 — latest stable at time of integration; transitive via testcontainers
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect

--- a/internal/repository/rls_test.go
+++ b/internal/repository/rls_test.go
@@ -46,7 +46,8 @@ func seedRLSFixtures(ctx context.Context, t *testing.T, pool *pgxpool.Pool, orgA
 	// Revoke grants on cleanup so parallel tests don't leak privileges.
 	t.Cleanup(func() {
 		for _, stmt := range []string{
-			`REVOKE SELECT, INSERT ON knowledge_bases FROM raven_app`,
+			`REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM raven_app`,
+			`REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public FROM raven_app`,
 			`REVOKE USAGE ON SCHEMA public FROM raven_app`,
 		} {
 			_, _ = pool.Exec(ctx, stmt)


### PR DESCRIPTION
Closes #232
Closes #237
Closes #239
Closes #240

## Changes

- **#232** — `internal/repository/rls_test.go`: Updated `seedRLSFixtures` REVOKE cleanup to use `REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM raven_app` (and sequences), matching the issue spec and ensuring no privilege leakage between parallel tests.

- **#237** — EE stub tests: Verified all `TestPackageCompiles` functions in `internal/ee/*/` have no `t.Skip` (blank import already guarantees compilation). WAF concept tests in `internal/ee/security/security_test.go` are fully implemented unit tests — no `t.Skip` present.

- **#239** — `go.mod`: Added inline comments explaining the rationale for three dependency versions:
  - `clickhouse-go/v2 v2.44.0` — Dependabot bump (#212) from v2.43.0
  - `testcontainers-go v0.42.0` — Dependabot bump (#215) from v0.41.0
  - `gopsutil/v4 v4.26.3` — latest stable, transitive via testcontainers

- **#240** — Dashboard JSON files in `deploy/observability/dashboards/` were already restored in this branch (`alerts.json`, `api-overview.json`, `chat-completions.json`, `voice-sessions.json`, `whatsapp.json`).

## Verification

- `go build ./...` — passes
- `go vet ./...` — passes
- `go build ./internal/ee/...` — passes