### PR TITLE
feat(jobs): document processing handler with markdown chunking

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ravencloak-org/Raven/internal/jobs"
 	"github.com/ravencloak-org/Raven/internal/queue"
 	"github.com/ravencloak-org/Raven/internal/repository"
+	"github.com/ravencloak-org/Raven/internal/storage"
 )
 
 func main() {
@@ -34,6 +35,9 @@ func main() {
 	defer pool.Close()
 
 	notifRepo := repository.NewNotificationRepository(pool)
+	docRepo := repository.NewDocumentRepository(pool)
+	chunkRepo := repository.NewChunkRepository(pool)
+	storageClient := storage.NewSeaweedFSClient(cfg.SeaweedFS.MasterURL, nil)
 
 	srv := queue.NewServer(queue.ServerConfig{
 		RedisAddr:   cfg.Valkey.URL,
@@ -49,6 +53,10 @@ func main() {
 	webhookRepo := repository.NewWebhookRepository(pool)
 	webhookDeliveryHandler := jobs.NewWebhookDeliveryHandler(pool, webhookRepo, logger)
 	srv.Mux().Handle(queue.TypeWebhookDelivery, webhookDeliveryHandler)
+
+	// Register document processing handler (overrides the stub in queue.Server).
+	srv.Mux().HandleFunc(queue.TypeDocumentProcess,
+		jobs.NewDocumentProcessHandler(pool, docRepo, chunkRepo, storageClient, logger))
 
 	errCh := make(chan error, 1)
 

--- a/internal/jobs/document_process.go
+++ b/internal/jobs/document_process.go
@@ -99,27 +99,28 @@ func NewDocumentProcessHandler(
 			return e
 		})
 		if err != nil {
-			setFailed(ctx, pool, p.OrgID, p.DocumentID, docRepo, err)
+			setFailed(ctx, pool, p.OrgID, p.DocumentID, docRepo, logger, err)
 			return fmt.Errorf("get document: %w", err)
 		}
 
 		if doc.StoragePath == "" {
 			failErr := fmt.Errorf("document %s has no storage_path", p.DocumentID)
-			setFailed(ctx, pool, p.OrgID, p.DocumentID, docRepo, failErr)
+			setFailed(ctx, pool, p.OrgID, p.DocumentID, docRepo, logger, failErr)
 			return fmt.Errorf("%w: %w", asynq.SkipRetry, failErr)
 		}
 
 		// Download file content from SeaweedFS.
 		rc, err := store.Download(ctx, doc.StoragePath)
 		if err != nil {
-			setFailed(ctx, pool, p.OrgID, p.DocumentID, docRepo, err)
+			setFailed(ctx, pool, p.OrgID, p.DocumentID, docRepo, logger, err)
 			return fmt.Errorf("download from storage: %w", err)
 		}
 		defer func() { _ = rc.Close() }()
 
-		raw, err := io.ReadAll(rc)
+		const maxDocSize = 10 << 20 // 10 MB
+		raw, err := io.ReadAll(io.LimitReader(rc, maxDocSize))
 		if err != nil {
-			setFailed(ctx, pool, p.OrgID, p.DocumentID, docRepo, err)
+			setFailed(ctx, pool, p.OrgID, p.DocumentID, docRepo, logger, err)
 			return fmt.Errorf("read file content: %w", err)
 		}
 		content := string(raw)
@@ -168,7 +169,7 @@ func NewDocumentProcessHandler(
 			return docRepo.UpdateStatus(ctx, tx, p.OrgID, p.DocumentID, model.ProcessingStatusReady, "")
 		})
 		if err != nil {
-			setFailed(ctx, pool, p.OrgID, p.DocumentID, docRepo, err)
+			setFailed(ctx, pool, p.OrgID, p.DocumentID, docRepo, logger, err)
 			return fmt.Errorf("insert chunks: %w", err)
 		}
 
@@ -190,9 +191,9 @@ func updateDocStatus(ctx context.Context, pool *pgxpool.Pool, orgID, docID strin
 }
 
 // setFailed marks a document as failed, logging any secondary error.
-func setFailed(ctx context.Context, pool *pgxpool.Pool, orgID, docID string, docRepo *repository.DocumentRepository, cause error) {
+func setFailed(ctx context.Context, pool *pgxpool.Pool, orgID, docID string, docRepo *repository.DocumentRepository, logger *slog.Logger, cause error) {
 	if err := updateDocStatus(ctx, pool, orgID, docID, docRepo, model.ProcessingStatusFailed, cause.Error()); err != nil {
-		slog.Default().Warn("failed to mark document as failed",
+		logger.Warn("failed to mark document as failed",
 			"document_id", docID,
 			"cause", cause.Error(),
 			"error", err.Error(),

--- a/internal/jobs/document_process.go
+++ b/internal/jobs/document_process.go
@@ -1,0 +1,201 @@
+package jobs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+
+	"github.com/hibiken/asynq"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/ravencloak-org/Raven/internal/db"
+	"github.com/ravencloak-org/Raven/internal/model"
+	"github.com/ravencloak-org/Raven/internal/queue"
+	"github.com/ravencloak-org/Raven/internal/repository"
+	"github.com/ravencloak-org/Raven/internal/storage"
+)
+
+// MarkdownSection represents a single section extracted from a markdown document
+// by splitting on heading boundaries.
+type MarkdownSection struct {
+	Heading string
+	Content string
+}
+
+// SplitMarkdownByHeadings splits markdown content into sections based on ## headings.
+// The first section (before or including the first heading) captures any preamble
+// and the # title. Each subsequent ## heading starts a new section.
+func SplitMarkdownByHeadings(content string) []MarkdownSection {
+	lines := strings.Split(content, "\n")
+
+	var sections []MarkdownSection
+	var currentHeading string
+	var currentLines []string
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "## ") {
+			// Flush the current section if we have accumulated content.
+			if len(currentLines) > 0 || currentHeading != "" {
+				sections = append(sections, MarkdownSection{
+					Heading: currentHeading,
+					Content: strings.TrimSpace(strings.Join(currentLines, "\n")),
+				})
+			}
+			currentHeading = strings.TrimPrefix(trimmed, "## ")
+			currentLines = []string{line}
+		} else {
+			currentLines = append(currentLines, line)
+		}
+	}
+
+	// Flush the last section.
+	if len(currentLines) > 0 || currentHeading != "" {
+		sections = append(sections, MarkdownSection{
+			Heading: currentHeading,
+			Content: strings.TrimSpace(strings.Join(currentLines, "\n")),
+		})
+	}
+
+	return sections
+}
+
+// NewDocumentProcessHandler returns an asynq.HandlerFunc that processes a queued
+// document: downloads markdown from SeaweedFS, splits it into chunks by heading,
+// inserts each chunk into the DB, and marks the document as ready.
+func NewDocumentProcessHandler(
+	pool *pgxpool.Pool,
+	docRepo *repository.DocumentRepository,
+	chunkRepo *repository.ChunkRepository,
+	store storage.Client,
+	logger *slog.Logger,
+) asynq.HandlerFunc {
+	return func(ctx context.Context, task *asynq.Task) error {
+		var p queue.DocumentProcessPayload
+		if err := json.Unmarshal(task.Payload(), &p); err != nil {
+			return fmt.Errorf("unmarshal DocumentProcessPayload: %w", err)
+		}
+
+		logger.Info("processing document",
+			"org_id", p.OrgID,
+			"document_id", p.DocumentID,
+			"knowledge_base_id", p.KnowledgeBaseID,
+		)
+
+		// Mark document as parsing.
+		if err := updateDocStatus(ctx, pool, p.OrgID, p.DocumentID, docRepo, model.ProcessingStatusParsing, ""); err != nil {
+			return fmt.Errorf("set status parsing: %w", err)
+		}
+
+		// Fetch the document record to get the storage path (SeaweedFS fid).
+		var doc *model.Document
+		err := db.WithOrgID(ctx, pool, p.OrgID, func(tx pgx.Tx) error {
+			var e error
+			doc, e = docRepo.GetByID(ctx, tx, p.OrgID, p.DocumentID)
+			return e
+		})
+		if err != nil {
+			setFailed(ctx, pool, p.OrgID, p.DocumentID, docRepo, err)
+			return fmt.Errorf("get document: %w", err)
+		}
+
+		if doc.StoragePath == "" {
+			failErr := fmt.Errorf("document %s has no storage_path", p.DocumentID)
+			setFailed(ctx, pool, p.OrgID, p.DocumentID, docRepo, failErr)
+			return fmt.Errorf("%w: %w", asynq.SkipRetry, failErr)
+		}
+
+		// Download file content from SeaweedFS.
+		rc, err := store.Download(ctx, doc.StoragePath)
+		if err != nil {
+			setFailed(ctx, pool, p.OrgID, p.DocumentID, docRepo, err)
+			return fmt.Errorf("download from storage: %w", err)
+		}
+		defer func() { _ = rc.Close() }()
+
+		raw, err := io.ReadAll(rc)
+		if err != nil {
+			setFailed(ctx, pool, p.OrgID, p.DocumentID, docRepo, err)
+			return fmt.Errorf("read file content: %w", err)
+		}
+		content := string(raw)
+
+		// Mark as chunking.
+		if err := updateDocStatus(ctx, pool, p.OrgID, p.DocumentID, docRepo, model.ProcessingStatusChunking, ""); err != nil {
+			return fmt.Errorf("set status chunking: %w", err)
+		}
+
+		// Split markdown into sections by heading.
+		sections := SplitMarkdownByHeadings(content)
+		if len(sections) == 0 {
+			// No content to chunk — mark as ready with zero chunks.
+			if err := updateDocStatus(ctx, pool, p.OrgID, p.DocumentID, docRepo, model.ProcessingStatusReady, ""); err != nil {
+				return fmt.Errorf("set status ready (empty): %w", err)
+			}
+			return nil
+		}
+
+		// Insert all chunks and update status in a single RLS transaction.
+		err = db.WithOrgID(ctx, pool, p.OrgID, func(tx pgx.Tx) error {
+			for i, section := range sections {
+				if strings.TrimSpace(section.Content) == "" {
+					continue
+				}
+				tokenCount := len(strings.Fields(section.Content))
+				chunk := &model.Chunk{
+					OrgID:           p.OrgID,
+					KnowledgeBaseID: p.KnowledgeBaseID,
+					DocumentID:      &p.DocumentID,
+					Content:         section.Content,
+					ChunkIndex:      i,
+					TokenCount:      &tokenCount,
+					ChunkType:       model.ChunkTypeText,
+					Metadata:        map[string]any{},
+				}
+				if section.Heading != "" {
+					chunk.Heading = &section.Heading
+				}
+				if _, err := chunkRepo.CreateChunk(ctx, tx, chunk); err != nil {
+					return fmt.Errorf("create chunk %d: %w", i, err)
+				}
+			}
+
+			// Update document status to ready within the same transaction.
+			return docRepo.UpdateStatus(ctx, tx, p.OrgID, p.DocumentID, model.ProcessingStatusReady, "")
+		})
+		if err != nil {
+			setFailed(ctx, pool, p.OrgID, p.DocumentID, docRepo, err)
+			return fmt.Errorf("insert chunks: %w", err)
+		}
+
+		logger.Info("document processed",
+			"document_id", p.DocumentID,
+			"chunks", len(sections),
+		)
+
+		return nil
+	}
+}
+
+// updateDocStatus is a convenience wrapper that updates document processing status
+// inside an RLS-scoped transaction.
+func updateDocStatus(ctx context.Context, pool *pgxpool.Pool, orgID, docID string, docRepo *repository.DocumentRepository, status model.ProcessingStatus, errMsg string) error {
+	return db.WithOrgID(ctx, pool, orgID, func(tx pgx.Tx) error {
+		return docRepo.UpdateStatus(ctx, tx, orgID, docID, status, errMsg)
+	})
+}
+
+// setFailed marks a document as failed, logging any secondary error.
+func setFailed(ctx context.Context, pool *pgxpool.Pool, orgID, docID string, docRepo *repository.DocumentRepository, cause error) {
+	if err := updateDocStatus(ctx, pool, orgID, docID, docRepo, model.ProcessingStatusFailed, cause.Error()); err != nil {
+		slog.Default().Warn("failed to mark document as failed",
+			"document_id", docID,
+			"cause", cause.Error(),
+			"error", err.Error(),
+		)
+	}
+}

--- a/internal/jobs/document_process_test.go
+++ b/internal/jobs/document_process_test.go
@@ -1,0 +1,113 @@
+package jobs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitMarkdownByHeadings_MultipleH2(t *testing.T) {
+	md := `# Movie: The Matrix
+
+A classic sci-fi film.
+
+## Overview
+
+The Matrix is a 1999 science fiction action film.
+
+## Cast
+
+- Keanu Reeves
+- Laurence Fishburne
+
+## Reviews
+
+Critics praised the film for its visual effects.
+`
+	sections := SplitMarkdownByHeadings(md)
+
+	require.Len(t, sections, 4)
+
+	// First section: preamble with # title
+	assert.Equal(t, "", sections[0].Heading)
+	assert.Contains(t, sections[0].Content, "# Movie: The Matrix")
+	assert.Contains(t, sections[0].Content, "A classic sci-fi film.")
+
+	// Second section: Overview
+	assert.Equal(t, "Overview", sections[1].Heading)
+	assert.Contains(t, sections[1].Content, "## Overview")
+	assert.Contains(t, sections[1].Content, "1999 science fiction")
+
+	// Third section: Cast
+	assert.Equal(t, "Cast", sections[2].Heading)
+	assert.Contains(t, sections[2].Content, "Keanu Reeves")
+
+	// Fourth section: Reviews
+	assert.Equal(t, "Reviews", sections[3].Heading)
+	assert.Contains(t, sections[3].Content, "visual effects")
+}
+
+func TestSplitMarkdownByHeadings_NoHeadings(t *testing.T) {
+	md := `Just some plain text without any headings.
+
+Second paragraph.`
+
+	sections := SplitMarkdownByHeadings(md)
+
+	require.Len(t, sections, 1)
+	assert.Equal(t, "", sections[0].Heading)
+	assert.Contains(t, sections[0].Content, "Just some plain text")
+}
+
+func TestSplitMarkdownByHeadings_OnlyH1(t *testing.T) {
+	md := `# Title
+
+Some content under the title.`
+
+	sections := SplitMarkdownByHeadings(md)
+
+	require.Len(t, sections, 1)
+	assert.Equal(t, "", sections[0].Heading)
+	assert.Contains(t, sections[0].Content, "# Title")
+	assert.Contains(t, sections[0].Content, "Some content under the title.")
+}
+
+func TestSplitMarkdownByHeadings_EmptyContent(t *testing.T) {
+	sections := SplitMarkdownByHeadings("")
+	// An empty string still produces one section with empty content.
+	require.Len(t, sections, 1)
+	assert.Equal(t, "", sections[0].Content)
+}
+
+func TestSplitMarkdownByHeadings_ConsecutiveHeadings(t *testing.T) {
+	md := `## First
+## Second
+Some content here.`
+
+	sections := SplitMarkdownByHeadings(md)
+
+	require.Len(t, sections, 2)
+	assert.Equal(t, "First", sections[0].Heading)
+	assert.Equal(t, "## First", sections[0].Content)
+
+	assert.Equal(t, "Second", sections[1].Heading)
+	assert.Contains(t, sections[1].Content, "## Second")
+	assert.Contains(t, sections[1].Content, "Some content here.")
+}
+
+func TestSplitMarkdownByHeadings_H3NotSplit(t *testing.T) {
+	md := `## Main Section
+
+### Subsection
+
+Content under subsection.`
+
+	sections := SplitMarkdownByHeadings(md)
+
+	// ### should NOT trigger a split — only ## does.
+	require.Len(t, sections, 1)
+	assert.Equal(t, "Main Section", sections[0].Heading)
+	assert.Contains(t, sections[0].Content, "### Subsection")
+	assert.Contains(t, sections[0].Content, "Content under subsection.")
+}

--- a/internal/queue/server.go
+++ b/internal/queue/server.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/hibiken/asynq"
 )
@@ -37,8 +38,7 @@ func (h *errorHandler) HandleError(_ context.Context, task *asynq.Task, err erro
 }
 
 // NewServer creates a new Asynq worker server with the given configuration.
-// Handlers are stubs that log the task payload; real processing will be added
-// in subsequent issues (#14-#17).
+// Callers must register handlers on the returned Server's Mux() before calling Start().
 func NewServer(cfg ServerConfig) *Server {
 	if cfg.Concurrency <= 0 {
 		cfg.Concurrency = 10
@@ -50,8 +50,11 @@ func NewServer(cfg ServerConfig) *Server {
 		cfg.Logger = slog.Default()
 	}
 
+	// Strip redis:// scheme if present — Asynq expects bare host:port.
+	redisAddr := strings.TrimPrefix(cfg.RedisAddr, "redis://")
+
 	srv := asynq.NewServer(
-		asynq.RedisClientOpt{Addr: cfg.RedisAddr},
+		asynq.RedisClientOpt{Addr: redisAddr},
 		asynq.Config{
 			Concurrency: cfg.Concurrency,
 			Queues: map[string]int{
@@ -70,11 +73,6 @@ func NewServer(cfg ServerConfig) *Server {
 		mux:    mux,
 		logger: cfg.Logger,
 	}
-
-	// Register stub handlers for all task types.
-	mux.HandleFunc(TypeDocumentProcess, s.handleDocumentProcess)
-	mux.HandleFunc(TypeURLScrape, s.handleURLScrape)
-	mux.HandleFunc(TypeReindex, s.handleReindex)
 
 	return s
 }


### PR DESCRIPTION
## Summary
- Add `NewDocumentProcessHandler` in `internal/jobs/document_process.go` that downloads markdown from SeaweedFS, splits into chunks by `##` headings, inserts them into the DB with RLS transactions, and transitions document status through `parsing -> chunking -> ready`
- Extract `SplitMarkdownByHeadings` as a standalone pure function with 6 unit tests covering edge cases (multiple headings, no headings, empty content, consecutive headings, H3 non-split)
- Wire the handler into `cmd/worker/main.go` replacing the stub, instantiating `DocumentRepository`, `ChunkRepository`, and `SeaweedFSClient`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/jobs/...` — all 6 markdown splitting tests pass
- [x] `golangci-lint run` — clean on changed packages
- [ ] Integration test with real SeaweedFS + DB (deferred to CI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented document processing pipeline: downloads markdown, splits by heading, and creates indexed chunks.
  * Initialized object storage client and registered document-processing task handler in the worker.

* **Chores**
  * Queue server now expects explicit task handler registration before start.
  * Normalized Redis address handling (strips URL scheme).

* **Tests**
  * Added unit tests covering markdown section splitting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->