### PR TITLE
ci(go): migrate to GOCOVERDIR-format mergeable coverage

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -49,52 +49,86 @@ jobs:
 
       - run: CGO_ENABLED=1 go build ./cmd/api
 
+      - name: Prepare coverage directories
+        run: mkdir -p .coverdata/unit .coverdata/migrations .coverdata/integration coverage
+
       - name: Run tests
         run: |
           if [ -n "$DOTENV_PRIVATE_KEY_CI" ]; then
-            dotenvx run -f .env.ci -- go test -race -timeout 30m -coverprofile=coverage.txt ./...
+            dotenvx run -f .env.ci -- go test -race -timeout 30m \
+              -cover -coverpkg="$COV_PKGS" ./... \
+              -args -test.gocoverdir="$PWD/.coverdata/unit"
           else
             echo "::warning::DOTENV_PRIVATE_KEY_CI not set (fork PR?) — running tests without dotenvx"
-            go test -race -timeout 30m -coverprofile=coverage.txt ./...
+            go test -race -timeout 30m \
+              -cover -coverpkg="$COV_PKGS" ./... \
+              -args -test.gocoverdir="$PWD/.coverdata/unit"
           fi
         env:
+          COV_PKGS: github.com/ravencloak-org/Raven/internal/...,github.com/ravencloak-org/Raven/pkg/...,github.com/ravencloak-org/Raven/cmd/...
           DOTENV_PRIVATE_KEY_CI: ${{ secrets.DOTENV_PRIVATE_KEY_CI }}
           TESTCONTAINERS_RYUK_DISABLED: "true"
 
       - name: Run migration tests
         run: |
           if [ -n "$DOTENV_PRIVATE_KEY_CI" ]; then
-            dotenvx run -f .env.ci -- go test -race -run '^TestMigrationsUpAndDown$' ./migrations/...
+            dotenvx run -f .env.ci -- go test -race -run '^TestMigrationsUpAndDown$' \
+              -cover -coverpkg="$COV_PKGS" ./migrations/... \
+              -args -test.gocoverdir="$PWD/.coverdata/migrations"
           else
-            go test -race -run '^TestMigrationsUpAndDown$' ./migrations/...
+            go test -race -run '^TestMigrationsUpAndDown$' \
+              -cover -coverpkg="$COV_PKGS" ./migrations/... \
+              -args -test.gocoverdir="$PWD/.coverdata/migrations"
           fi
         env:
+          COV_PKGS: github.com/ravencloak-org/Raven/internal/...,github.com/ravencloak-org/Raven/pkg/...,github.com/ravencloak-org/Raven/cmd/...
           DOTENV_PRIVATE_KEY_CI: ${{ secrets.DOTENV_PRIVATE_KEY_CI }}
           TESTCONTAINERS_RYUK_DISABLED: "true"
 
       - name: Run integration tests with coverage
         run: |
           go test -tags=integration -race -timeout 5m \
-            -coverprofile=coverage-integration.txt \
-            -coverpkg=./internal/... \
-            ./internal/integration/
+            -cover -coverpkg="$COV_PKGS" \
+            ./internal/integration/ \
+            -args -test.gocoverdir="$PWD/.coverdata/integration"
         env:
+          COV_PKGS: github.com/ravencloak-org/Raven/internal/...,github.com/ravencloak-org/Raven/pkg/...,github.com/ravencloak-org/Raven/cmd/...
           TESTCONTAINERS_RYUK_DISABLED: "true"
 
       - name: Merge coverage profiles
+        if: always()
         run: |
-          # Combine unit + integration coverage
-          if [ -f coverage-integration.txt ]; then
-            go tool covdata merge -i=coverage.txt,coverage-integration.txt -o=coverage-merged.txt 2>/dev/null || \
-            { head -1 coverage.txt > coverage-merged.txt; tail -n +2 coverage.txt >> coverage-merged.txt; tail -n +2 coverage-integration.txt >> coverage-merged.txt; }
-          else
-            cp coverage.txt coverage-merged.txt
+          INPUTS=""
+          for d in unit migrations integration; do
+            if compgen -G ".coverdata/$d/cov*" >/dev/null; then
+              INPUTS="${INPUTS:+$INPUTS,}.coverdata/$d"
+            fi
+          done
+          if [ -z "$INPUTS" ]; then
+            echo "::warning::no coverage data collected"
+            exit 0
           fi
