### PR TITLE
fix(auth): resolve Keycloak auth behind Cloudflare and broken nav links

### DIFF
--- a/deploy/ec2/docker-compose.server.yml
+++ b/deploy/ec2/docker-compose.server.yml
@@ -112,12 +112,12 @@ services:
       KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN:-admin}
       KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:?KEYCLOAK_ADMIN_PASSWORD is required}
       # Cloudflare Tunnel terminates TLS — Keycloak is behind a proxy.
-      # KC_HOSTNAME_URL sets the full external base URL so the issuer, auth
+      # KC_HOSTNAME accepts a full URL in KC 26 so the issuer, auth
       # endpoints and redirect URIs all use https:// without port leakage.
       KC_PROXY_HEADERS: xforwarded
       KC_HTTP_ENABLED: "true"
-      KC_HOSTNAME_URL: https://${KC_HOSTNAME}
-      KC_HOSTNAME_ADMIN_URL: https://${KC_HOSTNAME}
+      KC_HOSTNAME: https://${KC_HOSTNAME}
+      KC_HOSTNAME_ADMIN: https://${KC_HOSTNAME}
       # HOSTNAME_STRICT=false is safe here: Cloudflare Tunnel is the only ingress
       # (no ports are exposed to the public internet), so hostname spoofing is not possible.
       KC_HOSTNAME_STRICT: "false"

--- a/deploy/ec2/docker-compose.server.yml
+++ b/deploy/ec2/docker-compose.server.yml
@@ -111,10 +111,13 @@ services:
       KC_DB_PASSWORD: ${KC_DB_PASSWORD:?KC_DB_PASSWORD is required}
       KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN:-admin}
       KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:?KEYCLOAK_ADMIN_PASSWORD is required}
-      # Cloudflare Tunnel terminates TLS — Keycloak is behind a proxy
+      # Cloudflare Tunnel terminates TLS — Keycloak is behind a proxy.
+      # KC_HOSTNAME_URL sets the full external base URL so the issuer, auth
+      # endpoints and redirect URIs all use https:// without port leakage.
       KC_PROXY_HEADERS: xforwarded
       KC_HTTP_ENABLED: "true"
-      KC_HOSTNAME: ${KC_HOSTNAME}
+      KC_HOSTNAME_URL: https://${KC_HOSTNAME}
+      KC_HOSTNAME_ADMIN_URL: https://${KC_HOSTNAME}
       # HOSTNAME_STRICT=false is safe here: Cloudflare Tunnel is the only ingress
       # (no ports are exposed to the public internet), so hostname spoofing is not possible.
       KC_HOSTNAME_STRICT: "false"

--- a/deploy/keycloak/raven-realm.json
+++ b/deploy/keycloak/raven-realm.json
@@ -130,9 +130,10 @@
       "directAccessGrantsEnabled": false,
       "serviceAccountsEnabled": false,
       "protocol": "openid-connect",
-      "rootUrl": "https://raven-frontend.pages.dev",
+      "rootUrl": "https://www.ravencloak.org",
       "baseUrl": "/",
       "redirectUris": [
+        "https://www.ravencloak.org/*",
         "https://raven-frontend.pages.dev/*"
       ],
       "webOrigins": [

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -4,23 +4,47 @@
       <h2 class="text-sm font-semibold text-gray-700">Raven</h2>
     </div>
 
-    <div class="flex items-center gap-3">
+    <div class="relative flex items-center gap-3">
       <button
         class="flex h-8 w-8 items-center justify-center rounded-full bg-indigo-100 text-sm font-medium text-indigo-700 transition-colors hover:bg-indigo-200"
         title="User menu"
-        @click="handleUserMenu"
+        @click="menuOpen = !menuOpen"
       >
         {{ userInitial }}
       </button>
+
+      <div
+        v-if="menuOpen"
+        class="absolute right-0 top-10 z-50 w-56 rounded-md border border-gray-200 bg-white py-1 shadow-lg"
+      >
+        <div class="border-b border-gray-100 px-4 py-2">
+          <p class="text-sm font-medium text-gray-900">{{ user?.username }}</p>
+          <p class="truncate text-xs text-gray-500">{{ user?.email }}</p>
+        </div>
+        <button
+          class="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-50"
+          @click="handleLogout"
+        >
+          <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+          </svg>
+          Sign out
+        </button>
+      </div>
+
+      <div v-if="menuOpen" class="fixed inset-0 z-40" @click="menuOpen = false" />
     </div>
   </header>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useAuth } from '../composables/useAuth'
