### PR TITLE
docs(osps): architecture + dependency policy + README licensing

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@
   <a href="https://github.com/ravencloak-org/Raven/actions/workflows/docker.yml"><img src="https://github.com/ravencloak-org/Raven/actions/workflows/docker.yml/badge.svg" alt="Docker Build" /></a>
   <a href="https://github.com/ravencloak-org/Raven/actions/workflows/security.yml"><img src="https://github.com/ravencloak-org/Raven/actions/workflows/security.yml/badge.svg" alt="Security" /></a>
   <a href="https://codecov.io/gh/ravencloak-org/Raven"><img src="https://codecov.io/gh/ravencloak-org/Raven/branch/main/graph/badge.svg" alt="Coverage" /></a>
-  <img src="https://img.shields.io/badge/license-TBD-lightgrey" alt="License" />
+  <a href="./LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License: Apache 2.0" /></a>
+  <a href="https://baseline.openssf.org/versions/2026-02-19"><img src="https://img.shields.io/badge/OpenSSF%20Baseline-L2%20target-blue" alt="OpenSSF Baseline L2" /></a>
   <img src="https://img.shields.io/badge/PRs-welcome-blue" alt="PRs Welcome" />
 </p>
 <p><a href="https://www.bestpractices.dev/projects/12590"><img src="https://www.bestpractices.dev/projects/12590/badge"></a>
@@ -24,7 +25,7 @@
 
 Raven is a self-hostable, multi-tenant knowledge base platform that lets organizations ingest documents and web content, then query them through AI-powered channels -- an embeddable chatbot, a real-time voice agent, and WhatsApp. It combines hybrid retrieval (vector search + BM25), BYOK LLM support, and a modular architecture designed for both cloud and edge deployment.
 
-The platform is organized around a clear hierarchy: **Organizations** (tenant boundaries) contain **Workspaces** (operational sub-units), which contain **Knowledge Bases** (collections of documents and web sources). Each layer enforces data isolation through PostgreSQL Row-Level Security, Keycloak-based authentication, and API middleware.
+The platform is organized around a clear hierarchy: **Organizations** (tenant boundaries) contain **Workspaces** (operational sub-units), which contain **Knowledge Bases** (collections of documents and web sources). Each layer enforces data isolation through PostgreSQL Row-Level Security, SuperTokens-based authentication, and API middleware.
 
 Raven is built for teams that need a production-grade RAG platform without vendor lock-in. Bring your own LLM keys (Anthropic, OpenAI, Cohere), deploy on a cloud VM or a Raspberry Pi, and own your data end to end.
 
@@ -43,7 +44,7 @@ Raven is built for teams that need a production-grade RAG platform without vendo
 
 Raven uses a **two-process architecture**: a Go API server handles HTTP routing, authentication, and orchestration, while a Python AI worker handles all ML/AI workloads (embedding, RAG queries, document parsing, web scraping). The two communicate over gRPC, with Valkey (Redis-compatible) as the async job queue.
 
-PostgreSQL serves as the single source of truth -- storing relational data, vector embeddings (pgvector), and full-text search indexes. A Vue.js SPA provides the admin dashboard, and Keycloak handles identity management.
+PostgreSQL serves as the single source of truth -- storing relational data, vector embeddings (pgvector), and full-text search indexes. A Vue.js SPA provides the admin dashboard, and SuperTokens handles identity management.
 
 ## Tech Stack
 
@@ -54,7 +55,7 @@ PostgreSQL serves as the single source of truth -- storing relational data, vect
 | **Database** | PostgreSQL 18 + pgvector | Relational data, vector search, BM25 full-text |
 | **Frontend** | Vue.js 3 + Tailwind CSS | Admin dashboard (SPA, mobile-first, PWA-capable) |
 | **Chatbot Widget** | Web Component | Embeddable `<raven-chat>` element |
-| **Auth** | Keycloak | OIDC/OAuth2, user management, multi-tenant realms |
+| **Auth** | SuperTokens | Email/password + OAuth (Google), session management, MFA |
 | **Job Queue** | Valkey (Redis fork) | Async document processing, caching, rate limiting |
 | **Object Storage** | SeaweedFS | S3-compatible file storage (Apache 2.0) |
 | **Voice** | LiveKit Server + Agents | WebRTC SFU, STT/LLM/TTS voice pipeline |