+          echo "merging: $INPUTS"
+          go tool covdata textfmt -i="$INPUTS" -o=coverage/cov.out
+          go tool covdata percent -i="$INPUTS" | tee coverage/summary.txt
+          go tool cover -func=coverage/cov.out | tail -1 | tee -a coverage/summary.txt
+          go tool cover -html=coverage/cov.out -o coverage/coverage.html
+
+      - name: Upload coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-data
+          path: |
+            .coverdata/
+            coverage/
+          retention-days: 5
 
       - uses: codecov/codecov-action@v6
+        if: always()
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage-merged.txt
+          files: coverage/cov.out
           fail_ci_if_error: false
 
       - run: go vet ./...

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,9 @@ coverage.txt
 coverage.html
 htmlcov/
 .coverage
+.coverdata/
+coverage/
+bin/api-cover
 
 # Worktrees
 .worktrees/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,17 @@
-.PHONY: build run dev test test-integration bench-integration lint migrate-up migrate-down proto swagger compose compose-down
+.PHONY: build build-cover run dev test test-integration bench-integration coverage coverage-unit coverage-integration coverage-html coverage-clean lint migrate-up migrate-down proto swagger compose compose-down
 
 build:
 	go build -o bin/api ./cmd/api
+
+# Build an instrumented `./cmd/api` binary that writes coverage counters to
+# $$GOCOVERDIR at runtime. Point GOCOVERDIR at .coverdata/binary/ (or any dir)
+# before invoking the resulting binary in your harness; `make coverage` will
+# pick up anything it finds there automatically.
+build-cover:
+	mkdir -p bin .coverdata/binary
+	go build -cover \
+		-coverpkg=github.com/ravencloak-org/Raven/internal/...,github.com/ravencloak-org/Raven/pkg/...,github.com/ravencloak-org/Raven/cmd/... \
+		-o bin/api-cover ./cmd/api
 
 run:
 	dotenvx run -- go run ./cmd/api
@@ -17,6 +27,23 @@ test-integration:
 
 bench-integration:
 	go test -tags=integration ./internal/integration/ -bench=. -benchmem -timeout 10m
