### PR TITLE
docs: add MVP launch planning docs and implementation plans

### DIFF
--- a/docs/superpowers/plans/2026-04-09-go-backend-tests.md
+++ b/docs/superpowers/plans/2026-04-09-go-backend-tests.md
@@ -1140,6 +1140,7 @@ find internal/ee -type f -name '*.go' | grep -v _test | sort
 Then write tests following the same mock + testify pattern. Key cases per package:
 
 **`internal/ee/licensing/`**
+
 ```go
 func TestLicenseGuard_NoLicense_Returns402(t *testing.T) {}
 func TestLicenseGuard_ValidLicense_Passes(t *testing.T) {}
@@ -1148,6 +1149,7 @@ func TestLicenseGuard_FeatureADoesNotUnlockFeatureB(t *testing.T) {}
 ```
 
 **`internal/ee/security/`**
+
 ```go
 func TestWAFEngine_BlockRule_MatchingRequest_Blocked(t *testing.T) {}
 func TestWAFEngine_AllowRule_OverridesBlock(t *testing.T) {}
@@ -1157,6 +1159,7 @@ func TestWAFEngine_RegexRule_MatchingAndNonMatching(t *testing.T) {}
 ```
 
 **`internal/ee/webhooks/`**
+
 ```go
 func TestWebhookDelivery_HMACSignature_Correct(t *testing.T) {}
 func TestWebhookDelivery_Retry_Intervals_1s_5s_30s(t *testing.T) {}
@@ -1165,6 +1168,7 @@ func TestWebhookDelivery_Replay_DeadLettered(t *testing.T) {}
 ```
 
 **`internal/ee/audit/`**
