### PR TITLE
docs(osps): add SECURITY.md and MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,101 @@
+# Maintainers
+
+This document lists the people with sensitive access to the Raven project,
+their roles, and how additional maintainers are added. It satisfies the
+OpenSSF Baseline L2 controls **OSPS-GV-01.01** (list of members with sensitive
+access) and **OSPS-GV-01.02** (roles and responsibilities).
+
+## Current Maintainers
+
+| Name            | GitHub           | Role            | Areas of Ownership | Access Level |
+| --------------- | ---------------- | --------------- | ------------------ | ------------ |
+| Jobin Lawrance  | [@jobinlawrance](https://github.com/jobinlawrance) | Lead maintainer | All areas          | Admin        |
+
+"Sensitive access" here means any of the following on the
+[ravencloak-org/Raven](https://github.com/ravencloak-org/Raven) repository or
+the surrounding `ravencloak-org` GitHub organisation:
+
+- Admin on the repository (write, merge, and settings changes, including
+  branch protection rules)
+- Permission to push directly to protected branches (disabled in policy, but
+  access level still implies the capability)
+- Permission to publish releases or manage release artifacts
+- Permission to manage GitHub Actions secrets and environments
+- Permission to manage organisation-level settings, teams, and membership
+
+## Roles and Responsibilities
+
+### Lead maintainer
+
+The lead maintainer is accountable for the overall direction and health of the
+project. Concretely, that covers:
+
+- **Review authority:** may approve and merge pull requests. The lead
+  maintainer is listed as the default `CODEOWNERS` for the repository until
+  further owners are added.
+- **Release management:** cuts SemVer-tagged releases from `main`, signs
+  release artifacts via the project's release pipeline, and publishes release
+  notes and security advisories.
+- **Security triage:** is the primary recipient of reports filed under
+  [`SECURITY.md`](./SECURITY.md), owns the 72-hour acknowledgement SLA, drafts
+  GitHub Security Advisories, and coordinates CVE assignment.
+- **Project direction:** sets the roadmap, owns milestone planning, and makes
+  the final call on scope, technology choices, and breaking changes.
+- **Governance:** maintains this document, `CONTRIBUTING.md`,
+  `SECURITY.md`, and other governance files; enforces branch protection and
+  access policies on the repository and the `ravencloak-org` organisation.
+
+### Contributors
+
+Contributors submit issues, pull requests, and reviews but do not hold write
+access to the repository. Contribution requirements are documented in
+[`CONTRIBUTING.md`](./CONTRIBUTING.md).
+
+## Becoming a Maintainer
+
+Raven currently has a single maintainer. Additional maintainers will be added
+as the project grows and a track record of contribution is established. There
+is no fixed quota and no guaranteed path; the criteria below are the floor
+rather than an exhaustive checklist.
+
+### Criteria
+
+A candidate for maintainer is expected to demonstrate, over time:
+
+- **Sustained contribution:** a meaningful number of merged pull requests
+  across more than one area of the codebase (for example, API, AI worker,
+  frontend, docs, CI). A rough reference point is 10+ non-trivial contributions
+  over 3+ months, but quality, review participation, and subject-matter depth
+  weigh more than raw count.
+- **Good judgement in review:** thoughtful and technically rigorous code
+  review on others' pull requests.
+- **Alignment with project conventions:** familiarity with and adherence to
+  the conventions in [`CONTRIBUTING.md`](./CONTRIBUTING.md), the commit and
+  branch style documented in the repository, and the security posture in
+  [`SECURITY.md`](./SECURITY.md).
+- **Trustworthiness around sensitive access:** demonstrated care with
+  secrets, credentials, dependencies, and the release pipeline.
+
+### Process
+
+1. **Nomination.** An existing maintainer nominates the candidate in an issue
+   on the repository, summarising their contributions and proposed area of
+   ownership.
+2. **Consensus.** All existing maintainers must agree. While there is only one
+   maintainer, the decision rests with that maintainer; once additional
+   maintainers are added, nominations require consensus from all of them.
+3. **Access grant.** The candidate enables two-factor authentication on their
+   GitHub account, their access level is raised on the repository and the
+   organisation, and this document is updated in the same pull request that
+   records the addition.
+
+### Stepping down
+
+Maintainers may step down at any time by opening a pull request that updates
+this document. Inactive maintainers (no reviews, PRs, or security-triage
+activity for 6 consecutive months) may be moved to emeritus status by the
+remaining maintainers, with their access reduced accordingly.
+
+---
+
+Last updated: 2026-04-19.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,143 @@
+# Security Policy
+
+Raven takes the security of its users, operators, and contributors seriously.
+This document describes how to report vulnerabilities, what response you can
+expect, and the scope of this policy.
+
+## Supported Versions
+
+Security fixes are provided for the following versions:
+
+| Version                | Supported          |
+| ---------------------- | ------------------ |
+| `main` branch (HEAD)   | Yes                |
+| Latest tagged release  | Yes                |
+| All other versions     | No                 |
+
+Once multiple release lines exist, this table will be expanded with explicit
+version ranges and end-of-life dates.
+
+## Reporting a Vulnerability
+
+Please **do not** open public GitHub issues, pull requests, or discussions for
+suspected vulnerabilities. Use one of the private channels below.
+
+### Primary: GitHub Security Advisories (private reporting)
+
+Report through GitHub's private vulnerability reporting:
+
+<https://github.com/ravencloak-org/Raven/security/advisories/new>
+
+This is the preferred channel because it keeps the report, discussion, patch,
+and CVE assignment in a single place visible only to maintainers and invited
+collaborators.
+
+### Fallback: Email
+
+If you cannot use GitHub Security Advisories, email:
+
+- `security@ravencloak.org` (preferred)
+- `jobinlawrance@gmail.com` (temporary until `security@ravencloak.org` is
+  provisioned)
+
+Encrypt sensitive details where possible. A PGP key will be published here once
+the `security@` alias is live.
+
+### What to include
+
+To help us triage quickly, please include as much of the following as you can:
+
+- Affected component (API, AI worker, frontend, deployment manifests, etc.)
+- Affected versions or commit SHAs
+- A clear description of the issue and its impact
+- Reproduction steps, proof-of-concept, or exploit code
+- Any suggested mitigation or fix
+- Whether you would like public credit, and under what name
+
+## Response SLA
+
+| Stage                          | Target                  |
+| ------------------------------ | ----------------------- |
+| Initial acknowledgement        | Within **72 hours**     |
+| Triage and severity assessment | Within **7 days**       |
+| Fix, disclosure, and release   | Within **90 days**      |
+
+The 90-day window is the coordinated disclosure target. If a fix requires more
+time (for example, because the root cause spans an upstream dependency), we
+will agree an extended timeline with the reporter in writing.
+
+If we do not respond within the acknowledgement window, please escalate by
+emailing `jobinlawrance@gmail.com` directly and referencing your original
+report.
+
+## Disclosure Process
+
+1. Maintainers confirm the report and assess severity (CVSS where applicable).
+2. A fix is developed in a private fork or a temporary private branch.
+3. A GitHub Security Advisory (GHSA) is drafted in the repository.
+4. A CVE is requested through GitHub's CNA where the issue qualifies.
+5. A patched release is prepared and the advisory is published at release time.
+6. The reporter is credited in the advisory unless they opt out.
+
+Public disclosure happens via the published GitHub Security Advisory, the CVE
+record, and the release notes of the fixed version.
+
+## Scope
+
+### In scope
+
+All code, configuration, and documentation released under the top-level
+`LICENSE` file, including:
+
+- Go API (`cmd/`, `internal/`, `pkg/`)
+- Python AI worker (`ai-worker/`)
+- Frontend (`frontend/`)
+- Database migrations (`migrations/`)
+- Deployment manifests (`deploy/`, `docker-compose*.yml`, `Dockerfile*`)
+- Public documentation (`docs/`, `README.md`, `DEVELOPMENT.md`,
+  `CONTRIBUTING.md`, `SECURITY.md`, `MAINTAINERS.md`)
+- Build and release artifacts produced for tagged releases
+
+### Out of scope
+
+- Enterprise (EE) content released under `ee-LICENSE` (files such as
+  `ee-LICENSE`, `ee-README.md`, and any future `ee-*` content). EE content has
+  its own, separate handling process.
+- Third-party services, infrastructure, or dependencies not authored in this
+  repository. Report those to the corresponding upstream project.
+- Social engineering, physical attacks, and denial-of-service attacks against
+  infrastructure you do not own.
+- Findings that require a non-default, unsupported, or end-of-life
+  configuration.
+
+## Safe Harbor
+
+We support good-faith security research. If you make a good-faith effort to
+comply with this policy during your research, we will:
+
+- Consider your research authorised with respect to this project.
+- Not pursue or support any legal action against you related to your research.
+- Work with you to understand and resolve the issue promptly.
+
+Good faith means, at minimum:
+
+- You avoid privacy violations, data destruction, and degradation of service
+  for other users.
+- You only interact with test accounts you own or accounts for which you have
+  explicit permission from the account holder.
+- You give us reasonable time to fix the issue before any public disclosure.
+- You do not exploit the issue beyond what is necessary to demonstrate it.
+
+This safe harbor applies only to the OSS components listed under **In scope**.
+It does not grant permission to attack third-party services, and it cannot
+waive obligations you may have to third parties.
+
+## Maintainers and Escalation
+
+The list of maintainers authorised to receive and triage security reports is
+published in [`MAINTAINERS.md`](./MAINTAINERS.md). Reports sent through the
+channels above reach those maintainers directly.
+
+---
+
+Last updated: 2026-04-19.


### PR DESCRIPTION
## Summary

Adds `SECURITY.md` and `MAINTAINERS.md` to satisfy five OpenSSF Baseline L2
controls (Phase 1 of the OSPS L2 compliance milestone).

## Controls satisfied

- **OSPS-VM-01.01** — Coordinated Vulnerability Disclosure (CVD) policy, with
  a 90-day disclosure window, in `SECURITY.md`.
- **OSPS-VM-02.01** — Security contacts (GitHub private advisories as primary,
  `security@ravencloak.org` with `jobinlawrance@gmail.com` as a temporary
  fallback) in `SECURITY.md`.
- **OSPS-VM-04.01** — Vulnerability publishing process via GitHub Security
  Advisories and CVE assignment, documented in `SECURITY.md`.
- **OSPS-GV-01.01** — List of members with sensitive access in
  `MAINTAINERS.md`.
- **OSPS-GV-01.02** — Roles and responsibilities for maintainers and the path
  for additional maintainers in `MAINTAINERS.md`.

## Design reference

- Spec: `docs/superpowers/specs/2026-04-19-osps-l2-compliance-design.md`
  (Sections 1, 2 — VM and GV rows, and 4 — Phase 1).

## Notes

- Scope for security reports is limited to the OSS portion (content under
  `LICENSE`); `ee-LICENSE` content is explicitly out of scope.
- `SECURITY.md` and `MAINTAINERS.md` cross-reference each other.
- `security@ravencloak.org` is flagged as the preferred address with
  `jobinlawrance@gmail.com` as an explicit temporary fallback until the alias
  is provisioned.

## Test plan

- [ ] Review `SECURITY.md` for accuracy (supported versions, SLA, scope, safe
      harbor wording).
- [ ] Verify the GitHub Security Advisories URL resolves for the repo.
- [ ] Confirm the 72h / 7d / 90d SLA is acceptable.
- [ ] Verify `security@ravencloak.org` is the intended canonical address and
      that using `jobinlawrance@gmail.com` as a temporary fallback is
      acceptable.
- [ ] Review `MAINTAINERS.md` for correct name, GitHub handle, role, and
      access level.
- [ ] Confirm the "Becoming a maintainer" criteria and process are acceptable.