@@ -69,7 +70,7 @@ cp .env.example .env        # fill in required values (see comments inside)
 docker compose up -d        # starts all services
 ```
 
-The admin dashboard is available at `http://localhost:3000` once all containers are healthy. See [docs/quickstart.md](docs/quickstart.md) for a full walkthrough including first-user setup and Keycloak configuration.
+The admin dashboard is available at `http://localhost:3000` once all containers are healthy. See [docs/quickstart.md](docs/quickstart.md) for a full walkthrough including first-user setup and SuperTokens configuration.
 
 For local development without Docker, see [DEVELOPMENT.md](DEVELOPMENT.md).
 
@@ -122,6 +123,17 @@ Contributions are welcome. Please open an issue to discuss proposed changes befo
 - Browse [open issues](../../issues) for tasks and bug reports
 - See the [architecture overview](docs/wiki/Architecture-Overview.md) and [data model](docs/wiki/Data-Model.md) for context
 
-## License
+## Security
 
-License TBD -- to be determined before public release.
+Vulnerability disclosure, supported versions, and response SLAs are in [SECURITY.md](SECURITY.md). Please do not open public issues for suspected security problems; use GitHub private advisories instead.
+
+Current maintainers and their areas of ownership are in [MAINTAINERS.md](MAINTAINERS.md).
+
+## Licensing
+
+Raven is dual-licensed:
+
+- **Open-source portion** — everything in this repository is licensed under the [Apache License 2.0](./LICENSE) **except** files and directories whose name begins with `ee-`.
+- **Enterprise portion** — files prefixed with `ee-` (for example `ee-LICENSE`, `ee-README.md`) are covered by the [Raven Enterprise License](./ee-LICENSE) and are **not** open-source. They are not included in any Apache-2.0 obligations, nor in the release artifacts that target OpenSSF Baseline compliance.
+
+The open-source portion targets [OpenSSF Baseline 2026-02-19](https://baseline.openssf.org/versions/2026-02-19) **Level 2** compliance. See [`docs/architecture.md`](docs/architecture.md) for a system-level overview and [`docs/dependency-policy.md`](docs/dependency-policy.md) for how we manage supply chain.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,157 @@
+# Raven — Architecture Overview
+
+This document describes the Raven system's actors, components, and trust boundaries at a level sufficient for a security reviewer or new contributor to reason about data flow and attack surface. It satisfies **OSPS-SA-01.01** from the [OpenSSF Baseline](https://baseline.openssf.org/versions/2026-02-19).
+
+For a deeper feature-level walkthrough see [`docs/wiki/Architecture-Overview.md`](wiki/Architecture-Overview.md). For the historical design document see [`docs/superpowers/specs/`](superpowers/specs/).
+
+> **Threat model & attack-surface analysis** are deferred to Level 3 compliance and will be tracked in `docs/compliance/` once added.
+
+## System Diagram
+
+```mermaid
+flowchart LR
+    subgraph External
+      U[End users / admins]
+      EMB[Embedded chat widget]
+      WA[WhatsApp Business API]
+    end
+
+    subgraph Edge-or-cloud
+      FE[Vue 3 SPA<br/>admin dashboard]
+      API[Go + Gin API<br/>cmd/ + internal/]
+      AUTH[SuperTokens<br/>auth service]
+      QUE[Valkey<br/>Asynq queue]
+      WORK[Python gRPC<br/>AI worker<br/>ai-worker/]
+      DB[(PostgreSQL 18<br/>+ pgvector + BM25)]
+      OBJ[(SeaweedFS<br/>S3-compatible)]
+      LK[LiveKit<br/>SFU + agents]
+      OO[OpenObserve<br/>app telemetry]
+      BES[Beszel<br/>host metrics]
+    end
+
+    U --> FE
+    EMB --> API
+    WA --> API
+    FE --> API
+    API --> AUTH
+    API --> DB
+    API --> QUE
+    API --> WORK
+    API --> OBJ
+    API --> LK
+    WORK --> DB
+    WORK --> OBJ
+    QUE --> WORK
+    API -.-> OO
+    WORK -.-> OO
+    API -.-> BES
+```
+
+## Actors
+
+| Actor | Interaction | Trust level |
+|---|---|---|
+| End user (org member) | Uses the SPA or embedded widget | Low — authenticated via SuperTokens |
+| Admin (org owner) | Manages workspaces, KBs, API keys | Medium — session-scoped, MFA recommended |
+| API client (external system) | Calls `/api/v1/*` with API key | Low — key-scoped to a KB |
+| LLM provider (Anthropic / OpenAI / Cohere) | Called by AI worker with tenant-supplied keys (BYOK) | External — no credentials flow back to Raven |
+| AI worker | Embeds, retrieves, generates responses | Internal — trusted, sandboxed via gRPC boundary |
+| Ingestion job | Parses uploaded documents / scraped pages | Internal — untrusted input |
+| Observability agent (OpenObserve, Beszel) | Receives telemetry | Internal — one-way push |
+
+## Components
+
+| Component | Language / Runtime | Responsibility |
+|---|---|---|
+| API server | Go 1.26 + Gin | REST, auth, tenant routing, SSE streaming, RLS-scoped DB access |
+| AI worker | Python + gRPC | Embedding generation, hybrid retrieval (pgvector + BM25 + RRF), LLM orchestration, document parsing |
+| Frontend | Vue 3 + TypeScript + Tailwind | Admin dashboard (SPA), embeddable `<raven-chat>` web component |
+| Auth | SuperTokens | Email/password + OAuth (Google), session management, MFA |
+| Database | PostgreSQL 18 | Primary store; pgvector for embeddings, ParadeDB/BM25 for lexical search, RLS for tenant isolation |
+| Job queue | Valkey + Asynq (Go) | Asynchronous document processing, rate limiting, SHA256 response cache |
+| Object storage | SeaweedFS | S3-compatible file store for uploads + media |
+| Realtime media | LiveKit (server + agents) | WebRTC SFU, voice pipeline (STT → LLM → TTS) |
+| App telemetry | OpenObserve | Logs, traces, metrics via OpenTelemetry |
+| Host metrics | Beszel | Agent + hub for Raspberry Pi / VM host vitals |
+
+## Data Hierarchy
+
+```
+Organization  (tenant boundary — PostgreSQL RLS)
+  └── Workspace  (operational sub-unit within org)
+       └── Knowledge Base  (collection of documents + web sources)
+            ├── Source  (upload, URL, scrape)
+            │    └── Document  (parsed content)
+            │         └── Chunk  (retrieval unit)
+            │              └── Embedding  (pgvector + BM25 index)
+            └── APIKey  (KB-scoped, used by embeddable widget / external clients)
+```
+
+RLS policies on `documents`, `chunks`, `embeddings`, `cache`, and `sources` enforce that `org_id` on every row matches the session's `app.org_id` setting. Cross-org reads return zero rows; cross-org writes fail.
+
+## Trust Boundaries
+
+1. **External ↔ API** — every request traverses the API's auth middleware. Embeddable widget traffic authenticates by API key bound to a specific KB; browser sessions use SuperTokens cookies.
+2. **API ↔ Data plane (DB, Valkey, object store)** — the API holds the only credentials and always sets `app.org_id` before any query. Direct DB access from any other component is forbidden.
+3. **API ↔ AI worker (gRPC)** — intra-network gRPC; the worker does not trust arbitrary callers but in practice is reachable only from the API.
+4. **Edge ↔ Cloud (optional)** — when deployed split between a Raspberry Pi (API) and a cloud AI worker, the gRPC channel is TLS-terminated; the edge node holds only short-lived session material.
+5. **User content ↔ LLM providers** — tenant-supplied BYOK credentials live in Postgres (encrypted at rest). The AI worker uses them for outbound calls; response content is stored in the per-KB cache when hit.
+
+## Core Data Flows
+
+### Document ingestion
+
+```
+user → FE upload form → API /sources → SeaweedFS (blob)
+                              │
+                              ▼
+                        Valkey queue (ingest job)
+                              │
+                              ▼
+                        AI worker: parse → chunk → embed → persist
+                              │
+                              ▼
+                        PostgreSQL (chunks + embeddings)
+```
+
+### Chat / retrieval
+
+```
+user → FE or embedded widget → API /chat
+                                  │
+                                  ▼
+                              AI worker (gRPC):
+                                1. Hybrid search (pgvector + BM25 + RRF)
+                                2. Response cache lookup (SHA256 of query)
+                                3. If miss: LLM call with retrieved context
+                                4. Store response in cache
+                                  │
+                                  ▼
+                              API → SSE stream → client
+```
+
+### Voice session
+
+```
+user → FE WebRTC client → LiveKit SFU
+                             │
+                             ▼
+                        LiveKit agent (Python):
+                             STT → LLM (via AI worker) → TTS
+                             │
+                             ▼
+                        LiveKit SFU → audio back to user
+```
+
+## Security-Relevant Notes
+
+- **Secrets at rest** — tenant API keys (for LLM providers) encrypted with per-deployment AES-GCM; encryption key held in env (`RAVEN_SECRET_KEY`) or KMS.
+- **Session transport** — all external traffic is TLS (Traefik terminates); WebSockets and SSE inherit the outer TLS.
+- **Tenant isolation** — enforced at the row level by RLS (database layer), not relying on application-layer filtering alone.
+- **Dependency trust** — see [`docs/dependency-policy.md`](dependency-policy.md).
+- **Vulnerability disclosure** — see [`SECURITY.md`](../SECURITY.md).
+
+## Out of Scope
+
+- **Enterprise Edition** (files prefixed `ee-`) are licensed separately and not part of the L2-compliance scope.
+- **Billing integrations** (Razorpay / Hyperswitch / UPI) use tenant-supplied gateway keys and inherit the BYOK trust model.

--- a/docs/dependency-policy.md
+++ b/docs/dependency-policy.md
@@ -1,0 +1,74 @@
+# Dependency Policy
+
+How Raven selects, obtains, and tracks its dependencies. Satisfies **OSPS-DO-06.01** from the [OpenSSF Baseline](https://baseline.openssf.org/versions/2026-02-19).
+
+## Selection Criteria
+
+New dependencies are evaluated against:
+
+1. **License** — must be compatible with Apache 2.0 (the OSS project license). Preferred: Apache 2.0, MIT, BSD-2/3-Clause, ISC, MPL 2.0. Avoided without maintainer review: GPL / AGPL / SSPL / other copyleft.
+2. **Maintenance signal** — release within the last 12 months, active issue tracker, responsive to security reports.
+3. **Maintainer breadth** — prefer more than one active maintainer on the upstream.
+4. **Security track record** — no unresolved high-severity CVEs; a published security policy is a plus.
+5. **Footprint** — the minimum that solves the problem. Transitive dep count matters, especially for the edge/Raspberry Pi target.
+6. **Supply chain** — packages published under an identifiable org account; avoid long-tail single-author packages for security-sensitive paths.
+
+## Obtaining
+
+| Ecosystem | Source of truth | Lockfile | Registry |
+|---|---|---|---|
+| Go | `go.mod` | `go.sum` | proxy.golang.org (default) |
+| Python (ai-worker) | `ai-worker/pyproject.toml` (and/or `requirements*.txt`) | pip-tools output | PyPI |
+| Node / Bun (frontend) | `frontend/package.json` | `frontend/bun.lock` | npm registry |
+| Docker base images | `Dockerfile` and `ai-worker/Dockerfile` | tag pins | Docker Hub / GHCR official repos |
+| GitHub Actions | `.github/workflows/*.yml` | commit SHA pins | github.com |
+
+GitHub Actions are **pinned to commit SHA**, not floating tags. This prevents silent supply-chain attacks where a tag is retargeted.
+
+## Tracking
+
+Automated monitoring covers each ecosystem weekly:
+
+- **[Dependabot](../.github/dependabot.yml)** — weekly PRs for `gomod`, `pip`, `npm`, `docker`, `github-actions`. Up to 10 open per ecosystem.
+- **[Trivy](../.github/workflows/security.yml)** — filesystem scan (Critical + High only) on every push/PR that touches Go/Python/Docker; weekly scheduled run on Mondays.
+- **[govulncheck](../.github/workflows/security.yml)** — Go-specific advisory check on every push/PR.
+- **[CodeQL](../.github/workflows/codeql.yml)** — SAST covering Go + Python + JS/TS on every PR and weekly.
+- **[gitleaks](../.github/workflows/gitleaks.yml)** — secret scanning on every push/PR and weekly.
+- **GitHub Advanced Security / Dependabot alerts** — in-repo advisories surfaced at `/security/dependabot`.
+
+## Review & Update Cadence
+
+- Dependabot PRs are reviewed within **7 days** of opening. Patch/minor bumps that pass CI auto-merge after review; major bumps require manual validation.
+- Any CVE with CVSS ≥ 7.0 is triaged within **72 hours** of alert receipt. If no fix is available upstream, document the mitigation in `.trivyignore` with rationale and an expiry date.
+- Unmaintained dependencies (no release in 18+ months + no response to a security issue) are candidates for replacement or vendoring.
+
+## Vendoring & Pinning
+
+Raven does not vendor Go modules. Lockfiles (`go.sum`, `bun.lock`, Python pinned requirements) are committed and reviewed.
+
+Docker base images pin by tag (e.g., `postgres:18.2-alpine`) rather than SHA for readability; tag movement is caught by Dependabot's docker ecosystem.
+
+## Quarantined / Exempted Dependencies
+
+Entries in [`.trivyignore`](../.trivyignore) document every known unfixed vulnerability plus the reason it is exempted (upstream has no patch, not reachable in our code path, etc.) and — where possible — a date at which we should revisit.
+
+A CVE entering `.trivyignore` requires:
+
+1. Confirming no upstream fix is available.
+2. A code-level check that the vulnerable path is not exercised in our usage, or a mitigation note.
+3. Maintainer review.
+
+## License Compliance at Release
+
+Before any tagged release, `go-licenses` / `pip-licenses` / `license-checker` runs (or will run — see OpenSSF L2 Phase 4 work) produce a licenses manifest bundled with release artifacts. Apache-2.0-incompatible licenses in direct dependencies block the release.
+
+## Out of Scope
+
+- **Enterprise Edition** (`ee-*` files) may carry different dependency rules; covered separately.
+- **LLM provider APIs** — tenant-supplied at runtime (BYOK) and not part of the build-time dependency graph.
+
+## References
+
+- [`SECURITY.md`](../SECURITY.md) — vulnerability disclosure policy.
+- [`MAINTAINERS.md`](../MAINTAINERS.md) — who triages.
+- [OpenSSF Baseline 2026-02-19](https://baseline.openssf.org/versions/2026-02-19) — control taxonomy.


### PR DESCRIPTION
## Summary

Three doc changes for [OpenSSF Baseline L2](https://baseline.openssf.org/versions/2026-02-19) (see #330):

- **`docs/architecture.md`** — system actors, component table, trust boundaries, mermaid diagram, core data flows. Satisfies **OSPS-SA-01.01**.
- **`docs/dependency-policy.md`** — how we select / obtain / track dependencies, review cadence, quarantine procedure. Satisfies **OSPS-DO-06.01**.
- **`README.md`** — replaces the `license-TBD` badge with Apache 2.0, adds an OpenSSF Baseline L2 badge, replaces the "License TBD" footer with a full **Licensing** section that documents the OSS vs `ee-*` boundary, and adds a **Security** section linking to `SECURITY.md` and `MAINTAINERS.md`. Satisfies OSPS-LE-02 scope.

Drive-by cleanup: purges stale `Keycloak` references — auth was migrated to SuperTokens.

## Test plan

- [ ] Read architecture.md end-to-end; confirm components and trust boundaries match reality
- [ ] Read dependency-policy.md; confirm the review/triage cadence is one you can commit to
- [ ] View the rendered README on the PR and confirm the Licensing + Security sections render correctly
- [ ] Mermaid diagram renders in GitHub preview