### PR TITLE
ci(osps): add CodeQL SAST workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,85 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/*.go'
+      - '**/*.py'
+      - '**/*.ts'
+      - '**/*.tsx'
+      - '**/*.js'
+      - '**/*.vue'
+      - 'go.mod'
+      - 'go.sum'
+      - 'frontend/package.json'
+      - 'frontend/bun.lock'
+      - 'ai-worker/pyproject.toml'
+      - 'ai-worker/requirements*.txt'
+      - '.github/workflows/codeql.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - '**/*.go'
+      - '**/*.py'
+      - '**/*.ts'
+      - '**/*.tsx'
+      - '**/*.js'
+      - '**/*.vue'
+      - 'go.mod'
+      - 'go.sum'
+      - 'frontend/package.json'
+      - 'frontend/bun.lock'
+      - 'ai-worker/pyproject.toml'
+      - 'ai-worker/requirements*.txt'
+      - '.github/workflows/codeql.yml'
+  schedule:
+    - cron: '23 6 * * 1'
+
+permissions: {}
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: go
+            build-mode: autobuild
+          - language: python
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+
+      - name: Setup Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
+        with:
+          go-version: '1.26.2'
+          cache: true
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@865f5f5c36632f18690a3d569fa0a764f2da0c3e  # v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-extended
+
+      - name: Autobuild
+        if: matrix.build-mode == 'autobuild'
+        uses: github/codeql-action/autobuild@865f5f5c36632f18690a3d569fa0a764f2da0c3e  # v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@865f5f5c36632f18690a3d569fa0a764f2da0c3e  # v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

Adds CodeQL static analysis for Go, Python, and JavaScript/TypeScript. Implements **OSPS-SA-02** from the [OpenSSF Baseline L2](https://baseline.openssf.org/versions/2026-02-19) target (see design spec in #330).

- Triggers on PR, push to main (language-relevant paths only), and weekly (Mon 06:23 UTC — staggered from other security workflows).
- Matrix: `go` (autobuild), `python` (build-mode: none), `javascript-typescript` (build-mode: none).
- Query suite: `security-extended`.
- Top-level `permissions: {}`; per-job grants limited to `security-events: write`, `contents: read`, `actions: read`.
- All action SHAs pinned to commit digests (no floating tags).

## Test plan

- [ ] Workflow appears in Actions tab after merge
- [ ] First scheduled run produces findings visible at Security → Code scanning
- [ ] PR-triggered run completes in <30 min
- [ ] No false-positive failures on clean main branch