+
 ```go
 func TestAuditLog_Create_CapturesCorrectFields(t *testing.T) {}
 func TestAuditLog_Delete_EntryRetained(t *testing.T) {}

--- a/docs/superpowers/plans/2026-04-10-billing-subscription-enforcement.md
+++ b/docs/superpowers/plans/2026-04-10-billing-subscription-enforcement.md
@@ -1,0 +1,1538 @@
+# Billing Subscription Enforcement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enforce plan-tier limits (KB count, workspace seats, voice-minute quota, API rate limits) so Free/Pro orgs cannot exceed their plan allowances, while Enterprise bypasses all soft limits.
+
+**Architecture:** A new `QuotaChecker` service provides `GetOrgSubscription(ctx, orgID)` and limit-check methods. Enforcement is wired into existing service-layer `Create`/`AddMember`/`CreateSession` methods via dependency injection. Subscription plan data is cached in Valkey (TTL 5 min) to avoid per-request DB hits. A new `GET /billing/usage` endpoint exposes current-period usage vs limits. Returns `402 Payment Required` with `{"upgrade_required": true, "limit": N}` when limits are exceeded.
+
+**Tech Stack:** Go 1.24, Gin, pgx/v5, go-redis/v9 (Valkey), testify-free handler tests (httptest + mock services)
+
+---
+
+## File Structure
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `internal/service/quota.go` | `QuotaChecker` — subscription lookup, Valkey caching, limit-check methods, usage aggregation |
+| Create | `internal/service/quota_test.go` | Unit tests for QuotaChecker (mock repo + mock Valkey) |
+| Create | `internal/handler/usage.go` | `UsageHandler` — `GET /billing/usage` endpoint |
+| Create | `internal/handler/usage_test.go` | Handler-level tests for usage endpoint |
+| Modify | `internal/model/billing.go` | Add `OrgSubscription`, `UsageResponse`, `QuotaExceededError` types |
+| Modify | `internal/repository/billing.go` | Add `CountKBsByOrg`, `CountMembersByOrg`, `GetVoiceUsageForPeriod` queries |
+| Modify | `internal/service/kb.go` | Inject `QuotaChecker`, call limit check in `Create` |
+| Modify | `internal/service/kb_test.go` *(create if absent)* | Test KB creation with quota enforcement |
+| Modify | `internal/service/workspace.go` | Inject `QuotaChecker`, call limit check in `AddMember` |
+| Modify | `internal/service/workspace_test.go` *(create if absent)* | Test AddMember with quota enforcement |
+| Modify | `internal/service/voice.go` | Replace hardcoded `maxConcurrentSessions` with `QuotaChecker` lookup + monthly minute check |
+| Modify | `internal/service/voice_test.go` *(create if absent)* | Test voice session creation with quota enforcement |
+| Modify | `pkg/apierror/apierror.go` | Add `NewPaymentRequired` constructor (402) |
+| Modify | `cmd/api/main.go` | Wire `QuotaChecker` into services, register `/billing/usage` route, populate Valkey tier cache on subscription create, verify `ByOrgTier` middleware is wired |
+
+---
+
+### Task 1: Add 402 Payment Required error constructor
+
+**Files:**
+- Modify: `pkg/apierror/apierror.go`
+- Modify: existing test file or create `pkg/apierror/apierror_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `pkg/apierror/apierror_test.go` (if it doesn't exist) with:
+
+```go
+package apierror_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/ravencloak-org/Raven/pkg/apierror"
+)
+
+func TestNewPaymentRequired(t *testing.T) {
+	qErr := apierror.NewPaymentRequired("KB limit reached", 3)
+	if qErr.Code != http.StatusPaymentRequired {
+		t.Errorf("expected code 402, got %d", qErr.Code)
+	}
+	if qErr.Message != "Payment Required" {
+		t.Errorf("expected message 'Payment Required', got %q", qErr.Message)
+	}
+	if !qErr.UpgradeRequired {
+		t.Error("expected upgrade_required to be true")
+	}
+	if qErr.Limit != 3 {
+		t.Errorf("expected limit 3, got %d", qErr.Limit)
+	}
+
+	// Verify it satisfies the error interface.
+	var e error = qErr
+	if e.Error() != "Payment Required: KB limit reached" {
+		t.Errorf("unexpected Error() output: %q", e.Error())
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/jobinlawrance/Project/raven && go test ./pkg/apierror/ -run TestNewPaymentRequired -v`
+Expected: FAIL — `NewPaymentRequired` and `QuotaError` don't exist yet.
+
+- [ ] **Step 3: Add QuotaError type and NewPaymentRequired constructor**
+
+Add to `pkg/apierror/apierror.go`:
+
+```go
+// QuotaError extends AppError with billing-specific fields for 402 responses.
+type QuotaError struct {
+	AppError
+	UpgradeRequired bool `json:"upgrade_required"`
+	Limit           int  `json:"limit"`
+}
+
+// NewPaymentRequired creates a 402 Payment Required error with upgrade context.
+func NewPaymentRequired(detail string, limit int) *QuotaError {
+	return &QuotaError{
+		AppError: AppError{
+			Code:    http.StatusPaymentRequired,
+			Message: "Payment Required",
+			Detail:  detail,
+		},
+		UpgradeRequired: true,
+		Limit:           limit,
+	}
+}
+```
+
+Also update `ErrorHandler` to handle `*QuotaError`:
+
+```go
+// In ErrorHandler, before the AppError check:
+if quotaErr, ok := err.(*QuotaError); ok {
+	c.JSON(quotaErr.Code, quotaErr)
+} else if appErr, ok := err.(*AppError); ok {
+	c.JSON(appErr.Code, appErr)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/jobinlawrance/Project/raven && go test ./pkg/apierror/ -run TestNewPaymentRequired -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/apierror/apierror.go pkg/apierror/apierror_test.go
+git commit -m "feat(billing): add 402 Payment Required error with QuotaError type"
+```
+
+---
+
+### Task 2: Add billing model types (OrgSubscription, UsageResponse)
+
+**Files:**
+- Modify: `internal/model/billing.go`
+
+- [ ] **Step 1: Write a compile-check test**
+
+Create `internal/model/billing_test.go`:
+
+```go
+package model_test
+
+import (
+	"testing"
+
+	"github.com/ravencloak-org/Raven/internal/model"
+)
+
+func TestOrgSubscription_IsUnlimited(t *testing.T) {
+	enterprise := model.OrgSubscription{
+		Plan: model.DefaultPlans()[2], // Enterprise
+	}
+	if !enterprise.IsUnlimited() {
+		t.Error("enterprise plan should be unlimited")
+	}
+
+	free := model.OrgSubscription{
+		Plan: model.DefaultPlans()[0], // Free
+	}
+	if free.IsUnlimited() {
+		t.Error("free plan should not be unlimited")
+	}
+}
+
+func TestDefaultFreeSubscription(t *testing.T) {
+	sub := model.DefaultFreeSubscription()
+	if sub.Plan.Tier != model.PlanTierFree {
+		t.Errorf("expected free tier, got %s", sub.Plan.Tier)
+	}
+	if sub.Plan.MaxKBs != 3 {
+		t.Errorf("expected MaxKBs 3, got %d", sub.Plan.MaxKBs)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/jobinlawrance/Project/raven && go test ./internal/model/ -run TestOrgSubscription -v`
+Expected: FAIL — types don't exist yet.
+
+- [ ] **Step 3: Add types to billing.go**
+
+Append to `internal/model/billing.go`:
+
+First, add `MaxVoiceMinutesMonthly` to the `Plan` struct (insert after `MaxConcurrentVoiceSessions`):
+
+```go
+MaxVoiceMinutesMonthly int `json:"max_voice_minutes_monthly"` // -1 = unlimited
+```
+
+Update `DefaultPlans()` to include this field:
+- Free: `MaxVoiceMinutesMonthly: 60` (1 hour/month)
+- Pro: `MaxVoiceMinutesMonthly: 1200` (20 hours/month)
+- Enterprise: `MaxVoiceMinutesMonthly: -1` (unlimited)
+
+Then append these new types:
+
+```go
+// OrgSubscription holds the resolved subscription + plan for an org,
+// used by the quota checker to enforce limits.
+type OrgSubscription struct {
+	Subscription *Subscription `json:"subscription,omitempty"`
+	Plan         Plan          `json:"plan"`
+}
+
+// IsUnlimited returns true if the org is on the Enterprise tier (all limits are -1).
+func (o *OrgSubscription) IsUnlimited() bool {
+	return o.Plan.Tier == PlanTierEnterprise
+}
+
+// DefaultFreeSubscription returns the implicit subscription for orgs without
+// an explicit subscription record (defaults to Free tier).
+func DefaultFreeSubscription() OrgSubscription {
+	plans := DefaultPlans()
+	return OrgSubscription{Plan: plans[0]}
+}
+
+// UsageResponse is the response body for GET /billing/usage.
+type UsageResponse struct {
+	Plan                Plan  `json:"plan"`
+	KBsUsed             int   `json:"kbs_used"`
+	KBsLimit            int   `json:"kbs_limit"`
+	SeatsUsed           int   `json:"seats_used"`
+	SeatsLimit          int   `json:"seats_limit"`
+	VoiceMinutesUsed     int  `json:"voice_minutes_used"`
+	VoiceMinutesLimit    int  `json:"voice_minutes_limit"`    // from Plan.MaxVoiceMinutesMonthly
+	ConcurrentVoiceUsed  int  `json:"concurrent_voice_used"`
+	ConcurrentVoiceLimit int  `json:"concurrent_voice_limit"`
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/jobinlawrance/Project/raven && go test ./internal/model/ -run TestOrgSubscription -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/model/billing.go internal/model/billing_test.go
+git commit -m "feat(billing): add OrgSubscription and UsageResponse model types"
+```
+
+---
+
+### Task 3: Add count queries to billing repository
+
+**Files:**
+- Modify: `internal/repository/billing.go`
+
+- [ ] **Step 1: Add SQL constants and repository methods**
+
+Append to `internal/repository/billing.go`:
+
+```go
+const (
+	sqlCountKBsByOrg = `
+		SELECT COUNT(*) FROM knowledge_bases
+		WHERE org_id = $1 AND archived_at IS NULL`
+
+	sqlCountMembersByOrg = `
+		SELECT COUNT(DISTINCT user_id) FROM workspace_members
+		WHERE workspace_id IN (SELECT id FROM workspaces WHERE org_id = $1)`
+
+	sqlVoiceUsageForPeriod = `
+		SELECT COALESCE(SUM(total_duration_seconds), 0)
+		FROM voice_usage_summaries
+		WHERE org_id = $1 AND period_start >= $2`
+)
+
+// CountKBsByOrg returns the number of active (non-archived) knowledge bases for an org.
+func (r *BillingRepository) CountKBsByOrg(ctx context.Context, tx pgx.Tx, orgID string) (int, error) {
+	var count int
+	err := tx.QueryRow(ctx, sqlCountKBsByOrg, orgID).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("BillingRepository.CountKBsByOrg: %w", err)
+	}
+	return count, nil
+}
+
+// CountMembersByOrg returns the number of distinct users across all workspaces in an org.
+func (r *BillingRepository) CountMembersByOrg(ctx context.Context, tx pgx.Tx, orgID string) (int, error) {
+	var count int
+	err := tx.QueryRow(ctx, sqlCountMembersByOrg, orgID).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("BillingRepository.CountMembersByOrg: %w", err)
+	}
+	return count, nil
+}
+
+// GetVoiceUsageForPeriod returns total voice duration (seconds) for an org since periodStart.
+func (r *BillingRepository) GetVoiceUsageForPeriod(ctx context.Context, tx pgx.Tx, orgID string, periodStart time.Time) (int, error) {
+	var totalSeconds int
+	err := tx.QueryRow(ctx, sqlVoiceUsageForPeriod, orgID, periodStart).Scan(&totalSeconds)
+	if err != nil {
+		return 0, fmt.Errorf("BillingRepository.GetVoiceUsageForPeriod: %w", err)
+	}
+	return totalSeconds, nil
+}
+```
+
+Note: Add `"time"` to the imports in `internal/repository/billing.go`.
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd /Users/jobinlawrance/Project/raven && go build ./internal/repository/`
+Expected: BUILD SUCCESS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/repository/billing.go
+git commit -m "feat(billing): add count queries for KBs, members, and voice usage"
+```
+
+---
+
+### Task 4: Create QuotaChecker service
+
+**Files:**
+- Create: `internal/service/quota.go`
+- Create: `internal/service/quota_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/service/quota_test.go`:
+
+```go
+package service_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/ravencloak-org/Raven/internal/model"
+	"github.com/ravencloak-org/Raven/internal/service"
+	"github.com/ravencloak-org/Raven/pkg/apierror"
+)
+
+// mockQuotaRepo implements service.QuotaRepository for testing.
+type mockQuotaRepo struct {
+	activeSubscription *model.Subscription
+	activeSubErr       error
+	kbCount            int
+	kbCountErr         error
+	memberCount        int
+	memberCountErr     error
+	voiceUsage         int
+	voiceUsageErr      error
+}
+
+func (m *mockQuotaRepo) GetActiveSubscription(ctx context.Context, tx pgx.Tx, orgID string) (*model.Subscription, error) {
+	return m.activeSubscription, m.activeSubErr
+}
+
+func (m *mockQuotaRepo) CountKBsByOrg(ctx context.Context, tx pgx.Tx, orgID string) (int, error) {
+	return m.kbCount, m.kbCountErr
+}
+
+func (m *mockQuotaRepo) CountMembersByOrg(ctx context.Context, tx pgx.Tx, orgID string) (int, error) {
+	return m.memberCount, m.memberCountErr
+}
+
+func (m *mockQuotaRepo) GetVoiceUsageForPeriod(ctx context.Context, tx pgx.Tx, orgID string, periodStart time.Time) (int, error) {
+	return m.voiceUsage, m.voiceUsageErr
+}
+
+// mockValkeyCache implements service.SubscriptionCache for testing.
+type mockValkeyCache struct {
+	cached *model.OrgSubscription
+}
+
+func (m *mockValkeyCache) Get(ctx context.Context, orgID string) (*model.OrgSubscription, error) {
+	if m.cached != nil {
+		return m.cached, nil
+	}
+	return nil, nil
+}
+
+func (m *mockValkeyCache) Set(ctx context.Context, orgID string, sub *model.OrgSubscription) error {
+	m.cached = sub
+	return nil
+}
+
+func TestCheckKBQuota_FreeAtLimit_Returns402(t *testing.T) {
+	repo := &mockQuotaRepo{
+		activeSubscription: nil, // no subscription = free tier
+		kbCount:            3,   // at the free limit
+	}
+	qc := service.NewQuotaChecker(repo, &mockValkeyCache{}, nil)
+
+	err := qc.CheckKBQuota(context.Background(), "org-1")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	quotaErr, ok := err.(*apierror.QuotaError)
+	if !ok {
+		t.Fatalf("expected *QuotaError, got %T: %v", err, err)
+	}
+	if quotaErr.Code != 402 {
+		t.Errorf("expected 402, got %d", quotaErr.Code)
+	}
+	if quotaErr.Limit != 3 {
+		t.Errorf("expected limit 3, got %d", quotaErr.Limit)
+	}
+}
+
+func TestCheckKBQuota_EnterpriseBypass(t *testing.T) {
+	now := time.Now().UTC()
+	repo := &mockQuotaRepo{
+		activeSubscription: &model.Subscription{
+			ID:                 "sub-1",
+			OrgID:              "org-1",
+			PlanID:             "plan_enterprise",
+			Status:             model.SubscriptionStatusActive,
+			CurrentPeriodStart: now,
+			CurrentPeriodEnd:   now.AddDate(0, 1, 0),
+		},
+		kbCount: 999, // way over free/pro limits
+	}
+	qc := service.NewQuotaChecker(repo, &mockValkeyCache{}, nil)
+
+	err := qc.CheckKBQuota(context.Background(), "org-1")
+	if err != nil {
+		t.Errorf("enterprise should bypass, got error: %v", err)
+	}
+}
+
+func TestCheckKBQuota_ProUnderLimit_Passes(t *testing.T) {
+	now := time.Now().UTC()
+	repo := &mockQuotaRepo{
+		activeSubscription: &model.Subscription{
+			ID:                 "sub-1",
+			OrgID:              "org-1",
+			PlanID:             "plan_pro",
+			Status:             model.SubscriptionStatusActive,
+			CurrentPeriodStart: now,
+			CurrentPeriodEnd:   now.AddDate(0, 1, 0),
+		},
+		kbCount: 10, // under pro limit of 50
+	}
+	qc := service.NewQuotaChecker(repo, &mockValkeyCache{}, nil)
+
+	err := qc.CheckKBQuota(context.Background(), "org-1")
+	if err != nil {
+		t.Errorf("expected pass, got error: %v", err)
+	}
+}
+
+func TestCheckSeatQuota_FreeAtLimit_Returns402(t *testing.T) {
+	repo := &mockQuotaRepo{
+		activeSubscription: nil,
+		memberCount:        5, // free limit
+	}
+	qc := service.NewQuotaChecker(repo, &mockValkeyCache{}, nil)
+
+	err := qc.CheckSeatQuota(context.Background(), "org-1")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	quotaErr, ok := err.(*apierror.QuotaError)
+	if !ok {
+		t.Fatalf("expected *QuotaError, got %T", err)
+	}
+	if quotaErr.Code != 402 {
+		t.Errorf("expected 402, got %d", quotaErr.Code)
+	}
+}
+
+func TestCheckVoiceMinuteQuota_FreeAtLimit_Returns402(t *testing.T) {
+	repo := &mockQuotaRepo{
+		activeSubscription: nil,  // free tier (60 min/month)
+		voiceUsage:         3600, // 60 minutes in seconds — at limit
+	}
+	qc := service.NewQuotaChecker(repo, &mockValkeyCache{}, nil)
+
+	err := qc.CheckVoiceMinuteQuota(context.Background(), "org-1")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	quotaErr, ok := err.(*apierror.QuotaError)
+	if !ok {
+		t.Fatalf("expected *QuotaError, got %T: %v", err, err)
+	}
+	if quotaErr.Code != 402 {
+		t.Errorf("expected 402, got %d", quotaErr.Code)
+	}
+	if quotaErr.Limit != 60 {
+		t.Errorf("expected limit 60, got %d", quotaErr.Limit)
+	}
+}
+
+func TestCheckVoiceMinuteQuota_UnderLimit_Passes(t *testing.T) {
+	repo := &mockQuotaRepo{
+		activeSubscription: nil,  // free tier (60 min/month)
+		voiceUsage:         1800, // 30 minutes — under limit
+	}
+	qc := service.NewQuotaChecker(repo, &mockValkeyCache{}, nil)
+
+	err := qc.CheckVoiceMinuteQuota(context.Background(), "org-1")
+	if err != nil {
+		t.Errorf("expected pass, got error: %v", err)
+	}
+}
+
+func TestCheckConcurrentVoiceQuota_EnterpriseBypass(t *testing.T) {
+	now := time.Now().UTC()
+	repo := &mockQuotaRepo{
+		activeSubscription: &model.Subscription{
+			PlanID:             "plan_enterprise",
+			Status:             model.SubscriptionStatusActive,
+			CurrentPeriodStart: now,
+			CurrentPeriodEnd:   now.AddDate(0, 1, 0),
+		},
+	}
+	qc := service.NewQuotaChecker(repo, &mockValkeyCache{}, nil)
+
+	// Should not error even though we don't check count — enterprise bypasses
+	limit := qc.GetConcurrentVoiceLimit(context.Background(), "org-1")
+	if limit != -1 {
+		t.Errorf("expected -1 (unlimited), got %d", limit)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/jobinlawrance/Project/raven && go test ./internal/service/ -run TestCheck -v`
+Expected: FAIL — `QuotaChecker`, `QuotaRepository`, `SubscriptionCache` don't exist.
+
+- [ ] **Step 3: Implement QuotaChecker**
+
+Create `internal/service/quota.go`:
+
+```go
+package service
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/redis/go-redis/v9"
+
+	"github.com/ravencloak-org/Raven/internal/db"
+	"github.com/ravencloak-org/Raven/internal/model"
+	"github.com/ravencloak-org/Raven/pkg/apierror"
+)
+
+// QuotaRepository defines the persistence methods the quota checker needs.
+type QuotaRepository interface {
+	GetActiveSubscription(ctx context.Context, tx pgx.Tx, orgID string) (*model.Subscription, error)
+	CountKBsByOrg(ctx context.Context, tx pgx.Tx, orgID string) (int, error)
+	CountMembersByOrg(ctx context.Context, tx pgx.Tx, orgID string) (int, error)
+	GetVoiceUsageForPeriod(ctx context.Context, tx pgx.Tx, orgID string, periodStart time.Time) (int, error)
+}
+
+// SubscriptionCache provides cached subscription lookups.
+type SubscriptionCache interface {
+	Get(ctx context.Context, orgID string) (*model.OrgSubscription, error)
+	Set(ctx context.Context, orgID string, sub *model.OrgSubscription) error
+}
+
+// QuotaChecker enforces plan-tier resource limits for organisations.
+type QuotaChecker struct {
+	repo  QuotaRepository
+	cache SubscriptionCache
+	pool  *pgxpool.Pool
+	plans map[string]model.Plan
+}
+
+// NewQuotaChecker creates a new QuotaChecker.
+func NewQuotaChecker(repo QuotaRepository, cache SubscriptionCache, pool *pgxpool.Pool) *QuotaChecker {
+	plans := make(map[string]model.Plan)
+	for _, p := range model.DefaultPlans() {
+		plans[p.ID] = p
+	}
+	return &QuotaChecker{repo: repo, cache: cache, pool: pool, plans: plans}
+}
+
+// GetOrgSubscription resolves the current subscription and plan for an org.
+// Checks Valkey cache first, falls back to DB, caches result.
+// If no subscription exists, returns the default free plan.
+func (q *QuotaChecker) GetOrgSubscription(ctx context.Context, orgID string) (*model.OrgSubscription, error) {
+	// Check cache first.
+	if q.cache != nil {
+		cached, err := q.cache.Get(ctx, orgID)
+		if err == nil && cached != nil {
+			return cached, nil
+		}
+	}
+
+	// Fall back to DB.
+	var sub *model.Subscription
+	var lookupErr error
+
+	if q.pool != nil {
+		lookupErr = db.WithOrgID(ctx, q.pool, orgID, func(tx pgx.Tx) error {
+			var err error
+			sub, err = q.repo.GetActiveSubscription(ctx, tx, orgID)
+			return err
+		})
+	} else {
+		// No pool (unit test path) — call repo directly with nil tx.
+		sub, lookupErr = q.repo.GetActiveSubscription(ctx, nil, orgID)
+	}
+
+	if lookupErr != nil {
+		slog.ErrorContext(ctx, "QuotaChecker: failed to look up subscription", "org_id", orgID, "error", lookupErr)
+		// Fail-open: default to free tier rather than blocking the request.
+		result := model.DefaultFreeSubscription()
+		return &result, nil
+	}
+
+	var result model.OrgSubscription
+	if sub == nil {
+		result = model.DefaultFreeSubscription()
+	} else {
+		plan, ok := q.plans[sub.PlanID]
+		if !ok {
+			slog.WarnContext(ctx, "QuotaChecker: unknown plan_id, defaulting to free", "plan_id", sub.PlanID)
+			result = model.DefaultFreeSubscription()
+			result.Subscription = sub
+		} else {
+			result = model.OrgSubscription{Subscription: sub, Plan: plan}
+		}
+	}
+
+	// Cache the result.
+	if q.cache != nil {
+		if err := q.cache.Set(ctx, orgID, &result); err != nil {
+			slog.WarnContext(ctx, "QuotaChecker: failed to cache subscription", "org_id", orgID, "error", err)
+		}
+	}
+
+	return &result, nil
+}
+
+// CheckKBQuota verifies the org has not reached its knowledge base limit.
+// Returns nil if allowed, or a 402 QuotaError if at/over the limit.
+func (q *QuotaChecker) CheckKBQuota(ctx context.Context, orgID string) error {
+	orgSub, err := q.GetOrgSubscription(ctx, orgID)
+	if err != nil {
+		return err
+	}
+	if orgSub.IsUnlimited() {
+		return nil
+	}
+
+	var count int
+	if q.pool != nil {
+		err = db.WithOrgID(ctx, q.pool, orgID, func(tx pgx.Tx) error {
+			var e error
+			count, e = q.repo.CountKBsByOrg(ctx, tx, orgID)
+			return e
+		})
+	} else {
+		count, err = q.repo.CountKBsByOrg(ctx, nil, orgID)
+	}
+	if err != nil {
+		slog.ErrorContext(ctx, "QuotaChecker: failed to count KBs", "org_id", orgID, "error", err)
+		return nil // fail-open
+	}
+
+	if count >= orgSub.Plan.MaxKBs {
+		return apierror.NewPaymentRequired(
+			fmt.Sprintf("knowledge base limit reached (%d/%d)", count, orgSub.Plan.MaxKBs),
+			orgSub.Plan.MaxKBs,
+		)
+	}
+	return nil
+}
+
+// CheckSeatQuota verifies the org has not reached its user seat limit.
+func (q *QuotaChecker) CheckSeatQuota(ctx context.Context, orgID string) error {
+	orgSub, err := q.GetOrgSubscription(ctx, orgID)
+	if err != nil {
+		return err
+	}
+	if orgSub.IsUnlimited() {
+		return nil
+	}
+
+	var count int
+	if q.pool != nil {
+		err = db.WithOrgID(ctx, q.pool, orgID, func(tx pgx.Tx) error {
+			var e error
+			count, e = q.repo.CountMembersByOrg(ctx, tx, orgID)
+			return e
+		})
+	} else {
+		count, err = q.repo.CountMembersByOrg(ctx, nil, orgID)
+	}
+	if err != nil {
+		slog.ErrorContext(ctx, "QuotaChecker: failed to count members", "org_id", orgID, "error", err)
+		return nil // fail-open
+	}
+
+	if count >= orgSub.Plan.MaxUsers {
+		return apierror.NewPaymentRequired(
+			fmt.Sprintf("seat limit reached (%d/%d)", count, orgSub.Plan.MaxUsers),
+			orgSub.Plan.MaxUsers,
+		)
+	}
+	return nil
+}
+
+// GetConcurrentVoiceLimit returns the concurrent voice session limit for an org.
+// Returns -1 for unlimited (Enterprise).
+func (q *QuotaChecker) GetConcurrentVoiceLimit(ctx context.Context, orgID string) int {
+	orgSub, err := q.GetOrgSubscription(ctx, orgID)
+	if err != nil {
+		return 1 // default to free tier
+	}
+	return orgSub.Plan.MaxConcurrentVoiceSessions
+}
+
+// CheckVoiceMinuteQuota verifies the org has not exceeded its monthly voice-minute quota.
+// Returns nil if allowed, or a 402 QuotaError if at/over the limit.
+func (q *QuotaChecker) CheckVoiceMinuteQuota(ctx context.Context, orgID string) error {
+	orgSub, err := q.GetOrgSubscription(ctx, orgID)
+	if err != nil {
+		return err
+	}
+	if orgSub.IsUnlimited() || orgSub.Plan.MaxVoiceMinutesMonthly < 0 {
+		return nil
+	}
+
+	// Determine billing period start.
+	periodStart := time.Now().UTC().AddDate(0, -1, 0)
+	if orgSub.Subscription != nil {
+		periodStart = orgSub.Subscription.CurrentPeriodStart
+	}
+
+	var totalSeconds int
+	if q.pool != nil {
+		err = db.WithOrgID(ctx, q.pool, orgID, func(tx pgx.Tx) error {
+			var e error
+			totalSeconds, e = q.repo.GetVoiceUsageForPeriod(ctx, tx, orgID, periodStart)
+			return e
+		})
+	} else {
+		totalSeconds, err = q.repo.GetVoiceUsageForPeriod(ctx, nil, orgID, periodStart)
+	}
+	if err != nil {
+		slog.ErrorContext(ctx, "QuotaChecker: failed to check voice usage", "org_id", orgID, "error", err)
+		return nil // fail-open
+	}
+
+	usedMinutes := totalSeconds / 60
+	if usedMinutes >= orgSub.Plan.MaxVoiceMinutesMonthly {
+		return apierror.NewPaymentRequired(
+			fmt.Sprintf("monthly voice minute quota exceeded (%d/%d minutes)", usedMinutes, orgSub.Plan.MaxVoiceMinutesMonthly),
+			orgSub.Plan.MaxVoiceMinutesMonthly,
+		)
+	}
+	return nil
+}
+
+// GetUsage returns the full usage breakdown for an org for the billing/usage endpoint.
+func (q *QuotaChecker) GetUsage(ctx context.Context, orgID string) (*model.UsageResponse, error) {
+	orgSub, err := q.GetOrgSubscription(ctx, orgID)
+	if err != nil {
+		return nil, apierror.NewInternal("failed to resolve subscription")
+	}
+
+	var kbCount, memberCount, voiceSeconds, activeSessions int
+
+	if q.pool != nil {
+		err = db.WithOrgID(ctx, q.pool, orgID, func(tx pgx.Tx) error {
+			var e error
+			kbCount, e = q.repo.CountKBsByOrg(ctx, tx, orgID)
+			if e != nil {
+				return e
+			}
+			memberCount, e = q.repo.CountMembersByOrg(ctx, tx, orgID)
+			if e != nil {
+				return e
+			}
+			// Voice usage since the start of the current billing period.
+			periodStart := time.Now().UTC().AddDate(0, -1, 0)
+			if orgSub.Subscription != nil {
+				periodStart = orgSub.Subscription.CurrentPeriodStart
+			}
+			voiceSeconds, e = q.repo.GetVoiceUsageForPeriod(ctx, tx, orgID, periodStart)
+			return e
+		})
+	}
+	if err != nil {
+		slog.ErrorContext(ctx, "QuotaChecker.GetUsage: failed to aggregate usage", "org_id", orgID, "error", err)
+		return nil, apierror.NewInternal("failed to aggregate usage")
+	}
+
+	return &model.UsageResponse{
+		Plan:                 orgSub.Plan,
+		KBsUsed:              kbCount,
+		KBsLimit:             orgSub.Plan.MaxKBs,
+		SeatsUsed:            memberCount,
+		SeatsLimit:           orgSub.Plan.MaxUsers,
+		VoiceMinutesUsed:     voiceSeconds / 60,
+		VoiceMinutesLimit:    orgSub.Plan.MaxVoiceMinutesMonthly,
+		ConcurrentVoiceUsed:  0, // real-time count not tracked here; see voice service
+		ConcurrentVoiceLimit: orgSub.Plan.MaxConcurrentVoiceSessions,
+	}, nil
+}
+
+// ValkeySubscriptionCache implements SubscriptionCache using Valkey with a 5-minute TTL.
+type ValkeySubscriptionCache struct {
+	client redis.Cmdable
+	ttl    time.Duration
+}
+
+// NewValkeySubscriptionCache creates a cache backed by Valkey.
+func NewValkeySubscriptionCache(client redis.Cmdable) *ValkeySubscriptionCache {
+	return &ValkeySubscriptionCache{client: client, ttl: 5 * time.Minute}
+}
+
+const valkeyCacheKeyPrefix = "raven:org_sub:"
+
+// Get reads the cached OrgSubscription. Returns (nil, nil) on miss.
+func (c *ValkeySubscriptionCache) Get(ctx context.Context, orgID string) (*model.OrgSubscription, error) {
+	callCtx, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
+	defer cancel()
+
+	data, err := c.client.Get(callCtx, valkeyCacheKeyPrefix+orgID).Bytes()
+	if err != nil {
+		return nil, nil // cache miss
+	}
+
+	var sub model.OrgSubscription
+	if err := json.Unmarshal(data, &sub); err != nil {
+		return nil, nil
+	}
+	return &sub, nil
+}
+
+// Set caches the OrgSubscription with a 5-minute TTL.
+func (c *ValkeySubscriptionCache) Set(ctx context.Context, orgID string, sub *model.OrgSubscription) error {
+	callCtx, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
+	defer cancel()
+
+	data, err := json.Marshal(sub)
+	if err != nil {
+		return err
+	}
+	return c.client.Set(callCtx, valkeyCacheKeyPrefix+orgID, data, c.ttl).Err()
+}
+```
+
+Note: Add `"encoding/json"` to imports.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/jobinlawrance/Project/raven && go test ./internal/service/ -run TestCheck -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/service/quota.go internal/service/quota_test.go
+git commit -m "feat(billing): add QuotaChecker service with Valkey-cached subscription lookups"
+```
+
+---
+
+### Task 5: Wire QuotaChecker into KBService
+
+**Files:**
+- Modify: `internal/service/kb.go`
+- Create: `internal/service/kb_test.go`
+
+- [ ] **Step 1: Modify KBService to accept and use QuotaChecker**
+
+In `internal/service/kb.go`, update the struct and constructor:
+
+```go
+// QuotaCheckerI is the interface for quota enforcement.
+type QuotaCheckerI interface {
+	CheckKBQuota(ctx context.Context, orgID string) error
+	CheckSeatQuota(ctx context.Context, orgID string) error
+	CheckVoiceMinuteQuota(ctx context.Context, orgID string) error
+	GetConcurrentVoiceLimit(ctx context.Context, orgID string) int
+	GetUsage(ctx context.Context, orgID string) (*model.UsageResponse, error)
+	GetOrgSubscription(ctx context.Context, orgID string) (*model.OrgSubscription, error)
+}
+```
+
+Update `KBService`:
+
+```go
+type KBService struct {
+	repo  *repository.KBRepository
+	pool  *pgxpool.Pool
+	quota QuotaCheckerI
+}
+
+func NewKBService(repo *repository.KBRepository, pool *pgxpool.Pool, quota QuotaCheckerI) *KBService {
+	return &KBService{repo: repo, pool: pool, quota: quota}
+}
+```
+
+Add quota check at the top of `Create`:
+
+```go
+func (s *KBService) Create(ctx context.Context, orgID, wsID string, req model.CreateKBRequest) (*model.KnowledgeBase, error) {
+	// Enforce plan-tier KB limit.
+	if s.quota != nil {
+		if err := s.quota.CheckKBQuota(ctx, orgID); err != nil {
+			return nil, err
+		}
+	}
+
+	slug := toSlug(req.Name)
+	// ... rest unchanged
+}
+```
+
+- [ ] **Step 2: Write integration test verifying quota enforcement through KBService.Create**
+
+Create `internal/service/kb_test.go`:
+
+```go
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ravencloak-org/Raven/internal/model"
+	"github.com/ravencloak-org/Raven/internal/service"
+	"github.com/ravencloak-org/Raven/pkg/apierror"
+)
+
+// mockQuotaChecker implements service.QuotaCheckerI for testing.
+type mockQuotaChecker struct {
+	checkKBErr         error
+	checkSeatErr       error
+	checkVoiceMinErr   error
+	concurrentLimit    int
+	usage              *model.UsageResponse
+	usageErr           error
+	orgSub             *model.OrgSubscription
+}
+
+func (m *mockQuotaChecker) CheckKBQuota(_ context.Context, _ string) error           { return m.checkKBErr }
+func (m *mockQuotaChecker) CheckSeatQuota(_ context.Context, _ string) error         { return m.checkSeatErr }
+func (m *mockQuotaChecker) CheckVoiceMinuteQuota(_ context.Context, _ string) error  { return m.checkVoiceMinErr }
+func (m *mockQuotaChecker) GetConcurrentVoiceLimit(_ context.Context, _ string) int  { return m.concurrentLimit }
+func (m *mockQuotaChecker) GetUsage(_ context.Context, _ string) (*model.UsageResponse, error) { return m.usage, m.usageErr }
+func (m *mockQuotaChecker) GetOrgSubscription(_ context.Context, _ string) (*model.OrgSubscription, error) { return m.orgSub, nil }
+
+func TestKBCreate_QuotaExceeded_Returns402(t *testing.T) {
+	quota := &mockQuotaChecker{
+		checkKBErr: apierror.NewPaymentRequired("KB limit reached (3/3)", 3),
+	}
+	// Pass nil repo and pool since we expect the quota check to short-circuit
+	// before any DB call.
+	svc := service.NewKBService(nil, nil, quota)
+
+	_, err := svc.Create(context.Background(), "org-1", "ws-1", model.CreateKBRequest{Name: "test"})
+	if err == nil {
+		t.Fatal("expected quota error, got nil")
+	}
+	qErr, ok := err.(*apierror.QuotaError)
+	if !ok {
+		t.Fatalf("expected *QuotaError, got %T: %v", err, err)
+	}
+	if qErr.Code != 402 {
+		t.Errorf("expected 402, got %d", qErr.Code)
+	}
+	if !qErr.UpgradeRequired {
+		t.Error("expected upgrade_required true")
+	}
+}
+
+func TestKBCreate_QuotaOK_ProceedsToCreate(t *testing.T) {
+	quota := &mockQuotaChecker{checkKBErr: nil}
+	// With nil repo/pool, the service will panic at the DB step (after quota check).
+	// We recover and verify the panic is NOT a quota error — confirming the quota
+	// check passed and execution continued past it.
+	svc := service.NewKBService(nil, nil, quota)
+
+	defer func() {
+		if r := recover(); r != nil {
+			// Panic from nil pool is expected — means we got past the quota check.
+		}
+	}()
+
+	_, err := svc.Create(context.Background(), "org-1", "ws-1", model.CreateKBRequest{Name: "test"})
+	if err != nil {
+		if _, ok := err.(*apierror.QuotaError); ok {
+			t.Fatal("should not get quota error when under limit")
+		}
+		// Any other error is expected (nil repo)
+	}
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd /Users/jobinlawrance/Project/raven && go test ./internal/service/ -run TestKBCreate -v`
+Expected: PASS — quota enforcement short-circuits before DB calls
+
+- [ ] **Step 4: Verify compilation**
+
+Run: `cd /Users/jobinlawrance/Project/raven && go build ./internal/service/`
+Expected: BUILD SUCCESS (may need to update callers in main.go — defer to Task 9)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/service/kb.go internal/service/kb_test.go
+git commit -m "feat(billing): enforce KB quota in KBService.Create"
+```
+
+---
+
+### Task 6: Wire QuotaChecker into WorkspaceService
+
+**Files:**
+- Modify: `internal/service/workspace.go`
+
+- [ ] **Step 1: Update WorkspaceService struct and constructor**
+
+```go
+type WorkspaceService struct {
+	repo  *repository.WorkspaceRepository
+	pool  *pgxpool.Pool
+	quota QuotaCheckerI
+}
+
+func NewWorkspaceService(repo *repository.WorkspaceRepository, pool *pgxpool.Pool, quota QuotaCheckerI) *WorkspaceService {
+	return &WorkspaceService{repo: repo, pool: pool, quota: quota}
+}
+```
+
+- [ ] **Step 2: Add seat quota check to AddMember**
+
+At the top of `AddMember`:
+
+```go
+func (s *WorkspaceService) AddMember(ctx context.Context, orgID, wsID string, req model.AddWorkspaceMemberRequest) (*model.WorkspaceMember, error) {
+	// Enforce plan-tier seat limit.
+	if s.quota != nil {
+		if err := s.quota.CheckSeatQuota(ctx, orgID); err != nil {
+			return nil, err
+		}
+	}
+
+	var member *model.WorkspaceMember
+	// ... rest unchanged
+}
+```
+
+- [ ] **Step 3: Write integration test for AddMember quota enforcement**
+
+Add to `internal/service/kb_test.go` (shared test file) or create `internal/service/workspace_test.go`:
+
+```go
+func TestAddMember_QuotaExceeded_Returns402(t *testing.T) {
+	quota := &mockQuotaChecker{
+		checkSeatErr: apierror.NewPaymentRequired("seat limit reached (5/5)", 5),
+	}
+	svc := service.NewWorkspaceService(nil, nil, quota)
+
+	_, err := svc.AddMember(context.Background(), "org-1", "ws-1", model.AddWorkspaceMemberRequest{
+		UserID: "user-99",
+		Role:   "member",
+	})
+	if err == nil {
+		t.Fatal("expected quota error, got nil")
+	}
+	qErr, ok := err.(*apierror.QuotaError)
+	if !ok {
+		t.Fatalf("expected *QuotaError, got %T: %v", err, err)
+	}
+	if qErr.Code != 402 {
+		t.Errorf("expected 402, got %d", qErr.Code)
+	}
+}
+```
+
+- [ ] **Step 4: Run tests and verify compilation**
+
+Run: `cd /Users/jobinlawrance/Project/raven && go test ./internal/service/ -run TestAddMember_Quota -v && go build ./internal/service/`
+Expected: PASS + BUILD SUCCESS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/service/workspace.go internal/service/workspace_test.go
+git commit -m "feat(billing): enforce seat quota in WorkspaceService.AddMember"
+```
+
+---
+
+### Task 7: Wire QuotaChecker into VoiceService
+
+**Files:**
+- Modify: `internal/service/voice.go`
+
+- [ ] **Step 1: Update VoiceService to use QuotaChecker for concurrent session limit**
+
+Replace the hardcoded `maxConcurrentSessions` with a dynamic lookup. Update the struct:
+
+```go
+type VoiceService struct {
+	repo   VoiceRepository
+	pool   *pgxpool.Pool
+	lkc    LiveKitClient
+	lkHost string
+	quota  QuotaCheckerI
+}
+
+func NewVoiceService(repo VoiceRepository, pool *pgxpool.Pool, lkc LiveKitClient, lkHost string, quota QuotaCheckerI) *VoiceService {
+	return &VoiceService{
+		repo:   repo,
+		pool:   pool,
+		lkc:    lkc,
+		lkHost: lkHost,
+		quota:  quota,
+	}
+}
+```
+
+- [ ] **Step 2: Update CreateSession to use QuotaChecker for both concurrent limit and monthly quota**
+
+In `CreateSession`, replace the hardcoded limit check:
+
+```go
+func (s *VoiceService) CreateSession(ctx context.Context, orgID string, req *model.CreateVoiceSessionRequest) (*model.VoiceSession, error) {
+	if req == nil {
+		return nil, apierror.NewBadRequest("request body must not be nil")
+	}
+
+	// Enforce monthly voice-minute quota before creating session.
+	if s.quota != nil {
+		if err := s.quota.CheckVoiceMinuteQuota(ctx, orgID); err != nil {
+			return nil, err
+		}
+	}
+
+	req.LiveKitRoom = generateRoomName(orgID)
+
+	// Resolve concurrent session limit from subscription tier.
+	maxSessions := 1 // default free
+	if s.quota != nil {
+		maxSessions = s.quota.GetConcurrentVoiceLimit(ctx, orgID)
+	}
+
+	var session *model.VoiceSession
+	err := db.WithOrgID(ctx, s.pool, orgID, func(tx pgx.Tx) error {
+		if maxSessions >= 0 {
+			lockKey := int64(fnv32a(orgID))
+			if _, e := tx.Exec(ctx, "SELECT pg_advisory_xact_lock($1)", lockKey); e != nil {
+				return e
+			}
+			active, e := s.repo.CountActiveSessions(ctx, tx, orgID)
+			if e != nil {
+				return e
+			}
+			if active >= maxSessions {
+				return apierror.NewTooManyRequests("concurrent voice session limit reached")
+			}
+		}
+
+		var e error
+		session, e = s.repo.CreateSession(ctx, tx, orgID, req)
+		return e
+	})
+	// ... rest unchanged
+}
+```
+
+- [ ] **Step 3: Write integration test for voice quota enforcement**
+
+Add to a test file (e.g. `internal/service/voice_quota_test.go`):
+
+```go
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ravencloak-org/Raven/internal/model"
+	"github.com/ravencloak-org/Raven/internal/service"
+	"github.com/ravencloak-org/Raven/pkg/apierror"
+)
+
+func TestVoiceCreateSession_MonthlyQuotaExceeded_Returns402(t *testing.T) {
+	quota := &mockQuotaChecker{
+		checkVoiceMinErr: apierror.NewPaymentRequired("monthly voice minute quota exceeded (60/60 minutes)", 60),
+		concurrentLimit:  1,
+	}
+	svc := service.NewVoiceService(nil, nil, nil, "", quota)
+
+	_, err := svc.CreateSession(context.Background(), "org-1", &model.CreateVoiceSessionRequest{})
+	if err == nil {
+		t.Fatal("expected quota error, got nil")
+	}
+	qErr, ok := err.(*apierror.QuotaError)
+	if !ok {
+		t.Fatalf("expected *QuotaError, got %T: %v", err, err)
+	}
+	if qErr.Code != 402 {
+		t.Errorf("expected 402, got %d", qErr.Code)
+	}
+}
+```
+
+- [ ] **Step 4: Run tests and verify compilation**
+
+Run: `cd /Users/jobinlawrance/Project/raven && go test ./internal/service/ -run TestVoiceCreateSession -v && go build ./internal/service/`
+Expected: PASS + BUILD SUCCESS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/service/voice.go internal/service/voice_quota_test.go
+git commit -m "feat(billing): enforce concurrent + monthly voice quota in VoiceService"
+```
+
+---
+
+### Task 8: Create usage endpoint handler
+
+**Files:**
+- Create: `internal/handler/usage.go`
+- Create: `internal/handler/usage_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/handler/usage_test.go`:
+
+```go
+package handler_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/ravencloak-org/Raven/internal/handler"
+	"github.com/ravencloak-org/Raven/internal/middleware"
+	"github.com/ravencloak-org/Raven/internal/model"
+	"github.com/ravencloak-org/Raven/pkg/apierror"
+)
+
+type mockUsageService struct {
+	getUsageFn func(ctx context.Context, orgID string) (*model.UsageResponse, error)
+}
+
+func (m *mockUsageService) GetUsage(ctx context.Context, orgID string) (*model.UsageResponse, error) {
+	return m.getUsageFn(ctx, orgID)
+}
+
+func newUsageRouter(svc handler.UsageServicer) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(apierror.ErrorHandler())
+	h := handler.NewUsageHandler(svc)
+
+	authed := r.Group("/api/v1/billing")
+	authed.Use(func(c *gin.Context) {
+		c.Set(string(middleware.ContextKeyOrgID), "org-123")
+		c.Next()
+	})
+	authed.GET("/usage", h.GetUsage)
+
+	return r
+}
+
+func TestGetUsage_Success(t *testing.T) {
+	svc := &mockUsageService{
+		getUsageFn: func(_ context.Context, orgID string) (*model.UsageResponse, error) {
+			return &model.UsageResponse{
+				Plan:     model.DefaultPlans()[0],
+				KBsUsed:  2,
+				KBsLimit: 3,
+			}, nil
+		},
+	}
+	r := newUsageRouter(svc)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/billing/usage", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var usage model.UsageResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &usage); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if usage.KBsUsed != 2 {
+		t.Errorf("expected kbs_used 2, got %d", usage.KBsUsed)
+	}
+}
+
+func TestGetUsage_NoAuth_Returns401(t *testing.T) {
+	svc := &mockUsageService{}
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(apierror.ErrorHandler())
+	h := handler.NewUsageHandler(svc)
+	r.GET("/api/v1/billing/usage", h.GetUsage)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/billing/usage", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d: %s", w.Code, w.Body.String())
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/jobinlawrance/Project/raven && go test ./internal/handler/ -run TestGetUsage -v`
+Expected: FAIL — `UsageHandler`, `UsageServicer` don't exist.
+
+- [ ] **Step 3: Implement usage handler**
+
+Create `internal/handler/usage.go`:
+
+```go
+package handler
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/ravencloak-org/Raven/internal/middleware"
+	"github.com/ravencloak-org/Raven/internal/model"
+	"github.com/ravencloak-org/Raven/pkg/apierror"
+)
+
+// UsageServicer defines what the usage handler needs from the service layer.
+type UsageServicer interface {
+	GetUsage(ctx context.Context, orgID string) (*model.UsageResponse, error)
+}
+
+// UsageHandler handles HTTP requests for billing usage.
+type UsageHandler struct {
+	svc UsageServicer
+}
+
+// NewUsageHandler creates a new UsageHandler.
+func NewUsageHandler(svc UsageServicer) *UsageHandler {
+	return &UsageHandler{svc: svc}
+}
+
+// GetUsage handles GET /api/v1/billing/usage.
+//
+// @Summary     Get billing usage
+// @Tags        billing
+// @Produce     json
+// @Security    BearerAuth
+// @Success     200 {object} model.UsageResponse
+// @Failure     401 {object} apierror.AppError
+// @Failure     500 {object} apierror.AppError
+// @Router      /billing/usage [get]
+func (h *UsageHandler) GetUsage(c *gin.Context) {
+	orgID, exists := c.Get(string(middleware.ContextKeyOrgID))
+	if !exists {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, apierror.AppError{
+			Code:    http.StatusUnauthorized,
+			Message: "Unauthorized",
+			Detail:  "missing organisation context",
+		})
+		return
+	}
+
+	usage, err := h.svc.GetUsage(c.Request.Context(), orgID.(string))
+	if err != nil {
+		_ = c.Error(err)
+		c.Abort()
+		return
+	}
+	c.JSON(http.StatusOK, usage)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/jobinlawrance/Project/raven && go test ./internal/handler/ -run TestGetUsage -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/handler/usage.go internal/handler/usage_test.go
+git commit -m "feat(billing): add GET /billing/usage endpoint"
+```
+
+---
+
+### Task 9: Wire everything together in main.go and update Valkey tier cache
+
+**Files:**
+- Modify: `cmd/api/main.go`
+
+- [ ] **Step 1: Create QuotaChecker and wire into services**
+
+In `cmd/api/main.go`, after the `billingSvc` initialization (~line 295), add:
+
+```go
+// --- Quota enforcement ---
+subCache := service.NewValkeySubscriptionCache(valkeyClient)
+quotaChecker := service.NewQuotaChecker(billingRepo, subCache, pool)
+```
+
+- [ ] **Step 2: Update service constructors to pass quotaChecker**
+
+Update the `NewKBService`, `NewWorkspaceService`, and `NewVoiceService` calls:
+
+```go
+// Before (existing):
+kbSvc := service.NewKBService(kbRepo, pool)
+wsSvc := service.NewWorkspaceService(wsRepo, pool)
+voiceSvc := service.NewVoiceService(voiceRepo, pool, livekitClient, cfg.LiveKit.WSURL, 1)
+
+// After:
+kbSvc := service.NewKBService(kbRepo, pool, quotaChecker)
+wsSvc := service.NewWorkspaceService(wsRepo, pool, quotaChecker)
+voiceSvc := service.NewVoiceService(voiceRepo, pool, livekitClient, cfg.LiveKit.WSURL, quotaChecker)
+```
+
+- [ ] **Step 3: Create UsageHandler and register route**
+
+After billingHandler initialization:
+
+```go
+usageHandler := handler.NewUsageHandler(quotaChecker)
+```
+
+In the billing route group (~line 670):
+
+```go
+billing := api.Group("/billing")
+{
+	billing.GET("/plans", billingHandler.GetPlans)
+	billing.POST("/subscriptions", billingHandler.Subscribe)
+	billing.DELETE("/subscriptions/:id", billingHandler.Unsubscribe)
+	billing.POST("/payment-intents", billingHandler.CreatePaymentIntent)
+	billing.GET("/usage", usageHandler.GetUsage) // NEW
+}
+```
+
+- [ ] **Step 4: Update Valkey tier cache on subscription create**
+
+In `internal/service/billing.go`, add a cache update after creating a subscription. First, add a `tierCache` field:
+
+```go
+type BillingService struct {
+	repo          BillingRepository
+	pool          *pgxpool.Pool
+	hsClient      HyperswitchClient
+	webhookSecret string
+	plans         map[string]model.Plan
+	valkeyClient  redis.Cmdable // for tier cache
+}
+```
+
+Update `NewBillingService` to accept `valkeyClient redis.Cmdable`.
+
+After `s.repo.CreateSubscription` succeeds in `CreateSubscription`, cache the tier:
+
+```go
+// Update Valkey tier cache so rate limiter picks up the new tier.
+if s.valkeyClient != nil {
+	cacheCtx, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
+	defer cancel()
+	s.valkeyClient.Set(cacheCtx, "raven:org_tier:"+orgID, string(plan.Tier), 5*time.Minute)
+}
+```
+
+- [ ] **Step 5: Verify `ByOrgTier` middleware is already wired on API routes**
+
+The spec requires "Enforce API call rate limit by plan tier (wire into the existing Valkey-backed rate limiter)." Verify that `cmd/api/main.go` already has this line on the `api` group:
+
+```go
+api.Use(middleware.ByOrgTier(rl, tierResolver, tierCfg, middleware.RouteGroupGeneral))
+```
+
+This is already present at line ~434. The `ValkeyTierResolver` reads `raven:org_tier:{orgID}` from Valkey (line ~373 of `ratelimit.go`), and Step 4 above caches the tier there on subscription create. **No additional wiring needed** — just verify the line exists. If for any reason it's missing, add it.
+
+Also verify the completion route group uses `RouteGroupCompletion`. Check if any routes use `ByOrgTier(rl, tierResolver, tierCfg, middleware.RouteGroupCompletion)`. If not, and there are AI completion routes, add that middleware to those route groups.
+
+- [ ] **Step 6: Verify compilation and run existing tests**
+
+Run: `cd /Users/jobinlawrance/Project/raven && go build ./cmd/api/ && go test ./internal/... -count=1`
+Expected: BUILD SUCCESS, all tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cmd/api/main.go internal/service/billing.go
+git commit -m "feat(billing): wire QuotaChecker into services and register usage endpoint"
+```
+
+---
+
+### Task 10: Run full test suite and lint
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run all Go tests**
+
+Run: `cd /Users/jobinlawrance/Project/raven && go test ./... -count=1 -timeout 120s`
+Expected: All PASS
+
+- [ ] **Step 2: Run golangci-lint**
+
+Run: `cd /Users/jobinlawrance/Project/raven && golangci-lint run ./...`
+Expected: No errors (fix any issues before proceeding)
+
+- [ ] **Step 3: Final commit if lint fixes were needed**
+
+```bash
+git add -A
+git commit -m "fix(lint): address linter findings in billing enforcement"
+```

--- a/docs/superpowers/plans/2026-04-10-wave1-quick-fixes.md
+++ b/docs/superpowers/plans/2026-04-10-wave1-quick-fixes.md
@@ -1,0 +1,354 @@
+# Wave 1: Quick Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close three independent quick-fix issues (#233, #237, #232) to establish a clean test baseline before Wave 2 feature work begins.
+
+**Architecture:** All three issues are confined to Go test infrastructure — no production code changes. #233 hardens the shared test database helper, #237 removes vacuous compile-only tests and standalone WAF concept tests from EE stubs, and #232 adds REVOKE cleanup to RLS test fixtures to prevent privilege leakage between parallel tests.
+
+**Tech Stack:** Go 1.25, testify, goose v3, pgxpool, testcontainers-go, PostgreSQL 18 (pgvector)
+
+---
+
+## File Structure
+
+```
+internal/
+  testutil/
+    db.go                         # #233 — already fixed (os.Stat guard present)
+  ee/
+    analytics/analytics_test.go   # #237 — remove TestPackageCompiles
+    connectors/connectors_test.go # #237 — remove TestPackageCompiles
+    lead/lead_test.go             # #237 — remove TestPackageCompiles
+    sso/sso_test.go               # #237 — remove TestPackageCompiles
+    audit/audit_test.go           # #237 — remove TestPackageCompiles
+    webhooks/webhooks_test.go     # #237 — remove TestPackageCompiles (keep HMAC + retry tests)
+    security/security_test.go     # #237 — remove TestPackageCompiles, keep WAF concept tests
+  repository/
+    rls_test.go                   # #232 — already fixed (t.Cleanup with REVOKE present)
+```
+
+---
+
+## Issue #233 — Harden `testutil.NewTestDB` migrations path
+
+### Current State
+
+The `os.Stat(migrationsDir)` guard is **already present** in `internal/testutil/db.go` (lines 97-99):
+
+```go
+if _, err := os.Stat(migrationsDir); err != nil {
+    t.Fatalf("migrations directory not found at %s (resolved from testutil/db.go location): %v", migrationsDir, err)
+}
+```
+
+This was added in commit `ee54499` ("fix(test): add os.Stat guard for migrations directory in testutil.NewTestDB").
+
+### Tasks
+
+- [ ] **Task 1.1: Verify the fix is already on the current branch**
+
+  ```bash
+  cd /Users/jobinlawrance/Project/raven
+  git log --oneline --all --grep="os.Stat" -- internal/testutil/db.go
+  ```
+
+  Expected output includes commit `ee54499`.
+
+- [ ] **Task 1.2: Verify the guard works by running a targeted test**
+
+  ```bash
+  cd /Users/jobinlawrance/Project/raven
+  go test -v -run TestRLS_MigrationVersion_AllApplied -count=1 ./internal/repository/
+  ```
+
+  Expected: test passes (this exercises `NewTestDB` which calls `RunMigrations` with the `os.Stat` guard).
+
+- [ ] **Task 1.3: Confirm the issue can be closed as already resolved**
+
+  Since the fix is already committed, the PR for #233 should reference commit `ee54499` and close the issue. If creating a standalone PR, create a branch with a no-op commit that references the fix:
+
+  ```bash
+  # If the commit is already on main, just close the issue via:
+  gh issue close 233 --comment "Resolved in commit ee54499 — os.Stat guard added to RunMigrations in internal/testutil/db.go"
+  ```
+
+  If the commit is NOT yet on main (only on `test/go-backend-suite`), ensure it gets merged with that branch's PR.
+
+---
+
+## Issue #237 — Clean up `TestPackageCompiles` and `t.Skip` in EE stubs
+
+### Current State
+
+Six EE stub packages have vacuous `TestPackageCompiles` functions that only log a message and import the package with a blank identifier. These provide no value — the Go build system already catches compilation errors when any test in the package is run. Commit `8fad319` replaced the body of `TestPackageCompiles` in 3 files (`audit_test.go`, `security_test.go`, `webhooks_test.go`) with a log statement, but the function signatures remain in all 7 files. The `analytics`, `connectors`, `lead`, and `sso` test files were originally created without `t.Skip` at all. The remaining work is to remove the vacuous `TestPackageCompiles` function from all 7 files.
+
+The `security_test.go` file has three WAF concept tests (`TestWAFRuleEval_BlockPattern_Concept`, `TestWAFRuleEval_AllowOverridesBlock_Concept`, `TestWAFRuleEval_LogRule_PassesThrough_Concept`) plus a `TestPackageCompiles`. The WAF concept tests are self-contained design-documentation tests with local helper functions — they test inline logic, not actual package code. The spec says to "remove or implement" them. Since the `security` package is an empty stub (`package security` with no exports), these concept tests document future behaviour and should be **kept** — they are harmless, pass reliably, and serve as living documentation for the WAF rule engine contract.
+
+### Tasks
+
+- [ ] **Task 2.1: Remove `TestPackageCompiles` from `analytics_test.go`**
+
+  **File:** `internal/ee/analytics/analytics_test.go`
+
+  Replace the entire file contents with a minimal file that retains the blank import (ensuring the package still compiles as part of `go test ./...`):
+
+  ```go
+  package analytics_test
+
+  import (
+  	_ "github.com/ravencloak-org/Raven/internal/ee/analytics"
+  )
+  ```
+
+  **Verify:**
+  ```bash
+  cd /Users/jobinlawrance/Project/raven
+  go test -v -count=1 ./internal/ee/analytics/
+  ```
+
+  Expected: `ok` with no test functions listed (package compiles, no tests to run).
+
+- [ ] **Task 2.2: Remove `TestPackageCompiles` from `connectors_test.go`**
+
+  **File:** `internal/ee/connectors/connectors_test.go`
+
+  Replace the entire file contents with:
+
+  ```go
+  package connectors_test
+
+  import (
+  	_ "github.com/ravencloak-org/Raven/internal/ee/connectors"
+  )
+  ```
+
+  **Verify:**
+  ```bash
+  go test -v -count=1 ./internal/ee/connectors/
+  ```
+
+- [ ] **Task 2.3: Remove `TestPackageCompiles` from `lead_test.go`**
+
+  **File:** `internal/ee/lead/lead_test.go`
+
+  Replace the entire file contents with:
+
+  ```go
+  package lead_test
+
+  import (
+  	_ "github.com/ravencloak-org/Raven/internal/ee/lead"
+  )
+  ```
+
+  **Verify:**
+  ```bash
+  go test -v -count=1 ./internal/ee/lead/
+  ```
+
+- [ ] **Task 2.4: Remove `TestPackageCompiles` from `sso_test.go`**
+
+  **File:** `internal/ee/sso/sso_test.go`
+
+  Replace the entire file contents with:
+
+  ```go
+  package sso_test
+
+  import (
+  	_ "github.com/ravencloak-org/Raven/internal/ee/sso"
+  )
+  ```
+
+  **Verify:**
+  ```bash
+  go test -v -count=1 ./internal/ee/sso/
+  ```
+
+- [ ] **Task 2.5: Remove `TestPackageCompiles` from `audit_test.go`**
+
+  **File:** `internal/ee/audit/audit_test.go`
+
+  Replace the entire file contents with:
+
+  ```go
+  package audit_test
+
+  import (
+  	_ "github.com/ravencloak-org/Raven/internal/ee/audit"
+  )
+  ```
+
+  **Verify:**
+  ```bash
+  go test -v -count=1 ./internal/ee/audit/
+  ```
+
+- [ ] **Task 2.6: Remove `TestPackageCompiles` from `webhooks_test.go`**
+
+  **File:** `internal/ee/webhooks/webhooks_test.go`
+
+  Remove only the `TestPackageCompiles` function (lines 18-20). Keep everything else (HMAC and retry/dead-letter tests).
+
+  Delete these lines:
+  ```go
+  // TestPackageCompiles ensures the webhooks package is importable and correctly declared.
+  func TestPackageCompiles(t *testing.T) {
+  	t.Log("internal/ee/webhooks package compiles successfully")
+  }
+  ```
+
+  The blank import `_ "github.com/ravencloak-org/Raven/internal/ee/webhooks"` on line 14 must remain — it ensures compile-time verification.
+
+  **Verify:**
+  ```bash
+  go test -v -count=1 ./internal/ee/webhooks/
+  ```
+
+  Expected: 5 tests pass (HMAC + retry tests), no `TestPackageCompiles`.
+
+- [ ] **Task 2.7: Remove `TestPackageCompiles` from `security_test.go`**
+
+  **File:** `internal/ee/security/security_test.go`
+
+  Remove only the `TestPackageCompiles` function (lines 14-18). Keep the WAF concept tests and helper functions — they are self-contained, pass reliably, and document the future WAF rule engine contract.
+
+  Delete these lines:
+  ```go
+  // TestPackageCompiles ensures the security package is importable and correctly declared.
+  func TestPackageCompiles(t *testing.T) {
+  	// The EE security package is a stub pending implementation.
+  	// This test ensures the package declaration is correct and it builds cleanly.
+  	t.Log("internal/ee/security package compiles successfully")
+  }
+  ```
+
+  The blank import `_ "github.com/ravencloak-org/Raven/internal/ee/security"` on line 10 must remain.
+
+  **Verify:**
+  ```bash
+  go test -v -count=1 ./internal/ee/security/
+  ```
+
+  Expected: 3 WAF concept tests pass, no `TestPackageCompiles`.
+
+- [ ] **Task 2.8: Run full EE test suite**
+
+  ```bash
+  cd /Users/jobinlawrance/Project/raven
+  go test -v -count=1 ./internal/ee/...
+  ```
+
+  Expected: all EE packages pass. The `analytics`, `connectors`, `lead`, `sso`, and `audit` packages report `ok` with `testing: warning: no tests to run` (they have blank-import-only `_test.go` files but no test functions). The `webhooks`, `security`, and `licensing` packages run their substantive tests.
+
+- [ ] **Task 2.9: Lint check**
+
+  ```bash
+  cd /Users/jobinlawrance/Project/raven
+  golangci-lint run ./internal/ee/...
+  ```
+
+  Expected: no new lint errors.
+
+- [ ] **Task 2.10: Commit and create PR**
+
+  ```bash
+  cd /Users/jobinlawrance/Project/raven
+  git checkout -b chore/cleanup-ee-stub-tests
+  git add internal/ee/analytics/analytics_test.go \
+        internal/ee/connectors/connectors_test.go \
+        internal/ee/lead/lead_test.go \
+        internal/ee/sso/sso_test.go \
+        internal/ee/audit/audit_test.go \
+        internal/ee/webhooks/webhooks_test.go \
+        internal/ee/security/security_test.go
+  git commit -m "chore(test): remove vacuous TestPackageCompiles from EE stubs
+
+  Remove TestPackageCompiles functions from analytics, connectors, lead,
+  sso, audit, webhooks, and security test files. These tests only logged
+  a message and provided no value — the Go build system catches compile
+  errors when any test in the package runs.
+
+  Keep WAF concept tests in security_test.go as living documentation for
+  the future rule engine contract. Keep HMAC and retry tests in
+  webhooks_test.go. Retain blank imports in all files for compile-time
+  verification.
+
+  Closes #237"
+  git push -u origin chore/cleanup-ee-stub-tests
+  gh pr create --title "chore(test): remove vacuous TestPackageCompiles from EE stubs" \
+    --body "## Summary
+  - Remove \`TestPackageCompiles\` functions from 7 EE stub test files
+  - Keep WAF concept tests (security) and HMAC/retry tests (webhooks)
+  - Retain blank imports for compile-time verification
+
+  Closes #237
+
+  ## Test plan
+  - [ ] \`go test ./internal/ee/...\` passes
+  - [ ] \`golangci-lint run ./internal/ee/...\` clean"
+  gh pr merge --auto --squash
+  ```
+
+---
+
+## Issue #232 — Add REVOKE cleanup to RLS test fixtures
+
+### Current State
+
+The `t.Cleanup` with `REVOKE` statements is **already present** in `internal/repository/rls_test.go` (lines 47-54):
+
+```go
+// Revoke grants on cleanup so parallel tests don't leak privileges.
+t.Cleanup(func() {
+    for _, stmt := range []string{
+        `REVOKE SELECT, INSERT ON knowledge_bases FROM raven_app`,
+        `REVOKE USAGE ON SCHEMA public FROM raven_app`,
+    } {
+        _, _ = pool.Exec(ctx, stmt)
+    }
+})
+```
+
+This was added in commit `c761096` ("fix(test): add REVOKE cleanup to seedRLSFixtures") in the `test/go-backend-suite` branch.
+
+### Tasks
+
+- [ ] **Task 3.1: Verify the fix is already on the current branch**
+
+  ```bash
+  cd /Users/jobinlawrance/Project/raven
+  git log --oneline --all --grep="REVOKE" -- internal/repository/rls_test.go
+  ```
+
+  Expected: a commit referencing the REVOKE cleanup.
+
+- [ ] **Task 3.2: Verify the cleanup works by running the RLS tests**
+
+  ```bash
+  cd /Users/jobinlawrance/Project/raven
+  go test -v -run "TestRLS" -count=1 ./internal/repository/
+  ```
+
+  Expected: all 3 RLS tests pass (`TestRLS_CrossOrgKB_ReturnsZeroRows`, `TestRLS_CrossOrgKB_GetByID_ReturnsError`, `TestRLS_MigrationVersion_AllApplied`).
+
+- [ ] **Task 3.3: Confirm the issue can be closed as already resolved**
+
+  Same approach as #233 — if the commit is already on main, close directly. If only on the `test/go-backend-suite` branch, ensure it merges with that branch's PR.
+
+  ```bash
+  gh issue close 232 --comment "Resolved — t.Cleanup with REVOKE statements added to seedRLSFixtures in internal/repository/rls_test.go"
+  ```
+
+---
+
+## Summary of Actions Required
+
+| Issue | Status | Action Needed |
+|-------|--------|---------------|
+| #233 | **Already fixed** on `test/go-backend-suite` | Close issue when branch merges to main |
+| #237 | **Partially fixed** — `t.Skip` removed but `TestPackageCompiles` remains in 7 files | Execute Tasks 2.1-2.10 (new branch + PR) |
+| #232 | **Already fixed** on `test/go-backend-suite` | Close issue when branch merges to main |
+
+**Net new work:** Only issue #237 requires code changes — removing `TestPackageCompiles` from 7 EE test files. Issues #233 and #232 are already resolved in the current branch and just need their issues closed once the branch merges.