+
+# Produce a merged unit + integration (+ instrumented-binary if present)
+# coverage report. See scripts/coverage.sh for the full pipeline.
+coverage:
+	./scripts/coverage.sh
+
+coverage-unit:
+	SKIP_INTEGRATION=1 ./scripts/coverage.sh
+
+coverage-integration:
+	SKIP_UNIT=1 ./scripts/coverage.sh
+
+coverage-html: coverage
+	@printf 'open %s/coverage/coverage.html in a browser\n' "$$PWD"
+
+coverage-clean:
+	rm -rf .coverdata coverage
 
 lint:
 	golangci-lint run

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Generate a merged Go coverage report across unit, integration, and (optionally)
+# instrumented-binary runs, using the Go 1.20+ coverage-directory format so
+# multiple runs can be merged with `go tool covdata`.
+#
+# Outputs:
+#   .coverdata/unit/          raw coverage from `go test ./...`
+#   .coverdata/integration/   raw coverage from `go test -tags=integration`
+#   .coverdata/binary/        raw coverage from any instrumented-binary runs
+#                             (populated externally; see `make build-cover`)
+#   coverage/cov.out          merged legacy textfmt profile
+#   coverage/coverage.html    browsable HTML report
+#   coverage/summary.txt      per-package percent summary
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+COV_ROOT="${COV_ROOT:-$ROOT/.coverdata}"
+OUT_DIR="${OUT_DIR:-$ROOT/coverage}"
+COV_PKGS="${COV_PKGS:-github.com/ravencloak-org/Raven/internal/...,github.com/ravencloak-org/Raven/pkg/...,github.com/ravencloak-org/Raven/cmd/...}"
+
+SKIP_UNIT="${SKIP_UNIT:-0}"
+SKIP_INTEGRATION="${SKIP_INTEGRATION:-0}"
+
+log() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+
+mkdir -p "$COV_ROOT/unit" "$COV_ROOT/integration" "$COV_ROOT/binary" "$OUT_DIR"
+
+if [ "$SKIP_UNIT" != "1" ]; then
+  log "Running unit tests with coverage into $COV_ROOT/unit"
+  rm -f "$COV_ROOT/unit"/cov*
+  if command -v dotenvx >/dev/null 2>&1 && [ -f .env.ci ]; then
+    dotenvx run -f .env.ci --quiet -- \
+      go test -cover -coverpkg="$COV_PKGS" -timeout 30m ./... \
+      -args -test.gocoverdir="$COV_ROOT/unit"
+  else
+    go test -cover -coverpkg="$COV_PKGS" -timeout 30m ./... \
+      -args -test.gocoverdir="$COV_ROOT/unit"
+  fi
+fi
+
+if [ "$SKIP_INTEGRATION" != "1" ]; then
+  log "Running integration tests with coverage into $COV_ROOT/integration"
+  rm -f "$COV_ROOT/integration"/cov*
+  go test -tags=integration -cover -coverpkg="$COV_PKGS" \
+    -timeout 10m ./internal/integration/ \
+    -args -test.gocoverdir="$COV_ROOT/integration"
+fi
+
+INPUTS=()
+for d in unit integration binary; do
+  if compgen -G "$COV_ROOT/$d/cov*" >/dev/null; then
+    INPUTS+=("$COV_ROOT/$d")
+  fi
+done
+
+if [ "${#INPUTS[@]}" -eq 0 ]; then
+  echo "no coverage data found under $COV_ROOT" >&2
+  exit 1
+fi
+
+IFS=','; INPUT_CSV="${INPUTS[*]}"; unset IFS
+
+log "Merging coverage from: $INPUT_CSV"
+go tool covdata textfmt -i="$INPUT_CSV" -o="$OUT_DIR/cov.out"
+
+log "Writing HTML report to $OUT_DIR/coverage.html"
+go tool cover -html="$OUT_DIR/cov.out" -o "$OUT_DIR/coverage.html"
+
+log "Writing per-package summary to $OUT_DIR/summary.txt"
+go tool covdata percent -i="$INPUT_CSV" | tee "$OUT_DIR/summary.txt"
+
+TOTAL="$(go tool cover -func="$OUT_DIR/cov.out" | awk '/^total:/ {print $3}')"
+log "Total coverage: ${TOTAL:-unknown}"


### PR DESCRIPTION
Implements the approach from the DoltHub blog post [Automated Go test coverage production](https://www.dolthub.com/blog/2026-04-17-automating-go-test-coverage/), adapted to Raven.

## Summary
- Switch unit, migration, and integration test runs in CI to the Go 1.20+ `-test.gocoverdir=DIR` coverage format so they can be merged with `go tool covdata textfmt` (replaces the previous concat hack that was relying on a failing `go tool covdata merge` fallback).
- Add `scripts/coverage.sh` as the single source of truth for producing a merged report locally; honours `SKIP_UNIT=1` / `SKIP_INTEGRATION=1` so you can iterate on one side.
- New Makefile targets: `coverage`, `coverage-unit`, `coverage-integration`, `coverage-html`, `coverage-clean`, and `build-cover` (produces an instrumented `./cmd/api` binary at `bin/api-cover` that writes counters to `$GOCOVERDIR` on exit — useful for any harness that exercises the running binary, e.g. Playwright e2e or future BATS-style CLI tests).
- CI uploads `.coverdata/` + rendered `coverage/coverage.html` as a workflow artifact (`coverage-data`, retention 5 days) and continues to publish the textfmt profile to Codecov.
- `.gitignore` updated for `.coverdata/`, `coverage/`, `bin/api-cover`.

Coverpkg in every run: `internal/...`, `pkg/...`, `cmd/...`.

## Test plan
- [x] `bash -n scripts/coverage.sh` passes
- [x] Verified end-to-end locally on `./internal/crypto/... ./pkg/apierror/...`: new-format counter/meta files written → `covdata textfmt` produces a valid profile → `go tool cover -html` renders → `go tool cover -func` reports total
- [x] `make build-cover` builds; running `bin/api-cover` with `GOCOVERDIR=.coverdata/binary` writes counters on exit even when the program aborts early
- [x] Workflow YAML parses (`python3 -c 'yaml.safe_load(...)'`)
- [ ] Full CI run on this PR to confirm the merge/artifact/Codecov steps behave as expected