+import { useAuthStore } from '../stores/auth'
 
 const { user } = useAuth()
+const authStore = useAuthStore()
+const menuOpen = ref(false)
 
 const userInitial = computed(() => {
   if (user.value?.username) {
@@ -29,7 +53,8 @@ const userInitial = computed(() => {
   return 'U'
 })
 
-function handleUserMenu() {
-  // Placeholder: will open a dropdown with profile/settings/logout
+function handleLogout() {
+  menuOpen.value = false
+  authStore.logout()
 }
 </script>

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -8,6 +8,9 @@
       <button
         class="flex h-8 w-8 items-center justify-center rounded-full bg-indigo-100 text-sm font-medium text-indigo-700 transition-colors hover:bg-indigo-200"
         title="User menu"
+        aria-haspopup="true"
+        :aria-expanded="menuOpen"
+        aria-controls="user-menu"
         @click="menuOpen = !menuOpen"
       >
         {{ userInitial }}
@@ -15,6 +18,8 @@
 
       <div
         v-if="menuOpen"
+        id="user-menu"
+        role="menu"
         class="absolute right-0 top-10 z-50 w-56 rounded-md border border-gray-200 bg-white py-1 shadow-lg"
       >
         <div class="border-b border-gray-100 px-4 py-2">
@@ -38,13 +43,19 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, onMounted, onUnmounted } from 'vue'
 import { useAuth } from '../composables/useAuth'
 import { useAuthStore } from '../stores/auth'
 
 const { user } = useAuth()
 const authStore = useAuthStore()
 const menuOpen = ref(false)
+
+function onEscape(e: KeyboardEvent) {
+  if (e.key === 'Escape' && menuOpen.value) menuOpen.value = false
+}
+onMounted(() => window.addEventListener('keydown', onEscape))
+onUnmounted(() => window.removeEventListener('keydown', onEscape))
 
 const userInitial = computed(() => {
   if (user.value?.username) {

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -70,7 +70,7 @@
 
         <!-- Voice Sessions -->
         <RouterLink
-          to="/orgs/_/voice"
+          :to="`${orgPrefix}/voice`"
           :class="[
             'flex items-center rounded-lg text-slate-400 transition-colors hover:bg-slate-800 hover:text-white',
             mobile
@@ -103,7 +103,7 @@
 
         <!-- Phone Numbers -->
         <RouterLink
-          to="/orgs/_/whatsapp/phone-numbers"
+          :to="`${orgPrefix}/whatsapp/phone-numbers`"
           :class="[
             'flex items-center rounded-lg text-slate-400 transition-colors hover:bg-slate-800 hover:text-white',
             mobile
@@ -129,7 +129,7 @@
 
         <!-- Calls -->
         <RouterLink
-          to="/orgs/_/whatsapp/calls"
+          :to="`${orgPrefix}/whatsapp/calls`"
           :class="[
             'flex items-center rounded-lg text-slate-400 transition-colors hover:bg-slate-800 hover:text-white',
             mobile
@@ -160,7 +160,7 @@
 
         <!-- Billing -->
         <RouterLink
-          to="/orgs/_/billing"
+          :to="`${orgPrefix}/billing`"
           :class="[
             'flex items-center rounded-lg text-slate-400 transition-colors hover:bg-slate-800 hover:text-white',
             mobile
@@ -189,7 +189,12 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import { RouterLink } from 'vue-router'
+import { useAuthStore } from '../stores/auth'
+
+const auth = useAuthStore()
+const orgPrefix = computed(() => `/orgs/${auth.user?.orgId || '_'}`)
 
 defineProps<{
   mobile?: boolean

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -70,6 +70,7 @@
 
         <!-- Voice Sessions -->
         <RouterLink
+          v-if="orgPrefix"
           :to="`${orgPrefix}/voice`"
           :class="[
             'flex items-center rounded-lg text-slate-400 transition-colors hover:bg-slate-800 hover:text-white',
@@ -97,12 +98,13 @@
         </RouterLink>
 
         <!-- WhatsApp section label (mobile only) -->
-        <span v-if="mobile" class="mt-4 px-1 text-xs font-semibold uppercase tracking-wider text-slate-500">
+        <span v-if="mobile && orgPrefix" class="mt-4 px-1 text-xs font-semibold uppercase tracking-wider text-slate-500">
           WhatsApp
         </span>
 
         <!-- Phone Numbers -->
         <RouterLink
+          v-if="orgPrefix"
           :to="`${orgPrefix}/whatsapp/phone-numbers`"
           :class="[
             'flex items-center rounded-lg text-slate-400 transition-colors hover:bg-slate-800 hover:text-white',
@@ -129,6 +131,7 @@
 
         <!-- Calls -->
         <RouterLink
+          v-if="orgPrefix"
           :to="`${orgPrefix}/whatsapp/calls`"
           :class="[
             'flex items-center rounded-lg text-slate-400 transition-colors hover:bg-slate-800 hover:text-white',
@@ -154,12 +157,13 @@
         </RouterLink>
 
         <!-- Billing section label (mobile only) -->
-        <span v-if="mobile" class="mt-4 px-1 text-xs font-semibold uppercase tracking-wider text-slate-500">
+        <span v-if="mobile && orgPrefix" class="mt-4 px-1 text-xs font-semibold uppercase tracking-wider text-slate-500">
           Account
         </span>
 
         <!-- Billing -->
         <RouterLink
+          v-if="orgPrefix"
           :to="`${orgPrefix}/billing`"
           :class="[
             'flex items-center rounded-lg text-slate-400 transition-colors hover:bg-slate-800 hover:text-white',
@@ -194,7 +198,9 @@ import { RouterLink } from 'vue-router'
 import { useAuthStore } from '../stores/auth'
 
 const auth = useAuthStore()
-const orgPrefix = computed(() => `/orgs/${auth.user?.orgId || '_'}`)
+const orgPrefix = computed(() =>
+  auth.user?.orgId ? `/orgs/${auth.user.orgId}` : null,
+)
 
 defineProps<{
   mobile?: boolean

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -12,6 +12,13 @@ app.use(pinia)
 app.use(router)
 app.use(posthogPlugin, { router })
 
-// Initialise Keycloak before mounting
+// Initialise Keycloak before mounting.
+// With onLoad: 'login-required', init() either:
+//   a) redirects to Keycloak (never resolves on this page load), or
+//   b) exchanges the code from the URL and resolves with authenticated=true.
+// The app only mounts after auth succeeds — no router guard needed.
 const authStore = useAuthStore()
-authStore.init().then(() => app.mount('#app'))
+authStore.init().then(() => {
+  console.log('[main] auth ready, mounting app')
+  app.mount('#app')
+})

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -12,13 +12,8 @@ app.use(pinia)
 app.use(router)
 app.use(posthogPlugin, { router })
 
-// Initialise Keycloak before mounting.
-// With onLoad: 'login-required', init() either:
-//   a) redirects to Keycloak (never resolves on this page load), or
-//   b) exchanges the code from the URL and resolves with authenticated=true.
-// The app only mounts after auth succeeds — no router guard needed.
+// Initialise Keycloak before mounting so the auth store is ready when the
+// router guard evaluates.  With check-sso the app mounts regardless of
+// whether the user is logged in — the router guard handles redirects.
 const authStore = useAuthStore()
-authStore.init().then(() => {
-  console.log('[main] auth ready, mounting app')
-  app.mount('#app')
-})
+authStore.init().then(() => app.mount('#app'))

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -147,6 +147,13 @@ const router = createRouter({
 })
 
 router.beforeEach(async (to) => {
+  // If the URL contains a Keycloak callback code, let keycloak.init() finish
+  // processing it before we evaluate auth state. Without this guard the router
+  // fires before the token exchange completes and triggers another redirect.
+  if (window.location.href.includes('code=') && window.location.href.includes('state=')) {
+    return
+  }
+
   if (to.meta.requiresAuth) {
     const auth = useAuthStore()
     if (!auth.isAuthenticated) {

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -6,7 +6,10 @@ const router = createRouter({
   routes: [
     {
       path: '/',
-      redirect: '/dashboard',
+      redirect: () => {
+        const auth = useAuthStore()
+        return auth.isAuthenticated ? '/dashboard' : '/login'
+      },
     },
     {
       path: '/login',
@@ -146,15 +149,16 @@ const router = createRouter({
   ],
 })
 
-// No auth guard needed — keycloak.init({ onLoad: 'login-required' })
-// guarantees the user is authenticated before the app mounts.
-// The only guard remaining redirects authenticated users away from /login.
 router.beforeEach(async (to) => {
-  if (to.name === 'login') {
-    const auth = useAuthStore()
-    if (auth.isAuthenticated) {
-      return { name: 'dashboard' }
-    }
+  const auth = useAuthStore()
+
+  if (to.meta.requiresAuth && !auth.isAuthenticated) {
+    auth.login()
+    return false
+  }
+
+  if (to.name === 'login' && auth.isAuthenticated) {
+    return { name: 'dashboard' }
   }
 })
 

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -146,22 +146,10 @@ const router = createRouter({
   ],
 })
 
+// No auth guard needed — keycloak.init({ onLoad: 'login-required' })
+// guarantees the user is authenticated before the app mounts.
+// The only guard remaining redirects authenticated users away from /login.
 router.beforeEach(async (to) => {
-  // If the URL contains a Keycloak callback code, let keycloak.init() finish
-  // processing it before we evaluate auth state. Without this guard the router
-  // fires before the token exchange completes and triggers another redirect.
-  if (window.location.href.includes('code=') && window.location.href.includes('state=')) {
-    return
-  }
-
-  if (to.meta.requiresAuth) {
-    const auth = useAuthStore()
-    if (!auth.isAuthenticated) {
-      auth.login()
-      return false
-    }
-  }
-
   if (to.name === 'login') {
     const auth = useAuthStore()
     if (auth.isAuthenticated) {

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -30,6 +30,9 @@ export const useAuthStore = defineStore('auth', () => {
         onLoad: 'check-sso',
         pkceMethod: 'S256',
         silentCheckSsoRedirectUri: window.location.origin + '/silent-check-sso.html',
+        // Must be false behind Cloudflare — the iframe-based session check uses
+        // third-party cookies that CF strips, causing an infinite redirect loop.
+        checkLoginIframe: false,
       })
       if (authenticated) {
         _syncFromKeycloak()

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -27,13 +27,16 @@ export const useAuthStore = defineStore('auth', () => {
   async function init(): Promise<void> {
     try {
       const authenticated = await keycloak.init({
-        onLoad: 'login-required',
+        onLoad: 'check-sso',
         pkceMethod: 'S256',
         checkLoginIframe: false,
       })
       if (authenticated) {
         await _syncFromKeycloak()
-        setInterval(() => keycloak.updateToken(30), 60_000)
+        setInterval(async () => {
+          const refreshed = await keycloak.updateToken(30)
+          if (refreshed) await _syncFromKeycloak()
+        }, 60_000)
       }
     } catch {
       // Keycloak unavailable — proceed as unauthenticated

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -27,16 +27,12 @@ export const useAuthStore = defineStore('auth', () => {
   async function init(): Promise<void> {
     try {
       const authenticated = await keycloak.init({
-        onLoad: 'check-sso',
+        onLoad: 'login-required',
         pkceMethod: 'S256',
-        silentCheckSsoRedirectUri: window.location.origin + '/silent-check-sso.html',
-        // Must be false behind Cloudflare — the iframe-based session check uses
-        // third-party cookies that CF strips, causing an infinite redirect loop.
         checkLoginIframe: false,
       })
       if (authenticated) {
-        _syncFromKeycloak()
-        // Auto-refresh token 30s before expiry
+        await _syncFromKeycloak()
         setInterval(() => keycloak.updateToken(30), 60_000)
       }
     } catch {
@@ -47,7 +43,7 @@ export const useAuthStore = defineStore('auth', () => {
   }
 
   function login(): void {
-    keycloak.login({ redirectUri: window.location.origin + '/dashboard' })
+    keycloak.login({ redirectUri: window.location.href })
   }
 
   function logout(): void {
@@ -57,25 +53,49 @@ export const useAuthStore = defineStore('auth', () => {
     keycloak.logout({ redirectUri: window.location.origin + '/' })
   }
 
-  function _syncFromKeycloak(): void {
-    const p = keycloak.tokenParsed as Record<string, unknown>
+  async function _syncFromKeycloak(): Promise<void> {
     accessToken.value = keycloak.token ?? null
-    user.value = {
-      id: p['sub'] as string,
-      email: p['email'] as string,
-      username: p['preferred_username'] as string,
-      orgId: p['org_id'] as string,
-      orgRole: p['org_role'] as string,
+
+    // Prefer ID token for standard OIDC claims (sub, email, preferred_username).
+    // Access token for custom claims (org_id, org_role).
+    const idClaims = (keycloak.idTokenParsed ?? {}) as Record<string, unknown>
+    const atClaims = (keycloak.tokenParsed ?? {}) as Record<string, unknown>
+
+    let id = (idClaims['sub'] ?? atClaims['sub']) as string | undefined
+    let email = (idClaims['email'] ?? atClaims['email']) as string | undefined
+    let username = (idClaims['preferred_username'] ?? atClaims['preferred_username']) as string | undefined
+    const orgId = (atClaims['org_id'] ?? idClaims['org_id']) as string | undefined
+    const orgRole = (atClaims['org_role'] ?? idClaims['org_role']) as string | undefined
+
+    // Fallback: fetch from Keycloak account API when tokens lack user claims.
+    if (!id || !email) {
+      try {
+        const profile = await keycloak.loadUserProfile()
+        id = id ?? profile.id
+        email = email ?? profile.email
+        username = username ?? profile.username
+      } catch {
+        // Profile endpoint unavailable — continue with what we have
+      }
     }
 
-    // Identify the authenticated user in PostHog for analytics.
-    const { identify } = usePostHog()
-    identify(user.value.id, {
-      email: user.value.email,
-      username: user.value.username,
-      org_id: user.value.orgId,
-      org_role: user.value.orgRole,
-    })
+    if (id) {
+      user.value = {
+        id,
+        email: email ?? '',
+        username: username ?? '',
+        orgId: orgId ?? '',
+        orgRole: orgRole ?? '',
+      }
+
+      const { identify } = usePostHog()
+      identify(user.value.id, {
+        email: user.value.email,
+        username: user.value.username,
+        org_id: user.value.orgId,
+        org_role: user.value.orgRole,
+      })
+    }
   }
 
   return { user, accessToken, isAuthenticated, initialized, init, login, logout }


### PR DESCRIPTION
## Summary

- **Switch from `check-sso` to `login-required`** — Cloudflare strips third-party cookies, causing the silent SSO iframe to always fail. This made every deep link bounce back to `/dashboard` via the auth guard → `login(redirectUri: '/dashboard')` chain.
- **Resilient user claim extraction** — read from ID token first, access token second, with `loadUserProfile()` fallback. The deployed Keycloak had zero default scopes on `raven-frontend`, producing tokens with no user claims.
- **Dynamic sidebar org links** — replaced hardcoded `/orgs/_/` with computed `orgPrefix` from the auth store.
- **Preserve deep links on login** — `login()` now uses `window.location.href` instead of hardcoding `/dashboard`.
- **Keycloak config fixes** — added `www.ravencloak.org` to redirect URIs, switched to `KC_HOSTNAME_URL`/`KC_HOSTNAME_ADMIN_URL` for proper HTTPS issuer behind Cloudflare Tunnel.

### Keycloak server changes (already applied)
- Created `profile` and `email` client scopes with access token mappers
- Assigned `profile`, `email`, `raven-org` as default scopes on `raven-frontend`
- Registered `org_id`, `org_role`, `workspace_ids` in User Profile policy (KC 26 silently drops undeclared attributes)
- Set user attributes (`org_id`, `org_role`) on existing user

## Test plan
- [ ] Fresh login at `www.ravencloak.org` produces JWT with `sub`, `email`, `preferred_username`, `org_id`, `org_role`
- [ ] Sidebar links navigate to `/orgs/<actual-uuid>/...` instead of `/orgs/_/...`
- [ ] Deep link to `/orgs/<id>/voice` works without redirect to dashboard
- [ ] Logout and re-login flow works end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebar navigation now builds organization-specific routes dynamically.
  * Header now shows a user menu with username, email, and Sign out action.

* **Bug Fixes**
  * Improved user profile retrieval with a fallback when identity claims are missing.
  * Analytics identity syncing made more robust for missing fields.

* **Chores**
  * Enforced HTTPS base URLs for authentication endpoints and updated redirect targets.
  * App now mounts only after authentication completes; router guard simplified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->