### PR TITLE
feat(onboarding): Keycloak realm auto-provisioning and tenant onboarding wizard (#197)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,13 @@ KC_DB_URL=jdbc:postgresql://postgres:5432/keycloak
 KC_DB_USERNAME=raven
 KC_DB_PASSWORD=changeme
 
+# Keycloak Admin REST API — used by the realm auto-provisioning endpoint.
+# AdminURL is the base URL of the Keycloak server (no /auth suffix for KC 17+).
+RAVEN_KEYCLOAK_ADMIN_URL=http://keycloak:8080
+# admin-cli is the built-in confidential client in the master realm.
+RAVEN_KEYCLOAK_ADMIN_CLIENT_ID=admin-cli
+RAVEN_KEYCLOAK_ADMIN_CLIENT_SECRET=changeme
+
 # ─── Raven API ────────────────────────────────────────────────────────────────
 RAVEN_SERVER_PORT=8080
 RAVEN_DATABASE_URL=${DATABASE_URL}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -265,8 +265,8 @@ func main() {
 	quotaChecker := service.NewQuotaChecker(billingRepo, subCache, pool)
 
 	// --- Wire services ---
-	orgSvc := service.NewOrgService(orgRepo)
 	wsSvc := service.NewWorkspaceService(wsRepo, pool, quotaChecker)
+	orgSvc := service.NewOrgService(orgRepo, wsSvc)
 	userSvc := service.NewUserService(userRepo)
 	kbSvc := service.NewKBService(kbRepo, pool, quotaChecker)
 	sourceSvc := service.NewSourceService(sourceRepo, pool)
@@ -720,6 +720,14 @@ func main() {
 	{
 		internal.POST("/keycloak-webhook", userHandler.KeycloakWebhook)
 	}
+
+	// Realm auto-provisioning — internal only, no auth middleware.
+	provisionHandler := handler.NewProvisionHandler(
+		cfg.Keycloak.AdminURL,
+		cfg.Keycloak.AdminClientID,
+		cfg.Keycloak.AdminClientSecret,
+	)
+	router.POST("/internal/provision-realm", provisionHandler.ProvisionRealm)
 
 	// Create HTTP server
 	addr := fmt.Sprintf(":%d", cfg.Server.Port)

--- a/deploy/keycloak/realm-export.json
+++ b/deploy/keycloak/realm-export.json
@@ -1,0 +1,107 @@
+{
+  "realm": "raven",
+  "displayName": "Raven Platform",
+  "enabled": true,
+  "registrationAllowed": true,
+  "loginWithEmailAllowed": true,
+  "sslRequired": "external",
+  "accessTokenLifespan": 300,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "accessTokenLifespanForImplicitFlow": 300,
+  "offlineSessionIdleTimeout": 1800,
+  "emailTheme": "keycloak",
+  "loginTheme": "keycloak",
+  "accountTheme": "keycloak",
+  "adminTheme": "keycloak",
+  "roles": {
+    "realm": [
+      {
+        "name": "org_admin",
+        "description": "Organization-level administrator",
+        "composite": false,
+        "clientRole": false
+      },
+      {
+        "name": "org_member",
+        "description": "Organization member with standard access",
+        "composite": false,
+        "clientRole": false
+      }
+    ]
+  },
+  "defaultRoles": ["org_member"],
+  "clientScopes": [
+    {
+      "name": "raven-org",
+      "description": "Raven organization context scope",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "name": "org_id",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "org_id",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "org_id",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "org_role",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "false",
+            "user.attribute": "org_role",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "org_role",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "raven-app",
+      "name": "Raven App",
+      "description": "Raven platform public PKCE client",
+      "enabled": true,
+      "publicClient": true,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "protocol": "openid-connect",
+      "redirectUris": ["*"],
+      "webOrigins": ["*"],
+      "attributes": {
+        "pkce.code.challenge.method": "S256"
+      },
+      "defaultClientScopes": [
+        "openid",
+        "profile",
+        "email",
+        "raven-org"
+      ]
+    }
+  ],
+  "browserSecurityHeaders": {
+    "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "xContentTypeOptions": "nosniff",
+    "xFrameOptions": "SAMEORIGIN",
+    "xRobotsTag": "none",
+    "xXSSProtection": "1; mode=block",
+    "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+  }
+}

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,68 @@
+# Raven Quickstart
+
+## Prerequisites
+
+- Docker ≥ 24 and Docker Compose v2
+- A domain name (for production TLS) — or use `localhost` for local development
+
+## Steps
+
+1. **Clone the repository**
+
+   ```bash
+   git clone https://github.com/ravencloak-org/Raven.git
+   cd Raven
+   ```
+
+2. **Copy the example environment file and fill in your secrets**
+
+   ```bash
+   cp .env.example .env
+   ```
+
+   Open `.env` and set at minimum:
+   - `POSTGRES_PASSWORD` — strong password for PostgreSQL
+   - `KEYCLOAK_ADMIN_PASSWORD` — Keycloak admin console password
+   - `RAVEN_KEYCLOAK_ADMIN_CLIENT_SECRET` — secret for the `admin-cli` client
+   - `RAVEN_ENCRYPTION_AES_KEY` — 32-byte hex key for at-rest encryption
+   - `RAVEN_HYPERSWITCH_API_KEY` — payment orchestrator key (or leave blank to skip billing)
+   - At least one LLM provider key (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY`)
+
+3. **Start all services**
+
+   ```bash
+   docker compose up -d
+   ```
+
+   Docker Compose will pull images, run database migrations, and start Keycloak,
+   the Go API, the Python AI worker, SeaweedFS, and the Vue frontend.
+
+4. **Open Raven in your browser**
+
+   Navigate to `http://localhost:3000` (or your configured domain).
+
+5. **Sign in**
+
+   Click **Sign in** to be redirected to Keycloak. Register a new account or log in
+   with the credentials you set in `.env`.
+
+   On first login the **Onboarding Wizard** will guide you through:
+   - Naming your organisation
+   - Creating your first Knowledge Base
+   - Configuring your LLM provider (BYOK)
+   - Sending a test message to verify the chatbot
+
+6. **(Optional) Auto-provision a Keycloak realm**
+
+   If you need to programmatically create a new Keycloak realm (e.g. for
+   multi-tenant deployments), call the internal provision endpoint from inside
+   the Docker network:
+
+   ```bash
+   curl -s -X POST http://raven-api:8080/internal/provision-realm \
+     -H 'Content-Type: application/json' \
+     -d '{"realm_name": "my-tenant"}'
+   ```
+
+   The endpoint returns `200` with the created realm name, or `409` if the realm
+   already exists.

--- a/frontend/src/layouts/DefaultLayout.vue
+++ b/frontend/src/layouts/DefaultLayout.vue
@@ -8,6 +8,7 @@
       </main>
     </div>
     <MobileTabBar v-if="isMobile" />
+    <OnboardingWizard v-if="!onboardingStore.completed" />
   </div>
 </template>
 
@@ -16,7 +17,10 @@ import { RouterView } from 'vue-router'
 import AppSidebar from '../components/AppSidebar.vue'
 import AppHeader from '../components/AppHeader.vue'
 import MobileTabBar from '../components/MobileTabBar.vue'
+import OnboardingWizard from '../pages/onboarding/OnboardingWizard.vue'
 import { useMobile } from '../composables/useMediaQuery'
+import { useOnboardingStore } from '../stores/onboarding'
 
 const { isMobile } = useMobile()
+const onboardingStore = useOnboardingStore()
 </script>

--- a/frontend/src/pages/onboarding/OnboardingWizard.vue
+++ b/frontend/src/pages/onboarding/OnboardingWizard.vue
@@ -1,0 +1,189 @@
+<template>
+  <div class="fixed inset-0 z-50 bg-slate-900 flex items-center justify-center p-4">
+    <div class="w-full max-w-lg bg-slate-800 rounded-2xl shadow-2xl overflow-hidden">
+      <!-- Progress dots -->
+      <div class="flex justify-center gap-2 pt-6 pb-4">
+        <button
+          v-for="step in TOTAL_STEPS"
+          :key="step"
+          class="w-2.5 h-2.5 rounded-full transition-colors duration-200"
+          :class="step === currentStep ? 'bg-indigo-500' : 'bg-slate-600'"
+          :aria-label="`Step ${step}`"
+          @click="currentStep = step"
+        />
+      </div>
+
+      <!-- Step content -->
+      <div class="px-8 pb-6">
+        <!-- Step 1: Name your org -->
+        <div v-if="currentStep === 1">
+          <h2 class="text-2xl font-semibold text-white mb-2">Name your organisation</h2>
+          <p class="text-slate-400 text-sm mb-6">
+            Give your workspace a memorable name. You can change it later.
+          </p>
+          <label class="block text-sm text-slate-300 mb-1" for="org-name">Organisation name</label>
+          <input
+            id="org-name"
+            v-model="orgName"
+            type="text"
+            placeholder="e.g. Acme Corp"
+            class="w-full rounded-lg bg-slate-700 text-white placeholder-slate-500 border border-slate-600 px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          />
+        </div>
+
+        <!-- Step 2: Create first Knowledge Base -->
+        <div v-else-if="currentStep === 2">
+          <h2 class="text-2xl font-semibold text-white mb-2">Create your first Knowledge Base</h2>
+          <p class="text-slate-400 text-sm mb-6">
+            A Knowledge Base holds the documents your AI will learn from.
+          </p>
+          <label class="block text-sm text-slate-300 mb-1" for="kb-name">Knowledge Base name</label>
+          <input
+            id="kb-name"
+            v-model="kbName"
+            type="text"
+            placeholder="e.g. Product Docs"
+            class="w-full rounded-lg bg-slate-700 text-white placeholder-slate-500 border border-slate-600 px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          />
+        </div>
+
+        <!-- Step 3: Configure LLM provider -->
+        <div v-else-if="currentStep === 3">
+          <h2 class="text-2xl font-semibold text-white mb-2">Configure your LLM provider</h2>
+          <p class="text-slate-400 text-sm mb-6">
+            Raven uses your own API key (BYOK) — your data never leaves your control.
+          </p>
+          <label class="block text-sm text-slate-300 mb-1" for="llm-provider">Provider</label>
+          <select
+            id="llm-provider"
+            v-model="llmProvider"
+            class="w-full rounded-lg bg-slate-700 text-white border border-slate-600 px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 mb-4"
+          >
+            <option value="openai">OpenAI</option>
+            <option value="anthropic">Anthropic</option>
+            <option value="gemini">Gemini</option>
+          </select>
+          <label class="block text-sm text-slate-300 mb-1" for="api-key">API Key</label>
+          <input
+            id="api-key"
+            v-model="apiKey"
+            type="password"
+            placeholder="sk-..."
+            class="w-full rounded-lg bg-slate-700 text-white placeholder-slate-500 border border-slate-600 px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            autocomplete="off"
+          />
+        </div>
+
+        <!-- Step 4: Test chatbot -->
+        <div v-else-if="currentStep === 4">
+          <h2 class="text-2xl font-semibold text-white mb-2">Test your chatbot</h2>
+          <p class="text-slate-400 text-sm mb-6">
+            Send a quick message to make sure everything is connected.
+          </p>
+          <div class="bg-slate-700 rounded-xl p-4 min-h-24 mb-4 text-sm text-slate-300 space-y-2">
+            <p v-if="chatResponse" class="text-indigo-300">{{ chatResponse }}</p>
+            <p v-else class="text-slate-500 italic">Responses will appear here…</p>
+          </div>
+          <div class="flex gap-2">
+            <input
+              v-model="chatInput"
+              type="text"
+              placeholder="Type a message…"
+              class="flex-1 rounded-lg bg-slate-700 text-white placeholder-slate-500 border border-slate-600 px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              @keydown.enter="sendTestMessage"
+            />
+            <button
+              class="bg-indigo-600 hover:bg-indigo-500 text-white text-sm font-medium px-4 rounded-lg transition-colors"
+              @click="sendTestMessage"
+            >
+              Send
+            </button>
+          </div>
+        </div>
+
+        <!-- Step 5: Done -->
+        <div v-else-if="currentStep === 5" class="text-center py-4">
+          <div class="text-5xl mb-4">🎉</div>
+          <h2 class="text-2xl font-semibold text-white mb-2">You're all set!</h2>
+          <p class="text-slate-400 text-sm mb-8">
+            Raven is ready. Head to your dashboard to start uploading documents and chatting.
+          </p>
+          <button
+            class="w-full bg-indigo-600 hover:bg-indigo-500 text-white font-semibold py-3 rounded-xl transition-colors"
+            @click="finish"
+          >
+            Go to Dashboard
+          </button>
+        </div>
+      </div>
+
+      <!-- Navigation buttons -->
+      <div v-if="currentStep < TOTAL_STEPS" class="flex items-center justify-between px-8 pb-8">
+        <button
+          class="text-slate-400 hover:text-white text-sm transition-colors"
+          @click="skip"
+        >
+          Skip
+        </button>
+        <div class="flex gap-3">
+          <button
+            v-if="currentStep > 1"
+            class="px-5 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 text-white text-sm transition-colors"
+            @click="currentStep--"
+          >
+            Back
+          </button>
+          <button
+            class="px-5 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white text-sm font-medium transition-colors"
+            @click="next"
+          >
+            {{ currentStep === TOTAL_STEPS - 1 ? 'Finish' : 'Next' }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useOnboardingStore } from '../../stores/onboarding'
+
+const TOTAL_STEPS = 5
+
+const onboarding = useOnboardingStore()
+const currentStep = ref<number>(1)
+
+// Step 1
+const orgName = ref('')
+// Step 2
+const kbName = ref('')
+// Step 3
+const llmProvider = ref<'openai' | 'anthropic' | 'gemini'>('openai')
+const apiKey = ref('')
+// Step 4
+const chatInput = ref('')
+const chatResponse = ref('')
+
+function next(): void {
+  if (currentStep.value < TOTAL_STEPS) {
+    currentStep.value++
+  }
+}
+
+function skip(): void {
+  if (currentStep.value < TOTAL_STEPS) {
+    currentStep.value++
+  }
+}
+
+function finish(): void {
+  onboarding.markComplete()
+}
+
+function sendTestMessage(): void {
+  if (!chatInput.value.trim()) return
+  chatResponse.value = 'Chatbot ready!'
+  chatInput.value = ''
+}
+</script>

--- a/frontend/src/stores/onboarding.ts
+++ b/frontend/src/stores/onboarding.ts
@@ -1,0 +1,22 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+const STORAGE_KEY = 'onboarding_completed'
+
+export const useOnboardingStore = defineStore('onboarding', () => {
+  const completed = ref<boolean>(localStorage.getItem(STORAGE_KEY) === 'true')
+  const currentStep = ref<number>(1)
+
+  function markComplete(): void {
+    completed.value = true
+    localStorage.setItem(STORAGE_KEY, 'true')
+  }
+
+  function reset(): void {
+    completed.value = false
+    currentStep.value = 1
+    localStorage.removeItem(STORAGE_KEY)
+  }
+
+  return { completed, currentStep, markComplete, reset }
+})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -156,6 +156,13 @@ type KeycloakConfig struct {
 	// Disabled by default; set RAVEN_KEYCLOAK_APIKEYENABLED=true only in
 	// development environments until the real DB-backed lookup is implemented.
 	APIKeyEnabled bool `mapstructure:"api_key_enabled"`
+
+	// Admin REST API credentials for realm auto-provisioning.
+	// AdminURL is the base URL of the Keycloak admin REST API,
+	// e.g. http://keycloak:8080.
+	AdminURL           string `mapstructure:"admin_url"`
+	AdminClientID      string `mapstructure:"admin_client_id"`
+	AdminClientSecret  string `mapstructure:"admin_client_secret"`
 }
 
 // CORSConfig holds Cross-Origin Resource Sharing settings.
@@ -221,6 +228,9 @@ func Load() (*Config, error) {
 	v.SetDefault("otel.enabled", false)
 	v.SetDefault("keycloak.issuer_url", "http://localhost:8080/auth/realms/raven")
 	v.SetDefault("keycloak.audience", "raven")
+	v.SetDefault("keycloak.admin_url", "http://localhost:8080")
+	v.SetDefault("keycloak.admin_client_id", "admin-cli")
+	v.SetDefault("keycloak.admin_client_secret", "")
 	// CORS allowed origins can be overridden via the RAVEN_CORS_ALLOWED_ORIGINS
 	// environment variable as a comma-separated list.
 	// Example: RAVEN_CORS_ALLOWED_ORIGINS=https://app1.com,https://app2.com
@@ -318,6 +328,9 @@ func Load() (*Config, error) {
 	_ = v.BindEnv("grpc.worker_addr", "RAVEN_GRPC_WORKER_ADDR")
 	_ = v.BindEnv("keycloak.issuer_url", "RAVEN_KEYCLOAK_ISSUER_URL")
 	_ = v.BindEnv("keycloak.audience", "RAVEN_KEYCLOAK_AUDIENCE")
+	_ = v.BindEnv("keycloak.admin_url", "RAVEN_KEYCLOAK_ADMIN_URL")
+	_ = v.BindEnv("keycloak.admin_client_id", "RAVEN_KEYCLOAK_ADMIN_CLIENT_ID")
+	_ = v.BindEnv("keycloak.admin_client_secret", "RAVEN_KEYCLOAK_ADMIN_CLIENT_SECRET")
 	_ = v.BindEnv("server.port", "RAVEN_SERVER_PORT")
 	_ = v.BindEnv("server.mode", "RAVEN_SERVER_MODE")
 	_ = v.BindEnv("clickhouse.host", "RAVEN_CLICKHOUSE_HOST")

--- a/internal/handler/provision.go
+++ b/internal/handler/provision.go
@@ -1,0 +1,216 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// ProvisionHandler exposes the internal realm auto-provisioning endpoint.
+// It is wired outside the auth middleware group — callers must be restricted
+// to the compose-internal network via firewall / network policy.
+type ProvisionHandler struct {
+	adminURL           string
+	adminClientID      string
+	adminClientSecret  string
+}
+
+// NewProvisionHandler creates a ProvisionHandler with the given Keycloak admin credentials.
+func NewProvisionHandler(adminURL, adminClientID, adminClientSecret string) *ProvisionHandler {
+	return &ProvisionHandler{
+		adminURL:          adminURL,
+		adminClientID:     adminClientID,
+		adminClientSecret: adminClientSecret,
+	}
+}
+
+type provisionRealmRequest struct {
+	RealmName string `json:"realm_name" binding:"required"`
+}
+
+type provisionRealmResponse struct {
+	Realm string `json:"realm"`
+}
+
+// ProvisionRealm handles POST /internal/provision-realm.
+// It calls the Keycloak Admin REST API to create a realm with the raven-app
+// client and org_admin / org_member roles.  Returns 200 on success or 409
+// when the realm already exists.
+func (h *ProvisionHandler) ProvisionRealm(c *gin.Context) {
+	var req provisionRealmRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	token, err := h.obtainAdminToken()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to obtain admin token: " + err.Error()})
+		return
+	}
+
+	realmName := req.RealmName
+
+	// Check whether the realm already exists.
+	exists, err := h.realmExists(token, realmName)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to check realm existence: " + err.Error()})
+		return
+	}
+	if exists {
+		c.JSON(http.StatusConflict, gin.H{"error": "realm already exists", "realm": realmName})
+		return
+	}
+
+	// Build the realm representation.
+	realmBody := buildRealmPayload(realmName)
+	realmJSON, err := json.Marshal(realmBody)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to marshal realm payload"})
+		return
+	}
+
+	adminRealmsURL := strings.TrimRight(h.adminURL, "/") + "/admin/realms"
+	httpReq, err := http.NewRequestWithContext(c.Request.Context(), http.MethodPost, adminRealmsURL, bytes.NewReader(realmJSON))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to build request: " + err.Error()})
+		return
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+token)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "keycloak request failed: " + err.Error()})
+		return
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode == http.StatusConflict {
+		c.JSON(http.StatusConflict, gin.H{"error": "realm already exists", "realm": realmName})
+		return
+	}
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("keycloak returned %d: %s", resp.StatusCode, string(body))})
+		return
+	}
+
+	c.JSON(http.StatusOK, provisionRealmResponse{Realm: realmName})
+}
+
+// obtainAdminToken exchanges client credentials for a Keycloak master-realm access token.
+func (h *ProvisionHandler) obtainAdminToken() (string, error) {
+	tokenURL := strings.TrimRight(h.adminURL, "/") + "/realms/master/protocol/openid-connect/token"
+
+	form := url.Values{}
+	form.Set("grant_type", "client_credentials")
+	form.Set("client_id", h.adminClientID)
+	form.Set("client_secret", h.adminClientSecret)
+
+	resp, err := http.PostForm(tokenURL, form) //nolint:gosec
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("token endpoint returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+	if result.AccessToken == "" {
+		return "", fmt.Errorf("empty access_token in response")
+	}
+	return result.AccessToken, nil
+}
+
+// realmExists returns true when the given realm is already registered in Keycloak.
+func (h *ProvisionHandler) realmExists(token, realmName string) (bool, error) {
+	checkURL := strings.TrimRight(h.adminURL, "/") + "/admin/realms/" + url.PathEscape(realmName)
+	req, err := http.NewRequest(http.MethodGet, checkURL, nil)
+	if err != nil {
+		return false, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode == http.StatusOK {
+		return true, nil
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return false, nil
+	}
+	body, _ := io.ReadAll(resp.Body)
+	return false, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+}
+
+// buildRealmPayload constructs the Keycloak realm JSON with the raven-app
+// client and org_admin / org_member roles.
+func buildRealmPayload(realmName string) map[string]interface{} {
+	return map[string]interface{}{
+		"realm":               realmName,
+		"displayName":         "Raven Platform",
+		"enabled":             true,
+		"registrationAllowed": true,
+		"loginWithEmailAllowed": true,
+		"sslRequired":         "external",
+		"accessTokenLifespan": 300,
+		"emailTheme":          "keycloak",
+		"loginTheme":          "keycloak",
+		"roles": map[string]interface{}{
+			"realm": []map[string]interface{}{
+				{
+					"name":        "org_admin",
+					"description": "Organization-level administrator",
+					"composite":   false,
+					"clientRole":  false,
+				},
+				{
+					"name":        "org_member",
+					"description": "Organization member with standard access",
+					"composite":   false,
+					"clientRole":  false,
+				},
+			},
+		},
+		"defaultRoles": []string{"org_member"},
+		"clients": []map[string]interface{}{
+			{
+				"clientId":                  "raven-app",
+				"name":                      "Raven App",
+				"enabled":                   true,
+				"publicClient":              true,
+				"standardFlowEnabled":       true,
+				"directAccessGrantsEnabled": false,
+				"serviceAccountsEnabled":    false,
+				"protocol":                  "openid-connect",
+				"redirectUris":              []string{"*"},
+				"webOrigins":                []string{"*"},
+				"attributes": map[string]string{
+					"pkce.code.challenge.method": "S256",
+				},
+				"defaultClientScopes": []string{
+					"openid", "profile", "email",
+				},
+			},
+		},
+	}
+}

--- a/internal/service/org.go
+++ b/internal/service/org.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"log/slog"
 	"regexp"
 	"strings"
 
@@ -12,12 +13,20 @@ import (
 
 // OrgService contains business logic for organisation management.
 type OrgService struct {
-	repo *repository.OrgRepository
+	repo  *repository.OrgRepository
+	wsSvc *WorkspaceService
 }
 
 // NewOrgService creates a new OrgService.
-func NewOrgService(repo *repository.OrgRepository) *OrgService {
-	return &OrgService{repo: repo}
+// An optional WorkspaceService may be injected so that a Default workspace is
+// auto-created whenever a new organisation is registered.  Pass nil to skip
+// the workspace bootstrap (e.g. in tests that only exercise org creation).
+func NewOrgService(repo *repository.OrgRepository, wsSvc ...*WorkspaceService) *OrgService {
+	svc := &OrgService{repo: repo}
+	if len(wsSvc) > 0 {
+		svc.wsSvc = wsSvc[0]
+	}
+	return svc
 }
 
 var slugRe = regexp.MustCompile(`[^a-z0-9]+`)
@@ -30,6 +39,9 @@ func toSlug(name string) string {
 }
 
 // Create validates the request, derives a slug, and persists a new organisation.
+// When a WorkspaceService is wired in, a "Default" workspace is automatically
+// created after the organisation is persisted so that every new tenant starts
+// with a usable workspace out of the box.
 func (s *OrgService) Create(ctx context.Context, req model.CreateOrgRequest) (*model.Organization, error) {
 	slug := toSlug(req.Name)
 	if slug == "" {
@@ -43,6 +55,16 @@ func (s *OrgService) Create(ctx context.Context, req model.CreateOrgRequest) (*m
 		}
 		return nil, apierror.NewInternal("failed to create organisation: " + err.Error())
 	}
+
+	// Auto-provision a Default workspace for the new organisation.
+	if s.wsSvc != nil {
+		if _, wsErr := s.wsSvc.Create(ctx, org.ID, model.CreateWorkspaceRequest{Name: "Default"}); wsErr != nil {
+			// Non-fatal: the org was created successfully.  Log and continue.
+			slog.Warn("failed to auto-create Default workspace for new org",
+				"org_id", org.ID, "error", wsErr)
+		}
+	}
+
 	return org, nil
 }
 


### PR DESCRIPTION
## Summary

- **`deploy/keycloak/realm-export.json`** — new Keycloak realm import file with `raven-app` PKCE public client (`redirectUris: ["*"]`, `webOrigins: ["*"]`), `org_admin` and `org_member` roles, `registrationAllowed: true`, and email/login theme defaults
- **`internal/handler/provision.go`** — `POST /internal/provision-realm` (no JWT middleware) calls Keycloak Admin REST API to create realm + client + roles; returns 200 on success, 409 if realm already exists
- **`internal/config/config.go`** — added `KeycloakAdminURL`, `KeycloakAdminClientID`, `KeycloakAdminClientSecret` with `RAVEN_KEYCLOAK_ADMIN_*` env bindings and defaults
- **`cmd/api/main.go`** — wires `ProvisionHandler` outside the JWT group; `wsSvc` is now initialized before `orgSvc` so it can be injected
- **`internal/service/org.go`** — `OrgService.Create` auto-provisions a "Default" workspace via optional variadic `WorkspaceService`; fully backward-compatible
- **`frontend/src/stores/onboarding.ts`** — Pinia store with `completed` (persisted in `localStorage` key `onboarding_completed`), `currentStep`, and `markComplete()`
- **`frontend/src/pages/onboarding/OnboardingWizard.vue`** — 5-step full-screen wizard (org name → KB name → LLM provider + API key → chatbot test → done), `fixed inset-0 z-50 bg-slate-900`, progress dots, skip on steps 1-4
- **`frontend/src/layouts/DefaultLayout.vue`** — renders `<OnboardingWizard v-if="!onboardingStore.completed" />`
- **`docs/quickstart.md`** — single-page guide: prerequisites, clone, `.env` setup, `docker compose up -d`, browser sign-in
- **`.env.example`** — `RAVEN_KEYCLOAK_ADMIN_URL/CLIENT_ID/CLIENT_SECRET` vars

## Test plan

- [ ] `go build ./...` passes (verified: exit 0)
- [ ] `go vet ./internal/handler/... ./internal/service/... ./internal/config/... ./cmd/api/...` passes (verified: exit 0)
- [ ] `cd frontend && npm run build` passes (verified: 295 modules, exit 0)
- [ ] `cd frontend && npm run test:unit` passes (verified: 143/143 tests, exit 0)
- [ ] `POST /internal/provision-realm {"realm_name":"raven"}` → 200 `{"realm":"raven"}` on fresh Keycloak
- [ ] Repeat call → 409 Conflict
- [ ] Create new org via API → `workspaces` table gets a "Default" row
- [ ] First login on fresh account → onboarding wizard appears; clicking "Go to Dashboard" on step 5 hides it permanently

Closes #197