### PR TITLE
fix(frontend): remove duplicate isMobile in DefaultLayout

### DIFF
--- a/frontend/src/layouts/DefaultLayout.vue
+++ b/frontend/src/layouts/DefaultLayout.vue
@@ -23,14 +23,12 @@ import AppSidebar from '../components/AppSidebar.vue'
 import AppHeader from '../components/AppHeader.vue'
 import MobileTabBar from '../components/MobileTabBar.vue'
 import UpgradePrompt from '../components/UpgradePrompt.vue'
+import OnboardingWizard from '../pages/onboarding/OnboardingWizard.vue'
 import { useMobile } from '../composables/useMediaQuery'
 import { useBillingStore } from '../stores/billing'
-
-const { isMobile } = useMobile()
-const billingStore = useBillingStore()
-import OnboardingWizard from '../pages/onboarding/OnboardingWizard.vue'
 import { useOnboardingStore } from '../stores/onboarding'
 
 const { isMobile } = useMobile()
+const billingStore = useBillingStore()
 const onboardingStore = useOnboardingStore()
 </script>


### PR DESCRIPTION
ESLint `no-redeclare` error caused by two script blocks being merged during billing+onboarding PRs. Removes the duplicate `const { isMobile } = useMobile()` and consolidates all imports into one block.

Unblocks Cloudflare Pages deployment (was failing on the Lint step).