### PR TITLE
fix(auth): disable checkLoginIframe to fix infinite redirect behind Cloudflare

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,7 @@ name: Docker Build & Push
 on:
   push:
     branches: [main]
+    tags: ['v*.*.*']
     paths:
       - 'Dockerfile'
       - 'ai-worker/Dockerfile'
@@ -35,8 +36,20 @@ jobs:
 
       - uses: docker/setup-buildx-action@v4
 
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/go-api
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
       - uses: docker/login-action@v4
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name != 'pull_request'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -46,13 +59,12 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          push: ${{ github.event_name != 'pull_request' }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/go-api:${{ github.sha }}
-            ghcr.io/${{ github.repository_owner }}/go-api:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
   build-python-worker:
     name: Build python-worker
@@ -64,8 +76,20 @@ jobs:
 
       - uses: docker/setup-buildx-action@v4
 
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/python-worker
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
       - uses: docker/login-action@v4
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name != 'pull_request'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -75,13 +99,12 @@ jobs:
         with:
           context: ai-worker
           file: ai-worker/Dockerfile
-          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          push: ${{ github.event_name != 'pull_request' }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/python-worker:${{ github.sha }}
-            ghcr.io/${{ github.repository_owner }}/python-worker:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
   build-frontend:
     name: Build frontend
@@ -93,8 +116,20 @@ jobs:
 
       - uses: docker/setup-buildx-action@v4
 
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/frontend
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
       - uses: docker/login-action@v4
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name != 'pull_request'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -104,7 +139,7 @@ jobs:
         with:
           context: frontend
           file: frontend/Dockerfile
-          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          push: ${{ github.event_name != 'pull_request' }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -115,6 +150,5 @@ jobs:
             VITE_KEYCLOAK_REALM=${{ vars.VITE_KEYCLOAK_REALM || 'raven' }}
             VITE_KEYCLOAK_CLIENT_ID=${{ vars.VITE_KEYCLOAK_CLIENT_ID || 'raven-frontend' }}
             VITE_LIVEKIT_URL=${{ vars.VITE_LIVEKIT_URL || '' }}
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/frontend:${{ github.sha }}
-            ghcr.io/${{ github.repository_owner }}/frontend:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - 'Dockerfile'
       - 'ai-worker/Dockerfile'
+      - 'frontend/Dockerfile'
+      - 'frontend/nginx.conf'
       - 'docker-compose.yml'
       - '.github/workflows/docker.yml'
   pull_request:
@@ -13,6 +15,8 @@ on:
     paths:
       - 'Dockerfile'
       - 'ai-worker/Dockerfile'
+      - 'frontend/Dockerfile'
+      - 'frontend/nginx.conf'
       - 'docker-compose.yml'
       - '.github/workflows/docker.yml'
 
@@ -78,3 +82,39 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository_owner }}/python-worker:${{ github.sha }}
             ghcr.io/${{ github.repository_owner }}/python-worker:latest
+
+  build-frontend:
+    name: Build frontend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-qemu-action@v4
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v7
+        with:
+          context: frontend
+          file: frontend/Dockerfile
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            VITE_API_URL=${{ vars.VITE_API_URL || 'https://api.ravencloak.org' }}
+            VITE_API_BASE_URL=${{ vars.VITE_API_BASE_URL || 'https://api.ravencloak.org/api/v1' }}
+            VITE_KEYCLOAK_URL=${{ vars.VITE_KEYCLOAK_URL || 'https://auth.ravencloak.org' }}
+            VITE_KEYCLOAK_REALM=${{ vars.VITE_KEYCLOAK_REALM || 'raven' }}
+            VITE_KEYCLOAK_CLIENT_ID=${{ vars.VITE_KEYCLOAK_CLIENT_ID || 'raven-frontend' }}
+            VITE_LIVEKIT_URL=${{ vars.VITE_LIVEKIT_URL || '' }}
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/frontend:${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/frontend:latest

--- a/.github/workflows/landing.yml
+++ b/.github/workflows/landing.yml
@@ -1,0 +1,34 @@
+name: Deploy Landing to Cloudflare Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "landing/**"
+      - ".github/workflows/landing.yml"
+
+concurrency:
+  group: landing-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Deploy to Cloudflare Pages
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        if: env.CLOUDFLARE_API_TOKEN != ''
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ env.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy landing --project-name=raven-landing --branch=main --commit-dirty=true

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,38 @@
+title: Raven
+description: Open-source multi-tenant knowledge base platform with AI-powered chat, voice, and WhatsApp
+url: https://ravencloak-org.github.io
+baseurl: /Raven
+repository: ravencloak-org/Raven
+
+remote_theme: pages-themes/cayman@v0.2.0
+plugins:
+  - jekyll-remote-theme
+  - jekyll-seo-tag
+
+markdown: kramdown
+kramdown:
+  input: GFM
+  hard_wrap: false
+
+defaults:
+  - scope:
+      path: ""
+    values:
+      layout: default
+
+exclude:
+  - .worktrees/
+  - .claude/
+  - ai-worker/.venv/
+  - frontend/node_modules/
+  - frontend/dist/
+  - "*.sh"
+  - Makefile
+  - go.mod
+  - go.sum
+
+header_pages:
+  - docs/project-status.md
+  - docs/milestones.md
+  - DEVELOPMENT.md
+  - CONTRIBUTING.md

--- a/deploy/ec2/docker-compose.server.yml
+++ b/deploy/ec2/docker-compose.server.yml
@@ -8,6 +8,20 @@
 #   docker compose -f deploy/ec2/docker-compose.server.yml --env-file .env.server up -d
 
 services:
+  # ─── Frontend (Vue SPA served via nginx) ───────────────────────────────────
+  frontend:
+    image: ${FRONTEND_IMAGE:-ghcr.io/ravencloak-org/frontend:latest}
+    ports:
+      - "127.0.0.1:3080:80"
+    networks:
+      - raven-net
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
   # ─── Go API ────────────────────────────────────────────────────────────────
   go-api:
     image: ${GO_API_IMAGE:-ghcr.io/ravencloak-org/go-api:latest}

--- a/docs/project-status.md
+++ b/docs/project-status.md
@@ -1,0 +1,137 @@
+---
+layout: default
+title: Project Status
+nav_order: 1
+---
+
+# Raven — Project Status
+
+**Repository:** [ravencloak-org/Raven](https://github.com/ravencloak-org/Raven)  
+**Last updated:** April 2026
+
+---
+
+## Milestone Summary
+
+| # | Milestone | Issues | Status |
+|---|-----------|--------|--------|
+| M1 | [Project Scaffolding](https://github.com/ravencloak-org/Raven/milestone/1) | 9 closed | ✅ Complete |
+| M2 | [Core API + Auth](https://github.com/ravencloak-org/Raven/milestone/2) | 10 closed | ✅ Complete |
+| M3 | [Ingestion Pipeline](https://github.com/ravencloak-org/Raven/milestone/3) | 13 closed | ✅ Complete |
+| M4 | [Chatbot MVP](https://github.com/ravencloak-org/Raven/milestone/4) | 8 closed | ✅ Complete |
+| M5 | [Admin Dashboard](https://github.com/ravencloak-org/Raven/milestone/5) | 9 closed | ✅ Complete |
+| M6 | [SaaS Infrastructure](https://github.com/ravencloak-org/Raven/milestone/6) | 7 closed | ✅ Complete |
+| M7 | [Phase 2 — Voice Agent](https://github.com/ravencloak-org/Raven/milestone/7) | 8 closed | ✅ Complete |
+| M8 | [Phase 3 — WebRTC/WhatsApp](https://github.com/ravencloak-org/Raven/milestone/8) | 5 closed | ✅ Complete |
+| — | [Raven Pro: Enterprise Connectors](https://github.com/ravencloak-org/Raven/milestone/9) | 7 closed | ✅ Complete |
+| M10 | [Edge Optimization](https://github.com/ravencloak-org/Raven/milestone/10) | 3 closed | ✅ Complete |
+| — | [MVP Launch](https://github.com/ravencloak-org/Raven/milestone/11) | 14 closed | ✅ Complete |
+| M9 | [Intelligence & Retention](https://github.com/ravencloak-org/Raven/milestone/12) | 3 open | 🔵 In planning |
+
+---
+
+## Open Issues — M9: Intelligence & Retention
+
+| Issue | Title |
+|-------|-------|
+| [#256](https://github.com/ravencloak-org/Raven/issues/256) | feat(cache): semantic response cache — embedding similarity lookup before LLM calls |
+| [#257](https://github.com/ravencloak-org/Raven/issues/257) | feat(notifications): post-session conversation email summaries via AWS SES |
+| [#258](https://github.com/ravencloak-org/Raven/issues/258) | feat(memory): cross-channel conversation memory and PostHog session tracking |
+
+---
+
+## Merged PRs by Feature Area
+
+### MVP Launch
+
+| PR | Title | Branch |
+|----|-------|--------|
+| [#251](https://github.com/ravencloak-org/Raven/pull/251) | feat(onboarding): Keycloak realm auto-provisioning and tenant onboarding wizard | `feat/onboarding-keycloak-realm-wizard` |
+| [#250](https://github.com/ravencloak-org/Raven/pull/250) | feat(frontend): billing and subscription management UI | `feat/billing-ui-194` |
+| [#249](https://github.com/ravencloak-org/Raven/pull/249) | chore: P2 fixes — RLS cleanup, EE stubs, go.mod, dashboards | `chore/p2-fixes` |
+| [#248](https://github.com/ravencloak-org/Raven/pull/248) | docs(ci): document required E2E secrets | `docs/e2e-secrets-238` |
+| [#247](https://github.com/ravencloak-org/Raven/pull/247) | fix(observability): restore OTel log exporter and HTTP structured logging | `fix/restore-otel-log-exporter` |
+| [#246](https://github.com/ravencloak-org/Raven/pull/246) | fix(test): replace t.Skip on webhook retry/dead-letter tests | `fix/webhook-retry-deadletter-tests` |
+| [#245](https://github.com/ravencloak-org/Raven/pull/245) | fix(test): harden testutil.NewTestDB migrations path | `fix/testutil-migrations-path` |
+| [#244](https://github.com/ravencloak-org/Raven/pull/244) | feat(billing): subscription enforcement — plan limit checks and feature gates | `feat/issue-193-billing-enforcement` |
+| [#243](https://github.com/ravencloak-org/Raven/pull/243) | test(e2e): Playwright mobile viewport tests for critical flows | `feat/issue-225-mobile-e2e` |
+| [#242](https://github.com/ravencloak-org/Raven/pull/242) | fix(frontend): remove duplicate useMobile import | `fix/duplicate-usemobile-import` |
+| [#241](https://github.com/ravencloak-org/Raven/pull/241) | fix: address code review findings on Go backend test suite | `test/go-backend-suite` |
+
+### Mobile-First Responsive Redesign
+
+| PR | Title | Branch |
+|----|-------|--------|
+| [#229](https://github.com/ravencloak-org/Raven/pull/229) | feat(mobile): form adaptations and touch target sizing | `feat/issue-224-mobile-forms` |
+| [#228](https://github.com/ravencloak-org/Raven/pull/228) | feat(mobile): table-to-card views for list pages | `feat/issue-222-mobile-cards` |
+| [#227](https://github.com/ravencloak-org/Raven/pull/227) | feat(mobile): responsive modals and bottom-sheet confirms | `feat/issue-223-mobile-modals` |
+| [#226](https://github.com/ravencloak-org/Raven/pull/226) | feat(mobile): bottom tab bar navigation | `feat/issue-200-mobile-responsive` |
+
+### Observability & Billing
+
+| PR | Title | Branch |
+|----|-------|--------|
+| [#209](https://github.com/ravencloak-org/Raven/pull/209) | feat(observability): wire OpenObserve log aggregation and OTEL metrics | `feat/observability-openobserve-otel` |
+| [#207](https://github.com/ravencloak-org/Raven/pull/207) | test(go): Go backend unit and integration test suite | `test/go-backend-suite` |
+| [#208](https://github.com/ravencloak-org/Raven/pull/208) | test(python): AI worker pytest suite | `test/python-ai-worker-suite` |
+| [#206](https://github.com/ravencloak-org/Raven/pull/206) | feat(billing): Hyperswitch + Razorpay payment integration | `feat/billing-hyperswitch-razorpay` |
+| [#205](https://github.com/ravencloak-org/Raven/pull/205) | feat(api): per-org rate limiting by subscription tier | `feat/rate-limiting-valkey` |
+| [#204](https://github.com/ravencloak-org/Raven/pull/204) | feat(frontend): WhatsApp Business calling UI | `feat/whatsapp-calling-ui` |
+| [#203](https://github.com/ravencloak-org/Raven/pull/203) | feat(frontend): voice session management UI | `feat/voice-session-ui` |
+| [#202](https://github.com/ravencloak-org/Raven/pull/202) | test(ebpf): privileged eBPF kernel test harness | `test/ebpf-harness` |
+| [#201](https://github.com/ravencloak-org/Raven/pull/201) | test(e2e): Playwright E2E test suite — all journeys | `test/playwright-e2e-suite` |
+
+### Edge Optimization (M10)
+
+| PR | Title | Branch |
+|----|-------|--------|
+| [#191](https://github.com/ravencloak-org/Raven/pull/191) | feat(ebpf): eBPF edge optimization — XDP pre-filtering, kernel observability | `feat/ebpf-edge-optimization` |
+
+### WebRTC / WhatsApp (M8)
+
+| PR | Title | Branch |
+|----|-------|--------|
+| [#190](https://github.com/ravencloak-org/Raven/pull/190) | feat(whatsapp): WhatsApp Business Calling API | `feat/whatsapp-calling-api-impl` |
+| [#189](https://github.com/ravencloak-org/Raven/pull/189) | feat(webhooks): Meta Graph API webhook receiver | `feat/meta-graph-webhooks` |
+| [#188](https://github.com/ravencloak-org/Raven/pull/188) | feat(voice): WebRTC session management with LiveKit | `feat/webrtc-session-management` |
+| [#187](https://github.com/ravencloak-org/Raven/pull/187) | feat(voice): LiveKit room bridging for WhatsApp calls | `feat/livekit-whatsapp-bridge` |
+
+### Voice Agent (M7)
+
+| PR | Title | Branch |
+|----|-------|--------|
+| [#186](https://github.com/ravencloak-org/Raven/pull/186) | feat(deploy): EC2 deployment stack with Ansible and Cloudflare Pages | `feat/ec2-deployment-stack` |
+| [#184](https://github.com/ravencloak-org/Raven/pull/184) | feat: TTS integration — Cartesia Sonic + Piper | `feat/issue-60-tts-integration` |
+| [#183](https://github.com/ravencloak-org/Raven/pull/183) | feat: STT integration — Deepgram + faster-whisper | `feat/issue-59-stt-integration` |
+| [#182](https://github.com/ravencloak-org/Raven/pull/182) | fix(voice): nil-request guards, interface repo, not-found handling | `fix/voice-service-review` |
+| [#181](https://github.com/ravencloak-org/Raven/pull/181) | feat: ClickHouse QBit vector storage with hybrid RRF retrieval | `feat/issue-118-clickhouse-qbit` |
+| [#178](https://github.com/ravencloak-org/Raven/pull/178) | feat: voice session management — tables, lifecycle, transcription storage | `feat/issue-61-voice-sessions` |
+| [#177](https://github.com/ravencloak-org/Raven/pull/177) | feat: stranger block/ban, per-user rate limiting, suspicious behavior | `feat/issue-115-stranger-management` |
+
+---
+
+## CI Status
+
+| Check | Status |
+|-------|--------|
+| Go CI | [![Go CI](https://github.com/ravencloak-org/Raven/actions/workflows/go.yml/badge.svg)](https://github.com/ravencloak-org/Raven/actions/workflows/go.yml) |
+| Frontend CI | [![Frontend CI](https://github.com/ravencloak-org/Raven/actions/workflows/frontend.yml/badge.svg)](https://github.com/ravencloak-org/Raven/actions/workflows/frontend.yml) |
+| Python CI | [![Python CI](https://github.com/ravencloak-org/Raven/actions/workflows/python.yml/badge.svg)](https://github.com/ravencloak-org/Raven/actions/workflows/python.yml) |
+| Security | [![Security](https://github.com/ravencloak-org/Raven/actions/workflows/security.yml/badge.svg)](https://github.com/ravencloak-org/Raven/actions/workflows/security.yml) |
+| Coverage | [![codecov](https://codecov.io/gh/ravencloak-org/Raven/branch/main/graph/badge.svg)](https://codecov.io/gh/ravencloak-org/Raven) |
+
+---
+
+## Quick Links
+
+| Resource | Link |
+|----------|------|
+| Repository | [github.com/ravencloak-org/Raven](https://github.com/ravencloak-org/Raven) |
+| Issues | [All open issues](https://github.com/ravencloak-org/Raven/issues) |
+| Pull Requests | [All PRs](https://github.com/ravencloak-org/Raven/pulls) |
+| Milestones | [All milestones](https://github.com/ravencloak-org/Raven/milestones) |
+| Development Guide | [DEVELOPMENT.md](../DEVELOPMENT.md) |
+| Contributing | [CONTRIBUTING.md](../CONTRIBUTING.md) |
+| Architecture | [docs/wiki/Architecture-Overview.md](wiki/Architecture-Overview.md) |
+| Data Model | [docs/wiki/Data-Model.md](wiki/Data-Model.md) |
+| Quickstart | [docs/quickstart.md](quickstart.md) |

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,28 @@
+# ── Stage 1: build ────────────────────────────────────────────────────────────
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+
+ARG VITE_API_URL=https://api.ravencloak.org
+ARG VITE_API_BASE_URL=https://api.ravencloak.org/api/v1
+ARG VITE_KEYCLOAK_URL=https://auth.ravencloak.org
+ARG VITE_KEYCLOAK_REALM=raven
+ARG VITE_KEYCLOAK_CLIENT_ID=raven-frontend
+ARG VITE_LIVEKIT_URL=
+
+RUN npm run build
+
+# ── Stage 2: serve ────────────────────────────────────────────────────────────
+FROM nginx:1.27-alpine
+
+COPY --from=builder /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,27 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    gzip on;
+    gzip_types text/plain text/css application/javascript application/json image/svg+xml;
+    gzip_min_length 1024;
+
+    # Cache static assets aggressively (Vite hashes filenames)
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # SPA fallback — all unmatched routes serve index.html
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Health check endpoint for cloudflared / monitoring
+    location /healthz {
+        return 200 "ok";
+        add_header Content-Type text/plain;
+    }
+}

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -147,6 +147,13 @@ const router = createRouter({
 })
 
 router.beforeEach(async (to) => {
+  // If the URL contains a Keycloak callback code, let keycloak.init() finish
+  // processing it before we evaluate auth state. Without this guard the router
+  // fires before the token exchange completes and triggers another redirect.
+  if (window.location.href.includes('code=') && window.location.href.includes('state=')) {
+    return
+  }
+
   if (to.meta.requiresAuth) {
     const auth = useAuthStore()
     if (!auth.isAuthenticated) {

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -30,6 +30,9 @@ export const useAuthStore = defineStore('auth', () => {
         onLoad: 'check-sso',
         pkceMethod: 'S256',
         silentCheckSsoRedirectUri: window.location.origin + '/silent-check-sso.html',
+        // Must be false behind Cloudflare — the iframe-based session check uses
+        // third-party cookies that CF strips, causing an infinite redirect loop.
+        checkLoginIframe: false,
       })
       if (authenticated) {
         _syncFromKeycloak()

--- a/index.html
+++ b/index.html
@@ -1,0 +1,579 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Raven — AI Knowledge Base for Modern Teams</title>
+  <meta name="description" content="Open-source, multi-tenant AI knowledge base with chat, voice, and WhatsApp support. Self-host for free or use our cloud." />
+  <meta property="og:title" content="Raven — AI Knowledge Base for Modern Teams" />
+  <meta property="og:description" content="Open-source, multi-tenant AI knowledge base. Deploy anywhere or use Raven Cloud." />
+  <meta property="og:url" content="https://ravencloak.org" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: { sans: ['Inter', 'system-ui', 'sans-serif'] },
+          colors: {
+            raven: {
+              50:  '#f0f4ff',
+              100: '#e0e9ff',
+              200: '#c7d6ff',
+              300: '#a5b8ff',
+              400: '#818ef8',
+              500: '#6366f1',
+              600: '#4f46e5',
+              700: '#4338ca',
+              800: '#3730a3',
+              900: '#312e81',
+              950: '#1e1b4b',
+            }
+          }
+        }
+      }
+    }
+  </script>
+  <style>
+    .gradient-hero {
+      background: linear-gradient(135deg, #1e1b4b 0%, #312e81 40%, #1e1b4b 100%);
+    }
+    .gradient-card {
+      background: linear-gradient(145deg, rgba(99,102,241,0.08) 0%, rgba(79,70,229,0.04) 100%);
+    }
+    .glow {
+      box-shadow: 0 0 60px -15px rgba(99,102,241,0.4);
+    }
+    .badge-popular {
+      background: linear-gradient(90deg, #6366f1, #818ef8);
+    }
+    @keyframes float {
+      0%, 100% { transform: translateY(0px); }
+      50% { transform: translateY(-8px); }
+    }
+    .float { animation: float 4s ease-in-out infinite; }
+    .feature-icon { transition: transform 0.2s ease; }
+    .feature-card:hover .feature-icon { transform: scale(1.1) rotate(-3deg); }
+  </style>
+</head>
+<body class="font-sans bg-white text-gray-900 antialiased">
+
+  <!-- ── Navigation ──────────────────────────────────────────────────────── -->
+  <nav class="fixed top-0 z-50 w-full border-b border-white/10 bg-raven-950/90 backdrop-blur-md">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+      <div class="flex h-16 items-center justify-between">
+        <div class="flex items-center gap-3">
+          <svg class="h-8 w-8 text-raven-400" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M16 3C9.925 3 5 7.925 5 14c0 3.866 1.945 7.28 4.906 9.35L8 29l5.447-2.723A11.94 11.94 0 0016 26.5c6.075 0 11-4.925 11-11S22.075 3 16 3z" fill="currentColor" opacity="0.3"/>
+            <path d="M16 3C9.925 3 5 7.925 5 14c0 3.866 1.945 7.28 4.906 9.35L8 29l5.447-2.723A11.94 11.94 0 0016 26.5c6.075 0 11-4.925 11-11S22.075 3 16 3z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/>
+            <circle cx="11" cy="13" r="1.5" fill="currentColor"/>
+            <circle cx="16" cy="13" r="1.5" fill="currentColor"/>
+            <circle cx="21" cy="13" r="1.5" fill="currentColor"/>
+          </svg>
+          <span class="text-xl font-bold text-white">Raven</span>
+        </div>
+        <div class="hidden md:flex items-center gap-8">
+          <a href="#features" class="text-sm text-gray-400 hover:text-white transition-colors">Features</a>
+          <a href="#pricing" class="text-sm text-gray-400 hover:text-white transition-colors">Pricing</a>
+          <a href="#self-host" class="text-sm text-gray-400 hover:text-white transition-colors">Self-Host</a>
+          <a href="https://github.com/ravencloak-org/Raven" class="text-sm text-gray-400 hover:text-white transition-colors flex items-center gap-1.5">
+            <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/></svg>
+            GitHub
+          </a>
+        </div>
+        <div class="flex items-center gap-3">
+          <a href="https://app.ravencloak.org" class="hidden sm:inline-flex text-sm text-gray-300 hover:text-white px-4 py-2 rounded-lg border border-white/20 hover:border-white/40 transition-all">Sign In</a>
+          <a href="https://app.ravencloak.org/register" class="inline-flex text-sm font-semibold text-white px-4 py-2 rounded-lg bg-raven-600 hover:bg-raven-500 transition-colors">Get Started Free</a>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <!-- ── Hero ────────────────────────────────────────────────────────────── -->
+  <section class="gradient-hero min-h-screen flex items-center pt-16">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-24 lg:py-32">
+      <div class="text-center">
+        <div class="inline-flex items-center gap-2 rounded-full border border-raven-400/30 bg-raven-400/10 px-4 py-1.5 mb-8">
+          <span class="h-2 w-2 rounded-full bg-green-400 animate-pulse"></span>
+          <span class="text-sm text-raven-300 font-medium">Open Source — MIT Licensed</span>
+        </div>
+        <h1 class="text-4xl sm:text-6xl lg:text-7xl font-extrabold text-white leading-tight tracking-tight mb-6">
+          The AI Brain for<br/>
+          <span class="bg-gradient-to-r from-raven-300 to-indigo-300 bg-clip-text text-transparent">Your Entire Team</span>
+        </h1>
+        <p class="mx-auto max-w-2xl text-lg sm:text-xl text-gray-300 mb-10 leading-relaxed">
+          Raven is an open-source, multi-tenant knowledge base with AI-powered chat, voice calls, and WhatsApp — built for teams that care about data sovereignty.
+        </p>
+        <div class="flex flex-col sm:flex-row items-center justify-center gap-4 mb-16">
+          <a href="https://app.ravencloak.org/register" class="w-full sm:w-auto inline-flex items-center justify-center gap-2 rounded-xl bg-raven-500 hover:bg-raven-400 text-white font-semibold px-8 py-4 text-lg transition-all glow">
+            Start for Free
+            <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6"/></svg>
+          </a>
+          <a href="https://github.com/ravencloak-org/Raven" class="w-full sm:w-auto inline-flex items-center justify-center gap-2 rounded-xl border border-white/25 text-white hover:bg-white/10 font-semibold px-8 py-4 text-lg transition-all">
+            <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/></svg>
+            View on GitHub
+          </a>
+        </div>
+
+        <!-- Stat bar -->
+        <div class="mx-auto max-w-3xl grid grid-cols-3 gap-px rounded-2xl overflow-hidden border border-white/10 bg-white/10">
+          <div class="bg-raven-950/60 backdrop-blur-sm px-6 py-5 text-center">
+            <div class="text-2xl font-bold text-white">MIT</div>
+            <div class="text-sm text-gray-400 mt-1">Open Source License</div>
+          </div>
+          <div class="bg-raven-950/60 backdrop-blur-sm px-6 py-5 text-center border-x border-white/10">
+            <div class="text-2xl font-bold text-white">4</div>
+            <div class="text-sm text-gray-400 mt-1">Deployment Options</div>
+          </div>
+          <div class="bg-raven-950/60 backdrop-blur-sm px-6 py-5 text-center">
+            <div class="text-2xl font-bold text-white">∞</div>
+            <div class="text-sm text-gray-400 mt-1">Knowledge Sources</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Features ────────────────────────────────────────────────────────── -->
+  <section id="features" class="py-24 bg-gray-50">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+      <div class="text-center mb-16">
+        <h2 class="text-3xl sm:text-4xl font-bold text-gray-900 mb-4">Everything your team needs to know</h2>
+        <p class="text-lg text-gray-500 max-w-2xl mx-auto">One platform for all your knowledge — chat, voice, messaging, and more.</p>
+      </div>
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
+
+        <div class="feature-card rounded-2xl border border-gray-200 bg-white p-6 hover:shadow-lg hover:border-raven-300 transition-all">
+          <div class="feature-icon mb-4 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-raven-100 text-raven-600">
+            <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M8.625 12a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0H8.25m4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0H12m4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0h-.375M21 12c0 4.556-4.03 8.25-9 8.25a9.764 9.764 0 01-2.555-.337A5.972 5.972 0 015.41 20.97a5.969 5.969 0 01-.474-.065 4.48 4.48 0 00.978-2.025c.09-.457-.133-.901-.467-1.226C3.93 16.178 3 14.189 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25z"/></svg>
+          </div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">AI-Powered Chat</h3>
+          <p class="text-sm text-gray-500 leading-relaxed">Semantic search + RAG over your documents. Ask questions in plain language and get cited, accurate answers.</p>
+        </div>
+
+        <div class="feature-card rounded-2xl border border-gray-200 bg-white p-6 hover:shadow-lg hover:border-raven-300 transition-all">
+          <div class="feature-icon mb-4 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-violet-100 text-violet-600">
+            <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M12 18.75a6 6 0 006-6v-1.5m-6 7.5a6 6 0 01-6-6v-1.5m6 7.5v3.75m-3.75 0h7.5M12 15.75a3 3 0 01-3-3V4.5a3 3 0 116 0v8.25a3 3 0 01-3 3z"/></svg>
+          </div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">Voice Agent</h3>
+          <p class="text-sm text-gray-500 leading-relaxed">Real-time voice calls via LiveKit WebRTC. Talk to your knowledge base hands-free — ideal for mobile and field teams.</p>
+        </div>
+
+        <div class="feature-card rounded-2xl border border-gray-200 bg-white p-6 hover:shadow-lg hover:border-raven-300 transition-all">
+          <div class="feature-icon mb-4 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-green-100 text-green-600">
+            <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 01.865-.501 48.172 48.172 0 003.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0012 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018z"/></svg>
+          </div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">WhatsApp Integration</h3>
+          <p class="text-sm text-gray-500 leading-relaxed">Let your customers query your knowledge base via WhatsApp. Zero friction — they already have the app.</p>
+        </div>
+
+        <div class="feature-card rounded-2xl border border-gray-200 bg-white p-6 hover:shadow-lg hover:border-raven-300 transition-all">
+          <div class="feature-icon mb-4 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-blue-100 text-blue-600">
+            <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 2.625V9m-16.5 0v-.375"/></svg>
+          </div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">Hybrid Vector Search</h3>
+          <p class="text-sm text-gray-500 leading-relaxed">pgvector + BM25 full-text search combined. Find the right chunk even when semantic search misses, and vice versa.</p>
+        </div>
+
+        <div class="feature-card rounded-2xl border border-gray-200 bg-white p-6 hover:shadow-lg hover:border-raven-300 transition-all">
+          <div class="feature-icon mb-4 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-orange-100 text-orange-600">
+            <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197M15 6.75a3 3 0 11-6 0 3 3 0 016 0zm6 3a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zm-13.5 0a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z"/></svg>
+          </div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">Multi-Tenant Architecture</h3>
+          <p class="text-sm text-gray-500 leading-relaxed">Serve multiple organisations from one installation. Full data isolation per tenant, managed via Keycloak IAM.</p>
+        </div>
+
+        <div class="feature-card rounded-2xl border border-gray-200 bg-white p-6 hover:shadow-lg hover:border-raven-300 transition-all">
+          <div class="feature-icon mb-4 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-red-100 text-red-600">
+            <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z"/></svg>
+          </div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">BYOK — Your Keys</h3>
+          <p class="text-sm text-gray-500 leading-relaxed">Bring your own LLM API keys. Use Anthropic, OpenAI, or any compatible provider. Zero lock-in.</p>
+        </div>
+
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Pricing ──────────────────────────────────────────────────────────── -->
+  <section id="pricing" class="py-24 bg-white">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+      <div class="text-center mb-16">
+        <h2 class="text-3xl sm:text-4xl font-bold text-gray-900 mb-4">One platform, four editions</h2>
+        <p class="text-lg text-gray-500 max-w-2xl mx-auto">Deploy the way that suits your team — from open-source self-hosting to a fully managed cloud experience.</p>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6 items-start">
+
+        <!-- ── Tier 1: Self-Hosted ──────────────────────────────────────── -->
+        <div class="rounded-2xl border border-gray-200 bg-white p-6 flex flex-col h-full">
+          <div class="mb-6">
+            <div class="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-gray-100 mb-4">
+              <svg class="h-5 w-5 text-gray-700" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M21.75 17.25v.75a3.75 3.75 0 01-3.75 3.75h-13.5A3.75 3.75 0 011.5 18v-.75m19.5 0a3.75 3.75 0 000-7.5h-19.5a3.75 3.75 0 000 7.5m19.5 0h.75a3.75 3.75 0 010 7.5h-.75m-19.5 0H1.5a3.75 3.75 0 010-7.5h.75"/></svg>
+            </div>
+            <h3 class="text-xl font-bold text-gray-900">Self-Hosted</h3>
+            <p class="text-sm text-gray-500 mt-1">Open source, forever free</p>
+            <div class="mt-4">
+              <span class="text-4xl font-extrabold text-gray-900">$0</span>
+              <span class="text-gray-500 ml-1">/ forever</span>
+            </div>
+          </div>
+          <ul class="space-y-3 flex-1 mb-6">
+            <li class="flex items-start gap-2.5 text-sm text-gray-600">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              Full MIT source code
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-600">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              Unlimited users &amp; documents
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-600">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              AI chat, voice &amp; WhatsApp
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-600">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              Bring your own LLM keys
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-600">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              Docker Compose + Kubernetes
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-600">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              Community support (GitHub)
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-400">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+              WAF / advanced security
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-400">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+              SLA guarantee
+            </li>
+          </ul>
+          <a href="https://github.com/ravencloak-org/Raven" class="w-full text-center rounded-xl border border-gray-300 text-gray-700 hover:bg-gray-50 font-semibold px-5 py-3 text-sm transition-all">
+            Deploy from GitHub
+          </a>
+        </div>
+
+        <!-- ── Tier 2: Self-Hosted + Enterprise ────────────────────────── -->
+        <div class="rounded-2xl border border-raven-200 bg-white p-6 flex flex-col h-full ring-1 ring-raven-200">
+          <div class="mb-6">
+            <div class="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-raven-100 mb-4">
+              <svg class="h-5 w-5 text-raven-700" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z"/></svg>
+            </div>
+            <h3 class="text-xl font-bold text-gray-900">Self-Hosted<br/><span class="text-raven-600">+ Enterprise</span></h3>
+            <p class="text-sm text-gray-500 mt-1">Maximum control with enterprise grade</p>
+            <div class="mt-4">
+              <span class="text-2xl font-extrabold text-gray-900">Custom</span>
+              <div class="text-xs text-gray-500 mt-1">Annual license · contact us</div>
+            </div>
+          </div>
+          <ul class="space-y-3 flex-1 mb-6">
+            <li class="flex items-start gap-2.5 text-sm text-gray-600">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              Everything in Self-Hosted
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-600">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              eBPF Web Application Firewall
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-600">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              SAML / SSO / SCIM
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-600">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              Immutable audit log
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-600">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              Advanced rate limiting
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-600">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              SOC2 / GDPR compliance pack
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-600">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              Priority email + Slack support
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-600">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              99.9% SLA guarantee
+            </li>
+          </ul>
+          <a href="mailto:enterprise@ravencloak.org" class="w-full text-center rounded-xl border border-raven-500 text-raven-600 hover:bg-raven-50 font-semibold px-5 py-3 text-sm transition-all">
+            Contact Sales
+          </a>
+        </div>
+
+        <!-- ── Tier 3: Cloud Free ─────────────────────────────────────── -->
+        <div class="rounded-2xl border border-gray-200 bg-gradient-to-b from-raven-950 to-raven-900 p-6 flex flex-col h-full relative overflow-hidden">
+          <div class="absolute inset-0 pointer-events-none">
+            <div class="absolute -right-10 -top-10 h-40 w-40 rounded-full bg-raven-500/20 blur-2xl"></div>
+          </div>
+          <div class="relative mb-6">
+            <div class="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-raven-800 mb-4">
+              <svg class="h-5 w-5 text-raven-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 15a4.5 4.5 0 004.5 4.5H18a3.75 3.75 0 001.332-7.257 3 3 0 00-3.758-3.848 5.25 5.25 0 00-10.233 2.33A4.502 4.502 0 002.25 15z"/></svg>
+            </div>
+            <h3 class="text-xl font-bold text-white">Cloud <span class="text-raven-300">Free</span></h3>
+            <p class="text-sm text-raven-400 mt-1">Raven-hosted, zero setup</p>
+            <div class="mt-4">
+              <span class="text-4xl font-extrabold text-white">$0</span>
+              <span class="text-raven-400 ml-1">/ month</span>
+            </div>
+          </div>
+          <ul class="relative space-y-3 flex-1 mb-6">
+            <li class="flex items-start gap-2.5 text-sm text-gray-300">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              Managed &amp; hosted by Raven
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-300">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              500 AI messages / month
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-300">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              5 users
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-300">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              1 GB document storage
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-300">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              AI chat &amp; knowledge base
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-400">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-700" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+              Voice / WhatsApp
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-400">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-700" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+              Custom domain
+            </li>
+          </ul>
+          <a href="https://app.ravencloak.org/register" class="relative w-full text-center rounded-xl bg-white text-raven-700 hover:bg-raven-50 font-semibold px-5 py-3 text-sm transition-all">
+            Get Started Free
+          </a>
+        </div>
+
+        <!-- ── Tier 4: Cloud Pro ──────────────────────────────────────── -->
+        <div class="rounded-2xl border border-raven-500 bg-gradient-to-b from-raven-950 to-raven-900 p-6 flex flex-col h-full relative overflow-hidden glow">
+          <div class="absolute inset-0 pointer-events-none">
+            <div class="absolute -left-10 -bottom-10 h-40 w-40 rounded-full bg-indigo-500/20 blur-2xl"></div>
+          </div>
+          <!-- Popular badge -->
+          <div class="absolute -top-px left-1/2 -translate-x-1/2">
+            <span class="badge-popular inline-flex items-center rounded-b-xl px-4 py-1 text-xs font-semibold text-white tracking-wide uppercase">Most Popular</span>
+          </div>
+          <div class="relative mb-6 mt-4">
+            <div class="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-raven-500/30 mb-4">
+              <svg class="h-5 w-5 text-raven-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z"/></svg>
+            </div>
+            <h3 class="text-xl font-bold text-white">Cloud <span class="text-raven-300">Pro</span></h3>
+            <p class="text-sm text-raven-400 mt-1">Full power, fully managed</p>
+            <div class="mt-4">
+              <span class="text-4xl font-extrabold text-white">$29</span>
+              <span class="text-raven-400 ml-1">/ month</span>
+            </div>
+            <div class="text-xs text-raven-500 mt-1">per workspace · billed monthly</div>
+          </div>
+          <ul class="relative space-y-3 flex-1 mb-6">
+            <li class="flex items-start gap-2.5 text-sm text-gray-300">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              Everything in Cloud Free
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-300">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              Unlimited AI messages
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-300">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              Unlimited users
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-300">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              100 GB storage
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-300">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              Voice agent included
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-300">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              WhatsApp integration
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-300">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              Custom domain + SSL
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-300">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              Priority support
+            </li>
+          </ul>
+          <a href="https://app.ravencloak.org/register?plan=pro" class="relative w-full text-center rounded-xl bg-raven-500 hover:bg-raven-400 text-white font-semibold px-5 py-3 text-sm transition-all">
+            Start 14-day Free Trial
+          </a>
+        </div>
+
+      </div>
+
+      <!-- Comparison footer note -->
+      <p class="text-center text-sm text-gray-400 mt-8">
+        All plans include UPI, RuPay &amp; card payments. India-first infrastructure.
+        <a href="mailto:support@ravencloak.org" class="text-raven-600 hover:underline">Contact us</a> for volume discounts.
+      </p>
+    </div>
+  </section>
+
+  <!-- ── Self-Host section ──────────────────────────────────────────────── -->
+  <section id="self-host" class="py-24 bg-gray-50">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-16 items-center">
+        <div>
+          <div class="inline-flex items-center gap-2 rounded-full bg-green-100 text-green-700 px-3 py-1 text-xs font-semibold uppercase tracking-wide mb-4">
+            Self-Host
+          </div>
+          <h2 class="text-3xl sm:text-4xl font-bold text-gray-900 mb-4">Your data, your rules</h2>
+          <p class="text-lg text-gray-500 mb-8 leading-relaxed">
+            Raven ships as a single Docker Compose file. Run it on a Raspberry Pi, a VPS, or your on-premise Kubernetes cluster. No external dependencies, no data leaves your network.
+          </p>
+          <div class="space-y-4 mb-8">
+            <div class="flex items-start gap-3">
+              <div class="mt-0.5 flex-shrink-0 h-6 w-6 rounded-full bg-green-100 flex items-center justify-center">
+                <svg class="h-3.5 w-3.5 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              </div>
+              <div>
+                <p class="text-sm font-semibold text-gray-900">One command setup</p>
+                <p class="text-sm text-gray-500">Copy <code class="bg-gray-100 px-1 rounded">.env.example</code>, run <code class="bg-gray-100 px-1 rounded">docker compose up</code> and you're live.</p>
+              </div>
+            </div>
+            <div class="flex items-start gap-3">
+              <div class="mt-0.5 flex-shrink-0 h-6 w-6 rounded-full bg-green-100 flex items-center justify-center">
+                <svg class="h-3.5 w-3.5 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              </div>
+              <div>
+                <p class="text-sm font-semibold text-gray-900">Runs on edge hardware</p>
+                <p class="text-sm text-gray-500">Optimised for Raspberry Pi 5 and low-memory ARM nodes. Native Go binary, no JVM overhead.</p>
+              </div>
+            </div>
+            <div class="flex items-start gap-3">
+              <div class="mt-0.5 flex-shrink-0 h-6 w-6 rounded-full bg-green-100 flex items-center justify-center">
+                <svg class="h-3.5 w-3.5 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              </div>
+              <div>
+                <p class="text-sm font-semibold text-gray-900">Automatic HTTPS</p>
+                <p class="text-sm text-gray-500">Traefik with Let's Encrypt or Cloudflare Tunnel — zero-port-exposure ingress included.</p>
+              </div>
+            </div>
+          </div>
+          <a href="https://github.com/ravencloak-org/Raven#quick-start" class="inline-flex items-center gap-2 rounded-xl border border-gray-300 text-gray-700 hover:bg-gray-100 font-semibold px-6 py-3 text-sm transition-all">
+            Read the Quickstart Guide
+            <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6"/></svg>
+          </a>
+        </div>
+        <div class="rounded-2xl bg-raven-950 border border-white/10 overflow-hidden">
+          <div class="flex items-center gap-1.5 px-4 py-3 border-b border-white/10">
+            <div class="h-3 w-3 rounded-full bg-red-400"></div>
+            <div class="h-3 w-3 rounded-full bg-yellow-400"></div>
+            <div class="h-3 w-3 rounded-full bg-green-400"></div>
+            <span class="ml-2 text-xs text-gray-500 font-mono">terminal</span>
+          </div>
+          <div class="px-5 py-6 font-mono text-sm leading-7">
+            <p><span class="text-gray-500"># Clone and configure</span></p>
+            <p><span class="text-green-400">$</span> <span class="text-white">git clone https://github.com/ravencloak-org/Raven</span></p>
+            <p><span class="text-green-400">$</span> <span class="text-white">cp .env.example .env</span></p>
+            <p><span class="text-green-400">$</span> <span class="text-white">nano .env</span>  <span class="text-gray-500"># set your secrets</span></p>
+            <br/>
+            <p><span class="text-gray-500"># Start everything</span></p>
+            <p><span class="text-green-400">$</span> <span class="text-white">docker compose up -d</span></p>
+            <br/>
+            <p class="text-gray-500"># ✅ Raven is running at http://localhost:8080</p>
+            <p class="text-gray-500"># ✅ Keycloak at http://localhost:8180</p>
+            <p class="text-gray-500"># ✅ OpenObserve at http://localhost:5080</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── CTA ─────────────────────────────────────────────────────────────── -->
+  <section class="gradient-hero py-24">
+    <div class="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8 text-center">
+      <h2 class="text-3xl sm:text-4xl font-extrabold text-white mb-4">
+        Ready to give your team a brain?
+      </h2>
+      <p class="text-lg text-gray-300 mb-10 max-w-2xl mx-auto">
+        Join teams already using Raven to turn scattered documents into instant answers — across chat, voice, and WhatsApp.
+      </p>
+      <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
+        <a href="https://app.ravencloak.org/register" class="w-full sm:w-auto inline-flex items-center justify-center gap-2 rounded-xl bg-white text-raven-700 hover:bg-raven-50 font-bold px-8 py-4 text-lg transition-all">
+          Get Started for Free
+        </a>
+        <a href="https://github.com/ravencloak-org/Raven" class="w-full sm:w-auto inline-flex items-center justify-center gap-2 rounded-xl border border-white/25 text-white hover:bg-white/10 font-semibold px-8 py-4 text-lg transition-all">
+          <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/></svg>
+          Star on GitHub
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Footer ──────────────────────────────────────────────────────────── -->
+  <footer class="bg-gray-900 text-gray-400 py-12">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+      <div class="grid grid-cols-2 md:grid-cols-4 gap-8 mb-10">
+        <div class="col-span-2 md:col-span-1">
+          <div class="flex items-center gap-2 mb-3">
+            <svg class="h-7 w-7 text-raven-400" viewBox="0 0 32 32" fill="none"><path d="M16 3C9.925 3 5 7.925 5 14c0 3.866 1.945 7.28 4.906 9.35L8 29l5.447-2.723A11.94 11.94 0 0016 26.5c6.075 0 11-4.925 11-11S22.075 3 16 3z" fill="currentColor" opacity="0.3"/><path d="M16 3C9.925 3 5 7.925 5 14c0 3.866 1.945 7.28 4.906 9.35L8 29l5.447-2.723A11.94 11.94 0 0016 26.5c6.075 0 11-4.925 11-11S22.075 3 16 3z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/><circle cx="11" cy="13" r="1.5" fill="currentColor"/><circle cx="16" cy="13" r="1.5" fill="currentColor"/><circle cx="21" cy="13" r="1.5" fill="currentColor"/></svg>
+            <span class="text-white font-bold">Raven</span>
+          </div>
+          <p class="text-sm leading-relaxed">Open-source AI knowledge base. Built in India.</p>
+        </div>
+        <div>
+          <h4 class="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-3">Product</h4>
+          <ul class="space-y-2 text-sm">
+            <li><a href="#features" class="hover:text-white transition-colors">Features</a></li>
+            <li><a href="#pricing" class="hover:text-white transition-colors">Pricing</a></li>
+            <li><a href="#self-host" class="hover:text-white transition-colors">Self-Host</a></li>
+            <li><a href="https://app.ravencloak.org" class="hover:text-white transition-colors">Cloud App</a></li>
+          </ul>
+        </div>
+        <div>
+          <h4 class="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-3">Developers</h4>
+          <ul class="space-y-2 text-sm">
+            <li><a href="https://github.com/ravencloak-org/Raven" class="hover:text-white transition-colors">GitHub</a></li>
+            <li><a href="https://github.com/ravencloak-org/Raven/blob/main/CONTRIBUTING.md" class="hover:text-white transition-colors">Contributing</a></li>
+            <li><a href="https://api.ravencloak.org/swagger" class="hover:text-white transition-colors">API Docs</a></li>
+            <li><a href="https://github.com/ravencloak-org/Raven/releases" class="hover:text-white transition-colors">Changelog</a></li>
+          </ul>
+        </div>
+        <div>
+          <h4 class="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-3">Company</h4>
+          <ul class="space-y-2 text-sm">
+            <li><a href="mailto:support@ravencloak.org" class="hover:text-white transition-colors">Support</a></li>
+            <li><a href="mailto:enterprise@ravencloak.org" class="hover:text-white transition-colors">Enterprise Sales</a></li>
+            <li><a href="/privacy" class="hover:text-white transition-colors">Privacy Policy</a></li>
+            <li><a href="/terms" class="hover:text-white transition-colors">Terms of Service</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="border-t border-gray-800 pt-8 flex flex-col sm:flex-row items-center justify-between gap-4 text-xs">
+        <p>&copy; 2026 Raven. Released under the <a href="https://github.com/ravencloak-org/Raven/blob/main/LICENSE" class="hover:text-white underline">MIT License</a>.</p>
+        <div class="flex items-center gap-4">
+          <a href="https://github.com/ravencloak-org/Raven" class="hover:text-white transition-colors">GitHub</a>
+          <a href="https://twitter.com/ravencloak" class="hover:text-white transition-colors">Twitter</a>
+          <a href="mailto:support@ravencloak.org" class="hover:text-white transition-colors">Email</a>
+        </div>
+      </div>
+    </div>
+  </footer>
+
+</body>
+</html>

--- a/landing/index.html
+++ b/landing/index.html
@@ -1,0 +1,579 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Raven — AI Knowledge Base for Modern Teams</title>
+  <meta name="description" content="Open-source, multi-tenant AI knowledge base with chat, voice, and WhatsApp support. Self-host for free or use our cloud." />
+  <meta property="og:title" content="Raven — AI Knowledge Base for Modern Teams" />
+  <meta property="og:description" content="Open-source, multi-tenant AI knowledge base. Deploy anywhere or use Raven Cloud." />
+  <meta property="og:url" content="https://ravencloak.org" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: { sans: ['Inter', 'system-ui', 'sans-serif'] },
+          colors: {
+            raven: {
+              50:  '#f0f4ff',
+              100: '#e0e9ff',
+              200: '#c7d6ff',
+              300: '#a5b8ff',
+              400: '#818ef8',
+              500: '#6366f1',
+              600: '#4f46e5',
+              700: '#4338ca',
+              800: '#3730a3',
+              900: '#312e81',
+              950: '#1e1b4b',
+            }
+          }
+        }
+      }
+    }
+  </script>
+  <style>
+    .gradient-hero {
+      background: linear-gradient(135deg, #1e1b4b 0%, #312e81 40%, #1e1b4b 100%);
+    }
+    .gradient-card {
+      background: linear-gradient(145deg, rgba(99,102,241,0.08) 0%, rgba(79,70,229,0.04) 100%);
+    }
+    .glow {
+      box-shadow: 0 0 60px -15px rgba(99,102,241,0.4);
+    }
+    .badge-popular {
+      background: linear-gradient(90deg, #6366f1, #818ef8);
+    }
+    @keyframes float {
+      0%, 100% { transform: translateY(0px); }
+      50% { transform: translateY(-8px); }
+    }
+    .float { animation: float 4s ease-in-out infinite; }
+    .feature-icon { transition: transform 0.2s ease; }
+    .feature-card:hover .feature-icon { transform: scale(1.1) rotate(-3deg); }
+  </style>
+</head>
+<body class="font-sans bg-white text-gray-900 antialiased">
+
+  <!-- ── Navigation ──────────────────────────────────────────────────────── -->
+  <nav class="fixed top-0 z-50 w-full border-b border-white/10 bg-raven-950/90 backdrop-blur-md">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+      <div class="flex h-16 items-center justify-between">
+        <div class="flex items-center gap-3">
+          <svg class="h-8 w-8 text-raven-400" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M16 3C9.925 3 5 7.925 5 14c0 3.866 1.945 7.28 4.906 9.35L8 29l5.447-2.723A11.94 11.94 0 0016 26.5c6.075 0 11-4.925 11-11S22.075 3 16 3z" fill="currentColor" opacity="0.3"/>
+            <path d="M16 3C9.925 3 5 7.925 5 14c0 3.866 1.945 7.28 4.906 9.35L8 29l5.447-2.723A11.94 11.94 0 0016 26.5c6.075 0 11-4.925 11-11S22.075 3 16 3z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/>
+            <circle cx="11" cy="13" r="1.5" fill="currentColor"/>
+            <circle cx="16" cy="13" r="1.5" fill="currentColor"/>
+            <circle cx="21" cy="13" r="1.5" fill="currentColor"/>
+          </svg>
+          <span class="text-xl font-bold text-white">Raven</span>
+        </div>
+        <div class="hidden md:flex items-center gap-8">
+          <a href="#features" class="text-sm text-gray-400 hover:text-white transition-colors">Features</a>
+          <a href="#pricing" class="text-sm text-gray-400 hover:text-white transition-colors">Pricing</a>
+          <a href="#self-host" class="text-sm text-gray-400 hover:text-white transition-colors">Self-Host</a>
+          <a href="https://github.com/ravencloak-org/Raven" class="text-sm text-gray-400 hover:text-white transition-colors flex items-center gap-1.5">
+            <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/></svg>
+            GitHub
+          </a>
+        </div>
+        <div class="flex items-center gap-3">
+          <a href="https://app.ravencloak.org" class="hidden sm:inline-flex text-sm text-gray-300 hover:text-white px-4 py-2 rounded-lg border border-white/20 hover:border-white/40 transition-all">Sign In</a>
+          <a href="https://app.ravencloak.org/register" class="inline-flex text-sm font-semibold text-white px-4 py-2 rounded-lg bg-raven-600 hover:bg-raven-500 transition-colors">Get Started Free</a>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <!-- ── Hero ────────────────────────────────────────────────────────────── -->
+  <section class="gradient-hero min-h-screen flex items-center pt-16">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-24 lg:py-32">
+      <div class="text-center">
+        <div class="inline-flex items-center gap-2 rounded-full border border-raven-400/30 bg-raven-400/10 px-4 py-1.5 mb-8">
+          <span class="h-2 w-2 rounded-full bg-green-400 animate-pulse"></span>
+          <span class="text-sm text-raven-300 font-medium">Open Source — MIT Licensed</span>
+        </div>
+        <h1 class="text-4xl sm:text-6xl lg:text-7xl font-extrabold text-white leading-tight tracking-tight mb-6">
+          The AI Brain for<br/>
+          <span class="bg-gradient-to-r from-raven-300 to-indigo-300 bg-clip-text text-transparent">Your Entire Team</span>
+        </h1>
+        <p class="mx-auto max-w-2xl text-lg sm:text-xl text-gray-300 mb-10 leading-relaxed">
+          Raven is an open-source, multi-tenant knowledge base with AI-powered chat, voice calls, and WhatsApp — built for teams that care about data sovereignty.
+        </p>
+        <div class="flex flex-col sm:flex-row items-center justify-center gap-4 mb-16">
+          <a href="https://app.ravencloak.org/register" class="w-full sm:w-auto inline-flex items-center justify-center gap-2 rounded-xl bg-raven-500 hover:bg-raven-400 text-white font-semibold px-8 py-4 text-lg transition-all glow">
+            Start for Free
+            <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6"/></svg>
+          </a>
+          <a href="https://github.com/ravencloak-org/Raven" class="w-full sm:w-auto inline-flex items-center justify-center gap-2 rounded-xl border border-white/25 text-white hover:bg-white/10 font-semibold px-8 py-4 text-lg transition-all">
+            <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/></svg>
+            View on GitHub
+          </a>
+        </div>
+
+        <!-- Stat bar -->
+        <div class="mx-auto max-w-3xl grid grid-cols-3 gap-px rounded-2xl overflow-hidden border border-white/10 bg-white/10">
+          <div class="bg-raven-950/60 backdrop-blur-sm px-6 py-5 text-center">
+            <div class="text-2xl font-bold text-white">MIT</div>
+            <div class="text-sm text-gray-400 mt-1">Open Source License</div>
+          </div>
+          <div class="bg-raven-950/60 backdrop-blur-sm px-6 py-5 text-center border-x border-white/10">
+            <div class="text-2xl font-bold text-white">4</div>
+            <div class="text-sm text-gray-400 mt-1">Deployment Options</div>
+          </div>
+          <div class="bg-raven-950/60 backdrop-blur-sm px-6 py-5 text-center">
+            <div class="text-2xl font-bold text-white">∞</div>
+            <div class="text-sm text-gray-400 mt-1">Knowledge Sources</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Features ────────────────────────────────────────────────────────── -->
+  <section id="features" class="py-24 bg-gray-50">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+      <div class="text-center mb-16">
+        <h2 class="text-3xl sm:text-4xl font-bold text-gray-900 mb-4">Everything your team needs to know</h2>
+        <p class="text-lg text-gray-500 max-w-2xl mx-auto">One platform for all your knowledge — chat, voice, messaging, and more.</p>
+      </div>
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
+
+        <div class="feature-card rounded-2xl border border-gray-200 bg-white p-6 hover:shadow-lg hover:border-raven-300 transition-all">
+          <div class="feature-icon mb-4 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-raven-100 text-raven-600">
+            <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M8.625 12a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0H8.25m4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0H12m4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0h-.375M21 12c0 4.556-4.03 8.25-9 8.25a9.764 9.764 0 01-2.555-.337A5.972 5.972 0 015.41 20.97a5.969 5.969 0 01-.474-.065 4.48 4.48 0 00.978-2.025c.09-.457-.133-.901-.467-1.226C3.93 16.178 3 14.189 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25z"/></svg>
+          </div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">AI-Powered Chat</h3>
+          <p class="text-sm text-gray-500 leading-relaxed">Semantic search + RAG over your documents. Ask questions in plain language and get cited, accurate answers.</p>
+        </div>
+
+        <div class="feature-card rounded-2xl border border-gray-200 bg-white p-6 hover:shadow-lg hover:border-raven-300 transition-all">
+          <div class="feature-icon mb-4 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-violet-100 text-violet-600">
+            <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M12 18.75a6 6 0 006-6v-1.5m-6 7.5a6 6 0 01-6-6v-1.5m6 7.5v3.75m-3.75 0h7.5M12 15.75a3 3 0 01-3-3V4.5a3 3 0 116 0v8.25a3 3 0 01-3 3z"/></svg>
+          </div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">Voice Agent</h3>
+          <p class="text-sm text-gray-500 leading-relaxed">Real-time voice calls via LiveKit WebRTC. Talk to your knowledge base hands-free — ideal for mobile and field teams.</p>
+        </div>
+
+        <div class="feature-card rounded-2xl border border-gray-200 bg-white p-6 hover:shadow-lg hover:border-raven-300 transition-all">
+          <div class="feature-icon mb-4 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-green-100 text-green-600">
+            <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 01.865-.501 48.172 48.172 0 003.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0012 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018z"/></svg>
+          </div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">WhatsApp Integration</h3>
+          <p class="text-sm text-gray-500 leading-relaxed">Let your customers query your knowledge base via WhatsApp. Zero friction — they already have the app.</p>
+        </div>
+
+        <div class="feature-card rounded-2xl border border-gray-200 bg-white p-6 hover:shadow-lg hover:border-raven-300 transition-all">
+          <div class="feature-icon mb-4 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-blue-100 text-blue-600">
+            <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 2.625V9m-16.5 0v-.375"/></svg>
+          </div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">Hybrid Vector Search</h3>
+          <p class="text-sm text-gray-500 leading-relaxed">pgvector + BM25 full-text search combined. Find the right chunk even when semantic search misses, and vice versa.</p>
+        </div>
+
+        <div class="feature-card rounded-2xl border border-gray-200 bg-white p-6 hover:shadow-lg hover:border-raven-300 transition-all">
+          <div class="feature-icon mb-4 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-orange-100 text-orange-600">
+            <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197M15 6.75a3 3 0 11-6 0 3 3 0 016 0zm6 3a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zm-13.5 0a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z"/></svg>
+          </div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">Multi-Tenant Architecture</h3>
+          <p class="text-sm text-gray-500 leading-relaxed">Serve multiple organisations from one installation. Full data isolation per tenant, managed via Keycloak IAM.</p>
+        </div>
+
+        <div class="feature-card rounded-2xl border border-gray-200 bg-white p-6 hover:shadow-lg hover:border-raven-300 transition-all">
+          <div class="feature-icon mb-4 inline-flex h-12 w-12 items-center justify-center rounded-xl bg-red-100 text-red-600">
+            <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z"/></svg>
+          </div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2">BYOK — Your Keys</h3>
+          <p class="text-sm text-gray-500 leading-relaxed">Bring your own LLM API keys. Use Anthropic, OpenAI, or any compatible provider. Zero lock-in.</p>
+        </div>
+
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Pricing ──────────────────────────────────────────────────────────── -->
+  <section id="pricing" class="py-24 bg-white">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+      <div class="text-center mb-16">
+        <h2 class="text-3xl sm:text-4xl font-bold text-gray-900 mb-4">One platform, four editions</h2>
+        <p class="text-lg text-gray-500 max-w-2xl mx-auto">Deploy the way that suits your team — from open-source self-hosting to a fully managed cloud experience.</p>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6 items-start">
+
+        <!-- ── Tier 1: Self-Hosted ──────────────────────────────────────── -->
+        <div class="rounded-2xl border border-gray-200 bg-white p-6 flex flex-col h-full">
+          <div class="mb-6">
+            <div class="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-gray-100 mb-4">
+              <svg class="h-5 w-5 text-gray-700" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M21.75 17.25v.75a3.75 3.75 0 01-3.75 3.75h-13.5A3.75 3.75 0 011.5 18v-.75m19.5 0a3.75 3.75 0 000-7.5h-19.5a3.75 3.75 0 000 7.5m19.5 0h.75a3.75 3.75 0 010 7.5h-.75m-19.5 0H1.5a3.75 3.75 0 010-7.5h.75"/></svg>
+            </div>
+            <h3 class="text-xl font-bold text-gray-900">Self-Hosted</h3>
+            <p class="text-sm text-gray-500 mt-1">Open source, forever free</p>
+            <div class="mt-4">
+              <span class="text-4xl font-extrabold text-gray-900">$0</span>
+              <span class="text-gray-500 ml-1">/ forever</span>
+            </div>
+          </div>
+          <ul class="space-y-3 flex-1 mb-6">
+            <li class="flex items-start gap-2.5 text-sm text-gray-600">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              Full MIT source code
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-600">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              Unlimited users &amp; documents
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-600">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              AI chat, voice &amp; WhatsApp
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-600">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              Bring your own LLM keys
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-600">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              Docker Compose + Kubernetes
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-600">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              Community support (GitHub)
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-400">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+              WAF / advanced security
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-400">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+              SLA guarantee
+            </li>
+          </ul>
+          <a href="https://github.com/ravencloak-org/Raven" class="w-full text-center rounded-xl border border-gray-300 text-gray-700 hover:bg-gray-50 font-semibold px-5 py-3 text-sm transition-all">
+            Deploy from GitHub
+          </a>
+        </div>
+
+        <!-- ── Tier 2: Self-Hosted + Enterprise ────────────────────────── -->
+        <div class="rounded-2xl border border-raven-200 bg-white p-6 flex flex-col h-full ring-1 ring-raven-200">
+          <div class="mb-6">
+            <div class="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-raven-100 mb-4">
+              <svg class="h-5 w-5 text-raven-700" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z"/></svg>
+            </div>
+            <h3 class="text-xl font-bold text-gray-900">Self-Hosted<br/><span class="text-raven-600">+ Enterprise</span></h3>
+            <p class="text-sm text-gray-500 mt-1">Maximum control with enterprise grade</p>
+            <div class="mt-4">
+              <span class="text-2xl font-extrabold text-gray-900">Custom</span>
+              <div class="text-xs text-gray-500 mt-1">Annual license · contact us</div>
+            </div>
+          </div>
+          <ul class="space-y-3 flex-1 mb-6">
+            <li class="flex items-start gap-2.5 text-sm text-gray-600">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              Everything in Self-Hosted
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-600">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              eBPF Web Application Firewall
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-600">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              SAML / SSO / SCIM
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-600">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              Immutable audit log
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-600">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              Advanced rate limiting
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-600">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              SOC2 / GDPR compliance pack
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-600">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              Priority email + Slack support
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-600">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              99.9% SLA guarantee
+            </li>
+          </ul>
+          <a href="mailto:enterprise@ravencloak.org" class="w-full text-center rounded-xl border border-raven-500 text-raven-600 hover:bg-raven-50 font-semibold px-5 py-3 text-sm transition-all">
+            Contact Sales
+          </a>
+        </div>
+
+        <!-- ── Tier 3: Cloud Free ─────────────────────────────────────── -->
+        <div class="rounded-2xl border border-gray-200 bg-gradient-to-b from-raven-950 to-raven-900 p-6 flex flex-col h-full relative overflow-hidden">
+          <div class="absolute inset-0 pointer-events-none">
+            <div class="absolute -right-10 -top-10 h-40 w-40 rounded-full bg-raven-500/20 blur-2xl"></div>
+          </div>
+          <div class="relative mb-6">
+            <div class="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-raven-800 mb-4">
+              <svg class="h-5 w-5 text-raven-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 15a4.5 4.5 0 004.5 4.5H18a3.75 3.75 0 001.332-7.257 3 3 0 00-3.758-3.848 5.25 5.25 0 00-10.233 2.33A4.502 4.502 0 002.25 15z"/></svg>
+            </div>
+            <h3 class="text-xl font-bold text-white">Cloud <span class="text-raven-300">Free</span></h3>
+            <p class="text-sm text-raven-400 mt-1">Raven-hosted, zero setup</p>
+            <div class="mt-4">
+              <span class="text-4xl font-extrabold text-white">$0</span>
+              <span class="text-raven-400 ml-1">/ month</span>
+            </div>
+          </div>
+          <ul class="relative space-y-3 flex-1 mb-6">
+            <li class="flex items-start gap-2.5 text-sm text-gray-300">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              Managed &amp; hosted by Raven
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-300">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              500 AI messages / month
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-300">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              5 users
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-300">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              1 GB document storage
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-300">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              AI chat &amp; knowledge base
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-400">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-700" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+              Voice / WhatsApp
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-400">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-700" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+              Custom domain
+            </li>
+          </ul>
+          <a href="https://app.ravencloak.org/register" class="relative w-full text-center rounded-xl bg-white text-raven-700 hover:bg-raven-50 font-semibold px-5 py-3 text-sm transition-all">
+            Get Started Free
+          </a>
+        </div>
+
+        <!-- ── Tier 4: Cloud Pro ──────────────────────────────────────── -->
+        <div class="rounded-2xl border border-raven-500 bg-gradient-to-b from-raven-950 to-raven-900 p-6 flex flex-col h-full relative overflow-hidden glow">
+          <div class="absolute inset-0 pointer-events-none">
+            <div class="absolute -left-10 -bottom-10 h-40 w-40 rounded-full bg-indigo-500/20 blur-2xl"></div>
+          </div>
+          <!-- Popular badge -->
+          <div class="absolute -top-px left-1/2 -translate-x-1/2">
+            <span class="badge-popular inline-flex items-center rounded-b-xl px-4 py-1 text-xs font-semibold text-white tracking-wide uppercase">Most Popular</span>
+          </div>
+          <div class="relative mb-6 mt-4">
+            <div class="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-raven-500/30 mb-4">
+              <svg class="h-5 w-5 text-raven-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z"/></svg>
+            </div>
+            <h3 class="text-xl font-bold text-white">Cloud <span class="text-raven-300">Pro</span></h3>
+            <p class="text-sm text-raven-400 mt-1">Full power, fully managed</p>
+            <div class="mt-4">
+              <span class="text-4xl font-extrabold text-white">$29</span>
+              <span class="text-raven-400 ml-1">/ month</span>
+            </div>
+            <div class="text-xs text-raven-500 mt-1">per workspace · billed monthly</div>
+          </div>
+          <ul class="relative space-y-3 flex-1 mb-6">
+            <li class="flex items-start gap-2.5 text-sm text-gray-300">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              Everything in Cloud Free
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-300">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              Unlimited AI messages
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-300">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              Unlimited users
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-300">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              100 GB storage
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-300">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              Voice agent included
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-300">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              WhatsApp integration
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-300">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              Custom domain + SSL
+            </li>
+            <li class="flex items-start gap-2.5 text-sm text-gray-300">
+              <svg class="mt-0.5 h-4 w-4 flex-shrink-0 text-raven-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              Priority support
+            </li>
+          </ul>
+          <a href="https://app.ravencloak.org/register?plan=pro" class="relative w-full text-center rounded-xl bg-raven-500 hover:bg-raven-400 text-white font-semibold px-5 py-3 text-sm transition-all">
+            Start 14-day Free Trial
+          </a>
+        </div>
+
+      </div>
+
+      <!-- Comparison footer note -->
+      <p class="text-center text-sm text-gray-400 mt-8">
+        All plans include UPI, RuPay &amp; card payments. India-first infrastructure.
+        <a href="mailto:support@ravencloak.org" class="text-raven-600 hover:underline">Contact us</a> for volume discounts.
+      </p>
+    </div>
+  </section>
+
+  <!-- ── Self-Host section ──────────────────────────────────────────────── -->
+  <section id="self-host" class="py-24 bg-gray-50">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-16 items-center">
+        <div>
+          <div class="inline-flex items-center gap-2 rounded-full bg-green-100 text-green-700 px-3 py-1 text-xs font-semibold uppercase tracking-wide mb-4">
+            Self-Host
+          </div>
+          <h2 class="text-3xl sm:text-4xl font-bold text-gray-900 mb-4">Your data, your rules</h2>
+          <p class="text-lg text-gray-500 mb-8 leading-relaxed">
+            Raven ships as a single Docker Compose file. Run it on a Raspberry Pi, a VPS, or your on-premise Kubernetes cluster. No external dependencies, no data leaves your network.
+          </p>
+          <div class="space-y-4 mb-8">
+            <div class="flex items-start gap-3">
+              <div class="mt-0.5 flex-shrink-0 h-6 w-6 rounded-full bg-green-100 flex items-center justify-center">
+                <svg class="h-3.5 w-3.5 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              </div>
+              <div>
+                <p class="text-sm font-semibold text-gray-900">One command setup</p>
+                <p class="text-sm text-gray-500">Copy <code class="bg-gray-100 px-1 rounded">.env.example</code>, run <code class="bg-gray-100 px-1 rounded">docker compose up</code> and you're live.</p>
+              </div>
+            </div>
+            <div class="flex items-start gap-3">
+              <div class="mt-0.5 flex-shrink-0 h-6 w-6 rounded-full bg-green-100 flex items-center justify-center">
+                <svg class="h-3.5 w-3.5 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              </div>
+              <div>
+                <p class="text-sm font-semibold text-gray-900">Runs on edge hardware</p>
+                <p class="text-sm text-gray-500">Optimised for Raspberry Pi 5 and low-memory ARM nodes. Native Go binary, no JVM overhead.</p>
+              </div>
+            </div>
+            <div class="flex items-start gap-3">
+              <div class="mt-0.5 flex-shrink-0 h-6 w-6 rounded-full bg-green-100 flex items-center justify-center">
+                <svg class="h-3.5 w-3.5 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/></svg>
+              </div>
+              <div>
+                <p class="text-sm font-semibold text-gray-900">Automatic HTTPS</p>
+                <p class="text-sm text-gray-500">Traefik with Let's Encrypt or Cloudflare Tunnel — zero-port-exposure ingress included.</p>
+              </div>
+            </div>
+          </div>
+          <a href="https://github.com/ravencloak-org/Raven#quick-start" class="inline-flex items-center gap-2 rounded-xl border border-gray-300 text-gray-700 hover:bg-gray-100 font-semibold px-6 py-3 text-sm transition-all">
+            Read the Quickstart Guide
+            <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M13 7l5 5m0 0l-5 5m5-5H6"/></svg>
+          </a>
+        </div>
+        <div class="rounded-2xl bg-raven-950 border border-white/10 overflow-hidden">
+          <div class="flex items-center gap-1.5 px-4 py-3 border-b border-white/10">
+            <div class="h-3 w-3 rounded-full bg-red-400"></div>
+            <div class="h-3 w-3 rounded-full bg-yellow-400"></div>
+            <div class="h-3 w-3 rounded-full bg-green-400"></div>
+            <span class="ml-2 text-xs text-gray-500 font-mono">terminal</span>
+          </div>
+          <div class="px-5 py-6 font-mono text-sm leading-7">
+            <p><span class="text-gray-500"># Clone and configure</span></p>
+            <p><span class="text-green-400">$</span> <span class="text-white">git clone https://github.com/ravencloak-org/Raven</span></p>
+            <p><span class="text-green-400">$</span> <span class="text-white">cp .env.example .env</span></p>
+            <p><span class="text-green-400">$</span> <span class="text-white">nano .env</span>  <span class="text-gray-500"># set your secrets</span></p>
+            <br/>
+            <p><span class="text-gray-500"># Start everything</span></p>
+            <p><span class="text-green-400">$</span> <span class="text-white">docker compose up -d</span></p>
+            <br/>
+            <p class="text-gray-500"># ✅ Raven is running at http://localhost:8080</p>
+            <p class="text-gray-500"># ✅ Keycloak at http://localhost:8180</p>
+            <p class="text-gray-500"># ✅ OpenObserve at http://localhost:5080</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── CTA ─────────────────────────────────────────────────────────────── -->
+  <section class="gradient-hero py-24">
+    <div class="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8 text-center">
+      <h2 class="text-3xl sm:text-4xl font-extrabold text-white mb-4">
+        Ready to give your team a brain?
+      </h2>
+      <p class="text-lg text-gray-300 mb-10 max-w-2xl mx-auto">
+        Join teams already using Raven to turn scattered documents into instant answers — across chat, voice, and WhatsApp.
+      </p>
+      <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
+        <a href="https://app.ravencloak.org/register" class="w-full sm:w-auto inline-flex items-center justify-center gap-2 rounded-xl bg-white text-raven-700 hover:bg-raven-50 font-bold px-8 py-4 text-lg transition-all">
+          Get Started for Free
+        </a>
+        <a href="https://github.com/ravencloak-org/Raven" class="w-full sm:w-auto inline-flex items-center justify-center gap-2 rounded-xl border border-white/25 text-white hover:bg-white/10 font-semibold px-8 py-4 text-lg transition-all">
+          <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/></svg>
+          Star on GitHub
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Footer ──────────────────────────────────────────────────────────── -->
+  <footer class="bg-gray-900 text-gray-400 py-12">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+      <div class="grid grid-cols-2 md:grid-cols-4 gap-8 mb-10">
+        <div class="col-span-2 md:col-span-1">
+          <div class="flex items-center gap-2 mb-3">
+            <svg class="h-7 w-7 text-raven-400" viewBox="0 0 32 32" fill="none"><path d="M16 3C9.925 3 5 7.925 5 14c0 3.866 1.945 7.28 4.906 9.35L8 29l5.447-2.723A11.94 11.94 0 0016 26.5c6.075 0 11-4.925 11-11S22.075 3 16 3z" fill="currentColor" opacity="0.3"/><path d="M16 3C9.925 3 5 7.925 5 14c0 3.866 1.945 7.28 4.906 9.35L8 29l5.447-2.723A11.94 11.94 0 0016 26.5c6.075 0 11-4.925 11-11S22.075 3 16 3z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/><circle cx="11" cy="13" r="1.5" fill="currentColor"/><circle cx="16" cy="13" r="1.5" fill="currentColor"/><circle cx="21" cy="13" r="1.5" fill="currentColor"/></svg>
+            <span class="text-white font-bold">Raven</span>
+          </div>
+          <p class="text-sm leading-relaxed">Open-source AI knowledge base. Built in India.</p>
+        </div>
+        <div>
+          <h4 class="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-3">Product</h4>
+          <ul class="space-y-2 text-sm">
+            <li><a href="#features" class="hover:text-white transition-colors">Features</a></li>
+            <li><a href="#pricing" class="hover:text-white transition-colors">Pricing</a></li>
+            <li><a href="#self-host" class="hover:text-white transition-colors">Self-Host</a></li>
+            <li><a href="https://app.ravencloak.org" class="hover:text-white transition-colors">Cloud App</a></li>
+          </ul>
+        </div>
+        <div>
+          <h4 class="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-3">Developers</h4>
+          <ul class="space-y-2 text-sm">
+            <li><a href="https://github.com/ravencloak-org/Raven" class="hover:text-white transition-colors">GitHub</a></li>
+            <li><a href="https://github.com/ravencloak-org/Raven/blob/main/CONTRIBUTING.md" class="hover:text-white transition-colors">Contributing</a></li>
+            <li><a href="https://api.ravencloak.org/swagger" class="hover:text-white transition-colors">API Docs</a></li>
+            <li><a href="https://github.com/ravencloak-org/Raven/releases" class="hover:text-white transition-colors">Changelog</a></li>
+          </ul>
+        </div>
+        <div>
+          <h4 class="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-3">Company</h4>
+          <ul class="space-y-2 text-sm">
+            <li><a href="mailto:support@ravencloak.org" class="hover:text-white transition-colors">Support</a></li>
+            <li><a href="mailto:enterprise@ravencloak.org" class="hover:text-white transition-colors">Enterprise Sales</a></li>
+            <li><a href="/privacy" class="hover:text-white transition-colors">Privacy Policy</a></li>
+            <li><a href="/terms" class="hover:text-white transition-colors">Terms of Service</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="border-t border-gray-800 pt-8 flex flex-col sm:flex-row items-center justify-between gap-4 text-xs">
+        <p>&copy; 2026 Raven. Released under the <a href="https://github.com/ravencloak-org/Raven/blob/main/LICENSE" class="hover:text-white underline">MIT License</a>.</p>
+        <div class="flex items-center gap-4">
+          <a href="https://github.com/ravencloak-org/Raven" class="hover:text-white transition-colors">GitHub</a>
+          <a href="https://twitter.com/ravencloak" class="hover:text-white transition-colors">Twitter</a>
+          <a href="mailto:support@ravencloak.org" class="hover:text-white transition-colors">Email</a>
+        </div>
+      </div>
+    </div>
+  </footer>
+
+</body>
+</html>


### PR DESCRIPTION
## Problem

After Keycloak redirects back with `#code=...`, the app reloads and `keycloak.init()` tries to exchange the code for tokens. But `checkLoginIframe: true` (default) creates an iframe to `auth.ravencloak.org` for session validation — Cloudflare strips the third-party cookies this iframe needs, the check fails, `init()` returns `authenticated = false`, and the router's `beforeEach` guard immediately triggers `auth.login()` again → infinite loop.

## Fix

- `checkLoginIframe: false` in `keycloak.init()` — eliminates the iframe session check entirely (not needed when using PKCE + `silentCheckSsoRedirectUri`)
- Router guard skips the auth check when the URL still contains `code=` + `state=` — prevents the guard firing during the in-flight token exchange

## Test plan

- [ ] Visit `https://app.ravencloak.org` → redirects to Keycloak login
- [ ] Log in → lands on `/dashboard` without looping
- [ ] Hard refresh on `/dashboard` → stays on dashboard (token refreshes silently)
- [ ] Logout → redirects to `/`