### PR TITLE
fix(ci): remove stale Zitadel preflight from Cloudflare Pages deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -50,18 +50,8 @@ jobs:
         env:
           VITE_API_URL: ${{ vars.VITE_API_URL || 'https://api.ravencloak.org' }}
           VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL || 'https://api.ravencloak.org/api/v1' }}
-          VITE_ZITADEL_URL: ${{ vars.VITE_ZITADEL_URL || 'https://auth.ravencloak.org' }}
-          VITE_ZITADEL_CLIENT_ID: ${{ vars.VITE_ZITADEL_CLIENT_ID || '' }}
-          VITE_GOOGLE_IDP_ID: ${{ vars.VITE_GOOGLE_IDP_ID || '' }}
+          VITE_API_DOMAIN: ${{ vars.VITE_API_DOMAIN || 'https://api.ravencloak.org' }}
           VITE_LIVEKIT_URL: ${{ vars.VITE_LIVEKIT_URL || '' }}
-
-      - name: Preflight — require OIDC client ID for deploy
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          if [ -z "${{ vars.VITE_ZITADEL_CLIENT_ID }}" ]; then
-            echo "::error::VITE_ZITADEL_CLIENT_ID is not set — deploy would ship a broken frontend"
-            exit 1
-          fi
 
       - name: Deploy to Cloudflare Pages
         # Only deploy on push to main when the API token is available.


### PR DESCRIPTION
## Summary

- Removed `VITE_ZITADEL_CLIENT_ID` preflight check that blocks every frontend deploy since the SuperTokens migration
- Removed stale `VITE_ZITADEL_URL`, `VITE_ZITADEL_CLIENT_ID`, `VITE_GOOGLE_IDP_ID` env vars from build step
- Added `VITE_API_DOMAIN` (used by SuperTokens frontend plugin)

## Root Cause

The Cloudflare Pages workflow (`pages.yml`) still had a preflight gate requiring `VITE_ZITADEL_CLIENT_ID` — a variable that was deleted during the Zitadel→SuperTokens migration. Every push to main with frontend changes failed immediately.

## Test plan

- [ ] Verify Cloudflare Pages deploy succeeds on merge
- [ ] Verify frontend loads correctly with SuperTokens auth

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration environment variables to remove authentication provider configuration and add API domain variable.
  * Removed deployment preflight validation check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->