--- a/docs/superpowers/plans/2026-04-10-wave2-ee-tests-and-billing.md
+++ b/docs/superpowers/plans/2026-04-10-wave2-ee-tests-and-billing.md
@@ -1,0 +1,768 @@
+# Wave 2: EE Tests + Billing Enforcement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace vacuous webhook retry/dead-letter tests with real integration tests backed by testcontainers (Valkey + Asynq), and enforce subscription plan limits across KB, workspace, and voice services with a new `QuotaChecker` and `/billing/usage` endpoint.
+
+**Architecture:** Track A creates a `NewTestValkey` testcontainer helper and rewrites the skipped webhook tests as integration tests that enqueue real Asynq tasks against a Valkey container, verifying retry behaviour and dead-letter semantics end-to-end. Track B adds a `QuotaChecker` service with Valkey-cached subscription lookups, injects limit-check calls into existing `Create`/`AddMember`/`CreateSession` service methods, exposes a `GET /billing/usage` endpoint, and returns `402 Payment Required` when limits are exceeded. Both tracks are independent and can run in parallel.
+
+**Tech Stack:** Go 1.24, Gin, pgx/v5, go-redis/v9 (Valkey), hibiken/asynq, alicebob/miniredis, testcontainers-go, testify, httptest
+
+---
+
+## Track B: Billing Subscription Enforcement (#193)
+
+Track B follows the existing plan at `docs/superpowers/plans/2026-04-10-billing-subscription-enforcement.md`.
+
+**Validation against codebase (2026-04-10):** The existing plan is accurate. All assumptions hold:
+- `NewKBService(kbRepo, pool)` at `cmd/api/main.go:267` matches the plan's modification target
+- `NewWorkspaceService(wsRepo, pool)` at `cmd/api/main.go:265` matches
+- `NewVoiceService(voiceRepo, pool, livekitClient, cfg.LiveKit.WSURL, 1)` at `cmd/api/main.go:313` matches (hardcoded `maxSessions=1` to be replaced with `QuotaChecker`)
+- `NewBillingService(billingRepo, pool, hsClient, cfg.Hyperswitch.WebhookSecret)` at `cmd/api/main.go:295` matches (needs `valkeyClient` parameter added)
+- `ByOrgTier` is already wired at `cmd/api/main.go:434` (general), `:692` (widget), `:696` (completion) -- no additional rate-limit wiring needed
+- `ValkeyTierResolver` reads `raven:org_tier:{orgID}` keys -- matches the plan's cache write on subscription create
+- `pkg/apierror` does not yet have `NewPaymentRequired` or `QuotaError` -- plan's Task 1 creates them
+- `voice_usage_summaries` table exists (migration `00030_voice_usage.sql`) -- matches the plan's SQL query
+- No code divergence detected. Execute the existing plan as-is.
+
+---
+
+## Track A: Webhook Retry/Dead-Letter Tests (#236)
+
+### File Structure
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `internal/testutil/valkey_test.go` | Smoke test for `NewTestValkey` (written first — TDD) |
+| Create | `internal/testutil/valkey.go` | `NewTestValkey` — testcontainers helper for Valkey + Asynq |
+| Modify | `internal/jobs/webhook_delivery.go` | Add `NewWebhookDeliveryHandlerWithClient` for test-injectable HTTP client |
+| Create | `internal/jobs/webhook_retry_integration_test.go` | Integration test: failure_count incremented on HTTP 500 |
+| Create | `internal/jobs/webhook_deadletter_integration_test.go` | Integration test: webhook marked "failed" after max_retries exhausted |
+| Create | `internal/jobs/webhook_success_reset_integration_test.go` | Integration test: failure_count reset to 0 on successful delivery |
+| Modify | `internal/ee/webhooks/webhooks_test.go` | Remove vacuous retry/dead-letter concept tests |
+
+---
+
+### Task 1: Create Valkey testcontainer helper
+
+**Files:**
+- Create: `internal/testutil/valkey_test.go` (first — TDD)
+- Create: `internal/testutil/valkey.go` (after test is confirmed failing)
+
+- [ ] **Step 1: Write the smoke test first (TDD — test before implementation)**
+
+Create `internal/testutil/valkey_test.go`:
+
+```go
+package testutil_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ravencloak-org/Raven/internal/testutil"
+)
+
+func TestNewTestValkey_Ping(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	vc := testutil.NewTestValkey(t)
+
+	client := redis.NewClient(&redis.Options{Addr: vc.Addr})
+	defer client.Close()
+
+	err := client.Ping(context.Background()).Err()
+	require.NoError(t, err, "Valkey container must be reachable via Ping")
+}
+```
+
+- [ ] **Step 2: Run the test — confirm it fails to compile (NewTestValkey undefined)**
+
+Run: `cd /Users/jobinlawrance/Project/raven && go test ./internal/testutil/ -run TestNewTestValkey_Ping -v -timeout 60s`
+Expected: COMPILE ERROR — `testutil.NewTestValkey` undefined
+
+- [ ] **Step 3: Create the helper implementation**
+
+Create `internal/testutil/valkey.go`:
+
+```go
+package testutil
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// ValkeyContainer holds the running Valkey container address for tests.
+type ValkeyContainer struct {
+	Addr string // host:port for redis/asynq clients
+}
+
+// NewTestValkey spins up a real Valkey (Redis-compatible) container using
+// testcontainers and returns its address. The container is terminated when t ends.
+func NewTestValkey(t *testing.T) *ValkeyContainer {
+	t.Helper()
+	ctx := context.Background()
+
+	req := testcontainers.ContainerRequest{
+		Image:        "valkey/valkey:8-alpine",
+		ExposedPorts: []string{"6379/tcp"},
+		WaitingFor: wait.ForLog("Ready to accept connections").
+			WithStartupTimeout(30 * time.Second),
+	}
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	require.NoError(t, err, "start valkey container")
+	t.Cleanup(func() { _ = container.Terminate(ctx) })
+
+	host, err := container.Host(ctx)
+	require.NoError(t, err)
+
+	port, err := container.MappedPort(ctx, "6379")
+	require.NoError(t, err)
+
+	addr := fmt.Sprintf("%s:%s", host, port.Port())
+
+	return &ValkeyContainer{Addr: addr}
+}
+```
+
+- [ ] **Step 4: Run the smoke test — confirm it passes**
+
+Run: `cd /Users/jobinlawrance/Project/raven && go test ./internal/testutil/ -run TestNewTestValkey_Ping -v -timeout 60s`
+Expected: PASS (container starts, ping succeeds, container terminates on cleanup)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/testutil/valkey.go internal/testutil/valkey_test.go
+git commit -m "test(infra): add Valkey testcontainer helper for integration tests"
+```
+
+---
+
+### Task 2: Rewrite webhook retry test as integration test
+
+**Files:**
+- Modify: `internal/jobs/webhook_delivery.go` (add `NewWebhookDeliveryHandlerWithClient`)
+- Create: `internal/jobs/webhook_retry_integration_test.go`
+
+The current test at lines 83-91 is vacuous -- it simply asserts that a hardcoded variable equals 0. The real retry logic lives in `internal/jobs/webhook_delivery.go` where the `ProcessTask` handler:
+1. Increments `failure_count` on failed delivery
+2. Compares against `max_retries` on the `WebhookConfig`
+3. Calls `asynq.SkipRetry` when threshold is reached
+4. Resets `failure_count` on success
+
+We need a real integration test that exercises this flow through an actual Asynq server + Valkey.
+
+**SSRF guard bypass:** `httptest.NewServer` binds to `127.0.0.1` which is blocked by the `safeDialContext` in `NewWebhookDeliveryHandler`. Integration tests must use a separate constructor that accepts a caller-supplied `*http.Client`, bypassing the SSRF transport.
+
+- [ ] **Step 1: Add `NewWebhookDeliveryHandlerWithClient` to `internal/jobs/webhook_delivery.go`**
+
+Add the following constructor immediately after `NewWebhookDeliveryHandler` in `internal/jobs/webhook_delivery.go`:
+
+```go
+// NewWebhookDeliveryHandlerWithClient creates a WebhookDeliveryHandler with a
+// caller-supplied HTTP client. Intended for testing only — the caller is
+// responsible for ensuring the client's transport is appropriately restricted.
+func NewWebhookDeliveryHandlerWithClient(pool *pgxpool.Pool, repo *repository.WebhookRepository, client *http.Client, logger *slog.Logger) *WebhookDeliveryHandler {
+	return &WebhookDeliveryHandler{
+		pool:       pool,
+		repo:       repo,
+		httpClient: client,
+		logger:     logger,
+	}
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd /Users/jobinlawrance/Project/raven && go build ./internal/jobs/`
+Expected: BUILD SUCCESS
+
+- [ ] **Step 3: Create the integration test file**
+
+Create `internal/jobs/webhook_retry_integration_test.go`:
+
+```go
+package jobs_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/hibiken/asynq"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ravencloak-org/Raven/internal/db"
+	"github.com/ravencloak-org/Raven/internal/jobs"
+	"github.com/ravencloak-org/Raven/internal/queue"
+	"github.com/ravencloak-org/Raven/internal/repository"
+	"github.com/ravencloak-org/Raven/internal/testutil"
+)
+
+// TestWebhookRetry_Integration verifies that the webhook delivery handler
+// increments failure_count on HTTP failures and eventually stops retrying
+// (dead-letter behaviour) when max_retries is reached.
+//
+// This test requires Docker and spins up real Valkey + Postgres containers.
+func TestWebhookRetry_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	// --- Infrastructure ---
+	pool := testutil.NewTestDB(t)
+	vc := testutil.NewTestValkey(t)
+	ctx := context.Background()
+	orgID := uuid.New().String()
+	webhookID := uuid.New().String()
+	deliveryID := uuid.New().String()
+	logger := slog.Default()
+
+	// --- Seed test data ---
+	// Insert org, then webhook config with max_retries=2 via direct SQL
+	// so we have a known webhook_id to reference.
+	_, err := pool.Exec(ctx, "INSERT INTO organizations (id, name, slug) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING",
+		orgID, "Retry Test Org", "retry-test-org")
+	require.NoError(t, err)
+
+	// Set RLS context for subsequent inserts.
+	tx, err := pool.Begin(ctx)
+	require.NoError(t, err)
+	_, err = tx.Exec(ctx, "SELECT set_config('app.current_org_id', $1, true)", orgID)
+	require.NoError(t, err)
+
+	// Create a target HTTP server that always returns 500.
+	// Use httptest.NewServer with NewWebhookDeliveryHandlerWithClient (bypasses SSRF guard).
+	var hitCount atomic.Int32
+	targetServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hitCount.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error": "forced failure"}`))
+	}))
+	defer targetServer.Close()
+
+	// Insert webhook config.
+	_, err = tx.Exec(ctx, `
+		INSERT INTO webhook_configs (id, org_id, name, url, secret, events, max_retries, status, failure_count)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+		webhookID, orgID, "Retry Test Hook", targetServer.URL,
+		"test-secret-key", []string{"lead.generated"}, 2, "active", 0)
+	require.NoError(t, err)
+
+	// Insert a delivery record.
+	_, err = tx.Exec(ctx, `
+		INSERT INTO webhook_deliveries (id, webhook_id, org_id, event_type, payload)
+		VALUES ($1, $2, $3, $4, $5)`,
+		deliveryID, webhookID, orgID, "lead.generated", `{"lead_id": "l-1"}`)
+	require.NoError(t, err)
+
+	require.NoError(t, tx.Commit(ctx))
+
+	// --- Set up Asynq server ---
+	// Use NewWebhookDeliveryHandlerWithClient with a plain http.Client to bypass
+	// the SSRF safeDialContext that blocks loopback addresses used by httptest.
+	webhookRepo := repository.NewWebhookRepository(pool)
+	handler := jobs.NewWebhookDeliveryHandlerWithClient(pool, webhookRepo, &http.Client{}, logger)
+
+	asynqSrv := asynq.NewServer(
+		asynq.RedisClientOpt{Addr: vc.Addr},
+		asynq.Config{
+			Concurrency: 1,
+			Queues:      map[string]int{"default": 1},
+		},
+	)
+	mux := asynq.NewServeMux()
+	mux.Handle(queue.TypeWebhookDelivery, handler)
+
+	require.NoError(t, asynqSrv.Start(mux))
+	defer asynqSrv.Shutdown()
+
+	// --- Enqueue the task ---
+	asynqClient := asynq.NewClient(asynq.RedisClientOpt{Addr: vc.Addr})
+	defer asynqClient.Close()
+
+	payload := queue.WebhookDeliveryPayload{
+		DeliveryID: deliveryID,
+		WebhookID:  webhookID,
+		OrgID:      orgID,
+		EventType:  "lead.generated",
+		Payload:    map[string]any{"lead_id": "l-1"},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	task := asynq.NewTask(queue.TypeWebhookDelivery, data)
+	_, err = asynqClient.Enqueue(task,
+		asynq.MaxRetry(0), // retries managed by handler
+		asynq.Queue("default"),
+	)
+	require.NoError(t, err)
+
+	// --- Wait for processing (polling, not fixed sleep) ---
+	require.Eventually(t, func() bool {
+		return hitCount.Load() >= 1
+	}, 10*time.Second, 200*time.Millisecond, "target server must have been hit at least once")
+
+	// --- Verify: failure_count incremented ---
+	// Check failure_count in DB using WithOrgID to set RLS context.
+	var failureCount int
+	var status string
+	err = db.WithOrgID(ctx, pool, orgID, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			"SELECT failure_count, status FROM webhook_configs WHERE id = $1 AND org_id = $2",
+			webhookID, orgID).Scan(&failureCount, &status)
+	})
+	require.NoError(t, err)
+
+	assert.GreaterOrEqual(t, failureCount, 1,
+		"failure_count must be incremented after failed delivery")
+}
+```
+
+- [ ] **Step 4: Run the integration test**
+
+Run: `cd /Users/jobinlawrance/Project/raven && go test ./internal/jobs/ -run TestWebhookRetry_Integration -v -timeout 120s`
+Expected: PASS -- the handler hits the 500 server, increments failure_count, delivery record is updated.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/jobs/webhook_delivery.go internal/jobs/webhook_retry_integration_test.go
+git commit -m "test(webhooks): add integration test for retry behaviour with real Valkey + Asynq"
+```
+
+---
+
+### Task 3: Rewrite dead-letter test as integration test
+
+**Files:**
+- Create: `internal/jobs/webhook_deadletter_integration_test.go`
+
+The current test at lines 95-115 in `webhooks_test.go` uses inline structs to simulate dead-letter logic. We need a real test that verifies: after `max_retries` failed deliveries, the webhook status is set to `"failed"` (dead-lettered).
+
+- [ ] **Step 1: Create the dead-letter integration test**
+
+Create `internal/jobs/webhook_deadletter_integration_test.go`:
+
+```go
+package jobs_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/hibiken/asynq"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ravencloak-org/Raven/internal/db"
+	"github.com/ravencloak-org/Raven/internal/jobs"
+	"github.com/ravencloak-org/Raven/internal/queue"
+	"github.com/ravencloak-org/Raven/internal/repository"
+	"github.com/ravencloak-org/Raven/internal/testutil"
+)
+
+// TestWebhookDeadLetter_Integration verifies that after max_retries failed
+// deliveries, the webhook config status is set to "failed" (dead-lettered)
+// and asynq.SkipRetry prevents further processing.
+//
+// This test requires Docker and spins up real Valkey + Postgres containers.
+func TestWebhookDeadLetter_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	pool := testutil.NewTestDB(t)
+	vc := testutil.NewTestValkey(t)
+	ctx := context.Background()
+	orgID := uuid.New().String()
+	webhookID := uuid.New().String()
+	deliveryID := uuid.New().String()
+	logger := slog.Default()
+
+	// --- Seed data ---
+	_, err := pool.Exec(ctx, "INSERT INTO organizations (id, name, slug) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING",
+		orgID, "Dead Letter Org", "deadletter-org")
+	require.NoError(t, err)
+
+	tx, err := pool.Begin(ctx)
+	require.NoError(t, err)
+	_, err = tx.Exec(ctx, "SELECT set_config('app.current_org_id', $1, true)", orgID)
+	require.NoError(t, err)
+
+	// Server that always fails.
+	// Use httptest.NewServer with NewWebhookDeliveryHandlerWithClient (bypasses SSRF guard).
+	var hitCount atomic.Int32
+	targetServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hitCount.Add(1)
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`{"error": "always fails"}`))
+	}))
+	defer targetServer.Close()
+
+	// Webhook with max_retries=1 and failure_count already at 0.
+	// After one failed delivery, failure_count reaches 1 == max_retries,
+	// so the webhook should be marked "failed".
+	_, err = tx.Exec(ctx, `
+		INSERT INTO webhook_configs (id, org_id, name, url, secret, events, max_retries, status, failure_count)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+		webhookID, orgID, "Dead Letter Hook", targetServer.URL,
+		"dl-secret-key", []string{"lead.generated"}, 1, "active", 0)
+	require.NoError(t, err)
+
+	_, err = tx.Exec(ctx, `
+		INSERT INTO webhook_deliveries (id, webhook_id, org_id, event_type, payload)
+		VALUES ($1, $2, $3, $4, $5)`,
+		deliveryID, webhookID, orgID, "lead.generated", `{"lead_id": "dl-1"}`)
+	require.NoError(t, err)
+
+	require.NoError(t, tx.Commit(ctx))
+
+	// --- Asynq server ---
+	// Use NewWebhookDeliveryHandlerWithClient with a plain http.Client to bypass
+	// the SSRF safeDialContext that blocks loopback addresses used by httptest.
+	webhookRepo := repository.NewWebhookRepository(pool)
+	handler := jobs.NewWebhookDeliveryHandlerWithClient(pool, webhookRepo, &http.Client{}, logger)
+
+	asynqSrv := asynq.NewServer(
+		asynq.RedisClientOpt{Addr: vc.Addr},
+		asynq.Config{
+			Concurrency: 1,
+			Queues:      map[string]int{"default": 1},
+		},
+	)
+	mux := asynq.NewServeMux()
+	mux.Handle(queue.TypeWebhookDelivery, handler)
+
+	require.NoError(t, asynqSrv.Start(mux))
+	defer asynqSrv.Shutdown()
+
+	// --- Enqueue ---
+	asynqClient := asynq.NewClient(asynq.RedisClientOpt{Addr: vc.Addr})
+	defer asynqClient.Close()
+
+	payload := queue.WebhookDeliveryPayload{
+		DeliveryID: deliveryID,
+		WebhookID:  webhookID,
+		OrgID:      orgID,
+		EventType:  "lead.generated",
+		Payload:    map[string]any{"lead_id": "dl-1"},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	task := asynq.NewTask(queue.TypeWebhookDelivery, data)
+	_, err = asynqClient.Enqueue(task,
+		asynq.MaxRetry(0),
+		asynq.Queue("default"),
+	)
+	require.NoError(t, err)
+
+	// --- Wait for processing (polling, not fixed sleep) ---
+	require.Eventually(t, func() bool {
+		return hitCount.Load() >= 1
+	}, 10*time.Second, 200*time.Millisecond, "target server must have been hit")
+
+	// --- Verify: webhook marked as "failed" (dead-lettered) ---
+	var failureCount int
+	var status string
+	require.Eventually(t, func() bool {
+		err = db.WithOrgID(ctx, pool, orgID, func(tx pgx.Tx) error {
+			return tx.QueryRow(ctx,
+				"SELECT failure_count, status FROM webhook_configs WHERE id = $1 AND org_id = $2",
+				webhookID, orgID).Scan(&failureCount, &status)
+		})
+		return err == nil && status == "failed"
+	}, 10*time.Second, 200*time.Millisecond, "webhook status must become 'failed' after max retries exhausted")
+
+	assert.GreaterOrEqual(t, failureCount, 1,
+		"failure_count must reach max_retries")
+	assert.Equal(t, "failed", status,
+		"webhook status must be 'failed' after max retries exhausted (dead-lettered)")
+}
+```
+
+- [ ] **Step 2: Run the dead-letter integration test**
+
+Run: `cd /Users/jobinlawrance/Project/raven && go test ./internal/jobs/ -run TestWebhookDeadLetter_Integration -v -timeout 120s`
+Expected: PASS -- after one failed delivery with max_retries=1, webhook status becomes "failed".
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/jobs/webhook_deadletter_integration_test.go
+git commit -m "test(webhooks): add integration test for dead-letter behaviour after max retries"
+```
+
+---
+
+### Task 4: Add success-resets-failure-count integration test
+
+**Files:**
+- Create: `internal/jobs/webhook_success_reset_integration_test.go`
+
+The handler also resets `failure_count` to 0 on a successful delivery. This verifies the "recovery from failure" path.
+
+- [ ] **Step 1: Create the success reset integration test**
+
+Create `internal/jobs/webhook_success_reset_integration_test.go`:
+
+```go
+package jobs_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/hibiken/asynq"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ravencloak-org/Raven/internal/db"
+	"github.com/ravencloak-org/Raven/internal/jobs"
+	"github.com/ravencloak-org/Raven/internal/queue"
+	"github.com/ravencloak-org/Raven/internal/repository"
+	"github.com/ravencloak-org/Raven/internal/testutil"
+)
+
+// TestWebhookSuccessReset_Integration verifies that a successful delivery
+// resets the failure_count to 0 on the webhook config.
+func TestWebhookSuccessReset_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	pool := testutil.NewTestDB(t)
+	vc := testutil.NewTestValkey(t)
+	ctx := context.Background()
+	orgID := uuid.New().String()
+	webhookID := uuid.New().String()
+	deliveryID := uuid.New().String()
+	logger := slog.Default()
+
+	// --- Seed data ---
+	_, err := pool.Exec(ctx, "INSERT INTO organizations (id, name, slug) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING",
+		orgID, "Success Reset Org", "success-reset-org")
+	require.NoError(t, err)
+
+	tx, err := pool.Begin(ctx)
+	require.NoError(t, err)
+	_, err = tx.Exec(ctx, "SELECT set_config('app.current_org_id', $1, true)", orgID)
+	require.NoError(t, err)
+
+	// Server that returns 200 OK.
+	// Use httptest.NewServer with NewWebhookDeliveryHandlerWithClient (bypasses SSRF guard).
+	targetServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status": "ok"}`))
+	}))
+	defer targetServer.Close()
+
+	// Webhook with prior failures (failure_count=2, max_retries=3).
+	_, err = tx.Exec(ctx, `
+		INSERT INTO webhook_configs (id, org_id, name, url, secret, events, max_retries, status, failure_count)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+		webhookID, orgID, "Success Reset Hook", targetServer.URL,
+		"success-secret", []string{"lead.generated"}, 3, "active", 2)
+	require.NoError(t, err)
+
+	_, err = tx.Exec(ctx, `
+		INSERT INTO webhook_deliveries (id, webhook_id, org_id, event_type, payload)
+		VALUES ($1, $2, $3, $4, $5)`,
+		deliveryID, webhookID, orgID, "lead.generated", `{"lead_id": "s-1"}`)
+	require.NoError(t, err)
+
+	require.NoError(t, tx.Commit(ctx))
+
+	// --- Asynq server ---
+	// Use NewWebhookDeliveryHandlerWithClient with a plain http.Client to bypass
+	// the SSRF safeDialContext that blocks loopback addresses used by httptest.
+	webhookRepo := repository.NewWebhookRepository(pool)
+	handler := jobs.NewWebhookDeliveryHandlerWithClient(pool, webhookRepo, &http.Client{}, logger)
+
+	asynqSrv := asynq.NewServer(
+		asynq.RedisClientOpt{Addr: vc.Addr},
+		asynq.Config{
+			Concurrency: 1,
+			Queues:      map[string]int{"default": 1},
+		},
+	)
+	mux := asynq.NewServeMux()
+	mux.Handle(queue.TypeWebhookDelivery, handler)
+
+	require.NoError(t, asynqSrv.Start(mux))
+	defer asynqSrv.Shutdown()
+
+	// --- Enqueue ---
+	asynqClient := asynq.NewClient(asynq.RedisClientOpt{Addr: vc.Addr})
+	defer asynqClient.Close()
+
+	payload := queue.WebhookDeliveryPayload{
+		DeliveryID: deliveryID,
+		WebhookID:  webhookID,
+		OrgID:      orgID,
+		EventType:  "lead.generated",
+		Payload:    map[string]any{"lead_id": "s-1"},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	task := asynq.NewTask(queue.TypeWebhookDelivery, data)
+	_, err = asynqClient.Enqueue(task,
+		asynq.MaxRetry(0),
+		asynq.Queue("default"),
+	)
+	require.NoError(t, err)
+
+	// --- Wait for processing (polling, not fixed sleep) ---
+	// Poll until failure_count is reset to 0 indicating successful delivery.
+	var failureCount int
+	var status string
+	require.Eventually(t, func() bool {
+		err = db.WithOrgID(ctx, pool, orgID, func(tx pgx.Tx) error {
+			return tx.QueryRow(ctx,
+				"SELECT failure_count, status FROM webhook_configs WHERE id = $1 AND org_id = $2",
+				webhookID, orgID).Scan(&failureCount, &status)
+		})
+		return err == nil && failureCount == 0
+	}, 10*time.Second, 200*time.Millisecond, "failure_count must be reset to 0 after successful delivery")
+
+	// --- Verify: failure_count reset to 0, status still active ---
+	assert.Equal(t, 0, failureCount,
+		"failure_count must be reset to 0 after successful delivery")
+	assert.Equal(t, "active", status,
+		"webhook status must remain active after successful delivery")
+
+	// Verify delivery record was updated as successful.
+	// The column is `status` (VARCHAR), not `success` (bool).
+	var deliveryStatus string
+	var responseStatus int
+	err = db.WithOrgID(ctx, pool, orgID, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			"SELECT status, response_status FROM webhook_deliveries WHERE id = $1 AND org_id = $2",
+			deliveryID, orgID).Scan(&deliveryStatus, &responseStatus)
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "delivered", deliveryStatus, "delivery must be marked as 'delivered'")
+	assert.Equal(t, http.StatusOK, responseStatus, "response status must be 200")
+}
+```
+
+- [ ] **Step 2: Run the success reset test**
+
+Run: `cd /Users/jobinlawrance/Project/raven && go test ./internal/jobs/ -run TestWebhookSuccessReset_Integration -v -timeout 120s`
+Expected: PASS -- successful delivery resets failure_count to 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/jobs/webhook_success_reset_integration_test.go
+git commit -m "test(webhooks): add integration test for failure_count reset on successful delivery"
+```
+
+---
+
+### Task 5: Remove vacuous tests from webhooks_test.go
+
+**Files:**
+- Modify: `internal/ee/webhooks/webhooks_test.go`
+
+Now that real integration tests exist in `internal/jobs/`, the vacuous concept tests can be removed. The HMAC tests (lines 31-78) are legitimate unit tests and should be kept. The `TestPackageCompiles` test (line 18-20) can also be kept as a compile guard.
+
+- [ ] **Step 1: Remove the two vacuous tests**
+
+Remove `TestWebhookDelivery_Retry_ManagedByHandler` (lines 83-91) and `TestWebhookDelivery_DeadLetter_AfterMaxRetries` (lines 95-115) from `internal/ee/webhooks/webhooks_test.go`.
+
+The file should retain:
+- `TestPackageCompiles` (line 18)
+- `computeHMAC` helper (line 23)
+- `TestWebhookDelivery_HMACSignature_Correct` (line 31)
+- `TestWebhookDelivery_HMACSignature_WrongSecret_NotEqual` (line 53)
+- `TestWebhookDelivery_HMAC_Verification` (line 64)
+
+After removal, the file ends at line 78 (the closing brace of `TestWebhookDelivery_HMAC_Verification`).
+
+- [ ] **Step 2: Remove unused imports if any**
+
+After removing the two tests, verify no unused imports remain. The `assert` and `require` imports are still used by the remaining HMAC tests.
+
+- [ ] **Step 3: Run remaining tests to confirm they still pass**
+
+Run: `cd /Users/jobinlawrance/Project/raven && go test ./internal/ee/webhooks/ -v`
+Expected: PASS (3 HMAC tests + 1 compile test)
+
+- [ ] **Step 4: Run the new integration tests to confirm they still pass**
+
+Run: `cd /Users/jobinlawrance/Project/raven && go test ./internal/jobs/ -run 'TestWebhook(Retry|DeadLetter|SuccessReset)_Integration' -v -timeout 180s`
+Expected: PASS (all 3 integration tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/ee/webhooks/webhooks_test.go
+git commit -m "test(webhooks): remove vacuous retry/dead-letter concept tests replaced by integration tests"
+```
+
+---
+
+### Task 6: Run full test suite and lint for Track A
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run all Go tests (excluding short mode so integration tests run)**
+
+Run: `cd /Users/jobinlawrance/Project/raven && go test ./... -count=1 -timeout 300s`
+Expected: All PASS
+
+- [ ] **Step 2: Run golangci-lint**
+
+Run: `cd /Users/jobinlawrance/Project/raven && golangci-lint run ./...`
+Expected: No errors
+
+- [ ] **Step 3: Fix any lint or test issues and commit if needed**
+
+```bash
+git add -A
+git commit -m "fix(lint): address linter findings in webhook integration tests"
+```

--- a/docs/superpowers/plans/2026-04-10-wave3-mvp-features.md
+++ b/docs/superpowers/plans/2026-04-10-wave3-mvp-features.md
@@ -1,0 +1,2958 @@
+# Wave 3: MVP Frontend Features Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver the final two MVP Launch features -- a billing/subscription management UI (#194) and Keycloak realm auto-provisioning with a tenant onboarding wizard (#197) -- to complete the MVP milestone.
+
+**Architecture:** The billing UI is a Vue 3 frontend feature at `/settings/billing` that consumes the existing backend billing endpoints (`GET /billing/plans`, `POST /billing/subscriptions`, `GET /billing/usage`) and integrates Hyperswitch's client SDK for payment collection via Razorpay. The Keycloak onboarding feature adds a `POST /internal/provision-realm` backend endpoint that calls the Keycloak Admin REST API to create per-tenant realms, plus a frontend onboarding wizard shown on first login. Both features follow the existing handler/service/repository pattern on the backend and the Pinia store + API module + page component pattern on the frontend.
+
+**Tech Stack:** Vue 3.5, Tailwind CSS 4, Pinia 3, TypeScript, vue-router 5, Go 1.24, Gin, pgx/v5, Keycloak Admin REST API, Hyperswitch Client SDK, Vitest, httptest
+
+---
+
+## File Structure
+
+### #194 -- Billing and Subscription Management UI
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `frontend/src/api/billing.ts` | API client for billing endpoints (`getPlans`, `getUsage`, `createSubscription`, `cancelSubscription`, `createPaymentIntent`) |
+| Create | `frontend/src/stores/billing.ts` | Pinia store for billing state (plans, current subscription, usage data) |
+| Create | `frontend/src/pages/settings/BillingPage.vue` | Plan selection cards, usage dashboard, payment flow |
+| Create | `frontend/src/components/billing/PlanCard.vue` | Individual plan card component (Free/Pro/Enterprise) |
+| Create | `frontend/src/components/billing/UsageDashboard.vue` | Usage bars showing consumption vs limits |
+| Create | `frontend/src/components/billing/UpgradePrompt.vue` | Global 402 upgrade prompt modal |
+| Create | `frontend/src/components/billing/PaymentModal.vue` | Hyperswitch SDK payment collection modal |
+| Create | `frontend/src/stores/billing.spec.ts` | Unit tests for billing store |
+| Modify | `frontend/src/router/index.ts` | Add `/settings/billing` route |
+| Modify | `frontend/src/api/billing.ts` | Add 402 response handling inside `authFetch` for upgrade prompts |
+| Modify | `frontend/src/components/AppSidebar.vue` | Add Settings/Billing nav link |
+
+### #197 -- Keycloak Realm Auto-Provisioning and Tenant Onboarding Wizard
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `internal/keycloak/admin.go` | Keycloak Admin API client (create realm, create client, set redirect URIs) |
+| Create | `internal/keycloak/admin_test.go` | Unit tests for Keycloak admin client (httptest mock server) |
+| Create | `internal/service/provisioning.go` | `ProvisioningService` -- orchestrates realm creation, client config, org update |
+| Create | `internal/service/provisioning_test.go` | Unit tests for provisioning service (mock Keycloak client + mock repo) |
+| Create | `internal/handler/provisioning.go` | `ProvisioningHandler` -- `POST /internal/provision-realm` endpoint |
+| Create | `internal/handler/provisioning_test.go` | Handler-level tests (httptest) |
+| Create | `internal/model/provisioning.go` | `ProvisionRealmRequest`, `ProvisionRealmResponse` types |
+| Create | `frontend/src/pages/onboarding/OnboardingWizardPage.vue` | Multi-step onboarding wizard for new tenants |
+| Create | `frontend/src/api/onboarding.ts` | API client for onboarding (check tenant status, trigger provisioning) |
+| Create | `frontend/src/stores/onboarding.ts` | Pinia store for onboarding wizard state |
+| Create | `frontend/src/stores/onboarding.spec.ts` | Unit tests for onboarding store |
+| Modify | `internal/config/config.go` | Add `KeycloakAdminURL`, `KeycloakAdminUser`, `KeycloakAdminPassword` to `KeycloakConfig` |
+| Modify | `internal/repository/org.go` | Add `UpdateKeycloakRealm(ctx, orgID, realm)` method |
+| Modify | `cmd/api/main.go` | Wire provisioning handler, register on `/api/v1/internal` group |
+| Modify | `frontend/src/router/index.ts` | Add `/onboarding` route with first-run guard |
+
+---
+
+## Feature A: Billing and Subscription Management UI (#194)
+
+### Task 0: Write design spec for billing UI
+
+**Purpose:** Document the UI/UX decisions, Hyperswitch SDK integration approach, and 402 interception strategy before writing code.
+
+- [ ] **Step 1: Create design spec file**
+
+Create `docs/superpowers/specs/194-billing-subscription-ui.md` with the following sections:
+
+```markdown
+# Design Spec: Billing and Subscription Management UI (#194)
+
+## Overview
+Frontend billing page at `/settings/billing` for plan management, payment collection, and usage monitoring.
+
+## Dependencies
+- #193 (billing subscription enforcement) must be merged -- provides:
+  - `GET /api/v1/billing/plans` -- returns plan definitions
+  - `GET /api/v1/billing/usage` -- returns current-period usage vs limits
+  - `POST /api/v1/billing/subscriptions` -- create subscription (returns client_secret for paid plans)
+  - `DELETE /api/v1/billing/subscriptions/:id` -- cancel subscription
+  - `POST /api/v1/billing/payment-intents` -- create payment intent
+  - 402 responses with `{"upgrade_required": true, "limit": N}` on quota exceeded
+
+## UI Layout
+
+### /settings/billing page
+1. **Current Plan Banner** -- shows active plan name, status, billing period
+2. **Plan Selection Cards** -- 3 cards (Free/Pro/Enterprise) in a responsive grid
+   - Current plan highlighted with "Current Plan" badge
+   - Upgrade/Downgrade CTA buttons
+   - Feature comparison list per card
+3. **Usage Dashboard** -- progress bars for each quota dimension:
+   - Knowledge Bases: X / Y used
+   - Team Members (seats): X / Y used
+   - Voice Minutes: X / Y used this period
+   - Concurrent Voice Sessions: X / Y active
+4. **Billing History** (future -- out of MVP scope, show placeholder)
+
+### Payment Flow (Hyperswitch SDK)
+1. User clicks "Upgrade to Pro" or "Upgrade to Enterprise"
+2. Frontend calls `POST /billing/subscriptions` with `{plan_id: "plan_pro"}`
+3. Backend creates Hyperswitch payment, returns `{client_secret: "..."}`
+4. Frontend opens Hyperswitch SDK checkout modal with the client_secret
+5. Hyperswitch SDK handles payment (Razorpay as connector -- supports UPI, cards, etc.)
+6. On success, SDK callback triggers page refresh to show new plan
+7. Backend webhook confirms payment and activates subscription
+
+### 402 Upgrade Prompt
+- 402 handling is inlined in `billing.ts`'s own `authFetch` (not `client.ts`, which billing does not call through)
+- Shows a modal with "You've reached your plan limit" message
+- CTA button links to `/settings/billing`
+- Displays which limit was hit (from response body)
+
+### Responsive Design
+- Mobile: cards stack vertically, usage bars full-width
+- Desktop: 3-column card grid, usage in 2-column layout
+
+## Environment Variables
+- `VITE_HYPERSWITCH_PUBLISHABLE_KEY` -- Hyperswitch client-side publishable key
+- `VITE_HYPERSWITCH_BASE_URL` -- Hyperswitch SDK base URL (default: https://api.hyperswitch.io)
+
+## Out of Scope (MVP)
+- Invoice PDF download
+- Payment method management
+- Billing history table
+- Plan downgrade with prorated refund logic
+```
+
+- [ ] **Step 2: Review spec for completeness**
+
+Verify the spec covers: plan cards, payment flow, usage dashboard, 402 handling, mobile responsiveness, and environment variables.
+
+- [ ] **Step 3: Commit the spec**
+
+```bash
+git add docs/superpowers/specs/194-billing-subscription-ui.md
+git commit -m "docs: add design spec for billing subscription UI (#194)"
+```
+
+---
+
+### Task 1: Create billing API client module
+
+**Files:** Create `frontend/src/api/billing.ts`
+
+- [ ] **Step 1: Create the API client file**
+
+Create `frontend/src/api/billing.ts`:
+
+```typescript
+import { useAuthStore } from '../stores/auth'
+
+// --- Interfaces ---
+
+export interface Plan {
+  id: string
+  tier: 'free' | 'pro' | 'enterprise'
+  name: string
+  price_monthly: number // cents
+  max_users: number // -1 = unlimited
+  max_workspaces: number
+  max_kbs: number
+  max_storage_mb: number
+  max_concurrent_voice_sessions: number
+  max_voice_minutes_monthly: number
+}
+
+export interface Subscription {
+  id: string
+  org_id: string
+  plan_id: string
+  status: 'active' | 'canceled' | 'past_due' | 'trialing' | 'paused' | 'expired'
+  hyperswitch_subscription_id?: string
+  current_period_start: string
+  current_period_end: string
+  created_at: string
+  client_secret?: string
+}
+
+export interface UsageResponse {
+  plan: Plan
+  kbs_used: number
+  kbs_limit: number
+  seats_used: number
+  seats_limit: number
+  voice_minutes_used: number
+  voice_minutes_limit: number
+  concurrent_voice_used: number
+  concurrent_voice_limit: number
+}
+
+export interface CreateSubscriptionRequest {
+  plan_id: string
+}
+
+export interface CreatePaymentIntentRequest {
+  amount: number
+  currency: string
+}
+
+export interface PaymentIntent {
+  id: string
+  org_id: string
+  amount: number
+  currency: string
+  status: string
+  hyperswitch_payment_id?: string
+  client_secret?: string
+  created_at: string
+}
+
+// --- Auth helper (follows existing api/ module pattern) ---
+
+async function authFetch(path: string, init?: RequestInit): Promise<Response> {
+  const auth = useAuthStore()
+  const base = import.meta.env.VITE_API_BASE_URL ?? '/api/v1'
+  return fetch(base + path, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${auth.accessToken ?? ''}`,
+      ...init?.headers,
+    },
+  })
+}
+
+// --- API functions ---
+
+export async function getPlans(): Promise<Plan[]> {
+  const res = await authFetch('/billing/plans')
+  if (!res.ok) throw new Error(`getPlans failed: ${res.status}`)
+  return res.json()
+}
+
+export async function getUsage(): Promise<UsageResponse> {
+  const res = await authFetch('/billing/usage')
+  if (!res.ok) throw new Error(`getUsage failed: ${res.status}`)
+  return res.json()
+}
+
+export async function createSubscription(
+  req: CreateSubscriptionRequest,
+): Promise<Subscription> {
+  const res = await authFetch('/billing/subscriptions', {
+    method: 'POST',
+    body: JSON.stringify(req),
+  })
+  if (!res.ok) throw new Error(`createSubscription failed: ${res.status}`)
+  return res.json()
+}
+
+export async function cancelSubscription(subscriptionId: string): Promise<void> {
+  const res = await authFetch(`/billing/subscriptions/${subscriptionId}`, {
+    method: 'DELETE',
+  })
+  if (!res.ok) throw new Error(`cancelSubscription failed: ${res.status}`)
+}
+
+export async function createPaymentIntent(
+  req: CreatePaymentIntentRequest,
+): Promise<PaymentIntent> {
+  const res = await authFetch('/billing/payment-intents', {
+    method: 'POST',
+    body: JSON.stringify(req),
+  })
+  if (!res.ok) throw new Error(`createPaymentIntent failed: ${res.status}`)
+  return res.json()
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+cd /Users/jobinlawrance/Project/raven/frontend && npx vue-tsc --noEmit --pretty 2>&1 | head -20
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/api/billing.ts
+git commit -m "feat(billing-ui): add billing API client module"
+```
+
+---
+
+### Task 2: Create billing Pinia store
+
+**Files:** Create `frontend/src/stores/billing.ts`, `frontend/src/stores/billing.spec.ts`
+
+- [ ] **Step 1: Create the billing store**
+
+Create `frontend/src/stores/billing.ts`:
+
+```typescript
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import {
+  getPlans,
+  getUsage,
+  createSubscription,
+  cancelSubscription,
+  type Plan,
+  type Subscription,
+  type UsageResponse,
+} from '../api/billing'
+
+export const useBillingStore = defineStore('billing', () => {
+  const plans = ref<Plan[]>([])
+  const usage = ref<UsageResponse | null>(null)
+  const currentSubscription = ref<Subscription | null>(null)
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  // Show/hide the global upgrade prompt modal
+  const showUpgradePrompt = ref(false)
+  const upgradePromptMessage = ref('')
+  const upgradePromptLimit = ref(0)
+
+  const currentPlan = computed(() => {
+    if (!usage.value) return null
+    return usage.value.plan
+  })
+
+  async function fetchPlans(): Promise<void> {
+    loading.value = true
+    error.value = null
+    try {
+      plans.value = await getPlans()
+    } catch (e) {
+      error.value = (e as Error).message
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function fetchUsage(): Promise<void> {
+    loading.value = true
+    error.value = null
+    try {
+      usage.value = await getUsage()
+    } catch (e) {
+      error.value = (e as Error).message
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function fetchAll(): Promise<void> {
+    loading.value = true
+    error.value = null
+    try {
+      const [plansData, usageData] = await Promise.all([getPlans(), getUsage()])
+      plans.value = plansData
+      usage.value = usageData
+    } catch (e) {
+      error.value = (e as Error).message
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function subscribe(planId: string): Promise<Subscription> {
+    error.value = null
+    try {
+      const sub = await createSubscription({ plan_id: planId })
+      currentSubscription.value = sub
+      return sub
+    } catch (e) {
+      error.value = (e as Error).message
+      throw e
+    }
+  }
+
+  async function cancel(subscriptionId: string): Promise<void> {
+    error.value = null
+    try {
+      await cancelSubscription(subscriptionId)
+      currentSubscription.value = null
+      // Refresh usage to reflect downgrade
+      await fetchUsage()
+    } catch (e) {
+      error.value = (e as Error).message
+      throw e
+    }
+  }
+
+  function triggerUpgradePrompt(message: string, limit: number): void {
+    upgradePromptMessage.value = message
+    upgradePromptLimit.value = limit
+    showUpgradePrompt.value = true
+  }
+
+  function dismissUpgradePrompt(): void {
+    showUpgradePrompt.value = false
+    upgradePromptMessage.value = ''
+    upgradePromptLimit.value = 0
+  }
+
+  return {
+    plans,
+    usage,
+    currentSubscription,
+    currentPlan,
+    loading,
+    error,
+    showUpgradePrompt,
+    upgradePromptMessage,
+    upgradePromptLimit,
+    fetchPlans,
+    fetchUsage,
+    fetchAll,
+    subscribe,
+    cancel,
+    triggerUpgradePrompt,
+    dismissUpgradePrompt,
+  }
+})
+```
+
+- [ ] **Step 2: Create store unit test**
+
+Create `frontend/src/stores/billing.spec.ts`:
+
+```typescript
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useBillingStore } from './billing'
+
+// Mock the API module
+vi.mock('../api/billing', () => ({
+  getPlans: vi.fn(),
+  getUsage: vi.fn(),
+  createSubscription: vi.fn(),
+  cancelSubscription: vi.fn(),
+}))
+
+import { getPlans, getUsage, createSubscription, cancelSubscription } from '../api/billing'
+
+const mockPlans = [
+  { id: 'plan_free', tier: 'free', name: 'Free', price_monthly: 0, max_users: 5, max_workspaces: 2, max_kbs: 3, max_storage_mb: 500, max_concurrent_voice_sessions: 1, max_voice_minutes_monthly: 60 },
+  { id: 'plan_pro', tier: 'pro', name: 'Pro', price_monthly: 2900, max_users: 25, max_workspaces: 10, max_kbs: 50, max_storage_mb: 10240, max_concurrent_voice_sessions: 5, max_voice_minutes_monthly: 1200 },
+]
+
+const mockUsage = {
+  plan: mockPlans[0],
+  kbs_used: 2,
+  kbs_limit: 3,
+  seats_used: 3,
+  seats_limit: 5,
+  voice_minutes_used: 30,
+  voice_minutes_limit: 60,
+  concurrent_voice_used: 0,
+  concurrent_voice_limit: 1,
+}
+
+describe('useBillingStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('fetchAll loads plans and usage', async () => {
+    vi.mocked(getPlans).mockResolvedValue(mockPlans)
+    vi.mocked(getUsage).mockResolvedValue(mockUsage)
+
+    const store = useBillingStore()
+    await store.fetchAll()
+
+    expect(store.plans).toEqual(mockPlans)
+    expect(store.usage).toEqual(mockUsage)
+    expect(store.loading).toBe(false)
+    expect(store.error).toBeNull()
+  })
+
+  it('sets error on fetchAll failure', async () => {
+    vi.mocked(getPlans).mockRejectedValue(new Error('network error'))
+    vi.mocked(getUsage).mockResolvedValue(mockUsage)
+
+    const store = useBillingStore()
+    await store.fetchAll()
+
+    expect(store.error).toBe('network error')
+  })
+
+  it('subscribe calls API and stores result', async () => {
+    const mockSub = { id: 'sub_1', org_id: 'org_1', plan_id: 'plan_pro', status: 'active' as const, current_period_start: '', current_period_end: '', created_at: '', client_secret: 'cs_test' }
+    vi.mocked(createSubscription).mockResolvedValue(mockSub)
+
+    const store = useBillingStore()
+    const result = await store.subscribe('plan_pro')
+
+    expect(createSubscription).toHaveBeenCalledWith({ plan_id: 'plan_pro' })
+    expect(result.client_secret).toBe('cs_test')
+    expect(store.currentSubscription).toEqual(mockSub)
+  })
+
+  it('triggerUpgradePrompt shows the modal', () => {
+    const store = useBillingStore()
+    store.triggerUpgradePrompt('KB limit reached', 3)
+
+    expect(store.showUpgradePrompt).toBe(true)
+    expect(store.upgradePromptMessage).toBe('KB limit reached')
+    expect(store.upgradePromptLimit).toBe(3)
+  })
+})
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cd /Users/jobinlawrance/Project/raven/frontend && npx vitest run src/stores/billing.spec.ts
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/stores/billing.ts frontend/src/stores/billing.spec.ts
+git commit -m "feat(billing-ui): add billing Pinia store with tests"
+```
+
+---
+
+### Task 3: Add 402 response handling directly in billing.ts authFetch
+
+**Files:** Modify `frontend/src/api/billing.ts`
+
+> **Note:** The 402 interceptor must live in `billing.ts`'s own `authFetch`, not in `client.ts`.
+> `client.ts` is a separate localStorage-based client that `billing.ts` does not call through —
+> any interceptor added there would be dead code for billing flows.
+
+- [ ] **Step 1: Add 402 handling inside billing.ts authFetch**
+
+In `frontend/src/api/billing.ts`, update the `authFetch` helper to detect 402 responses and trigger the upgrade prompt:
+
+```typescript
+import { useAuthStore } from '../stores/auth'
+import { useBillingStore } from '../stores/billing'
+
+async function authFetch(path: string, init?: RequestInit): Promise<Response> {
+  const auth = useAuthStore()
+  const base = import.meta.env.VITE_API_BASE_URL ?? '/api/v1'
+  const response = await fetch(base + path, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${auth.accessToken ?? ''}`,
+      ...init?.headers,
+    },
+  })
+
+  // 402 Payment Required -- trigger the global upgrade prompt
+  if (response.status === 402) {
+    try {
+      const errBody = await response.clone().json().catch(() => ({}))
+      const billing = useBillingStore()
+      const detail = errBody.detail ?? errBody.message ?? 'Plan limit reached'
+      const limit = errBody.limit ?? 0
+      billing.triggerUpgradePrompt(detail, limit)
+    } catch {
+      // Store may not be initialized yet -- ignore
+    }
+  }
+
+  return response
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+cd /Users/jobinlawrance/Project/raven/frontend && npx vue-tsc --noEmit --pretty 2>&1 | head -20
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/api/billing.ts
+git commit -m "feat(billing-ui): add 402 upgrade prompt handling in billing authFetch"
+```
+
+---
+
+### Task 4: Create plan card and usage dashboard components
+
+**Files:** Create `frontend/src/components/billing/PlanCard.vue`, `frontend/src/components/billing/UsageDashboard.vue`
+
+- [ ] **Step 1: Create the PlanCard component**
+
+Create `frontend/src/components/billing/PlanCard.vue`:
+
+```vue
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { Plan } from '../../api/billing'
+
+const props = defineProps<{
+  plan: Plan
+  isCurrent: boolean
+  isUpgrade: boolean
+  loading: boolean
+}>()
+
+const emit = defineEmits<{
+  select: [planId: string]
+}>()
+
+function formatPrice(cents: number): string {
+  if (cents === 0) return 'Free'
+  return `$${(cents / 100).toFixed(0)}/mo`
+}
+
+function formatLimit(value: number): string {
+  return value === -1 ? 'Unlimited' : String(value)
+}
+
+// Use computed so values stay reactive to prop changes
+const features = computed(() => [
+  { label: 'Team members', value: formatLimit(props.plan.max_users) },
+  { label: 'Workspaces', value: formatLimit(props.plan.max_workspaces) },
+  { label: 'Knowledge bases', value: formatLimit(props.plan.max_kbs) },
+  { label: 'Storage', value: props.plan.max_storage_mb === -1 ? 'Unlimited' : `${props.plan.max_storage_mb / 1024} GB` },
+  { label: 'Voice sessions', value: formatLimit(props.plan.max_concurrent_voice_sessions) },
+])
+
+const tierColors: Record<string, string> = {
+  free: 'border-gray-200',
+  pro: 'border-indigo-500 ring-2 ring-indigo-100',
+  enterprise: 'border-amber-500 ring-2 ring-amber-100',
+}
+</script>
+
+<template>
+  <div
+    class="relative flex flex-col rounded-2xl border bg-white p-6 shadow-sm transition-shadow hover:shadow-md"
+    :class="tierColors[plan.tier] ?? 'border-gray-200'"
+  >
+    <!-- Current badge -->
+    <span
+      v-if="isCurrent"
+      class="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-indigo-600 px-3 py-0.5 text-xs font-semibold text-white"
+    >
+      Current Plan
+    </span>
+
+    <!-- Plan name and price -->
+    <h3 class="text-lg font-bold text-gray-900">{{ plan.name }}</h3>
+    <p class="mt-1 text-3xl font-bold text-gray-900">
+      {{ formatPrice(plan.price_monthly) }}
+    </p>
+    <p v-if="plan.price_monthly > 0" class="text-sm text-gray-500">per month</p>
+
+    <!-- Feature list -->
+    <ul class="mt-6 flex-1 space-y-3">
+      <li
+        v-for="feat in features"
+        :key="feat.label"
+        class="flex items-center justify-between text-sm"
+      >
+        <span class="text-gray-600">{{ feat.label }}</span>
+        <span class="font-medium text-gray-900">{{ feat.value }}</span>
+      </li>
+    </ul>
+
+    <!-- CTA button -->
+    <button
+      v-if="!isCurrent"
+      :disabled="loading"
+      class="mt-6 w-full rounded-lg px-4 py-2.5 text-sm font-semibold transition-colors min-h-[44px] disabled:opacity-50 disabled:cursor-not-allowed"
+      :class="
+        isUpgrade
+          ? 'bg-indigo-600 text-white hover:bg-indigo-700'
+          : 'border border-gray-300 text-gray-700 hover:bg-gray-50'
+      "
+      @click="emit('select', plan.id)"
+    >
+      {{ loading ? 'Processing...' : isUpgrade ? 'Upgrade' : 'Downgrade' }}
+    </button>
+    <div
+      v-else
+      class="mt-6 w-full rounded-lg border border-gray-200 bg-gray-50 px-4 py-2.5 text-center text-sm font-medium text-gray-500"
+    >
+      Your current plan
+    </div>
+  </div>
+</template>
+```
+
+- [ ] **Step 2: Create the UsageDashboard component**
+
+Create `frontend/src/components/billing/UsageDashboard.vue`:
+
+```vue
+<script setup lang="ts">
+import type { UsageResponse } from '../../api/billing'
+
+const props = defineProps<{
+  usage: UsageResponse
+}>()
+
+interface UsageRow {
+  label: string
+  used: number
+  limit: number
+  unit: string
+}
+
+function getRows(): UsageRow[] {
+  const u = props.usage
+  return [
+    { label: 'Knowledge Bases', used: u.kbs_used, limit: u.kbs_limit, unit: '' },
+    { label: 'Team Members', used: u.seats_used, limit: u.seats_limit, unit: '' },
+    { label: 'Voice Minutes', used: u.voice_minutes_used, limit: u.voice_minutes_limit, unit: 'min' },
+    { label: 'Concurrent Voice', used: u.concurrent_voice_used, limit: u.concurrent_voice_limit, unit: '' },
+  ]
+}
+
+function percentage(used: number, limit: number): number {
+  if (limit <= 0) return 0 // unlimited
+  return Math.min((used / limit) * 100, 100)
+}
+
+function barColor(used: number, limit: number): string {
+  if (limit <= 0) return 'bg-gray-300' // unlimited
+  const pct = (used / limit) * 100
+  if (pct >= 90) return 'bg-red-500'
+  if (pct >= 70) return 'bg-amber-500'
+  return 'bg-indigo-500'
+}
+
+function formatLimit(limit: number, unit: string): string {
+  if (limit < 0) return 'Unlimited'
+  return unit ? `${limit} ${unit}` : String(limit)
+}
+</script>
+
+<template>
+  <div class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+    <h2 class="mb-6 text-lg font-semibold text-gray-900">Current Usage</h2>
+    <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
+      <div v-for="row in getRows()" :key="row.label" class="space-y-2">
+        <div class="flex items-center justify-between text-sm">
+          <span class="font-medium text-gray-700">{{ row.label }}</span>
+          <span class="text-gray-500">
+            {{ row.used }}{{ row.unit ? ' ' + row.unit : '' }} / {{ formatLimit(row.limit, row.unit) }}
+          </span>
+        </div>
+        <div class="h-2.5 w-full overflow-hidden rounded-full bg-gray-100">
+          <div
+            v-if="row.limit > 0"
+            class="h-full rounded-full transition-all"
+            :class="barColor(row.used, row.limit)"
+            :style="{ width: percentage(row.used, row.limit) + '%' }"
+          />
+          <div
+            v-else
+            class="h-full w-full rounded-full bg-gray-200"
+            title="Unlimited"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+```bash
+cd /Users/jobinlawrance/Project/raven/frontend && npx vue-tsc --noEmit --pretty 2>&1 | head -20
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/billing/PlanCard.vue frontend/src/components/billing/UsageDashboard.vue
+git commit -m "feat(billing-ui): add PlanCard and UsageDashboard components"
+```
+
+---
+
+### Task 5: Create upgrade prompt and payment modal components
+
+**Files:** Create `frontend/src/components/billing/UpgradePrompt.vue`, `frontend/src/components/billing/PaymentModal.vue`
+
+- [ ] **Step 1: Create the UpgradePrompt component**
+
+Create `frontend/src/components/billing/UpgradePrompt.vue`:
+
+```vue
+<script setup lang="ts">
+import { useRouter } from 'vue-router'
+import { useBillingStore } from '../../stores/billing'
+
+const router = useRouter()
+const billing = useBillingStore()
+
+function goToBilling() {
+  billing.dismissUpgradePrompt()
+  router.push('/settings/billing')
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      v-if="billing.showUpgradePrompt"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      @click.self="billing.dismissUpgradePrompt()"
+    >
+      <div class="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl">
+        <!-- Icon -->
+        <div class="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-amber-100">
+          <svg class="h-6 w-6 text-amber-600" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
+          </svg>
+        </div>
+
+        <h2 class="mt-4 text-center text-lg font-semibold text-gray-900">
+          Plan Limit Reached
+        </h2>
+        <p class="mt-2 text-center text-sm text-gray-600">
+          {{ billing.upgradePromptMessage }}
+        </p>
+        <p v-if="billing.upgradePromptLimit > 0" class="mt-1 text-center text-xs text-gray-400">
+          Current limit: {{ billing.upgradePromptLimit }}
+        </p>
+
+        <div class="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-end">
+          <button
+            class="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 min-h-[44px]"
+            @click="billing.dismissUpgradePrompt()"
+          >
+            Dismiss
+          </button>
+          <button
+            class="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700 min-h-[44px]"
+            @click="goToBilling"
+          >
+            View Plans
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+```
+
+- [ ] **Step 2: Create the PaymentModal component**
+
+Create `frontend/src/components/billing/PaymentModal.vue`:
+
+```vue
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue'
+
+const props = defineProps<{
+  clientSecret: string
+  planName: string
+}>()
+
+const emit = defineEmits<{
+  success: []
+  cancel: []
+  error: [message: string]
+}>()
+
+const paymentContainer = ref<HTMLDivElement | null>(null)
+const loading = ref(true)
+const paymentError = ref<string | null>(null)
+
+// Hyperswitch SDK integration
+// The SDK is loaded from the Hyperswitch CDN and initialized with the publishable key.
+// See: https://docs.hyperswitch.io/hyperswitch-cloud/integration-guide
+let hyper: any = null
+let widgets: any = null
+
+const PUBLISHABLE_KEY = import.meta.env.VITE_HYPERSWITCH_PUBLISHABLE_KEY ?? ''
+
+onMounted(async () => {
+  try {
+    // Wait for Hyperswitch SDK to be available (loaded via script tag in index.html)
+    if (typeof (window as any).Hyper === 'undefined') {
+      throw new Error('Hyperswitch SDK not loaded. Add the SDK script to index.html.')
+    }
+
+    hyper = (window as any).Hyper(PUBLISHABLE_KEY)
+    widgets = hyper.widgets({
+      clientSecret: props.clientSecret,
+      appearance: {
+        theme: 'default',
+        variables: {
+          colorPrimary: '#4f46e5', // indigo-600
+          fontFamily: 'Inter, system-ui, sans-serif',
+          borderRadius: '8px',
+        },
+      },
+    })
+
+    const unifiedCheckout = widgets.create('payment')
+    if (paymentContainer.value) {
+      unifiedCheckout.mount(paymentContainer.value)
+    }
+    loading.value = false
+  } catch (e) {
+    paymentError.value = (e as Error).message
+    loading.value = false
+  }
+})
+
+onUnmounted(() => {
+  // Unmount the payment container DOM element to clean up Hyperswitch SDK state.
+  // widgets.destroy() is not a standard Hyperswitch SDK API; removing the mount
+  // point from the DOM is the correct cleanup approach.
+  if (paymentContainer.value) {
+    paymentContainer.value.innerHTML = ''
+  }
+  hyper = null
+  widgets = null
+})
+
+async function handleConfirmPayment() {
+  if (!hyper) return
+  loading.value = true
+  paymentError.value = null
+
+  try {
+    const { error, status } = await hyper.confirmPayment({
+      widgets,
+      confirmParams: {
+        return_url: `${window.location.origin}/settings/billing?payment=success`,
+      },
+      redirect: 'if_required',
+    })
+
+    if (error) {
+      paymentError.value = error.message ?? 'Payment failed'
+      emit('error', paymentError.value!)
+    } else if (status === 'succeeded' || status === 'processing') {
+      emit('success')
+    }
+  } catch (e) {
+    paymentError.value = (e as Error).message
+    emit('error', paymentError.value)
+  } finally {
+    loading.value = false
+  }
+}
+</script>
+
+<template>
+  <div
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+    @click.self="emit('cancel')"
+  >
+    <div class="w-full max-w-lg rounded-2xl bg-white p-6 shadow-xl">
+      <h2 class="text-lg font-semibold text-gray-900">
+        Subscribe to {{ planName }}
+      </h2>
+      <p class="mt-1 text-sm text-gray-500">
+        Complete your payment to activate your subscription.
+      </p>
+
+      <!-- Hyperswitch payment element mount point -->
+      <div class="mt-6 min-h-[200px]">
+        <div v-if="loading && !paymentError" class="flex items-center justify-center py-12">
+          <div class="h-8 w-8 animate-spin rounded-full border-4 border-indigo-200 border-t-indigo-600" />
+          <span class="ml-3 text-sm text-gray-500">Loading payment form...</span>
+        </div>
+        <div ref="paymentContainer" />
+      </div>
+
+      <!-- Error -->
+      <div
+        v-if="paymentError"
+        class="mt-4 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700"
+      >
+        {{ paymentError }}
+      </div>
+
+      <!-- Actions -->
+      <div class="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-end">
+        <button
+          class="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 min-h-[44px]"
+          @click="emit('cancel')"
+        >
+          Cancel
+        </button>
+        <button
+          :disabled="loading"
+          class="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed min-h-[44px]"
+          @click="handleConfirmPayment"
+        >
+          {{ loading ? 'Processing...' : 'Pay Now' }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+```bash
+cd /Users/jobinlawrance/Project/raven/frontend && npx vue-tsc --noEmit --pretty 2>&1 | head -20
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/billing/UpgradePrompt.vue frontend/src/components/billing/PaymentModal.vue
+git commit -m "feat(billing-ui): add UpgradePrompt and PaymentModal components"
+```
+
+---
+
+### Task 6: Create the billing page and register routes
+
+**Files:** Create `frontend/src/pages/settings/BillingPage.vue`, modify `frontend/src/router/index.ts`, modify `frontend/src/components/AppSidebar.vue`
+
+- [ ] **Step 1: Create the billing page**
+
+Create `frontend/src/pages/settings/BillingPage.vue`:
+
+```vue
+<script setup lang="ts">
+import { onMounted, computed, ref } from 'vue'
+import { useRoute } from 'vue-router'
+import { useBillingStore } from '../../stores/billing'
+import PlanCard from '../../components/billing/PlanCard.vue'
+import UsageDashboard from '../../components/billing/UsageDashboard.vue'
+import PaymentModal from '../../components/billing/PaymentModal.vue'
+
+const store = useBillingStore()
+const route = useRoute()
+
+const subscribing = ref(false)
+const showPayment = ref(false)
+const pendingClientSecret = ref('')
+const pendingPlanName = ref('')
+
+onMounted(async () => {
+  await store.fetchAll()
+
+  // Handle return from Hyperswitch redirect
+  if (route.query.payment === 'success') {
+    await store.fetchUsage()
+  }
+})
+
+const currentTierIndex = computed(() => {
+  const tiers = ['free', 'pro', 'enterprise']
+  const currentTier = store.currentPlan?.tier ?? 'free'
+  return tiers.indexOf(currentTier)
+})
+
+function isCurrentPlan(planId: string): boolean {
+  return store.currentPlan?.id === planId
+}
+
+function isUpgrade(planTier: string): boolean {
+  const tiers = ['free', 'pro', 'enterprise']
+  return tiers.indexOf(planTier) > currentTierIndex.value
+}
+
+async function handleSelectPlan(planId: string) {
+  subscribing.value = true
+  try {
+    const sub = await store.subscribe(planId)
+
+    // If the subscription has a client_secret, we need to collect payment
+    if (sub.client_secret) {
+      pendingClientSecret.value = sub.client_secret
+      const plan = store.plans.find((p) => p.id === planId)
+      pendingPlanName.value = plan?.name ?? 'Selected Plan'
+      showPayment.value = true
+    } else {
+      // Free plan -- no payment needed, refresh usage
+      await store.fetchUsage()
+    }
+  } finally {
+    subscribing.value = false
+  }
+}
+
+function handlePaymentSuccess() {
+  showPayment.value = false
+  pendingClientSecret.value = ''
+  store.fetchUsage()
+}
+
+function handlePaymentCancel() {
+  showPayment.value = false
+  pendingClientSecret.value = ''
+}
+
+function handlePaymentError(message: string) {
+  store.error = message
+}
+</script>
+
+<template>
+  <div class="space-y-8">
+    <!-- Header -->
+    <div>
+      <h1 class="text-2xl font-bold text-gray-900">Billing & Subscription</h1>
+      <p class="mt-1 text-sm text-gray-500">
+        Manage your plan and monitor resource usage.
+      </p>
+    </div>
+
+    <!-- Loading -->
+    <div v-if="store.loading" class="flex items-center justify-center py-20">
+      <div class="h-8 w-8 animate-spin rounded-full border-4 border-indigo-200 border-t-indigo-600" />
+      <span class="ml-3 text-sm text-gray-500">Loading billing information...</span>
+    </div>
+
+    <!-- Error -->
+    <div
+      v-else-if="store.error"
+      class="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700"
+    >
+      {{ store.error }}
+    </div>
+
+    <!-- Content -->
+    <template v-else>
+      <!-- Plan cards -->
+      <div>
+        <h2 class="mb-4 text-lg font-semibold text-gray-900">Choose Your Plan</h2>
+        <div class="grid grid-cols-1 gap-6 md:grid-cols-3">
+          <PlanCard
+            v-for="plan in store.plans"
+            :key="plan.id"
+            :plan="plan"
+            :is-current="isCurrentPlan(plan.id)"
+            :is-upgrade="isUpgrade(plan.tier)"
+            :loading="subscribing"
+            @select="handleSelectPlan"
+          />
+        </div>
+      </div>
+
+      <!-- Usage dashboard -->
+      <UsageDashboard v-if="store.usage" :usage="store.usage" />
+
+      <!-- Billing period info -->
+      <div v-if="store.currentSubscription" class="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <h2 class="text-lg font-semibold text-gray-900">Billing Period</h2>
+        <div class="mt-3 flex items-center gap-4 text-sm text-gray-600">
+          <span>
+            Current period: {{ new Date(store.currentSubscription.current_period_start).toLocaleDateString() }}
+            &mdash; {{ new Date(store.currentSubscription.current_period_end).toLocaleDateString() }}
+          </span>
+          <span
+            class="inline-flex rounded-full px-2 py-0.5 text-xs font-semibold"
+            :class="store.currentSubscription.status === 'active' ? 'bg-green-100 text-green-800' : 'bg-amber-100 text-amber-800'"
+          >
+            {{ store.currentSubscription.status }}
+          </span>
+        </div>
+      </div>
+    </template>
+
+    <!-- Payment modal -->
+    <PaymentModal
+      v-if="showPayment"
+      :client-secret="pendingClientSecret"
+      :plan-name="pendingPlanName"
+      @success="handlePaymentSuccess"
+      @cancel="handlePaymentCancel"
+      @error="handlePaymentError"
+    />
+  </div>
+</template>
+```
+
+- [ ] **Step 2: Add route to router**
+
+In `frontend/src/router/index.ts`, add the billing route inside the `DefaultLayout` children array, after the existing `chatbot-config` route:
+
+```typescript
+        {
+          path: 'settings/billing',
+          name: 'billing',
+          component: () => import('../pages/settings/BillingPage.vue'),
+          meta: { requiresAuth: true },
+        },
+```
+
+- [ ] **Step 3: Add billing nav link to sidebar**
+
+In `frontend/src/components/AppSidebar.vue`, add a billing/settings link in the `<nav>` section before the closing `</nav>` tag. Add it after the Calls RouterLink block:
+
+```vue
+        <!-- Settings / Billing -->
+        <RouterLink
+          to="/settings/billing"
+          :class="[
+            'flex items-center rounded-lg text-slate-400 transition-colors hover:bg-slate-800 hover:text-white',
+            mobile
+              ? 'h-10 w-full gap-3 px-3'
+              : 'h-10 w-10 justify-center',
+          ]"
+          active-class="bg-slate-800 text-white"
+          title="Billing"
+          @click="mobile && $emit('close')"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-5 w-5 shrink-0"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+          >
+            <path d="M4 4a2 2 0 00-2 2v1h16V6a2 2 0 00-2-2H4z" />
+            <path fill-rule="evenodd" d="M18 9H2v5a2 2 0 002 2h12a2 2 0 002-2V9zM4 13a1 1 0 011-1h1a1 1 0 110 2H5a1 1 0 01-1-1zm5-1a1 1 0 100 2h1a1 1 0 100-2H9z" clip-rule="evenodd" />
+          </svg>
+          <span v-if="mobile" class="text-sm font-medium">Billing</span>
+        </RouterLink>
+```
+
+- [ ] **Step 4: Mount the UpgradePrompt globally**
+
+In `frontend/src/layouts/DefaultLayout.vue`, import and render the upgrade prompt so it is available on every page. Add the component after `<MobileTabBar>`:
+
+```vue
+<template>
+  <div class="flex h-screen bg-gray-100">
+    <AppSidebar v-if="!isMobile" :mobile="false" :open="false" />
+    <div class="flex flex-1 flex-col overflow-hidden">
+      <AppHeader />
+      <main class="flex-1 overflow-y-auto p-4 md:p-6" :class="isMobile ? 'pb-24' : ''">
+        <RouterView />
+      </main>
+    </div>
+    <MobileTabBar v-if="isMobile" />
+    <UpgradePrompt />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { RouterView } from 'vue-router'
+import AppSidebar from '../components/AppSidebar.vue'
+import AppHeader from '../components/AppHeader.vue'
+import MobileTabBar from '../components/MobileTabBar.vue'
+import UpgradePrompt from '../components/billing/UpgradePrompt.vue'
+import { useMobile } from '../composables/useMediaQuery'
+
+const { isMobile } = useMobile()
+</script>
+```
+
+- [ ] **Step 5: Add Hyperswitch SDK script to index.html**
+
+In `frontend/index.html`, add the Hyperswitch SDK script tag in the `<head>`:
+
+```html
+<script src="https://beta.hyperswitch.io/v1/HyperLoader.js"></script>
+```
+
+- [ ] **Step 6: Verify build**
+
+```bash
+cd /Users/jobinlawrance/Project/raven/frontend && npx vue-tsc --noEmit --pretty 2>&1 | head -20
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/pages/settings/BillingPage.vue \
+       frontend/src/router/index.ts \
+       frontend/src/components/AppSidebar.vue \
+       frontend/src/layouts/DefaultLayout.vue \
+       frontend/index.html
+git commit -m "feat(billing-ui): add billing page, route, nav link, and global upgrade prompt"
+```
+
+---
+
+### Task 7: Add lint and type-check pass
+
+- [ ] **Step 1: Run ESLint**
+
+```bash
+cd /Users/jobinlawrance/Project/raven/frontend && npx eslint src/api/billing.ts src/stores/billing.ts src/pages/settings/BillingPage.vue src/components/billing/ --fix
+```
+
+- [ ] **Step 2: Run vue-tsc type check**
+
+```bash
+cd /Users/jobinlawrance/Project/raven/frontend && npx vue-tsc --noEmit --pretty
+```
+
+- [ ] **Step 3: Run vitest**
+
+```bash
+cd /Users/jobinlawrance/Project/raven/frontend && npx vitest run
+```
+
+- [ ] **Step 4: Fix any issues and commit**
+
+```bash
+git add -u
+git commit -m "fix(billing-ui): resolve lint and type-check issues"
+```
+
+---
+
+## Feature B: Keycloak Realm Auto-Provisioning and Tenant Onboarding Wizard (#197)
+
+### Task 0: Write design spec for Keycloak provisioning
+
+**Purpose:** Document the Keycloak Admin API integration, security model for the internal endpoint, realm configuration template, and onboarding wizard UX flow.
+
+- [ ] **Step 1: Create design spec file**
+
+Create `docs/superpowers/specs/197-keycloak-realm-provisioning.md`:
+
+```markdown
+# Design Spec: Keycloak Realm Auto-Provisioning and Tenant Onboarding Wizard (#197)
+
+## Overview
+Backend endpoint for creating per-tenant Keycloak realms and a frontend onboarding wizard for new tenant setup.
+
+## Dependencies
+- None (independent of billing features)
+- Requires Keycloak instance with Admin REST API access
+
+## Backend Architecture
+
+### New Config Fields
+Add to `KeycloakConfig` in `internal/config/config.go`:
+- `AdminURL` (string): Keycloak Admin REST API base URL (e.g. `http://keycloak:8080/admin/realms`)
+- `AdminUser` (string): Service account username for Admin API
+- `AdminPassword` (string): Service account password
+
+### Keycloak Admin Client (`internal/keycloak/admin.go`)
+HTTP client wrapping the Keycloak Admin REST API:
+- `GetAdminToken()` -- authenticate with admin credentials, cache token
+- `CreateRealm(ctx, realmName, displayName)` -- POST /admin/realms
+- `CreateClient(ctx, realmName, clientID, redirectURIs)` -- POST /admin/realms/{realm}/clients
+- `ConfigureRealm(ctx, realmName, settings)` -- PUT /admin/realms/{realm} (set login theme, token lifespans, etc.)
+
+### Provisioning Service (`internal/service/provisioning.go`)
+Orchestrates the full provisioning flow:
+1. Validate org exists and has no realm yet
+2. Generate realm name from org slug (e.g. `raven-{org_slug}`)
+3. Call Keycloak Admin to create realm
+4. Call Keycloak Admin to create OIDC client with standard config
+5. Update org record with `keycloak_realm` field
+6. Return realm details to caller
+
+### Internal Endpoint (`POST /internal/provision-realm`)
+- Registered on the `/api/v1/internal` group (no JWT -- network-only access)
+- Request body: `{"org_id": "...", "admin_email": "..."}`
+- Response: `{"realm_name": "...", "client_id": "...", "issuer_url": "..."}`
+- Idempotent: if realm already exists, return existing details
+
+### Security Considerations
+- Internal-only endpoint -- must not be exposed to public internet
+- Keycloak admin credentials stored as secrets (env vars, not config file)
+- Realm names derived from org slugs to prevent injection
+- Rate limiting not needed (internal network only)
+
+## Frontend Architecture
+
+### Onboarding Wizard (`/onboarding`)
+Multi-step wizard shown when:
+1. User logs in for the first time (org has no workspaces)
+2. Admin creates a new organisation
+
+Steps:
+1. **Welcome** -- "Welcome to Raven! Let's set up your workspace."
+2. **Organization Details** -- Confirm org name, add description
+3. **First Workspace** -- Create the first workspace name
+4. **Complete** -- Success message with link to dashboard
+
+### Router Guard
+- After login, check if org has any workspaces
+- If zero workspaces, redirect to `/onboarding`
+- Store onboarding completion flag in org settings
+
+## Realm Template Configuration
+Default realm settings applied during provisioning:
+- Login theme: `raven`
+- Token lifespan: access=5min, refresh=30min, SSO=8hr
+- Client protocol: openid-connect
+- Client access type: public (PKCE)
+- Redirect URIs: `{frontend_url}/*`
+- Web origins: `{frontend_url}`
+- Required actions: VERIFY_EMAIL
+
+## Out of Scope (MVP)
+- Custom realm branding/theming
+- SAML federation
+- Multi-realm per org
+- Realm deletion/cleanup
+```
+
+- [ ] **Step 2: Review spec for security considerations**
+
+Verify: internal-only endpoint, no credential exposure, slug-based realm naming, idempotency.
+
+- [ ] **Step 3: Commit the spec**
+
+```bash
+git add docs/superpowers/specs/197-keycloak-realm-provisioning.md
+git commit -m "docs: add design spec for Keycloak realm provisioning (#197)"
+```
+
+---
+
+### Task 1: Add Keycloak admin config fields and AppURL
+
+**Files:** Modify `internal/config/config.go`
+
+- [ ] **Step 1: Add `AppURL` to the top-level `Config` struct**
+
+In `internal/config/config.go`, add `AppURL` to the `Config` struct (after the existing `Meta` field):
+
+```go
+// Config holds all configuration for the application.
+type Config struct {
+    // ... existing fields ...
+    Meta         MetaConfig
+    // AppURL is the canonical frontend application URL used for Keycloak
+    // redirect URIs and OIDC client configuration during realm provisioning.
+    // Set via RAVEN_APP_URL (e.g. https://app.raven.example.com).
+    AppURL string `mapstructure:"app_url"`
+}
+```
+
+- [ ] **Step 2: Add admin fields to KeycloakConfig**
+
+In `internal/config/config.go`, extend the `KeycloakConfig` struct:
+
+```go
+// KeycloakConfig holds Keycloak/OIDC settings for JWT validation.
+type KeycloakConfig struct {
+	IssuerURL string `mapstructure:"issuer_url"`
+	Audience  string `mapstructure:"audience"`
+	// APIKeyEnabled enables the unvalidated API-key stub (see issue-24).
+	// Disabled by default; set RAVEN_KEYCLOAK_APIKEYENABLED=true only in
+	// development environments until the real DB-backed lookup is implemented.
+	APIKeyEnabled bool `mapstructure:"api_key_enabled"`
+	// AdminURL is the Keycloak server base URL for Admin REST API calls.
+	// Example: http://keycloak:8080
+	AdminURL      string `mapstructure:"admin_url"`
+	AdminUser     string `mapstructure:"admin_user"`
+	AdminPassword string `mapstructure:"admin_password"`
+}
+```
+
+- [ ] **Step 3: Add defaults and env bindings in Load()**
+
+Add these defaults and bindings in the `Load()` function:
+
+```go
+v.SetDefault("app_url", "http://localhost:5173")
+v.SetDefault("keycloak.admin_url", "http://localhost:8080")
+v.SetDefault("keycloak.admin_user", "admin")
+v.SetDefault("keycloak.admin_password", "")
+
+_ = v.BindEnv("app_url", "RAVEN_APP_URL")
+_ = v.BindEnv("keycloak.admin_url", "RAVEN_KEYCLOAK_ADMIN_URL")
+_ = v.BindEnv("keycloak.admin_user", "RAVEN_KEYCLOAK_ADMIN_USER")
+_ = v.BindEnv("keycloak.admin_password", "RAVEN_KEYCLOAK_ADMIN_PASSWORD")
+```
+
+- [ ] **Step 3: Verify compilation**
+
+```bash
+cd /Users/jobinlawrance/Project/raven && go build ./...
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/config/config.go
+git commit -m "feat(keycloak): add admin API config fields to KeycloakConfig"
+```
+
+---
+
+### Task 2: Create Keycloak Admin API client
+
+**Files:** Create `internal/keycloak/admin.go`, `internal/keycloak/admin_test.go`
+
+- [ ] **Step 1: Create the admin client**
+
+Create `internal/keycloak/admin.go`:
+
+```go
+// Package keycloak provides an HTTP client for the Keycloak Admin REST API.
+// Used for tenant realm provisioning during onboarding.
+package keycloak
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// AdminClient communicates with the Keycloak Admin REST API.
+type AdminClient struct {
+	httpClient *http.Client
+	baseURL    string
+	username   string
+	password   string
+
+	mu    sync.RWMutex
+	token string
+	expAt time.Time
+}
+
+// NewAdminClient creates a new Keycloak Admin API client.
+func NewAdminClient(baseURL, username, password string) *AdminClient {
+	return &AdminClient{
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		username:   username,
+		password:   password,
+	}
+}
+
+// tokenResponse is the OAuth2 token response from Keycloak.
+type tokenResponse struct {
+	AccessToken string `json:"access_token"`
+	ExpiresIn   int    `json:"expires_in"`
+}
+
+// RealmRepresentation is the Keycloak realm payload for creation.
+type RealmRepresentation struct {
+	Realm       string `json:"realm"`
+	DisplayName string `json:"displayName,omitempty"`
+	Enabled     bool   `json:"enabled"`
+
+	// Token lifespans (seconds).
+	AccessTokenLifespan   int `json:"accessTokenLifespan,omitempty"`
+	SsoSessionMaxLifespan int `json:"ssoSessionMaxLifespan,omitempty"`
+
+	// Login settings.
+	LoginWithEmailAllowed   bool     `json:"loginWithEmailAllowed,omitempty"`
+	RegistrationAllowed     bool     `json:"registrationAllowed,omitempty"`
+	RequiredActions         []string `json:"-"` // set separately via realm update
+}
+
+// ClientRepresentation is the Keycloak client payload for creation.
+type ClientRepresentation struct {
+	ClientID                string   `json:"clientId"`
+	Name                    string   `json:"name,omitempty"`
+	Enabled                 bool     `json:"enabled"`
+	Protocol                string   `json:"protocol"`
+	PublicClient            bool     `json:"publicClient"`
+	RedirectUris            []string `json:"redirectUris"`
+	WebOrigins              []string `json:"webOrigins"`
+	StandardFlowEnabled     bool     `json:"standardFlowEnabled"`
+	DirectAccessGrantsEnabled bool   `json:"directAccessGrantsEnabled"`
+
+	// PKCE settings.
+	Attributes map[string]string `json:"attributes,omitempty"`
+}
+
+// ProvisionResult contains the details of a provisioned realm.
+type ProvisionResult struct {
+	RealmName string `json:"realm_name"`
+	ClientID  string `json:"client_id"`
+	IssuerURL string `json:"issuer_url"`
+}
+
+// getToken retrieves or refreshes the admin access token.
+func (c *AdminClient) getToken(ctx context.Context) (string, error) {
+	c.mu.RLock()
+	if c.token != "" && time.Now().Before(c.expAt) {
+		t := c.token
+		c.mu.RUnlock()
+		return t, nil
+	}
+	c.mu.RUnlock()
+
+	// Fetch new token.
+	data := url.Values{
+		"grant_type": {"password"},
+		"client_id":  {"admin-cli"},
+		"username":   {c.username},
+		"password":   {c.password},
+	}
+
+	tokenURL := c.baseURL + "/realms/master/protocol/openid-connect/token"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("keycloak: create token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("keycloak: token request failed: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("keycloak: token request returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var tr tokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
+		return "", fmt.Errorf("keycloak: decode token response: %w", err)
+	}
+
+	c.mu.Lock()
+	c.token = tr.AccessToken
+	// Expire 30s early to avoid edge-case rejections.
+	c.expAt = time.Now().Add(time.Duration(tr.ExpiresIn-30) * time.Second)
+	c.mu.Unlock()
+
+	return tr.AccessToken, nil
+}
+
+// CreateRealm creates a new Keycloak realm.
+func (c *AdminClient) CreateRealm(ctx context.Context, realm RealmRepresentation) error {
+	token, err := c.getToken(ctx)
+	if err != nil {
+		return err
+	}
+
+	body, err := json.Marshal(realm)
+	if err != nil {
+		return fmt.Errorf("keycloak: marshal realm: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/admin/realms", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("keycloak: create realm request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("keycloak: create realm failed: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	// 409 Conflict means realm already exists -- treat as success (idempotent).
+	if resp.StatusCode == http.StatusConflict {
+		return nil
+	}
+	if resp.StatusCode >= 400 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("keycloak: create realm returned %d: %s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+
+// CreateClient creates an OIDC client in the given realm.
+func (c *AdminClient) CreateClient(ctx context.Context, realmName string, client ClientRepresentation) error {
+	token, err := c.getToken(ctx)
+	if err != nil {
+		return err
+	}
+
+	body, err := json.Marshal(client)
+	if err != nil {
+		return fmt.Errorf("keycloak: marshal client: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/admin/realms/%s/clients", c.baseURL, realmName)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("keycloak: create client request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("keycloak: create client failed: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	// 409 Conflict means client already exists -- treat as success (idempotent).
+	if resp.StatusCode == http.StatusConflict {
+		return nil
+	}
+	if resp.StatusCode >= 400 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("keycloak: create client returned %d: %s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+```
+
+- [ ] **Step 2: Create tests for the admin client**
+
+Create `internal/keycloak/admin_test.go`:
+
+```go
+package keycloak_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ravencloak-org/Raven/internal/keycloak"
+)
+
+func TestCreateRealm_Success(t *testing.T) {
+	mux := http.NewServeMux()
+
+	// Token endpoint
+	mux.HandleFunc("/realms/master/protocol/openid-connect/token", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "test-token",
+			"expires_in":   300,
+		})
+	})
+
+	// Create realm endpoint
+	mux.HandleFunc("/admin/realms", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			t.Error("missing or wrong Authorization header")
+		}
+
+		var realm keycloak.RealmRepresentation
+		if err := json.NewDecoder(r.Body).Decode(&realm); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if realm.Realm != "raven-test-org" {
+			t.Errorf("expected realm 'raven-test-org', got %q", realm.Realm)
+		}
+		if !realm.Enabled {
+			t.Error("expected realm to be enabled")
+		}
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	client := keycloak.NewAdminClient(ts.URL, "admin", "password")
+	err := client.CreateRealm(context.Background(), keycloak.RealmRepresentation{
+		Realm:       "raven-test-org",
+		DisplayName: "Test Org",
+		Enabled:     true,
+	})
+	if err != nil {
+		t.Fatalf("CreateRealm: %v", err)
+	}
+}
+
+func TestCreateRealm_Conflict_Idempotent(t *testing.T) {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/realms/master/protocol/openid-connect/token", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"access_token": "test-token", "expires_in": 300})
+	})
+
+	mux.HandleFunc("/admin/realms", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+	})
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	client := keycloak.NewAdminClient(ts.URL, "admin", "password")
+	err := client.CreateRealm(context.Background(), keycloak.RealmRepresentation{
+		Realm:   "raven-existing",
+		Enabled: true,
+	})
+	if err != nil {
+		t.Fatalf("expected nil error for 409 Conflict, got: %v", err)
+	}
+}
+
+func TestCreateClient_Success(t *testing.T) {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/realms/master/protocol/openid-connect/token", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"access_token": "test-token", "expires_in": 300})
+	})
+
+	mux.HandleFunc("/admin/realms/raven-test/clients", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		var client keycloak.ClientRepresentation
+		if err := json.NewDecoder(r.Body).Decode(&client); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if client.ClientID != "raven-admin" {
+			t.Errorf("expected clientId 'raven-admin', got %q", client.ClientID)
+		}
+		if !client.PublicClient {
+			t.Error("expected public client")
+		}
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	client := keycloak.NewAdminClient(ts.URL, "admin", "password")
+	err := client.CreateClient(context.Background(), "raven-test", keycloak.ClientRepresentation{
+		ClientID:            "raven-admin",
+		Enabled:             true,
+		Protocol:            "openid-connect",
+		PublicClient:        true,
+		RedirectUris:        []string{"http://localhost:5173/*"},
+		WebOrigins:          []string{"http://localhost:5173"},
+		StandardFlowEnabled: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateClient: %v", err)
+	}
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cd /Users/jobinlawrance/Project/raven && go test ./internal/keycloak/ -v
+```
+
+- [ ] **Step 4: Run linter**
+
+```bash
+cd /Users/jobinlawrance/Project/raven && golangci-lint run ./internal/keycloak/
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/keycloak/admin.go internal/keycloak/admin_test.go
+git commit -m "feat(keycloak): add Admin REST API client for realm provisioning"
+```
+
+---
+
+### Task 3: Create provisioning model types
+
+**Files:** Create `internal/model/provisioning.go`
+
+- [ ] **Step 1: Create model file**
+
+Create `internal/model/provisioning.go`:
+
+```go
+package model
+
+// ProvisionRealmRequest is the payload for POST /internal/provision-realm.
+type ProvisionRealmRequest struct {
+	OrgID      string `json:"org_id" binding:"required"`
+	AdminEmail string `json:"admin_email" binding:"required,email"`
+}
+
+// ProvisionRealmResponse is returned after successful realm provisioning.
+type ProvisionRealmResponse struct {
+	RealmName string `json:"realm_name"`
+	ClientID  string `json:"client_id"`
+	IssuerURL string `json:"issuer_url"`
+}
+```
+
+- [ ] **Step 2: Verify compilation**
+
+```bash
+cd /Users/jobinlawrance/Project/raven && go build ./internal/model/
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/model/provisioning.go
+git commit -m "feat(keycloak): add ProvisionRealmRequest/Response model types"
+```
+
+---
+
+### Task 4: Add UpdateKeycloakRealm to org repository
+
+**Files:** Modify `internal/repository/org.go`
+
+- [ ] **Step 1: Add the update method**
+
+Add to `internal/repository/org.go`:
+
+```go
+const sqlOrgUpdateKeycloakRealm = `
+	UPDATE organizations SET keycloak_realm = $2, updated_at = now()
+	WHERE id = $1
+	RETURNING ` + orgColumns
+
+// UpdateKeycloakRealm sets the keycloak_realm field on an org record.
+func (r *OrgRepository) UpdateKeycloakRealm(ctx context.Context, orgID, realm string) (*model.Organization, error) {
+	row := r.pool.QueryRow(ctx, sqlOrgUpdateKeycloakRealm, orgID, realm)
+	org, err := scanOrg(row)
+	if err != nil {
+		return nil, fmt.Errorf("OrgRepository.UpdateKeycloakRealm: %w", err)
+	}
+	return org, nil
+}
+```
+
+- [ ] **Step 2: Verify compilation**
+
+```bash
+cd /Users/jobinlawrance/Project/raven && go build ./internal/repository/
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/repository/org.go
+git commit -m "feat(keycloak): add UpdateKeycloakRealm to org repository"
+```
+
+---
+
+### Task 5: Create provisioning service
+
+**Files:** Create `internal/service/provisioning.go`, `internal/service/provisioning_test.go`
+
+- [ ] **Step 1: Create the service**
+
+Create `internal/service/provisioning.go`:
+
+```go
+package service
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"strings"
+
+	"github.com/ravencloak-org/Raven/internal/keycloak"
+	"github.com/ravencloak-org/Raven/internal/model"
+	"github.com/ravencloak-org/Raven/pkg/apierror"
+)
+
+// KeycloakAdminClient defines the interface for Keycloak Admin API operations.
+type KeycloakAdminClient interface {
+	CreateRealm(ctx context.Context, realm keycloak.RealmRepresentation) error
+	CreateClient(ctx context.Context, realmName string, client keycloak.ClientRepresentation) error
+}
+
+// OrgLookup defines the interface for org repository operations needed by provisioning.
+type OrgLookup interface {
+	GetByID(ctx context.Context, orgID string) (*model.Organization, error)
+	UpdateKeycloakRealm(ctx context.Context, orgID, realm string) (*model.Organization, error)
+}
+
+// ProvisioningService orchestrates Keycloak realm provisioning for new tenants.
+type ProvisioningService struct {
+	kcClient    KeycloakAdminClient
+	orgRepo     OrgLookup
+	kcBaseURL   string // Keycloak base URL for constructing issuer URLs
+	frontendURL string // Frontend URL for redirect URIs
+}
+
+// NewProvisioningService creates a new ProvisioningService.
+func NewProvisioningService(
+	kcClient KeycloakAdminClient,
+	orgRepo OrgLookup,
+	kcBaseURL string,
+	frontendURL string,
+) *ProvisioningService {
+	return &ProvisioningService{
+		kcClient:    kcClient,
+		orgRepo:     orgRepo,
+		kcBaseURL:   strings.TrimRight(kcBaseURL, "/"),
+		frontendURL: strings.TrimRight(frontendURL, "/"),
+	}
+}
+
+// slugRegex strips non-alphanumeric characters from org slugs.
+var slugRegex = regexp.MustCompile(`[^a-z0-9-]`)
+
+// realmNameFromSlug generates a safe Keycloak realm name from an org slug.
+func realmNameFromSlug(slug string) string {
+	safe := slugRegex.ReplaceAllString(strings.ToLower(slug), "")
+	if safe == "" {
+		safe = "default"
+	}
+	return "raven-" + safe
+}
+
+// ProvisionRealm creates a Keycloak realm and OIDC client for the given org.
+// The operation is idempotent: if the org already has a realm, the existing
+// details are returned without making Keycloak API calls.
+func (s *ProvisioningService) ProvisionRealm(ctx context.Context, req model.ProvisionRealmRequest) (*model.ProvisionRealmResponse, error) {
+	// Look up the org.
+	org, err := s.orgRepo.GetByID(ctx, req.OrgID)
+	if err != nil {
+		slog.ErrorContext(ctx, "provisioning: failed to look up org", "error", err, "org_id", req.OrgID)
+		return nil, apierror.NewInternal("failed to look up organisation")
+	}
+	if org == nil {
+		return nil, apierror.NewNotFound("organisation not found: " + req.OrgID)
+	}
+
+	// Idempotent: if realm already provisioned, return existing.
+	if org.KeycloakRealm != "" {
+		return &model.ProvisionRealmResponse{
+			RealmName: org.KeycloakRealm,
+			ClientID:  "raven-admin",
+			IssuerURL: fmt.Sprintf("%s/realms/%s", s.kcBaseURL, org.KeycloakRealm),
+		}, nil
+	}
+
+	realmName := realmNameFromSlug(org.Slug)
+	clientID := "raven-admin"
+
+	// Create realm.
+	realm := keycloak.RealmRepresentation{
+		Realm:                   realmName,
+		DisplayName:             org.Name,
+		Enabled:                 true,
+		AccessTokenLifespan:     300,       // 5 minutes
+		SsoSessionMaxLifespan:   28800,     // 8 hours
+		LoginWithEmailAllowed:   true,
+		RegistrationAllowed:     false,
+	}
+	if err := s.kcClient.CreateRealm(ctx, realm); err != nil {
+		slog.ErrorContext(ctx, "provisioning: failed to create realm", "error", err, "realm", realmName)
+		return nil, apierror.NewInternal("failed to create Keycloak realm")
+	}
+
+	// Create OIDC client.
+	client := keycloak.ClientRepresentation{
+		ClientID:                  clientID,
+		Name:                     "Raven Admin Console",
+		Enabled:                  true,
+		Protocol:                 "openid-connect",
+		PublicClient:             true,
+		RedirectUris:             []string{s.frontendURL + "/*"},
+		WebOrigins:               []string{s.frontendURL},
+		StandardFlowEnabled:      true,
+		DirectAccessGrantsEnabled: false,
+		Attributes: map[string]string{
+			"pkce.code.challenge.method": "S256",
+		},
+	}
+	if err := s.kcClient.CreateClient(ctx, realmName, client); err != nil {
+		slog.ErrorContext(ctx, "provisioning: failed to create client", "error", err, "realm", realmName)
+		return nil, apierror.NewInternal("failed to create Keycloak client")
+	}
+
+	// Update org record.
+	if _, err := s.orgRepo.UpdateKeycloakRealm(ctx, req.OrgID, realmName); err != nil {
+		slog.ErrorContext(ctx, "provisioning: failed to update org realm", "error", err, "org_id", req.OrgID)
+		return nil, apierror.NewInternal("failed to update organisation with realm")
+	}
+
+	slog.InfoContext(ctx, "provisioning: realm created", "realm", realmName, "org_id", req.OrgID)
+
+	return &model.ProvisionRealmResponse{
+		RealmName: realmName,
+		ClientID:  clientID,
+		IssuerURL: fmt.Sprintf("%s/realms/%s", s.kcBaseURL, realmName),
+	}, nil
+}
+```
+
+- [ ] **Step 2: Create unit tests**
+
+Create `internal/service/provisioning_test.go`:
+
+```go
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ravencloak-org/Raven/internal/keycloak"
+	"github.com/ravencloak-org/Raven/internal/model"
+	"github.com/ravencloak-org/Raven/internal/service"
+)
+
+// mockKCClient implements service.KeycloakAdminClient.
+type mockKCClient struct {
+	createRealmCalled  bool
+	createClientCalled bool
+	createRealmErr     error
+	createClientErr    error
+}
+
+func (m *mockKCClient) CreateRealm(_ context.Context, _ keycloak.RealmRepresentation) error {
+	m.createRealmCalled = true
+	return m.createRealmErr
+}
+
+func (m *mockKCClient) CreateClient(_ context.Context, _ string, _ keycloak.ClientRepresentation) error {
+	m.createClientCalled = true
+	return m.createClientErr
+}
+
+// mockOrgLookup implements service.OrgLookup.
+type mockOrgLookup struct {
+	org             *model.Organization
+	getErr          error
+	updateRealmErr  error
+	updatedRealm    string
+}
+
+func (m *mockOrgLookup) GetByID(_ context.Context, _ string) (*model.Organization, error) {
+	return m.org, m.getErr
+}
+
+func (m *mockOrgLookup) UpdateKeycloakRealm(_ context.Context, _ string, realm string) (*model.Organization, error) {
+	m.updatedRealm = realm
+	if m.updateRealmErr != nil {
+		return nil, m.updateRealmErr
+	}
+	org := *m.org
+	org.KeycloakRealm = realm
+	return &org, nil
+}
+
+func TestProvisionRealm_Success(t *testing.T) {
+	kc := &mockKCClient{}
+	orgRepo := &mockOrgLookup{
+		org: &model.Organization{
+			ID:   "org-1",
+			Name: "Test Corp",
+			Slug: "test-corp",
+		},
+	}
+
+	svc := service.NewProvisioningService(kc, orgRepo, "http://keycloak:8080", "http://localhost:5173")
+
+	resp, err := svc.ProvisionRealm(context.Background(), model.ProvisionRealmRequest{
+		OrgID:      "org-1",
+		AdminEmail: "admin@test.com",
+	})
+	if err != nil {
+		t.Fatalf("ProvisionRealm: %v", err)
+	}
+
+	if resp.RealmName != "raven-test-corp" {
+		t.Errorf("expected realm 'raven-test-corp', got %q", resp.RealmName)
+	}
+	if resp.ClientID != "raven-admin" {
+		t.Errorf("expected client 'raven-admin', got %q", resp.ClientID)
+	}
+	if resp.IssuerURL != "http://keycloak:8080/realms/raven-test-corp" {
+		t.Errorf("unexpected issuer URL: %q", resp.IssuerURL)
+	}
+	if !kc.createRealmCalled {
+		t.Error("expected CreateRealm to be called")
+	}
+	if !kc.createClientCalled {
+		t.Error("expected CreateClient to be called")
+	}
+	if orgRepo.updatedRealm != "raven-test-corp" {
+		t.Errorf("expected org realm updated to 'raven-test-corp', got %q", orgRepo.updatedRealm)
+	}
+}
+
+func TestProvisionRealm_AlreadyProvisioned(t *testing.T) {
+	kc := &mockKCClient{}
+	orgRepo := &mockOrgLookup{
+		org: &model.Organization{
+			ID:            "org-1",
+			Slug:          "test-corp",
+			KeycloakRealm: "raven-test-corp",
+		},
+	}
+
+	svc := service.NewProvisioningService(kc, orgRepo, "http://keycloak:8080", "http://localhost:5173")
+
+	resp, err := svc.ProvisionRealm(context.Background(), model.ProvisionRealmRequest{
+		OrgID:      "org-1",
+		AdminEmail: "admin@test.com",
+	})
+	if err != nil {
+		t.Fatalf("ProvisionRealm: %v", err)
+	}
+
+	if resp.RealmName != "raven-test-corp" {
+		t.Errorf("expected realm 'raven-test-corp', got %q", resp.RealmName)
+	}
+	if kc.createRealmCalled {
+		t.Error("CreateRealm should NOT be called for already-provisioned org")
+	}
+}
+
+func TestProvisionRealm_OrgNotFound(t *testing.T) {
+	kc := &mockKCClient{}
+	orgRepo := &mockOrgLookup{org: nil}
+
+	svc := service.NewProvisioningService(kc, orgRepo, "http://keycloak:8080", "http://localhost:5173")
+
+	_, err := svc.ProvisionRealm(context.Background(), model.ProvisionRealmRequest{
+		OrgID:      "org-nonexistent",
+		AdminEmail: "admin@test.com",
+	})
+	if err == nil {
+		t.Fatal("expected error for nonexistent org")
+	}
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cd /Users/jobinlawrance/Project/raven && go test ./internal/service/ -run TestProvisionRealm -v
+```
+
+- [ ] **Step 4: Run linter**
+
+```bash
+cd /Users/jobinlawrance/Project/raven && golangci-lint run ./internal/service/provisioning.go ./internal/service/provisioning_test.go
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/service/provisioning.go internal/service/provisioning_test.go
+git commit -m "feat(keycloak): add ProvisioningService for realm creation"
+```
+
+---
+
+### Task 6: Create provisioning handler and register route
+
+**Files:** Create `internal/handler/provisioning.go`, `internal/handler/provisioning_test.go`, modify `cmd/api/main.go`
+
+- [ ] **Step 1: Create the handler**
+
+Create `internal/handler/provisioning.go`:
+
+```go
+package handler
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/ravencloak-org/Raven/internal/model"
+	"github.com/ravencloak-org/Raven/pkg/apierror"
+)
+
+// ProvisioningServicer is the interface the handler requires from the provisioning service.
+type ProvisioningServicer interface {
+	ProvisionRealm(ctx context.Context, req model.ProvisionRealmRequest) (*model.ProvisionRealmResponse, error)
+}
+
+// ProvisioningHandler handles internal provisioning requests.
+type ProvisioningHandler struct {
+	svc ProvisioningServicer
+}
+
+// NewProvisioningHandler creates a new ProvisioningHandler.
+func NewProvisioningHandler(svc ProvisioningServicer) *ProvisioningHandler {
+	return &ProvisioningHandler{svc: svc}
+}
+
+// ProvisionRealm handles POST /api/v1/internal/provision-realm.
+//
+// @Summary     Provision Keycloak realm for tenant
+// @Description Internal-only. Creates a Keycloak realm and OIDC client for the given org.
+// @Tags        internal
+// @Accept      json
+// @Produce     json
+// @Param       request body model.ProvisionRealmRequest true "Provisioning payload"
+// @Success     201 {object} model.ProvisionRealmResponse
+// @Failure     400 {object} apierror.AppError
+// @Failure     404 {object} apierror.AppError
+// @Failure     500 {object} apierror.AppError
+// @Router      /internal/provision-realm [post]
+func (h *ProvisioningHandler) ProvisionRealm(c *gin.Context) {
+	var req model.ProvisionRealmRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.AbortWithStatusJSON(http.StatusBadRequest, apierror.AppError{
+			Code:    http.StatusBadRequest,
+			Message: "Bad Request",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	resp, err := h.svc.ProvisionRealm(c.Request.Context(), req)
+	if err != nil {
+		_ = c.Error(err)
+		c.Abort()
+		return
+	}
+
+	c.JSON(http.StatusCreated, resp)
+}
+```
+
+- [ ] **Step 2: Create handler tests**
+
+Create `internal/handler/provisioning_test.go`:
+
+```go
+package handler_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/ravencloak-org/Raven/internal/handler"
+	"github.com/ravencloak-org/Raven/internal/model"
+	"github.com/ravencloak-org/Raven/pkg/apierror"
+)
+
+type mockProvisioningService struct {
+	resp *model.ProvisionRealmResponse
+	err  error
+}
+
+func (m *mockProvisioningService) ProvisionRealm(_ context.Context, _ model.ProvisionRealmRequest) (*model.ProvisionRealmResponse, error) {
+	return m.resp, m.err
+}
+
+// newProvisioningRouter creates a test Gin engine with the provisioning route.
+// It uses apierror.ErrorHandler() as middleware, consistent with other handler tests.
+func newProvisioningRouter(svc handler.ProvisioningServicer) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(apierror.ErrorHandler())
+
+	h := handler.NewProvisioningHandler(svc)
+	r.POST("/api/v1/internal/provision-realm", h.ProvisionRealm)
+
+	return r
+}
+
+func TestProvisionRealm_Success(t *testing.T) {
+	svc := &mockProvisioningService{
+		resp: &model.ProvisionRealmResponse{
+			RealmName: "raven-test-corp",
+			ClientID:  "raven-admin",
+			IssuerURL: "http://keycloak:8080/realms/raven-test-corp",
+		},
+	}
+
+	r := newProvisioningRouter(svc)
+
+	body, _ := json.Marshal(model.ProvisionRealmRequest{
+		OrgID:      "org-1",
+		AdminEmail: "admin@test.com",
+	})
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/internal/provision-realm", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("expected 201, got %d", w.Code)
+	}
+
+	var resp model.ProvisionRealmResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.RealmName != "raven-test-corp" {
+		t.Errorf("expected realm 'raven-test-corp', got %q", resp.RealmName)
+	}
+}
+
+func TestProvisionRealm_BadRequest(t *testing.T) {
+	svc := &mockProvisioningService{}
+	r := newProvisioningRouter(svc)
+
+	// Missing required fields
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/internal/provision-realm", bytes.NewBufferString(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestProvisionRealm_NotFound(t *testing.T) {
+	svc := &mockProvisioningService{
+		err: apierror.NewNotFound("organisation not found"),
+	}
+
+	r := newProvisioningRouter(svc)
+
+	body, _ := json.Marshal(model.ProvisionRealmRequest{
+		OrgID:      "org-nonexistent",
+		AdminEmail: "admin@test.com",
+	})
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/internal/provision-realm", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+```
+
+- [ ] **Step 3: Run handler tests**
+
+```bash
+cd /Users/jobinlawrance/Project/raven && go test ./internal/handler/ -run TestProvisionRealm -v
+```
+
+- [ ] **Step 4: Wire into main.go**
+
+In `cmd/api/main.go`, add the following:
+
+1. In the imports section, the `keycloak` package is already indirectly available. No new import needed if it's referenced through the service.
+
+2. After the existing service wiring (around line 295), add:
+
+```go
+	// Keycloak Admin client for realm provisioning.
+	kcAdmin := keycloak.NewAdminClient(cfg.Keycloak.AdminURL, cfg.Keycloak.AdminUser, cfg.Keycloak.AdminPassword)
+	provisioningSvc := service.NewProvisioningService(kcAdmin, orgRepo, cfg.Keycloak.AdminURL, cfg.AppURL)
+```
+
+3. After the existing handler wiring (around line 404), add:
+
+```go
+	provisioningHandler := handler.NewProvisioningHandler(provisioningSvc)
+```
+
+4. In the internal routes group (around line 714), add:
+
+```go
+		internal.POST("/provision-realm", provisioningHandler.ProvisionRealm)
+```
+
+5. Add the import for the keycloak package:
+
+```go
+	"github.com/ravencloak-org/Raven/internal/keycloak"
+```
+
+- [ ] **Step 5: Verify compilation**
+
+```bash
+cd /Users/jobinlawrance/Project/raven && go build ./cmd/api/
+```
+
+- [ ] **Step 6: Run linter**
+
+```bash
+cd /Users/jobinlawrance/Project/raven && golangci-lint run ./internal/handler/provisioning.go ./internal/handler/provisioning_test.go ./cmd/api/
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/handler/provisioning.go internal/handler/provisioning_test.go cmd/api/main.go
+git commit -m "feat(keycloak): add provisioning handler and wire into internal routes"
+```
+
+---
+
+### Task 7: Create frontend onboarding wizard
+
+**Files:** Create `frontend/src/api/onboarding.ts`, `frontend/src/stores/onboarding.ts`, `frontend/src/pages/onboarding/OnboardingWizardPage.vue`, modify `frontend/src/router/index.ts`
+
+- [ ] **Step 1: Create the onboarding API client**
+
+Create `frontend/src/api/onboarding.ts`:
+
+```typescript
+import { useAuthStore } from '../stores/auth'
+
+export interface TenantStatus {
+  has_workspaces: boolean
+  // Note: keycloak_realm and org_name are not available from the workspace list
+  // endpoint. If the org's keycloak_realm is needed, fetch it from a separate
+  // org endpoint (e.g. GET /orgs/:id).
+}
+
+async function authFetch(path: string, init?: RequestInit): Promise<Response> {
+  const auth = useAuthStore()
+  const base = import.meta.env.VITE_API_BASE_URL ?? '/api/v1'
+  return fetch(base + path, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${auth.accessToken ?? ''}`,
+      ...init?.headers,
+    },
+  })
+}
+
+export async function getTenantStatus(orgId: string): Promise<TenantStatus> {
+  // The workspace list endpoint returns a flat []Workspace array and uses
+  // offset/limit pagination (not page/page_size).
+  const res = await authFetch(`/orgs/${orgId}/workspaces?offset=0&limit=1`)
+  if (!res.ok) throw new Error(`getTenantStatus failed: ${res.status}`)
+  const data: unknown[] = await res.json()
+  return {
+    has_workspaces: data.length > 0,
+  }
+}
+```
+
+- [ ] **Step 2: Create the onboarding store**
+
+Create `frontend/src/stores/onboarding.ts`:
+
+```typescript
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export type OnboardingStep = 'welcome' | 'org-details' | 'first-workspace' | 'complete'
+
+export const useOnboardingStore = defineStore('onboarding', () => {
+  const currentStep = ref<OnboardingStep>('welcome')
+  const orgName = ref('')
+  const orgDescription = ref('')
+  const workspaceName = ref('')
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  const steps: OnboardingStep[] = ['welcome', 'org-details', 'first-workspace', 'complete']
+
+  function nextStep(): void {
+    const idx = steps.indexOf(currentStep.value)
+    if (idx < steps.length - 1) {
+      currentStep.value = steps[idx + 1]
+    }
+  }
+
+  function prevStep(): void {
+    const idx = steps.indexOf(currentStep.value)
+    if (idx > 0) {
+      currentStep.value = steps[idx - 1]
+    }
+  }
+
+  function reset(): void {
+    currentStep.value = 'welcome'
+    orgName.value = ''
+    orgDescription.value = ''
+    workspaceName.value = ''
+    error.value = null
+  }
+
+  return {
+    currentStep,
+    orgName,
+    orgDescription,
+    workspaceName,
+    loading,
+    error,
+    steps,
+    nextStep,
+    prevStep,
+    reset,
+  }
+})
+```
+
+- [ ] **Step 3: Create the onboarding wizard page**
+
+Create `frontend/src/pages/onboarding/OnboardingWizardPage.vue`:
+
+```vue
+<script setup lang="ts">
+import { useRouter } from 'vue-router'
+import { useOnboardingStore } from '../../stores/onboarding'
+import { useAuthStore } from '../../stores/auth'
+
+const router = useRouter()
+const store = useOnboardingStore()
+const auth = useAuthStore()
+
+// Pre-fill org name from auth context
+if (auth.user?.orgId && !store.orgName) {
+  store.orgName = 'My Organization'
+}
+
+async function handleCreateWorkspace() {
+  if (!store.workspaceName.trim()) return
+  store.loading = true
+  store.error = null
+  try {
+    const base = import.meta.env.VITE_API_BASE_URL ?? '/api/v1'
+    const orgId = auth.user?.orgId ?? ''
+    const res = await fetch(`${base}/orgs/${orgId}/workspaces`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${auth.accessToken ?? ''}`,
+      },
+      body: JSON.stringify({ name: store.workspaceName.trim() }),
+    })
+    if (!res.ok) throw new Error(`Failed to create workspace: ${res.status}`)
+    store.nextStep()
+  } catch (e) {
+    store.error = (e as Error).message
+  } finally {
+    store.loading = false
+  }
+}
+
+function goToDashboard() {
+  store.reset()
+  router.push('/dashboard')
+}
+</script>
+
+<template>
+  <div class="flex min-h-screen items-center justify-center bg-gray-50 p-4">
+    <div class="w-full max-w-lg">
+      <!-- Progress indicator -->
+      <div class="mb-8 flex items-center justify-center gap-2">
+        <div
+          v-for="(step, idx) in store.steps"
+          :key="step"
+          class="h-2 w-12 rounded-full transition-colors"
+          :class="idx <= store.steps.indexOf(store.currentStep) ? 'bg-indigo-600' : 'bg-gray-200'"
+        />
+      </div>
+
+      <!-- Card -->
+      <div class="rounded-2xl border border-gray-200 bg-white p-8 shadow-sm">
+
+        <!-- Step 1: Welcome -->
+        <div v-if="store.currentStep === 'welcome'" class="text-center">
+          <div class="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-indigo-100">
+            <span class="text-2xl font-bold text-indigo-600">R</span>
+          </div>
+          <h1 class="mt-6 text-2xl font-bold text-gray-900">Welcome to Raven</h1>
+          <p class="mt-3 text-gray-600">
+            Let's get your workspace set up. This will only take a minute.
+          </p>
+          <button
+            class="mt-8 w-full rounded-lg bg-indigo-600 px-4 py-3 text-sm font-semibold text-white hover:bg-indigo-700 min-h-[44px]"
+            @click="store.nextStep()"
+          >
+            Get Started
+          </button>
+        </div>
+
+        <!-- Step 2: Organization Details -->
+        <div v-else-if="store.currentStep === 'org-details'">
+          <h2 class="text-xl font-bold text-gray-900">Your Organization</h2>
+          <p class="mt-2 text-sm text-gray-500">Confirm your organization details.</p>
+
+          <form class="mt-6 space-y-4" @submit.prevent="store.nextStep()">
+            <div>
+              <label for="org-name" class="block text-sm font-medium text-gray-700">Organization Name</label>
+              <input
+                id="org-name"
+                v-model="store.orgName"
+                type="text"
+                required
+                class="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none min-h-[44px]"
+              />
+            </div>
+            <div>
+              <label for="org-desc" class="block text-sm font-medium text-gray-700">Description (optional)</label>
+              <textarea
+                id="org-desc"
+                v-model="store.orgDescription"
+                rows="3"
+                class="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+                placeholder="What does your organization do?"
+              />
+            </div>
+            <div class="flex gap-3 pt-2">
+              <button
+                type="button"
+                class="flex-1 rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 min-h-[44px]"
+                @click="store.prevStep()"
+              >
+                Back
+              </button>
+              <button
+                type="submit"
+                class="flex-1 rounded-lg bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-indigo-700 min-h-[44px]"
+              >
+                Continue
+              </button>
+            </div>
+          </form>
+        </div>
+
+        <!-- Step 3: First Workspace -->
+        <div v-else-if="store.currentStep === 'first-workspace'">
+          <h2 class="text-xl font-bold text-gray-900">Create Your First Workspace</h2>
+          <p class="mt-2 text-sm text-gray-500">
+            Workspaces organize your knowledge bases and team members.
+          </p>
+
+          <form class="mt-6 space-y-4" @submit.prevent="handleCreateWorkspace">
+            <div>
+              <label for="ws-name" class="block text-sm font-medium text-gray-700">Workspace Name</label>
+              <input
+                id="ws-name"
+                v-model="store.workspaceName"
+                type="text"
+                required
+                placeholder="e.g. Customer Support, Engineering"
+                class="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none min-h-[44px]"
+              />
+            </div>
+
+            <div v-if="store.error" class="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+              {{ store.error }}
+            </div>
+
+            <div class="flex gap-3 pt-2">
+              <button
+                type="button"
+                class="flex-1 rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50 min-h-[44px]"
+                @click="store.prevStep()"
+              >
+                Back
+              </button>
+              <button
+                type="submit"
+                :disabled="store.loading || !store.workspaceName.trim()"
+                class="flex-1 rounded-lg bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed min-h-[44px]"
+              >
+                {{ store.loading ? 'Creating...' : 'Create Workspace' }}
+              </button>
+            </div>
+          </form>
+        </div>
+
+        <!-- Step 4: Complete -->
+        <div v-else-if="store.currentStep === 'complete'" class="text-center">
+          <div class="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-green-100">
+            <svg class="h-8 w-8 text-green-600" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+            </svg>
+          </div>
+          <h2 class="mt-6 text-2xl font-bold text-gray-900">You're All Set!</h2>
+          <p class="mt-3 text-gray-600">
+            Your workspace is ready. Start adding knowledge bases and inviting your team.
+          </p>
+          <button
+            class="mt-8 w-full rounded-lg bg-indigo-600 px-4 py-3 text-sm font-semibold text-white hover:bg-indigo-700 min-h-[44px]"
+            @click="goToDashboard"
+          >
+            Go to Dashboard
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+```
+
+- [ ] **Step 4: Add onboarding route to router**
+
+In `frontend/src/router/index.ts`, add the onboarding route. Add it as a top-level route (not inside `DefaultLayout`) since the wizard has its own full-page layout:
+
+```typescript
+    {
+      path: '/onboarding',
+      name: 'onboarding',
+      component: () => import('../pages/onboarding/OnboardingWizardPage.vue'),
+      meta: { requiresAuth: true },
+    },
+```
+
+Place it after the login route block and before the DefaultLayout block.
+
+- [ ] **Step 5: Verify TypeScript compiles**
+
+```bash
+cd /Users/jobinlawrance/Project/raven/frontend && npx vue-tsc --noEmit --pretty 2>&1 | head -20
+```
+
+- [ ] **Step 6: Run ESLint**
+
+```bash
+cd /Users/jobinlawrance/Project/raven/frontend && npx eslint src/api/onboarding.ts src/stores/onboarding.ts src/pages/onboarding/OnboardingWizardPage.vue --fix
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/api/onboarding.ts \
+       frontend/src/stores/onboarding.ts \
+       frontend/src/pages/onboarding/OnboardingWizardPage.vue \
+       frontend/src/router/index.ts
+git commit -m "feat(onboarding): add tenant onboarding wizard with multi-step flow"
+```
+
+---
+
+### Task 7b: Add unit tests for onboarding store
+
+**Files:** Create `frontend/src/stores/onboarding.spec.ts`
+
+- [ ] **Step 1: Create the store spec**
+
+Create `frontend/src/stores/onboarding.spec.ts`:
+
+```typescript
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useOnboardingStore } from './onboarding'
+
+describe('useOnboardingStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('initial state starts at welcome step', () => {
+    const store = useOnboardingStore()
+    expect(store.currentStep).toBe('welcome')
+    expect(store.loading).toBe(false)
+    expect(store.error).toBeNull()
+  })
+
+  it('nextStep advances through the step sequence', () => {
+    const store = useOnboardingStore()
+    expect(store.currentStep).toBe('welcome')
+    store.nextStep()
+    expect(store.currentStep).toBe('org-details')
+    store.nextStep()
+    expect(store.currentStep).toBe('first-workspace')
+    store.nextStep()
+    expect(store.currentStep).toBe('complete')
+  })
+
+  it('nextStep does not advance past complete', () => {
+    const store = useOnboardingStore()
+    store.currentStep = 'complete'
+    store.nextStep()
+    expect(store.currentStep).toBe('complete')
+  })
+
+  it('prevStep moves back through the step sequence', () => {
+    const store = useOnboardingStore()
+    store.currentStep = 'first-workspace'
+    store.prevStep()
+    expect(store.currentStep).toBe('org-details')
+  })
+
+  it('prevStep does not go before welcome', () => {
+    const store = useOnboardingStore()
+    store.prevStep()
+    expect(store.currentStep).toBe('welcome')
+  })
+
+  it('reset clears all state back to welcome', () => {
+    const store = useOnboardingStore()
+    store.currentStep = 'complete'
+    store.orgName = 'Acme'
+    store.workspaceName = 'Support'
+    store.error = 'some error'
+    store.reset()
+    expect(store.currentStep).toBe('welcome')
+    expect(store.orgName).toBe('')
+    expect(store.workspaceName).toBe('')
+    expect(store.error).toBeNull()
+  })
+
+})
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+cd /Users/jobinlawrance/Project/raven/frontend && npx vitest run src/stores/onboarding.spec.ts
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/stores/onboarding.spec.ts
+git commit -m "test(onboarding): add unit tests for onboarding store"
+```
+
+---
+
+### Task 8: Final verification pass
+
+- [ ] **Step 1: Run all Go tests**
+
+```bash
+cd /Users/jobinlawrance/Project/raven && go test ./internal/keycloak/ ./internal/service/ ./internal/handler/ -v -count=1 2>&1 | tail -30
+```
+
+- [ ] **Step 2: Run Go linter**
+
+```bash
+cd /Users/jobinlawrance/Project/raven && golangci-lint run ./...
+```
+
+- [ ] **Step 3: Run all frontend tests**
+
+```bash
+cd /Users/jobinlawrance/Project/raven/frontend && npx vitest run
+```
+
+- [ ] **Step 4: Run frontend lint**
+
+```bash
+cd /Users/jobinlawrance/Project/raven/frontend && npx eslint src/ --fix
+```
+
+- [ ] **Step 5: Run full TypeScript check**
+
+```bash
+cd /Users/jobinlawrance/Project/raven/frontend && npx vue-tsc --noEmit --pretty
+```
+
+- [ ] **Step 6: Fix any remaining issues and commit**
+
+```bash
+git add -u
+git commit -m "fix: resolve lint and type-check issues for wave 3 features"
+```
+
+---
+
+## PR and Merge Strategy
+
+### For #194 (Billing UI):
+1. Create branch: `feat/194-billing-subscription-ui`
+2. Accumulate tasks 0-7 as commits on this branch
+3. Open PR targeting `main`
+4. Queue auto-merge: `gh pr merge <PR> --auto --squash`
+
+### For #197 (Keycloak Onboarding):
+1. Create branch: `feat/197-keycloak-realm-provisioning`
+2. Accumulate tasks 0-8 as commits on this branch
+3. Open PR targeting `main`
+4. Queue auto-merge: `gh pr merge <PR> --auto --squash`
+
+**Note:** #194 is blocked by #193. #197 is independent and can begin immediately (design spec phase can start during Wave 2). Both PRs should be opened and merged sequentially to avoid merge conflicts in shared files (`router/index.ts`, `cmd/api/main.go`).

--- a/docs/superpowers/specs/2026-04-10-mvp-launch-execution-order.md
+++ b/docs/superpowers/specs/2026-04-10-mvp-launch-execution-order.md
@@ -1,0 +1,128 @@
+# MVP Launch Execution Order
+
+**Date:** 2026-04-10
+**Milestone:** MVP Launch (4 open issues: #193, #194, #197, #200) + 7 non-milestone fixes/chores
+**Strategy:** Fix the foundation, then build features — three sequential waves with parallelism within each wave.
+
+---
+
+## Summary
+
+11 open issues prioritized into 3 waves. Wave 1 clears remaining quick bug fixes for a clean baseline. Wave 2 tackles the billing backend (which has an existing implementation plan) and one EE test gap. Wave 3 delivers the remaining MVP frontend features and the onboarding wizard. Two P2 chores are deferred.
+
+**Already closed (no action needed):** #230, #231, #234, #235 — resolved before this plan was written.
+
+---
+
+## Pre-flight: Close #200
+
+**Issue:** #200 — Mobile-first responsive redesign (parent issue)
+**Action:** Close now. All 5 sub-issues (#221, #222, #223, #224, #225) are merged.
+**Effort:** Zero — just close the issue.
+
+---
+
+## Wave 1 — Quick Fixes (parallel, no dependencies)
+
+Three remaining issues, all independent and small-scope. Can be executed as parallel worktree agents. Each produces one commit and one PR.
+
+| # | Title | Fix | Priority | Effort |
+|---|-------|-----|----------|--------|
+| #233 | Harden `testutil.NewTestDB` migrations path | Add `os.Stat(migrationsDir)` guard before `goose.Up` in `internal/testutil/db.go` | P1 | ~10 lines |
+| #237 | Clean up `TestPackageCompiles` and `t.Skip` in EE stubs | Remove `t.Skip` from compile tests, remove or implement WAF concept tests | P2 (included for trivial effort + test hygiene) | Small |
+| #232 | Add REVOKE cleanup to RLS test fixtures | Add `t.Cleanup` with `REVOKE` in `internal/repository/rls_test.go` | P2 (included for trivial effort + test hygiene) | ~5 lines |
+
+**Entry criteria:** None — can start immediately.
+**Exit criteria:** All 3 PRs merged, CI green.
+
+---
+
+## Wave 2 — EE Test Fix + Billing Backend (parallel, independent tracks)
+
+Two independent tracks. Both can run concurrently.
+
+### Track A: Webhook Retry/Dead-Letter Tests (#236)
+
+**Issue:** #236 — Replace permanent `t.Skip` on webhook retry/dead-letter tests
+**Priority:** P1
+
+**Scope:**
+- Convert skipped tests in `internal/ee/webhooks/webhooks_test.go` (lines 85-111) into integration tests
+- Use testcontainers for Valkey + Asynq test server
+- Verify retry behavior and dead-letter queue semantics
+
+### Track B: Billing Subscription Enforcement (#193)
+
+**Issue:** #193 — Subscription enforcement: plan limit checks and feature gates
+**Priority:** P1 (MVP blocker)
+**Existing plan:** `docs/superpowers/plans/2026-04-10-billing-subscription-enforcement.md`
+
+**Scope (from existing plan):**
+- `QuotaChecker` service with Valkey-cached subscription lookups (TTL 5 min)
+- Limit-check methods injected into KB, workspace, and voice services
+- `GET /billing/usage` endpoint exposing current-period usage vs limits
+- 402 Payment Required responses with `{"upgrade_required": true, "limit": N}`
+- New billing repo queries: `CountKBsByOrg`, `CountMembersByOrg`, `GetVoiceUsageForPeriod`
+
+**Entry criteria:** Wave 1 merged (clean test baseline).
+**Exit criteria:** Both tracks merged, CI green.
+
+---
+
+## Wave 3 — MVP Frontend Features
+
+Two features, one with a dependency. #197 can start during Wave 2 (design spec phase) since its only real entry criterion is having a design spec written — not Wave 2 completion.
+
+### Billing UI (#194)
+
+**Issue:** #194 — Billing and subscription management UI
+**Blocked by:** #193 (needs backend `GET /billing/usage` endpoint and quota enforcement)
+
+**Scope:**
+- Plan selection page at `/settings/billing` with Free/Pro/Enterprise cards
+- Payment flow integration via Hyperswitch
+- Usage dashboard showing current-period consumption vs plan limits
+- Upgrade prompt when 402 responses are received
+
+**Entry criterion:** #193 merged.
+**Needs:** Its own design spec before implementation (frontend feature with payment integration).
+
+### Keycloak Onboarding Wizard (#197)
+
+**Issue:** #197 — Keycloak realm auto-provisioning and tenant onboarding wizard
+**Blocked by:** Nothing — design spec work can begin during Wave 2.
+
+**Scope:**
+- Backend: `POST /internal/provision-realm` endpoint (internal-only)
+- Keycloak Admin API integration: create realm, configure client, set redirect URIs
+- Frontend: first-run onboarding wizard for new tenants
+
+**Entry criterion:** Design spec written and approved.
+**Needs:** Its own design spec before implementation (involves Keycloak Admin API, security considerations).
+
+**Exit criteria (Wave 3):** All MVP Launch issues closed, milestone complete.
+
+---
+
+## Deferred (P2, no milestone)
+
+| # | Title | Reason |
+|---|-------|--------|
+| #238 | Document required secrets for Playwright E2E tests | P2, CI docs — no user impact |
+| #239 | Document rationale for dependency downgrades in go.mod | P2, documentation only |
+| #240 | Restore deleted dashboard JSON files | P2, observability config — #235 (the code-level fix) is already closed; these are standalone dashboard configs |
+
+---
+
+## Execution Summary
+
+```
+Pre-flight:         close #200                            →  0 PRs, 1 issue closed
+Wave 1 (parallel):  #233, #237, #232                      →  3 PRs
+Wave 2 (parallel):  #236, #193                            →  2 PRs
+Wave 3:             #194 (after #193), #197 (independent) →  2 PRs
+Deferred:           #238, #239, #240                      →  backlog
+                                                          ─────────
+                                                          7 PRs, 8 issues resolved
+                                                          (+ 4 already closed: #230, #231, #234, #235)
+```


### PR DESCRIPTION
## Summary
- Add planning spec and 5 implementation plans created during the 2026-04-10 MVP Launch sprint
- These are historical planning artifacts — all implementation work is already merged to main (PRs #244–#251)

## Plans included
- `2026-04-10-mvp-launch-execution-order.md` — execution order spec (11 issues, 3 waves)
- `2026-04-09-go-backend-tests.md` — Go backend test suite plan
- `2026-04-10-wave1-quick-fixes.md` — Wave 1 quick fixes (#233, #237, #232)
- `2026-04-10-wave2-ee-tests-and-billing.md` — Wave 2 webhook tests + billing (#236, #193)
- `2026-04-10-wave3-mvp-features.md` — Wave 3 frontend features (#194, #197)
- `2026-04-10-billing-subscription-enforcement.md` — Billing enforcement detail plan (#193)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added implementation plans for billing subscription enforcement with quota checking and usage reporting features.
  * Added Wave 1 quick-fixes plan covering test infrastructure improvements.
  * Added Wave 2 implementation plan for integration tests and billing features.
  * Added Wave 3 implementation plan for billing UI and onboarding.
  * Added MVP Launch execution order specification defining a three-wave development roadmap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->