### PR TITLE
fix(frontend): normalize KB document fields and fix upload UI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -ldflags="-s -w -extldflags '-static'" -o 
 FROM alpine:3.23
 
 RUN apk add --no-cache ca-certificates tzdata curl \
-    && curl -sfS https://dotenvx.sh | sh \
+    && curl -sfS "https://dotenvx.sh?version=1.59.1" | sh \
     && addgroup -g 1000 raven \
     && adduser -u 1000 -G raven -D raven
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -ldflags="-s -w -extldflags '-static'" -o 
 FROM alpine:3.23
 
 RUN apk add --no-cache ca-certificates tzdata curl \
-    && curl -sfS https://dotenvx.sh/1.34.0 | sh \
+    && curl -sfS https://dotenvx.sh | sh \
     && addgroup -g 1000 raven \
     && adduser -u 1000 -G raven -D raven
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "8081:8081"
+      - "8081:8080"
     volumes:
       - ./.env:/app/.env:ro
     environment:
@@ -19,6 +19,9 @@ services:
       RAVEN_SUPERTOKENS_API_KEY: "${SUPERTOKENS_API_KEY:-supertokens-dev-key-replace-me}"
       GOOGLE_CLIENT_ID: "${GOOGLE_CLIENT_ID}"
       GOOGLE_CLIENT_SECRET: "${GOOGLE_CLIENT_SECRET}"
+      TMDB_API_KEY: "${TMDB_API_KEY:-}"
+      RAVEN_SEED_KEY: "${RAVEN_SEED_KEY:-}"
+      RAVEN_ENCRYPTION_AES_KEY: "${RAVEN_ENCRYPTION_AES_KEY:-}"
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "8081:8080"
+      - "8081:8081"
     volumes:
       - ./.env:/app/.env:ro
     environment:
@@ -21,7 +21,7 @@ services:
       GOOGLE_CLIENT_SECRET: "${GOOGLE_CLIENT_SECRET}"
       TMDB_API_KEY: "${TMDB_API_KEY:-}"
       RAVEN_SEED_KEY: "${RAVEN_SEED_KEY:-}"
-      RAVEN_ENCRYPTION_AES_KEY: "${RAVEN_ENCRYPTION_AES_KEY:-}"
+      RAVEN_ENCRYPTION_AES_KEY: "${RAVEN_ENCRYPTION_AES_KEY:?RAVEN_ENCRYPTION_AES_KEY is required}"
     depends_on:
       postgres:
         condition: service_healthy

--- a/frontend/src/api/knowledge-bases.ts
+++ b/frontend/src/api/knowledge-bases.ts
@@ -18,6 +18,8 @@ export interface KBListResponse {
   limit: number
 }
 
+export type KBDocumentStatus = 'pending' | 'processing' | 'completed' | 'failed'
+
 export interface KBDocument {
   id: string
   kb_id: string
@@ -25,8 +27,8 @@ export interface KBDocument {
   file_name: string
   type: string
   file_type: string
-  status: string
-  processing_status: string
+  status: KBDocumentStatus
+  processing_status: KBDocumentStatus
   created_at: string
 }
 
@@ -110,8 +112,8 @@ function normalizeDoc(d: Record<string, unknown>): KBDocument {
     file_name: (d.file_name ?? d.name ?? '') as string,
     type: (d.type ?? d.file_type ?? '') as string,
     file_type: (d.file_type ?? d.type ?? '') as string,
-    status: (d.status ?? d.processing_status ?? 'pending') as string,
-    processing_status: (d.processing_status ?? d.status ?? 'pending') as string,
+    status: (d.status ?? d.processing_status ?? 'pending') as KBDocumentStatus,
+    processing_status: (d.processing_status ?? d.status ?? 'pending') as KBDocumentStatus,
     created_at: (d.created_at ?? '') as string,
   }
 }

--- a/frontend/src/api/knowledge-bases.ts
+++ b/frontend/src/api/knowledge-bases.ts
@@ -22,8 +22,11 @@ export interface KBDocument {
   id: string
   kb_id: string
   name: string
-  type: 'file' | 'url'
-  status: 'pending' | 'processing' | 'completed' | 'failed'
+  file_name: string
+  type: string
+  file_type: string
+  status: string
+  processing_status: string
   created_at: string
 }
 
@@ -99,15 +102,30 @@ export async function archiveKnowledgeBase(
   await authFetch<void>(`${kbBasePath(orgId, wsId)}/${kbId}`, { method: 'DELETE' })
 }
 
