### PR TITLE
fix: address CodeRabbit review comments from #310 and #311

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -70,6 +70,6 @@ func main() {
 	}
 
 	srv.Shutdown()
-	pool.Close()
+	// pool.Close() is handled by defer above.
 	logger.Info("worker exited gracefully")
 }

--- a/internal/handler/seed.go
+++ b/internal/handler/seed.go
@@ -24,9 +24,13 @@ func NewSeedHandler(svc SeedServicer) *SeedHandler {
 }
 
 // SeedDemo handles POST /api/v1/admin/seed-demo.
-// Reads `size` query param (default "small").
+// Reads `size` query param (default "small"). Only "small" is supported.
 func (h *SeedHandler) SeedDemo(c *gin.Context) {
 	size := c.DefaultQuery("size", "small")
+	if size != "small" {
+		c.JSON(http.StatusNotImplemented, gin.H{"error": "only size=small is supported"})
+		return
+	}
 
 	result, err := h.svc.SeedDemo(c.Request.Context(), size)
 	if err != nil {

--- a/internal/handler/seed_test.go
+++ b/internal/handler/seed_test.go
@@ -52,7 +52,7 @@ func TestSeedDemo_Success(t *testing.T) {
 
 	r := newSeedRouter(svc)
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest(http.MethodPost, "/api/v1/admin/seed-demo?size=large", nil)
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/admin/seed-demo?size=small", nil)
 	r.ServeHTTP(w, req)
 
 	if w.Code != http.StatusOK {

--- a/internal/queue/client.go
+++ b/internal/queue/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/hibiken/asynq"
 
@@ -35,7 +36,9 @@ func WithLogger(l *slog.Logger) ClientOption {
 }
 
 // NewClient creates a new queue Client connected to the given Valkey/Redis address.
+// Accepts both "host:port" and "redis://host:port" formats.
 func NewClient(redisAddr string, opts ...ClientOption) *Client {
+	redisAddr = strings.TrimPrefix(redisAddr, "redis://")
 	c := &Client{
 		inner:    asynq.NewClient(asynq.RedisClientOpt{Addr: redisAddr}),
 		logger:   slog.Default(),

--- a/internal/service/demo_join.go
+++ b/internal/service/demo_join.go
@@ -26,8 +26,11 @@ func (d *DemoOrgJoiner) JoinDemoOrg(ctx context.Context, userID string) {
 	// Look up demo org by slug.
 	demoOrg, err := d.orgSvc.GetBySlug(ctx, "raven-demo")
 	if err != nil {
-		// Demo org doesn't exist — nothing to join.
+		slog.WarnContext(ctx, "demo-join: failed to look up demo org", "error", err)
 		return
+	}
+	if demoOrg == nil {
+		return // Demo org not seeded yet.
 	}
 
 	// List workspaces in demo org.

--- a/internal/service/seed.go
+++ b/internal/service/seed.go
@@ -106,15 +106,21 @@ func (s *SeedService) SeedDemo(ctx context.Context, size string) (*model.SeedRes
 
 	// 6. For each movie: render markdown, upload to SeaweedFS, create document, enqueue.
 	enqueued := 0
+	var failures int
 	for _, movie := range movies {
 		if processErr := s.processMovie(ctx, org.ID, kb.ID, movie); processErr != nil {
 			slog.Warn("seed: failed to process movie, skipping",
 				"movie_title", movie.Title,
 				"error", processErr,
 			)
+			failures++
 			continue
 		}
 		enqueued++
+	}
+
+	if enqueued == 0 && failures > 0 {
+		return nil, apierror.NewInternal(fmt.Sprintf("seed: all %d movies failed to process", failures))
 	}
 
 	return &model.SeedResult{


### PR DESCRIPTION
## Summary

Follow-up fixes for CodeRabbit review comments on PRs #310 and #311:

- **handler/seed.go** — Reject unsupported `size` values (only `"small"` returns 200; others get 501)
- **queue/client.go** — Strip `redis://` scheme from Valkey URL for Asynq compatibility
- **service/seed.go** — Return error when all movies fail to process (instead of silent 0-enqueued success)
- **service/demo_join.go** — Distinguish nil org (not seeded) from DB error in GetBySlug
- **cmd/worker/main.go** — Remove duplicate `pool.Close()` (already handled by defer)

## Test plan
- [x] `go build ./...` — clean
- [x] `go test ./internal/handler/... ./internal/service/... ./internal/queue/...` — pass