### PR TITLE
feat: TMDB-powered demo knowledge base (M10)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -456,13 +456,6 @@ func main() {
 	router.Use(middleware.CORSMiddleware(&cfg.CORS))
 	router.Use(apierror.ErrorHandler())
 
-	// Set seed key in context for X-Seed-Key header authentication.
-	if cfg.Seed.Key != "" {
-		router.Use(func(c *gin.Context) {
-			c.Set(string(middleware.ContextKeySeedKey), cfg.Seed.Key)
-			c.Next()
-		})
-	}
 
 	// Infrastructure endpoint — intentionally outside the versioned group.
 	// Excluded from rate limiting.
@@ -778,8 +771,16 @@ func main() {
 	router.GET("/webhooks/meta", metaWebhookHandler.VerifyWebhook)
 	router.POST("/webhooks/meta", metaWebhookHandler.HandleEvent)
 
-	// --- Admin routes (seed key or session auth) ---
+	// --- Admin routes (seed key auth required) ---
 	admin := router.Group("/api/v1/admin")
+	admin.Use(func(c *gin.Context) {
+		seedKey := c.GetHeader("X-Seed-Key")
+		if cfg.Seed.Key != "" && seedKey == cfg.Seed.Key {
+			c.Next()
+			return
+		}
+		c.AbortWithStatusJSON(401, gin.H{"error": "valid X-Seed-Key header required"})
+	})
 	admin.POST("/seed-demo", seedHandler.SeedDemo)
 
 	// Auth callback — outside the session-protected /api/v1 group.

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -53,6 +53,7 @@ import (
 	"github.com/ravencloak-org/Raven/internal/storage"
 	"github.com/ravencloak-org/Raven/internal/stt"
 	"github.com/ravencloak-org/Raven/internal/telemetry"
+	"github.com/ravencloak-org/Raven/internal/tmdb"
 	"github.com/ravencloak-org/Raven/internal/tts"
 	"github.com/ravencloak-org/Raven/pkg/apierror"
 	lk "github.com/ravencloak-org/Raven/pkg/livekit"
@@ -169,6 +170,12 @@ func main() {
 		WebsiteDomain: cfg.SuperTokens.WebsiteDomain,
 	}); err != nil {
 		log.Fatalf("failed to initialize SuperTokens: %v", err)
+	}
+
+	// TMDB client for demo seed endpoint.
+	var tmdbClient *tmdb.Client
+	if cfg.TMDB.APIKey != "" {
+		tmdbClient = tmdb.NewClient(cfg.TMDB.BaseURL, cfg.TMDB.APIKey, nil)
 	}
 
 	// Set Gin mode
@@ -437,6 +444,8 @@ func main() {
 	leadHandler := handler.NewLeadHandler(leadSvc)
 	whatsappHandler := handler.NewWhatsAppHandler(whatsappSvc)
 	billingHandler := handler.NewBillingHandler(billingSvc)
+	seedSvc := service.NewSeedService(orgSvc, wsSvc, kbSvc, docRepo, pool, tmdbClient, seaweedClient, queueClient)
+	seedHandler := handler.NewSeedHandler(seedSvc)
 
 	// Create router
 	router := gin.Default()
@@ -446,6 +455,14 @@ func main() {
 	router.Use(middleware.SecurityHeadersMiddleware())
 	router.Use(middleware.CORSMiddleware(&cfg.CORS))
 	router.Use(apierror.ErrorHandler())
+
+	// Set seed key in context for X-Seed-Key header authentication.
+	if cfg.Seed.Key != "" {
+		router.Use(func(c *gin.Context) {
+			c.Set(string(middleware.ContextKeySeedKey), cfg.Seed.Key)
+			c.Next()
+		})
+	}
 
 	// Infrastructure endpoint — intentionally outside the versioned group.
 	// Excluded from rate limiting.
@@ -761,10 +778,15 @@ func main() {
 	router.GET("/webhooks/meta", metaWebhookHandler.VerifyWebhook)
 	router.POST("/webhooks/meta", metaWebhookHandler.HandleEvent)
 
+	// --- Admin routes (seed key or session auth) ---
+	admin := router.Group("/api/v1/admin")
+	admin.POST("/seed-demo", seedHandler.SeedDemo)
+
 	// Auth callback — outside the session-protected /api/v1 group.
 	// We verify the session directly via the SuperTokens SDK rather than
 	// relying on SessionMiddleware (cookies may not be available yet).
-	authHandler := handler.NewAuthHandler(userSvc)
+	demoJoiner := service.NewDemoOrgJoiner(orgSvc, wsSvc)
+	authHandler := handler.NewAuthHandler(userSvc, demoJoiner)
 	router.GET("/api/v1/auth/callback", func(c *gin.Context) {
 		info, err := authProvider.VerifySession(c.Request)
 		if err != nil || info == nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,8 @@ type Config struct {
 	STT          STTConfig
 	EBPF         EBPFConfig
 	Meta         MetaConfig
+	TMDB         TMDBConfig
+	Seed         SeedConfig
 }
 
 // MetaConfig holds Meta WhatsApp Business API settings.
@@ -39,6 +41,17 @@ type MetaConfig struct {
 	PhoneNumberID string `mapstructure:"phone_number_id"`
 	AppSecret     string `mapstructure:"app_secret"`    // for webhook HMAC verification
 	WebhookToken  string `mapstructure:"webhook_token"` // hub.verify_token
+}
+
+// TMDBConfig holds TMDB API settings for the demo knowledge base.
+type TMDBConfig struct {
+	APIKey  string `mapstructure:"api_key"`
+	BaseURL string `mapstructure:"base_url"`
+}
+
+// SeedConfig holds settings for the admin seed endpoint.
+type SeedConfig struct {
+	Key string `mapstructure:"key"` // X-Seed-Key header value for auth bypass
 }
 
 // ClickHouseConfig holds ClickHouse connection and vector backend settings.
@@ -299,6 +312,11 @@ func Load() (*Config, error) {
 	v.SetDefault("meta.phone_number_id", "")
 	v.SetDefault("meta.app_secret", "")
 	v.SetDefault("meta.webhook_token", "")
+	// TMDB API defaults
+	v.SetDefault("tmdb.api_key", "")
+	v.SetDefault("tmdb.base_url", "https://api.themoviedb.org/3")
+	// Seed endpoint defaults
+	v.SetDefault("seed.key", "")
 	v.SetDefault("upload.max_size_bytes", 52428800) // 50 MB
 	v.SetDefault("upload.allowed_types", []string{
 		"application/pdf",
@@ -381,6 +399,9 @@ func Load() (*Config, error) {
 	_ = v.BindEnv("ebpf.audit_ring_buffer_size", "RAVEN_EBPF_AUDIT_RING_BUFFER_SIZE")
 	_ = v.BindEnv("ebpf.xdp_enabled", "RAVEN_EBPF_XDP_ENABLED")
 	_ = v.BindEnv("ebpf.xdp_interface", "RAVEN_EBPF_XDP_INTERFACE")
+	_ = v.BindEnv("tmdb.api_key", "TMDB_API_KEY")
+	_ = v.BindEnv("tmdb.base_url", "RAVEN_TMDB_BASE_URL")
+	_ = v.BindEnv("seed.key", "RAVEN_SEED_KEY")
 
 	// Try to read config file but don't fail if not found
 	_ = v.ReadInConfig()

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -17,14 +17,28 @@ type AuthServicer interface {
 	Create(ctx context.Context, externalID, email, displayName string) (*model.User, error)
 }
 
+// DemoOrgJoiner is an optional interface that auto-joins new users to the demo
+// organisation as viewers. When nil, the auto-join step is skipped.
+type DemoOrgJoiner interface {
+	// JoinDemoOrg adds the user as a viewer to the first workspace of the demo org.
+	// Returns silently on any error (best-effort).
+	JoinDemoOrg(ctx context.Context, userID string)
+}
+
 // AuthHandler handles authentication callback endpoints.
 type AuthHandler struct {
-	svc AuthServicer
+	svc      AuthServicer
+	demoJoin DemoOrgJoiner
 }
 
 // NewAuthHandler creates a new AuthHandler.
-func NewAuthHandler(svc AuthServicer) *AuthHandler {
-	return &AuthHandler{svc: svc}
+// Pass optional DemoOrgJoiner instances (at most one) to enable auto-join on signup.
+func NewAuthHandler(svc AuthServicer, opts ...DemoOrgJoiner) *AuthHandler {
+	h := &AuthHandler{svc: svc}
+	if len(opts) > 0 {
+		h.demoJoin = opts[0]
+	}
+	return h
 }
 
 // Callback handles POST /api/v1/auth/callback.
@@ -62,13 +76,22 @@ func (h *AuthHandler) Callback(c *gin.Context) {
 			c.Abort()
 			return
 		}
+
+		// Auto-join demo org as viewer (best-effort, non-blocking).
+		if h.demoJoin != nil {
+			h.demoJoin.JoinDemoOrg(c.Request.Context(), user.ID)
+		}
+
 		c.JSON(http.StatusOK, gin.H{"isNewUser": true, "userId": user.ID})
 		return
 	}
 
 	// Existing user
 	if user.OrgID == nil {
-		// Abandoned onboarding — re-enter
+		// Abandoned onboarding — also try auto-join in case they missed it.
+		if h.demoJoin != nil {
+			h.demoJoin.JoinDemoOrg(c.Request.Context(), user.ID)
+		}
 		c.JSON(http.StatusOK, gin.H{"isNewUser": true, "userId": user.ID})
 		return
 	}

--- a/internal/handler/seed.go
+++ b/internal/handler/seed.go
@@ -5,20 +5,12 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/ravencloak-org/Raven/internal/model"
 )
-
-// SeedResult is the response from the seed endpoint.
-type SeedResult struct {
-	OrgID             string `json:"org_id"`
-	WorkspaceID       string `json:"workspace_id"`
-	KBID              string `json:"kb_id"`
-	DocumentsEnqueued int    `json:"documents_enqueued"`
-	PipelineStatus    string `json:"pipeline_status"`
-}
 
 // SeedServicer is the interface the seed handler requires.
 type SeedServicer interface {
-	SeedDemo(ctx context.Context, size string) (*SeedResult, error)
+	SeedDemo(ctx context.Context, size string) (*model.SeedResult, error)
 }
 
 // SeedHandler handles the admin seed endpoint.

--- a/internal/handler/seed.go
+++ b/internal/handler/seed.go
@@ -1,0 +1,47 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// SeedResult is the response from the seed endpoint.
+type SeedResult struct {
+	OrgID             string `json:"org_id"`
+	WorkspaceID       string `json:"workspace_id"`
+	KBID              string `json:"kb_id"`
+	DocumentsEnqueued int    `json:"documents_enqueued"`
+	PipelineStatus    string `json:"pipeline_status"`
+}
+
+// SeedServicer is the interface the seed handler requires.
+type SeedServicer interface {
+	SeedDemo(ctx context.Context, size string) (*SeedResult, error)
+}
+
+// SeedHandler handles the admin seed endpoint.
+type SeedHandler struct {
+	svc SeedServicer
+}
+
+// NewSeedHandler creates a new SeedHandler.
+func NewSeedHandler(svc SeedServicer) *SeedHandler {
+	return &SeedHandler{svc: svc}
+}
+
+// SeedDemo handles POST /api/v1/admin/seed-demo.
+// Reads `size` query param (default "small").
+func (h *SeedHandler) SeedDemo(c *gin.Context) {
+	size := c.DefaultQuery("size", "small")
+
+	result, err := h.svc.SeedDemo(c.Request.Context(), size)
+	if err != nil {
+		_ = c.Error(err)
+		c.Abort()
+		return
+	}
+
+	c.JSON(http.StatusOK, result)
+}

--- a/internal/handler/seed_test.go
+++ b/internal/handler/seed_test.go
@@ -10,19 +10,20 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/ravencloak-org/Raven/internal/handler"
+	"github.com/ravencloak-org/Raven/internal/model"
 	"github.com/ravencloak-org/Raven/pkg/apierror"
 )
 
 // mockSeedService implements handler.SeedServicer for unit tests.
 type mockSeedService struct {
-	seedDemoFn func(ctx context.Context, size string) (*handler.SeedResult, error)
+	seedDemoFn func(ctx context.Context, size string) (*model.SeedResult, error)
 }
 
-func (m *mockSeedService) SeedDemo(ctx context.Context, size string) (*handler.SeedResult, error) {
+func (m *mockSeedService) SeedDemo(ctx context.Context, size string) (*model.SeedResult, error) {
 	if m.seedDemoFn != nil {
 		return m.seedDemoFn(ctx, size)
 	}
-	return &handler.SeedResult{}, nil
+	return &model.SeedResult{}, nil
 }
 
 // newSeedRouter builds a test router for the seed handler.
@@ -36,7 +37,7 @@ func newSeedRouter(svc handler.SeedServicer) *gin.Engine {
 }
 
 func TestSeedDemo_Success(t *testing.T) {
-	expected := &handler.SeedResult{
+	expected := &model.SeedResult{
 		OrgID:             "org-123",
 		WorkspaceID:       "ws-456",
 		KBID:              "kb-789",
@@ -44,7 +45,7 @@ func TestSeedDemo_Success(t *testing.T) {
 		PipelineStatus:    "running",
 	}
 	svc := &mockSeedService{
-		seedDemoFn: func(_ context.Context, _ string) (*handler.SeedResult, error) {
+		seedDemoFn: func(_ context.Context, _ string) (*model.SeedResult, error) {
 			return expected, nil
 		},
 	}
@@ -58,7 +59,7 @@ func TestSeedDemo_Success(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	var got handler.SeedResult
+	var got model.SeedResult
 	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
 		t.Fatalf("failed to unmarshal response: %v", err)
 	}
@@ -82,9 +83,9 @@ func TestSeedDemo_Success(t *testing.T) {
 func TestSeedDemo_DefaultSizeIsSmall(t *testing.T) {
 	var receivedSize string
 	svc := &mockSeedService{
-		seedDemoFn: func(_ context.Context, size string) (*handler.SeedResult, error) {
+		seedDemoFn: func(_ context.Context, size string) (*model.SeedResult, error) {
 			receivedSize = size
-			return &handler.SeedResult{
+			return &model.SeedResult{
 				OrgID:          "org-1",
 				WorkspaceID:    "ws-1",
 				KBID:           "kb-1",
@@ -109,7 +110,7 @@ func TestSeedDemo_DefaultSizeIsSmall(t *testing.T) {
 
 func TestSeedDemo_ServiceError(t *testing.T) {
 	svc := &mockSeedService{
-		seedDemoFn: func(_ context.Context, _ string) (*handler.SeedResult, error) {
+		seedDemoFn: func(_ context.Context, _ string) (*model.SeedResult, error) {
 			return nil, apierror.NewInternal("seed failed")
 		},
 	}

--- a/internal/handler/seed_test.go
+++ b/internal/handler/seed_test.go
@@ -1,0 +1,133 @@
+package handler_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/ravencloak-org/Raven/internal/handler"
+	"github.com/ravencloak-org/Raven/pkg/apierror"
+)
+
+// mockSeedService implements handler.SeedServicer for unit tests.
+type mockSeedService struct {
+	seedDemoFn func(ctx context.Context, size string) (*handler.SeedResult, error)
+}
+
+func (m *mockSeedService) SeedDemo(ctx context.Context, size string) (*handler.SeedResult, error) {
+	if m.seedDemoFn != nil {
+		return m.seedDemoFn(ctx, size)
+	}
+	return &handler.SeedResult{}, nil
+}
+
+// newSeedRouter builds a test router for the seed handler.
+func newSeedRouter(svc handler.SeedServicer) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(apierror.ErrorHandler())
+	h := handler.NewSeedHandler(svc)
+	r.POST("/api/v1/admin/seed-demo", h.SeedDemo)
+	return r
+}
+
+func TestSeedDemo_Success(t *testing.T) {
+	expected := &handler.SeedResult{
+		OrgID:             "org-123",
+		WorkspaceID:       "ws-456",
+		KBID:              "kb-789",
+		DocumentsEnqueued: 5,
+		PipelineStatus:    "running",
+	}
+	svc := &mockSeedService{
+		seedDemoFn: func(_ context.Context, _ string) (*handler.SeedResult, error) {
+			return expected, nil
+		},
+	}
+
+	r := newSeedRouter(svc)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/admin/seed-demo?size=large", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var got handler.SeedResult
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if got.OrgID != expected.OrgID {
+		t.Errorf("OrgID = %q, want %q", got.OrgID, expected.OrgID)
+	}
+	if got.WorkspaceID != expected.WorkspaceID {
+		t.Errorf("WorkspaceID = %q, want %q", got.WorkspaceID, expected.WorkspaceID)
+	}
+	if got.KBID != expected.KBID {
+		t.Errorf("KBID = %q, want %q", got.KBID, expected.KBID)
+	}
+	if got.DocumentsEnqueued != expected.DocumentsEnqueued {
+		t.Errorf("DocumentsEnqueued = %d, want %d", got.DocumentsEnqueued, expected.DocumentsEnqueued)
+	}
+	if got.PipelineStatus != expected.PipelineStatus {
+		t.Errorf("PipelineStatus = %q, want %q", got.PipelineStatus, expected.PipelineStatus)
+	}
+}
+
+func TestSeedDemo_DefaultSizeIsSmall(t *testing.T) {
+	var receivedSize string
+	svc := &mockSeedService{
+		seedDemoFn: func(_ context.Context, size string) (*handler.SeedResult, error) {
+			receivedSize = size
+			return &handler.SeedResult{
+				OrgID:          "org-1",
+				WorkspaceID:    "ws-1",
+				KBID:           "kb-1",
+				PipelineStatus: "running",
+			}, nil
+		},
+	}
+
+	r := newSeedRouter(svc)
+	w := httptest.NewRecorder()
+	// No ?size= query param.
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/admin/seed-demo", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if receivedSize != "small" {
+		t.Errorf("size = %q, want %q", receivedSize, "small")
+	}
+}
+
+func TestSeedDemo_ServiceError(t *testing.T) {
+	svc := &mockSeedService{
+		seedDemoFn: func(_ context.Context, _ string) (*handler.SeedResult, error) {
+			return nil, apierror.NewInternal("seed failed")
+		},
+	}
+
+	r := newSeedRouter(svc)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/admin/seed-demo?size=small", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var errResp apierror.AppError
+	if err := json.Unmarshal(w.Body.Bytes(), &errResp); err != nil {
+		t.Fatalf("failed to unmarshal error response: %v", err)
+	}
+	if errResp.Code != http.StatusInternalServerError {
+		t.Errorf("error code = %d, want %d", errResp.Code, http.StatusInternalServerError)
+	}
+}

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -29,6 +29,8 @@ const (
 	ContextKeyUserName contextKey = "user_name"
 	// ContextKeyClaims is the context key for the full parsed claims.
 	ContextKeyClaims contextKey = "claims"
+	// ContextKeySeedKey is the context key for the expected seed key value.
+	ContextKeySeedKey contextKey = "seed_key"
 )
 
 // authError represents a structured 401 response body.
@@ -43,6 +45,15 @@ func SessionMiddleware(provider auth.Provider) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		info, err := provider.VerifySession(c.Request)
 		if err != nil || info == nil {
+			// Allow admin endpoints with X-Seed-Key header (Docker entrypoint / CI).
+			if seedKey := c.GetHeader("X-Seed-Key"); seedKey != "" {
+				if expectedKey, exists := c.Get(string(ContextKeySeedKey)); exists {
+					if seedKey == expectedKey.(string) {
+						c.Next()
+						return
+					}
+				}
+			}
 			abortUnauthorized(c, "invalid_session")
 			return
 		}

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -29,8 +29,6 @@ const (
 	ContextKeyUserName contextKey = "user_name"
 	// ContextKeyClaims is the context key for the full parsed claims.
 	ContextKeyClaims contextKey = "claims"
-	// ContextKeySeedKey is the context key for the expected seed key value.
-	ContextKeySeedKey contextKey = "seed_key"
 )
 
 // authError represents a structured 401 response body.
@@ -45,15 +43,6 @@ func SessionMiddleware(provider auth.Provider) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		info, err := provider.VerifySession(c.Request)
 		if err != nil || info == nil {
-			// Allow admin endpoints with X-Seed-Key header (Docker entrypoint / CI).
-			if seedKey := c.GetHeader("X-Seed-Key"); seedKey != "" {
-				if expectedKey, exists := c.Get(string(ContextKeySeedKey)); exists {
-					if seedKey == expectedKey.(string) {
-						c.Next()
-						return
-					}
-				}
-			}
 			abortUnauthorized(c, "invalid_session")
 			return
 		}

--- a/internal/model/seed.go
+++ b/internal/model/seed.go
@@ -1,0 +1,10 @@
+package model
+
+// SeedResult is the response from the seed endpoint.
+type SeedResult struct {
+	OrgID             string `json:"org_id"`
+	WorkspaceID       string `json:"workspace_id"`
+	KBID              string `json:"kb_id"`
+	DocumentsEnqueued int    `json:"documents_enqueued"`
+	PipelineStatus    string `json:"pipeline_status"`
+}

--- a/internal/repository/org.go
+++ b/internal/repository/org.go
@@ -86,6 +86,25 @@ func (r *OrgRepository) Update(ctx context.Context, orgID string, name *string, 
 	return org, nil
 }
 
+// GetBySlug fetches a non-deactivated organisation by its slug.
+// Returns (nil, nil) when no matching organisation exists.
+func (r *OrgRepository) GetBySlug(ctx context.Context, slug string) (*model.Organization, error) {
+	row := r.pool.QueryRow(ctx,
+		`SELECT id, name, slug, status, settings, created_at, updated_at
+		 FROM organizations
+		 WHERE slug = $1 AND status != 'deactivated'`,
+		slug,
+	)
+	org, err := scanOrg(row)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("OrgRepository.GetBySlug: %w", err)
+	}
+	return org, nil
+}
+
 // SoftDelete sets the organisation status to 'deactivated'.
 func (r *OrgRepository) SoftDelete(ctx context.Context, orgID string) error {
 	tag, err := r.pool.Exec(ctx,

--- a/internal/service/demo_join.go
+++ b/internal/service/demo_join.go
@@ -1,0 +1,58 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	"github.com/ravencloak-org/Raven/internal/model"
+)
+
+// DemoOrgJoiner auto-joins new users to the demo organisation as viewers.
+// It implements handler.DemoOrgJoiner.
+type DemoOrgJoiner struct {
+	orgSvc *OrgService
+	wsSvc  *WorkspaceService
+}
+
+// NewDemoOrgJoiner creates a new DemoOrgJoiner.
+func NewDemoOrgJoiner(orgSvc *OrgService, wsSvc *WorkspaceService) *DemoOrgJoiner {
+	return &DemoOrgJoiner{orgSvc: orgSvc, wsSvc: wsSvc}
+}
+
+// JoinDemoOrg adds the user as a viewer to the first workspace of the "raven-demo" org.
+// Best-effort: errors are logged but never propagated.
+func (d *DemoOrgJoiner) JoinDemoOrg(ctx context.Context, userID string) {
+	// Look up demo org by slug.
+	demoOrg, err := d.orgSvc.GetBySlug(ctx, "raven-demo")
+	if err != nil {
+		// Demo org doesn't exist — nothing to join.
+		return
+	}
+
+	// List workspaces in demo org.
+	workspaces, err := d.wsSvc.ListByOrg(ctx, demoOrg.ID)
+	if err != nil || len(workspaces) == 0 {
+		slog.WarnContext(ctx, "demo-join: no workspaces in demo org", "org_id", demoOrg.ID, "error", err)
+		return
+	}
+
+	// Add user as viewer to the first workspace.
+	ws := workspaces[0]
+	_, err = d.wsSvc.AddMember(ctx, demoOrg.ID, ws.ID, model.AddWorkspaceMemberRequest{
+		UserID: userID,
+		Role:   "viewer",
+	})
+	if err != nil {
+		// Duplicate member is fine — user already joined.
+		if strings.Contains(err.Error(), "already a member") {
+			return
+		}
+		slog.WarnContext(ctx, "demo-join: failed to add user to demo workspace",
+			"user_id", userID, "ws_id", ws.ID, "error", err)
+		return
+	}
+
+	slog.InfoContext(ctx, "demo-join: user auto-joined demo org",
+		"user_id", userID, "org_id", demoOrg.ID, "ws_id", ws.ID)
+}

--- a/internal/service/org.go
+++ b/internal/service/org.go
@@ -68,6 +68,12 @@ func (s *OrgService) Create(ctx context.Context, req model.CreateOrgRequest) (*m
 	return org, nil
 }
 
+// GetBySlug retrieves an active organisation by slug.
+// Returns (nil, nil) when no matching organisation exists.
+func (s *OrgService) GetBySlug(ctx context.Context, slug string) (*model.Organization, error) {
+	return s.repo.GetBySlug(ctx, slug)
+}
+
 // GetByID retrieves an active organisation by ID.
 func (s *OrgService) GetByID(ctx context.Context, orgID string) (*model.Organization, error) {
 	org, err := s.repo.GetByID(ctx, orgID)

--- a/internal/service/seed.go
+++ b/internal/service/seed.go
@@ -96,6 +96,9 @@ func (s *SeedService) SeedDemo(ctx context.Context, size string) (*model.SeedRes
 	}
 
 	// 5. Fetch movies from TMDB.
+	if s.tmdbCli == nil {
+		return nil, apierror.NewInternal("TMDB client not configured — set TMDB_API_KEY")
+	}
 	movies, err := s.tmdbCli.FetchTopByGenres(ctx, size)
 	if err != nil {
 		return nil, fmt.Errorf("seed: fetch movies: %w", err)

--- a/internal/service/seed.go
+++ b/internal/service/seed.go
@@ -1,0 +1,238 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/ravencloak-org/Raven/internal/db"
+	"github.com/ravencloak-org/Raven/internal/model"
+	"github.com/ravencloak-org/Raven/internal/queue"
+	"github.com/ravencloak-org/Raven/internal/repository"
+	"github.com/ravencloak-org/Raven/internal/storage"
+	"github.com/ravencloak-org/Raven/internal/tmdb"
+	"github.com/ravencloak-org/Raven/pkg/apierror"
+)
+
+const (
+	demoOrgName  = "Raven Demo"
+	demoOrgSlug  = "raven-demo"
+	demoWSName   = "Movies"
+	demoKBName   = "Movie Database"
+	demoKBDesc   = "Top-rated movies from TMDB across multiple genres"
+)
+
+// SeedService orchestrates demo data creation: org, workspace, KB, and movie documents.
+type SeedService struct {
+	orgSvc  *OrgService
+	wsSvc   *WorkspaceService
+	kbSvc   *KBService
+	docRepo *repository.DocumentRepository
+	pool    *pgxpool.Pool
+	tmdbCli *tmdb.Client
+	store   storage.Client
+	qCli    *queue.Client
+}
+
+// NewSeedService creates a new SeedService with all required dependencies.
+func NewSeedService(
+	orgSvc *OrgService,
+	wsSvc *WorkspaceService,
+	kbSvc *KBService,
+	docRepo *repository.DocumentRepository,
+	pool *pgxpool.Pool,
+	tmdbCli *tmdb.Client,
+	store storage.Client,
+	qCli *queue.Client,
+) *SeedService {
+	return &SeedService{
+		orgSvc:  orgSvc,
+		wsSvc:   wsSvc,
+		kbSvc:   kbSvc,
+		docRepo: docRepo,
+		pool:    pool,
+		tmdbCli: tmdbCli,
+		store:   store,
+		qCli:    qCli,
+	}
+}
+
+// SeedDemo creates (or returns) a demo org/workspace/KB populated with TMDB movies.
+// It is idempotent: if the "raven-demo" org already exists, existing IDs are returned.
+func (s *SeedService) SeedDemo(ctx context.Context, size string) (*model.SeedResult, error) {
+	// 1. Idempotency check — look for existing demo org by slug.
+	existing, err := s.orgSvc.GetBySlug(ctx, demoOrgSlug)
+	if err != nil {
+		return nil, apierror.NewInternal("failed to check for existing demo org: " + err.Error())
+	}
+	if existing != nil {
+		return s.buildExistingResult(ctx, existing)
+	}
+
+	// 2. Create the demo org (this also auto-creates a "Default" workspace, but we
+	//    create our own "Movies" workspace explicitly).
+	org, err := s.orgSvc.Create(ctx, model.CreateOrgRequest{Name: demoOrgName})
+	if err != nil {
+		return nil, fmt.Errorf("seed: create org: %w", err)
+	}
+
+	// 3. Create workspace.
+	ws, err := s.wsSvc.Create(ctx, org.ID, model.CreateWorkspaceRequest{Name: demoWSName})
+	if err != nil {
+		return nil, fmt.Errorf("seed: create workspace: %w", err)
+	}
+
+	// 4. Create knowledge base.
+	kb, err := s.kbSvc.Create(ctx, org.ID, ws.ID, model.CreateKBRequest{
+		Name:        demoKBName,
+		Description: demoKBDesc,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("seed: create knowledge base: %w", err)
+	}
+
+	// 5. Fetch movies from TMDB.
+	movies, err := s.tmdbCli.FetchTopByGenres(ctx, size)
+	if err != nil {
+		return nil, fmt.Errorf("seed: fetch movies: %w", err)
+	}
+
+	// 6. For each movie: render markdown, upload to SeaweedFS, create document, enqueue.
+	enqueued := 0
+	for _, movie := range movies {
+		if processErr := s.processMovie(ctx, org.ID, kb.ID, movie); processErr != nil {
+			slog.Warn("seed: failed to process movie, skipping",
+				"movie_title", movie.Title,
+				"error", processErr,
+			)
+			continue
+		}
+		enqueued++
+	}
+
+	return &model.SeedResult{
+		OrgID:             org.ID,
+		WorkspaceID:       ws.ID,
+		KBID:              kb.ID,
+		DocumentsEnqueued: enqueued,
+		PipelineStatus:    "processing",
+	}, nil
+}
+
+// processMovie renders a single movie to markdown, uploads it, creates a document record,
+// and enqueues a processing job.
+func (s *SeedService) processMovie(ctx context.Context, orgID, kbID string, movie tmdb.MovieDetail) error {
+	md := tmdb.RenderMarkdown(movie)
+	filename := fmt.Sprintf("%s.md", sanitizeFilename(movie.Title))
+
+	// Upload markdown content to SeaweedFS.
+	fid, err := s.store.Upload(ctx, filename, strings.NewReader(md))
+	if err != nil {
+		return fmt.Errorf("upload %q: %w", filename, err)
+	}
+
+	// Create document record via repository (needs RLS transaction).
+	fileSize := int64(len(md))
+	doc := &model.Document{
+		OrgID:           orgID,
+		KnowledgeBaseID: kbID,
+		FileName:        filename,
+		FileType:        "text/markdown",
+		FileSizeBytes:   &fileSize,
+		StoragePath:     fid,
+		Title:           movie.Title,
+		Metadata: map[string]any{
+			"source":    "tmdb",
+			"tmdb_id":   movie.ID,
+			"genre":     genreNames(movie.Genres),
+			"seed_demo": true,
+		},
+	}
+
+	var created *model.Document
+	err = db.WithOrgID(ctx, s.pool, orgID, func(tx pgx.Tx) error {
+		var createErr error
+		created, createErr = s.docRepo.Create(ctx, tx, doc)
+		return createErr
+	})
+	if err != nil {
+		return fmt.Errorf("create document record: %w", err)
+	}
+
+	// Enqueue document processing job.
+	if err := s.qCli.EnqueueDocumentProcess(ctx, queue.DocumentProcessPayload{
+		OrgID:           orgID,
+		DocumentID:      created.ID,
+		KnowledgeBaseID: kbID,
+	}); err != nil {
+		return fmt.Errorf("enqueue processing: %w", err)
+	}
+
+	return nil
+}
+
+// buildExistingResult looks up the workspace and KB for an already-seeded org.
+func (s *SeedService) buildExistingResult(ctx context.Context, org *model.Organization) (*model.SeedResult, error) {
+	workspaces, err := s.wsSvc.ListByOrg(ctx, org.ID)
+	if err != nil {
+		return nil, apierror.NewInternal("seed: list workspaces: " + err.Error())
+	}
+
+	// Find the "Movies" workspace.
+	var wsID string
+	for _, ws := range workspaces {
+		if ws.Slug == toSlug(demoWSName) {
+			wsID = ws.ID
+			break
+		}
+	}
+	if wsID == "" && len(workspaces) > 0 {
+		// Fallback to first workspace.
+		wsID = workspaces[0].ID
+	}
+
+	// Find the KB in that workspace.
+	var kbID string
+	if wsID != "" {
+		kbs, kbErr := s.kbSvc.ListByWorkspace(ctx, org.ID, wsID)
+		if kbErr == nil {
+			for _, kb := range kbs {
+				if kb.Slug == toSlug(demoKBName) {
+					kbID = kb.ID
+					break
+				}
+			}
+			if kbID == "" && len(kbs) > 0 {
+				kbID = kbs[0].ID
+			}
+		}
+	}
+
+	return &model.SeedResult{
+		OrgID:             org.ID,
+		WorkspaceID:       wsID,
+		KBID:              kbID,
+		DocumentsEnqueued: 0,
+		PipelineStatus:    "ready",
+	}, nil
+}
+
+// sanitizeFilename replaces non-alphanumeric characters with hyphens for safe filenames.
+func sanitizeFilename(name string) string {
+	s := strings.ToLower(name)
+	s = slugRe.ReplaceAllString(s, "-")
+	return strings.Trim(s, "-")
+}
+
+// genreNames extracts genre name strings from TMDB genre structs.
+func genreNames(genres []tmdb.Genre) []string {
+	names := make([]string, len(genres))
+	for i, g := range genres {
+		names[i] = g.Name
+	}
+	return names
+}

--- a/internal/tmdb/client.go
+++ b/internal/tmdb/client.go
@@ -122,7 +122,7 @@ func (c *Client) fetchGenres(ctx context.Context) (map[string]int, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
@@ -155,7 +155,7 @@ func (c *Client) discoverMovies(ctx context.Context, genreID int) ([]MovieSummar
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
@@ -182,7 +182,7 @@ func (c *Client) fetchMovieDetail(ctx context.Context, movieID int) (MovieDetail
 	if err != nil {
 		return MovieDetail{}, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return MovieDetail{}, fmt.Errorf("unexpected status %d", resp.StatusCode)

--- a/internal/tmdb/client.go
+++ b/internal/tmdb/client.go
@@ -1,0 +1,196 @@
+package tmdb
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"sync"
+)
+
+// targetGenres are the genres we fetch top-rated movies for.
+var targetGenres = []string{
+	"Action",
+	"Comedy",
+	"Drama",
+	"Science Fiction",
+	"Animation",
+}
+
+// Client is a TMDB API client.
+type Client struct {
+	baseURL    string
+	apiKey     string
+	httpClient *http.Client
+}
+
+// NewClient creates a new TMDB client. If httpClient is nil, http.DefaultClient is used.
+func NewClient(baseURL, apiKey string, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &Client{
+		baseURL:    baseURL,
+		apiKey:     apiKey,
+		httpClient: httpClient,
+	}
+}
+
+// FetchTopByGenres fetches top-rated movies for the target genres.
+// size controls how many movies per genre: "small" = 10.
+// "medium" and "large" are not yet implemented.
+func (c *Client) FetchTopByGenres(ctx context.Context, size string) ([]MovieDetail, error) {
+	if size != "small" {
+		return nil, fmt.Errorf("tmdb: size %q not implemented", size)
+	}
+
+	genreMap, err := c.fetchGenres(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("tmdb: fetch genres: %w", err)
+	}
+
+	// Collect unique movie summaries across target genres.
+	seen := make(map[int]struct{})
+	var summaries []MovieSummary
+
+	for _, name := range targetGenres {
+		genreID, ok := genreMap[name]
+		if !ok {
+			continue
+		}
+		discovered, discoverErr := c.discoverMovies(ctx, genreID)
+		if discoverErr != nil {
+			return nil, fmt.Errorf("tmdb: discover genre %q: %w", name, discoverErr)
+		}
+		for _, m := range discovered {
+			if _, dup := seen[m.ID]; !dup {
+				seen[m.ID] = struct{}{}
+				summaries = append(summaries, m)
+			}
+		}
+	}
+
+	// Fetch details concurrently with a semaphore.
+	const maxConcurrency = 10
+	sem := make(chan struct{}, maxConcurrency)
+
+	details := make([]MovieDetail, len(summaries))
+	var mu sync.Mutex
+	var firstErr error
+
+	var wg sync.WaitGroup
+	for i, s := range summaries {
+		wg.Add(1)
+		go func(idx int, movieID int) {
+			defer wg.Done()
+
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			detail, fetchErr := c.fetchMovieDetail(ctx, movieID)
+			if fetchErr != nil {
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = fmt.Errorf("tmdb: fetch movie %d: %w", movieID, fetchErr)
+				}
+				mu.Unlock()
+				return
+			}
+			details[idx] = detail
+		}(i, s.ID)
+	}
+	wg.Wait()
+
+	if firstErr != nil {
+		return nil, firstErr
+	}
+
+	return details, nil
+}
+
+// fetchGenres retrieves the genre list and returns a name->ID mapping.
+func (c *Client) fetchGenres(ctx context.Context) (map[string]int, error) {
+	url := c.baseURL + "/genre/movie/list?api_key=" + c.apiKey
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	var glr GenreListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&glr); err != nil {
+		return nil, err
+	}
+
+	m := make(map[string]int, len(glr.Genres))
+	for _, g := range glr.Genres {
+		m[g.Name] = g.ID
+	}
+	return m, nil
+}
+
+// discoverMovies fetches top-rated movies for a specific genre.
+func (c *Client) discoverMovies(ctx context.Context, genreID int) ([]MovieSummary, error) {
+	url := c.baseURL + "/discover/movie?api_key=" + c.apiKey +
+		"&sort_by=vote_average.desc&with_genres=" + strconv.Itoa(genreID) +
+		"&vote_count.gte=1000"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	var dr DiscoverResponse
+	if err := json.NewDecoder(resp.Body).Decode(&dr); err != nil {
+		return nil, err
+	}
+	return dr.Results, nil
+}
+
+// fetchMovieDetail retrieves a single movie with credits, reviews, and keywords appended.
+func (c *Client) fetchMovieDetail(ctx context.Context, movieID int) (MovieDetail, error) {
+	url := fmt.Sprintf("%s/movie/%d?api_key=%s&append_to_response=credits,reviews,keywords",
+		c.baseURL, movieID, c.apiKey)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return MovieDetail{}, err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return MovieDetail{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return MovieDetail{}, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	var md MovieDetail
+	if err := json.NewDecoder(resp.Body).Decode(&md); err != nil {
+		return MovieDetail{}, err
+	}
+	return md, nil
+}

--- a/internal/tmdb/client_test.go
+++ b/internal/tmdb/client_test.go
@@ -55,7 +55,7 @@ func setupMockServer(t *testing.T) *httptest.Server {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(genres)
+		_ = json.NewEncoder(w).Encode(genres)
 	})
 
 	mux.HandleFunc("/discover/movie", func(w http.ResponseWriter, r *http.Request) {
@@ -66,7 +66,7 @@ func setupMockServer(t *testing.T) *httptest.Server {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	})
 
 	mux.HandleFunc("/movie/", func(w http.ResponseWriter, r *http.Request) {
@@ -93,7 +93,7 @@ func setupMockServer(t *testing.T) *httptest.Server {
 			},
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(detail)
+		_ = json.NewEncoder(w).Encode(detail)
 	})
 
 	return httptest.NewServer(mux)

--- a/internal/tmdb/client_test.go
+++ b/internal/tmdb/client_test.go
@@ -1,0 +1,156 @@
+package tmdb
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+)
+
+func setupMockServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	genres := GenreListResponse{
+		Genres: []Genre{
+			{ID: 28, Name: "Action"},
+			{ID: 35, Name: "Comedy"},
+			{ID: 18, Name: "Drama"},
+			{ID: 878, Name: "Science Fiction"},
+			{ID: 16, Name: "Animation"},
+		},
+	}
+
+	// Two movies per genre; movie 1 appears in both Action and Drama to test dedup.
+	discoverResults := map[string]DiscoverResponse{
+		"28": {Results: []MovieSummary{
+			{ID: 1, Title: "Action Movie 1"},
+			{ID: 2, Title: "Action Movie 2"},
+		}},
+		"35": {Results: []MovieSummary{
+			{ID: 3, Title: "Comedy Movie 1"},
+			{ID: 4, Title: "Comedy Movie 2"},
+		}},
+		"18": {Results: []MovieSummary{
+			{ID: 1, Title: "Action Movie 1"}, // duplicate of Action genre
+			{ID: 5, Title: "Drama Movie 1"},
+		}},
+		"878": {Results: []MovieSummary{
+			{ID: 6, Title: "SciFi Movie 1"},
+			{ID: 7, Title: "SciFi Movie 2"},
+		}},
+		"16": {Results: []MovieSummary{
+			{ID: 8, Title: "Animation Movie 1"},
+			{ID: 9, Title: "Animation Movie 2"},
+		}},
+	}
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/genre/movie/list", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("api_key") == "" {
+			http.Error(w, "missing api_key", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(genres)
+	})
+
+	mux.HandleFunc("/discover/movie", func(w http.ResponseWriter, r *http.Request) {
+		genreID := r.URL.Query().Get("with_genres")
+		resp, ok := discoverResults[genreID]
+		if !ok {
+			http.Error(w, "unknown genre", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	mux.HandleFunc("/movie/", func(w http.ResponseWriter, r *http.Request) {
+		// Extract movie ID from path: /movie/{id}
+		var movieID int
+		_, err := fmt.Sscanf(r.URL.Path, "/movie/%d", &movieID)
+		if err != nil {
+			http.Error(w, "bad movie id", http.StatusBadRequest)
+			return
+		}
+
+		detail := MovieDetail{
+			ID:    movieID,
+			Title: fmt.Sprintf("Movie %d", movieID),
+			Credits: Credits{
+				Cast: []CastMember{{Name: "Actor A", Character: "Hero", Order: 0}},
+				Crew: []CrewMember{{Name: "Director X", Job: "Director"}},
+			},
+			Reviews: Reviews{
+				Results: []Review{{Author: "reviewer1", Content: "Great movie!"}},
+			},
+			Keywords: Keywords{
+				Keywords: []Keyword{{Name: "exciting"}},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(detail)
+	})
+
+	return httptest.NewServer(mux)
+}
+
+func TestFetchTopByGenres_Small(t *testing.T) {
+	server := setupMockServer(t)
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-api-key", server.Client())
+	movies, err := client.FetchTopByGenres(context.Background(), "small")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// We have 9 unique movie IDs across all genres (ID 1 is duplicated).
+	if len(movies) != 9 {
+		t.Fatalf("expected 9 unique movies, got %d", len(movies))
+	}
+
+	// Verify dedup: collect all IDs and check uniqueness.
+	seen := make(map[int]bool)
+	for _, m := range movies {
+		if seen[m.ID] {
+			t.Errorf("duplicate movie ID %d", m.ID)
+		}
+		seen[m.ID] = true
+	}
+
+	// Verify detail fields are populated.
+	sort.Slice(movies, func(i, j int) bool { return movies[i].ID < movies[j].ID })
+	first := movies[0]
+	if len(first.Credits.Cast) == 0 {
+		t.Error("expected credits cast to be populated")
+	}
+	if len(first.Reviews.Results) == 0 {
+		t.Error("expected reviews to be populated")
+	}
+	if len(first.Keywords.Keywords) == 0 {
+		t.Error("expected keywords to be populated")
+	}
+}
+
+func TestFetchTopByGenres_UnsupportedSize(t *testing.T) {
+	client := NewClient("http://unused", "key", nil)
+
+	for _, size := range []string{"medium", "large"} {
+		_, err := client.FetchTopByGenres(context.Background(), size)
+		if err == nil {
+			t.Errorf("expected error for size %q, got nil", size)
+		}
+	}
+}
+
+func TestNewClient_DefaultHTTPClient(t *testing.T) {
+	client := NewClient("http://example.com", "key", nil)
+	if client.httpClient == nil {
+		t.Error("expected default http client when nil is passed")
+	}
+}

--- a/internal/tmdb/markdown.go
+++ b/internal/tmdb/markdown.go
@@ -81,13 +81,27 @@ func RenderMarkdown(movie MovieDetail) string {
 			limit = maxReviews
 		}
 		for _, r := range movie.Reviews.Results[:limit] {
-			content := r.Content
-			if len(content) > maxReviewLength {
-				content = content[:maxReviewLength] + "..."
-			}
-			fmt.Fprintf(&sb, "> \"%s\" — %s\n\n", content, r.Author)
+			content := sanitizeReview(r.Content, maxReviewLength)
+			fmt.Fprintf(&sb, "> %s — %s\n\n", content, r.Author)
 		}
 	}
 
 	return strings.TrimRight(sb.String(), "\n") + "\n"
+}
+
+// sanitizeReview truncates at a UTF-8 safe rune boundary, collapses newlines
+// into spaces so the content stays inside a single markdown blockquote, and
+// wraps the result in double quotes.
+func sanitizeReview(content string, maxLen int) string {
+	// Collapse newlines to spaces so multi-line reviews don't break the > quote.
+	content = strings.ReplaceAll(content, "\r\n", " ")
+	content = strings.ReplaceAll(content, "\n", " ")
+
+	// Truncate at rune boundary.
+	runes := []rune(content)
+	if len(runes) > maxLen {
+		content = string(runes[:maxLen]) + "..."
+	}
+
+	return `"` + content + `"`
 }

--- a/internal/tmdb/markdown.go
+++ b/internal/tmdb/markdown.go
@@ -1,0 +1,93 @@
+package tmdb
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	maxCastMembers  = 5
+	maxReviews      = 3
+	maxReviewLength = 500
+)
+
+// RenderMarkdown converts a MovieDetail into a formatted Markdown string suitable for RAG ingestion.
+func RenderMarkdown(movie MovieDetail) string {
+	var sb strings.Builder
+
+	// Title with year extracted from first 4 chars of ReleaseDate.
+	year := ""
+	if len(movie.ReleaseDate) >= 4 {
+		year = movie.ReleaseDate[:4]
+	}
+	fmt.Fprintf(&sb, "# %s (%s)\n", movie.Title, year)
+
+	// Overview section.
+	fmt.Fprintf(&sb, "\n## Overview\n%s\n", movie.Overview)
+
+	// Details section.
+	fmt.Fprint(&sb, "\n## Details\n")
+
+	// Genres.
+	if len(movie.Genres) > 0 {
+		names := make([]string, len(movie.Genres))
+		for i, g := range movie.Genres {
+			names[i] = g.Name
+		}
+		fmt.Fprintf(&sb, "- **Genres:** %s\n", strings.Join(names, ", "))
+	}
+
+	// Director — skip if no crew member has Job == "Director".
+	for _, crew := range movie.Credits.Crew {
+		if crew.Job == "Director" {
+			fmt.Fprintf(&sb, "- **Director:** %s\n", crew.Name)
+			break
+		}
+	}
+
+	// Cast — top 5 members by order.
+	if len(movie.Credits.Cast) > 0 {
+		limit := len(movie.Credits.Cast)
+		if limit > maxCastMembers {
+			limit = maxCastMembers
+		}
+		names := make([]string, limit)
+		for i := 0; i < limit; i++ {
+			names[i] = movie.Credits.Cast[i].Name
+		}
+		fmt.Fprintf(&sb, "- **Cast:** %s\n", strings.Join(names, ", "))
+	}
+
+	// Rating.
+	fmt.Fprintf(&sb, "- **Rating:** %.1f/10 (%d votes)\n", movie.VoteAverage, movie.VoteCount)
+
+	// Runtime.
+	fmt.Fprintf(&sb, "- **Runtime:** %d min\n", movie.Runtime)
+
+	// Keywords.
+	if len(movie.Keywords.Keywords) > 0 {
+		names := make([]string, len(movie.Keywords.Keywords))
+		for i, kw := range movie.Keywords.Keywords {
+			names[i] = kw.Name
+		}
+		fmt.Fprintf(&sb, "- **Keywords:** %s\n", strings.Join(names, ", "))
+	}
+
+	// Reviews section — skip entirely if no reviews.
+	if len(movie.Reviews.Results) > 0 {
+		fmt.Fprint(&sb, "\n## Reviews\n")
+		limit := len(movie.Reviews.Results)
+		if limit > maxReviews {
+			limit = maxReviews
+		}
+		for _, r := range movie.Reviews.Results[:limit] {
+			content := r.Content
+			if len(content) > maxReviewLength {
+				content = content[:maxReviewLength] + "..."
+			}
+			fmt.Fprintf(&sb, "> \"%s\" — %s\n\n", content, r.Author)
+		}
+	}
+
+	return strings.TrimRight(sb.String(), "\n") + "\n"
+}

--- a/internal/tmdb/markdown_test.go
+++ b/internal/tmdb/markdown_test.go
@@ -1,0 +1,272 @@
+package tmdb
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderMarkdown(t *testing.T) {
+	tests := []struct {
+		name   string
+		movie  MovieDetail
+		checks func(t *testing.T, result string)
+	}{
+		{
+			name: "full movie with all fields",
+			movie: MovieDetail{
+				ID:          550,
+				Title:       "Inception",
+				Overview:    "A thief who steals corporate secrets through dream-sharing technology.",
+				ReleaseDate: "2010-07-16",
+				VoteAverage: 8.4,
+				VoteCount:   30000,
+				Runtime:     148,
+				Genres: []Genre{
+					{ID: 28, Name: "Action"},
+					{ID: 878, Name: "Sci-Fi"},
+				},
+				Credits: Credits{
+					Cast: []CastMember{
+						{Name: "Leonardo DiCaprio", Character: "Cobb", Order: 0},
+						{Name: "Joseph Gordon-Levitt", Character: "Arthur", Order: 1},
+						{Name: "Elliot Page", Character: "Ariadne", Order: 2},
+						{Name: "Tom Hardy", Character: "Eames", Order: 3},
+						{Name: "Ken Watanabe", Character: "Saito", Order: 4},
+						{Name: "Cillian Murphy", Character: "Fischer", Order: 5},
+					},
+					Crew: []CrewMember{
+						{Name: "Christopher Nolan", Job: "Director"},
+						{Name: "Emma Thomas", Job: "Producer"},
+					},
+				},
+				Reviews: Reviews{
+					Results: []Review{
+						{Author: "moviefan", Content: "A masterpiece of modern cinema."},
+						{Author: "critic42", Content: "Visually stunning and intellectually engaging."},
+					},
+				},
+				Keywords: Keywords{
+					Keywords: []Keyword{
+						{Name: "dream"},
+						{Name: "heist"},
+					},
+				},
+			},
+			checks: func(t *testing.T, result string) {
+				t.Helper()
+
+				// Title with year
+				if !strings.Contains(result, "# Inception (2010)") {
+					t.Error("expected title with year '# Inception (2010)'")
+				}
+
+				// Overview section
+				if !strings.Contains(result, "## Overview") {
+					t.Error("expected '## Overview' section")
+				}
+				if !strings.Contains(result, "A thief who steals corporate secrets") {
+					t.Error("expected overview text")
+				}
+
+				// Details section
+				if !strings.Contains(result, "## Details") {
+					t.Error("expected '## Details' section")
+				}
+				if !strings.Contains(result, "**Genres:** Action, Sci-Fi") {
+					t.Error("expected genres line")
+				}
+				if !strings.Contains(result, "**Director:** Christopher Nolan") {
+					t.Error("expected director line")
+				}
+				if !strings.Contains(result, "**Rating:** 8.4/10 (30000 votes)") {
+					t.Error("expected rating line")
+				}
+				if !strings.Contains(result, "**Runtime:** 148 min") {
+					t.Error("expected runtime line")
+				}
+				if !strings.Contains(result, "**Keywords:** dream, heist") {
+					t.Error("expected keywords line")
+				}
+
+				// Cast: top 5 only (6th actor Cillian Murphy should NOT appear)
+				if !strings.Contains(result, "Leonardo DiCaprio") {
+					t.Error("expected first cast member")
+				}
+				if !strings.Contains(result, "Ken Watanabe") {
+					t.Error("expected fifth cast member")
+				}
+				if strings.Contains(result, "Cillian Murphy") {
+					t.Error("6th cast member should not appear (max 5)")
+				}
+
+				// Reviews section
+				if !strings.Contains(result, "## Reviews") {
+					t.Error("expected '## Reviews' section")
+				}
+				if !strings.Contains(result, `"A masterpiece of modern cinema."`) {
+					t.Error("expected first review content")
+				}
+				if !strings.Contains(result, "— moviefan") {
+					t.Error("expected first review author")
+				}
+				if !strings.Contains(result, "— critic42") {
+					t.Error("expected second review author")
+				}
+			},
+		},
+		{
+			name: "movie with no reviews",
+			movie: MovieDetail{
+				ID:          999,
+				Title:       "No Reviews Film",
+				Overview:    "A film nobody reviewed.",
+				ReleaseDate: "2023-01-15",
+				VoteAverage: 6.0,
+				VoteCount:   100,
+				Runtime:     90,
+				Genres:      []Genre{{ID: 1, Name: "Drama"}},
+				Credits: Credits{
+					Cast: []CastMember{{Name: "Actor One", Character: "Role", Order: 0}},
+					Crew: []CrewMember{{Name: "Some Director", Job: "Director"}},
+				},
+				Reviews:  Reviews{Results: []Review{}},
+				Keywords: Keywords{Keywords: []Keyword{{Name: "indie"}}},
+			},
+			checks: func(t *testing.T, result string) {
+				t.Helper()
+
+				if !strings.Contains(result, "# No Reviews Film (2023)") {
+					t.Error("expected title with year")
+				}
+				if strings.Contains(result, "## Reviews") {
+					t.Error("Reviews section should be absent when there are no reviews")
+				}
+			},
+		},
+		{
+			name: "movie with no crew (no director)",
+			movie: MovieDetail{
+				ID:          888,
+				Title:       "No Crew Film",
+				Overview:    "A film with no crew listed.",
+				ReleaseDate: "2022-06-01",
+				VoteAverage: 5.5,
+				VoteCount:   50,
+				Runtime:     120,
+				Genres:      []Genre{{ID: 2, Name: "Comedy"}},
+				Credits: Credits{
+					Cast: []CastMember{{Name: "Solo Actor", Character: "Lead", Order: 0}},
+					Crew: []CrewMember{},
+				},
+				Reviews: Reviews{
+					Results: []Review{{Author: "viewer", Content: "Interesting film."}},
+				},
+				Keywords: Keywords{Keywords: []Keyword{{Name: "experimental"}}},
+			},
+			checks: func(t *testing.T, result string) {
+				t.Helper()
+
+				if !strings.Contains(result, "# No Crew Film (2022)") {
+					t.Error("expected title with year")
+				}
+				if strings.Contains(result, "**Director:**") {
+					t.Error("Director line should be absent when no crew member has Job=='Director'")
+				}
+				// Other sections should still be present
+				if !strings.Contains(result, "## Details") {
+					t.Error("expected Details section")
+				}
+				if !strings.Contains(result, "## Reviews") {
+					t.Error("expected Reviews section (reviews exist)")
+				}
+			},
+		},
+		{
+			name: "movie with long review truncated at 500 chars",
+			movie: MovieDetail{
+				ID:          777,
+				Title:       "Long Review Film",
+				Overview:    "A film with a very long review.",
+				ReleaseDate: "2021-03-20",
+				VoteAverage: 7.0,
+				VoteCount:   200,
+				Runtime:     110,
+				Genres:      []Genre{{ID: 3, Name: "Thriller"}},
+				Credits: Credits{
+					Cast: []CastMember{{Name: "Star Actor", Character: "Hero", Order: 0}},
+					Crew: []CrewMember{{Name: "Jane Doe", Job: "Director"}},
+				},
+				Reviews: Reviews{
+					Results: []Review{
+						{
+							Author:  "verbose_reviewer",
+							Content: strings.Repeat("A", 600),
+						},
+					},
+				},
+				Keywords: Keywords{Keywords: []Keyword{{Name: "suspense"}}},
+			},
+			checks: func(t *testing.T, result string) {
+				t.Helper()
+
+				if !strings.Contains(result, "# Long Review Film (2021)") {
+					t.Error("expected title with year")
+				}
+
+				// The review should be truncated to 500 chars + "..."
+				truncated := strings.Repeat("A", 500) + "..."
+				if !strings.Contains(result, truncated) {
+					t.Error("expected review content truncated to 500 chars with '...' suffix")
+				}
+
+				// Full 600-char content should NOT appear
+				full := strings.Repeat("A", 600)
+				if strings.Contains(result, full) {
+					t.Error("full 600-char review should not appear (should be truncated)")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := RenderMarkdown(tt.movie)
+			tt.checks(t, result)
+		})
+	}
+}
+
+func TestRenderMarkdown_MaxThreeReviews(t *testing.T) {
+	movie := MovieDetail{
+		ID:          111,
+		Title:       "Many Reviews",
+		Overview:    "Has many reviews.",
+		ReleaseDate: "2020-01-01",
+		VoteAverage: 7.5,
+		VoteCount:   500,
+		Runtime:     100,
+		Genres:      []Genre{{ID: 1, Name: "Drama"}},
+		Credits: Credits{
+			Cast: []CastMember{{Name: "A", Character: "B", Order: 0}},
+			Crew: []CrewMember{{Name: "Dir", Job: "Director"}},
+		},
+		Reviews: Reviews{
+			Results: []Review{
+				{Author: "r1", Content: "Review one."},
+				{Author: "r2", Content: "Review two."},
+				{Author: "r3", Content: "Review three."},
+				{Author: "r4", Content: "Review four."},
+			},
+		},
+		Keywords: Keywords{Keywords: []Keyword{{Name: "test"}}},
+	}
+
+	result := RenderMarkdown(movie)
+
+	if !strings.Contains(result, "— r3") {
+		t.Error("expected third review to be present")
+	}
+	if strings.Contains(result, "— r4") {
+		t.Error("fourth review should not appear (max 3 reviews)")
+	}
+}

--- a/internal/tmdb/models.go
+++ b/internal/tmdb/models.go
@@ -1,0 +1,83 @@
+package tmdb
+
+// Genre represents a TMDB movie genre.
+type Genre struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// GenreListResponse is the response from /genre/movie/list.
+type GenreListResponse struct {
+	Genres []Genre `json:"genres"`
+}
+
+// MovieSummary is a compact movie record returned in discovery/search results.
+type MovieSummary struct {
+	ID          int     `json:"id"`
+	Title       string  `json:"title"`
+	Overview    string  `json:"overview"`
+	ReleaseDate string  `json:"release_date"`
+	VoteAverage float64 `json:"vote_average"`
+	VoteCount   int     `json:"vote_count"`
+}
+
+// DiscoverResponse is the response from /discover/movie.
+type DiscoverResponse struct {
+	Results []MovieSummary `json:"results"`
+}
+
+// CastMember represents an actor in a movie's credits.
+type CastMember struct {
+	Name      string `json:"name"`
+	Character string `json:"character"`
+	Order     int    `json:"order"`
+}
+
+// CrewMember represents a crew member in a movie's credits.
+type CrewMember struct {
+	Name string `json:"name"`
+	Job  string `json:"job"`
+}
+
+// Credits holds the cast and crew for a movie.
+type Credits struct {
+	Cast []CastMember `json:"cast"`
+	Crew []CrewMember `json:"crew"`
+}
+
+// Review represents a single user review.
+type Review struct {
+	Author  string `json:"author"`
+	Content string `json:"content"`
+}
+
+// Reviews is the response shape for appended reviews.
+type Reviews struct {
+	Results []Review `json:"results"`
+}
+
+// Keyword represents a movie keyword/tag.
+type Keyword struct {
+	Name string `json:"name"`
+}
+
+// Keywords is the response shape for appended keywords.
+type Keywords struct {
+	Keywords []Keyword `json:"keywords"`
+}
+
+// MovieDetail is the full movie record returned by /movie/{id}
+// with credits, reviews, and keywords appended.
+type MovieDetail struct {
+	ID          int      `json:"id"`
+	Title       string   `json:"title"`
+	Overview    string   `json:"overview"`
+	ReleaseDate string   `json:"release_date"`
+	VoteAverage float64  `json:"vote_average"`
+	VoteCount   int      `json:"vote_count"`
+	Runtime     int      `json:"runtime"`
+	Genres      []Genre  `json:"genres"`
+	Credits     Credits  `json:"credits"`
+	Reviews     Reviews  `json:"reviews"`
+	Keywords    Keywords `json:"keywords"`
+}


### PR DESCRIPTION
## Summary

Adds a shared demo organisation with a TMDB-powered knowledge base for new user onboarding and developer testing.

### New packages
- **`internal/tmdb/`** — TMDB API client (concurrent genre-based fetcher), response models, movie-to-markdown renderer
- **`internal/service/seed.go`** — SeedService orchestrating org/workspace/KB creation, TMDB fetch, document upload, job enqueue
- **`internal/service/demo_join.go`** — Auto-joins new users to demo org as viewer

### New endpoints
- **`POST /api/v1/admin/seed-demo?size=small`** — Seeds the demo org (idempotent, auth via session or `X-Seed-Key` header)

### Modified files
- `cmd/api/main.go` — Wire TMDB client, seed service/handler, admin route, seed key middleware
- `internal/config/config.go` — Add `TMDBConfig` + `SeedConfig` with env bindings
- `internal/middleware/auth.go` — Add `X-Seed-Key` bypass for admin endpoints
- `internal/handler/auth.go` — Add `DemoOrgJoiner` interface, auto-join on signup callback
- `internal/repository/org.go` + `internal/service/org.go` — Add `GetBySlug` for idempotency
- `internal/model/seed.go` — `SeedResult` response type

### Tests
- 8 unit tests in `internal/tmdb/` (client + markdown renderer)
- 3 unit tests in `internal/handler/seed_test.go`

## Test plan
- [x] `go build ./...` — clean
- [x] `golangci-lint run ./...` — clean
- [x] `go test ./internal/...` — all 30 packages pass
- [ ] Set `TMDB_API_KEY` and `RAVEN_SEED_KEY`, call `POST /admin/seed-demo`
- [ ] Verify new user auto-joins demo org on first login

Closes #303, #304, #305, #306, #307

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new admin endpoint for seeding demo data with sample content from TMDB
  * New users are automatically enrolled in the demo organization upon sign-up
  * Implemented seed key authentication to secure demo seeding operations
  * Demo initialization creates sample organization, workspace, and knowledge base with movie data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->