+function normalizeDoc(d: Record<string, unknown>): KBDocument {
+  return {
+    id: (d.id ?? '') as string,
+    kb_id: (d.kb_id ?? d.knowledge_base_id ?? '') as string,
+    name: (d.name ?? d.file_name ?? '') as string,
+    file_name: (d.file_name ?? d.name ?? '') as string,
+    type: (d.type ?? d.file_type ?? '') as string,
+    file_type: (d.file_type ?? d.type ?? '') as string,
+    status: (d.status ?? d.processing_status ?? 'pending') as string,
+    processing_status: (d.processing_status ?? d.status ?? 'pending') as string,
+    created_at: (d.created_at ?? '') as string,
+  }
+}
+
 export async function getDocuments(
   orgId: string,
   wsId: string,
   kbId: string,
 ): Promise<KBDocument[]> {
-  const data = await authFetch<KBDocument[] | { items: KBDocument[] }>(
+  const data = await authFetch<Record<string, unknown>[] | { items: Record<string, unknown>[] }>(
     `${kbBasePath(orgId, wsId)}/${kbId}/documents`,
   )
-  return Array.isArray(data) ? data : (data.items ?? [])
+  const items = Array.isArray(data) ? data : (data.items ?? [])
+  return items.map(normalizeDoc)
 }
 
 export async function addDocument(
@@ -126,7 +144,8 @@ export async function addDocument(
     const data = await res.json().catch(() => ({}))
     throw new Error(data.message || data.error || `Upload failed (${res.status})`)
   }
-  return res.json()
+  const raw = await res.json()
+  return normalizeDoc(raw as Record<string, unknown>)
 }
 
 export async function getSources(

--- a/frontend/src/pages/knowledge-bases/KBDetailPage.vue
+++ b/frontend/src/pages/knowledge-bases/KBDetailPage.vue
@@ -434,7 +434,7 @@ function statusBadgeClass(status: string): string {
             >
               <td class="py-3 pr-4 text-sm font-medium">{{ doc.file_name || doc.name }}</td>
               <td class="py-3 pr-4 text-sm text-gray-500">{{ doc.file_type || doc.type }}</td>
-              <td class="py-3 pr-4 text-sm text-gray-500">{{ doc.created_at ? doc.created_at.split('T')[0] : '—' }}</td>
+              <td class="py-3 pr-4 text-sm text-gray-500">{{ doc.created_at ? new Date(doc.created_at).toLocaleDateString() : '—' }}</td>
               <td class="py-3">
                 <span
                   class="inline-block rounded-full px-2 py-0.5 text-xs font-medium"

--- a/frontend/src/pages/knowledge-bases/KBDetailPage.vue
+++ b/frontend/src/pages/knowledge-bases/KBDetailPage.vue
@@ -421,8 +421,8 @@ function statusBadgeClass(status: string): string {
           <thead>
             <tr class="border-b border-gray-200 text-left text-sm font-medium text-gray-500">
               <th class="pb-3 pr-4">File Name</th>
-              <th class="pb-3 pr-4">Size</th>
               <th class="pb-3 pr-4">Type</th>
+              <th class="pb-3 pr-4">Uploaded</th>
               <th class="pb-3">Status</th>
             </tr>
           </thead>
@@ -432,9 +432,9 @@ function statusBadgeClass(status: string): string {
               :key="doc.id"
               class="border-b border-gray-100"
             >
-              <td class="py-3 pr-4 text-sm font-medium">{{ doc.name }}</td>
-              <td class="py-3 pr-4 text-sm text-gray-500">{{ doc.type }}</td>
-              <td class="py-3 pr-4 text-sm text-gray-500">{{ doc.created_at.split('T')[0] }}</td>
+              <td class="py-3 pr-4 text-sm font-medium">{{ doc.file_name || doc.name }}</td>
+              <td class="py-3 pr-4 text-sm text-gray-500">{{ doc.file_type || doc.type }}</td>
+              <td class="py-3 pr-4 text-sm text-gray-500">{{ doc.created_at ? doc.created_at.split('T')[0] : '—' }}</td>
               <td class="py-3">
                 <span
                   class="inline-block rounded-full px-2 py-0.5 text-xs font-medium"

--- a/frontend/src/stores/knowledge-bases.spec.ts
+++ b/frontend/src/stores/knowledge-bases.spec.ts
@@ -63,8 +63,11 @@ function fakeDocument(overrides: Partial<KBDocument> = {}): KBDocument {
     id: 'doc-1',
     kb_id: 'kb-1',
     name: 'test.pdf',
+    file_name: 'test.pdf',
     type: 'file',
+    file_type: 'file',
     status: 'completed',
+    processing_status: 'completed',
     created_at: '2026-03-16T10:00:00Z',
     ...overrides,
   }


### PR DESCRIPTION
## Summary
- Added `normalizeDoc()` to map API response fields (`file_name`, `file_type`, `processing_status`) to consistent frontend field names
- Applied normalization to both `getDocuments()` and `addDocument()` so uploaded documents appear in the table immediately after upload
- Fixed document table column headers and display to use correct fields with fallbacks
- Fixed Dockerfile dotenvx version pin and docker-compose port mapping

## Test plan
- [ ] Upload a document on the KB detail page — verify it appears in the document list immediately
- [ ] Refresh the KB detail page — verify previously uploaded documents display with correct file name, type, and status
- [ ] Verify `npm run build` passes without TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Uploaded" column to the Documents table in Knowledge Bases to display document upload dates.
  * Removed "Size" column from Documents table.

* **Chores**
  * Updated service configuration for deployment improvements.
  * Added environment variable support for API credentials and encryption keys.

* **Tests**
  * Enhanced test fixtures with additional document metadata fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->