### PR TITLE
ci(osps): lock down workflow permissions to least privilege

### DIFF
--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -6,8 +6,7 @@ on:
   pull_request:
     branches: [main]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   # Intentional Mergify marker job. Mergify gates merges on `#check-failure = 0`
@@ -16,5 +15,7 @@ jobs:
   gate:
     name: Gate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - run: echo "CI gate passed"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,6 +11,8 @@ on:
   issues:
     types: [opened, assigned]
 
+permissions: {}
+
 jobs:
   claude-assist:
     name: Claude (on-demand)

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,12 +25,27 @@ on:
 permissions: {}
 
 jobs:
-  build-go-api:
-    name: Build go-api
+  # PR-gated build: verifies the image still builds. No registry token, no
+  # push. `packages: write` is deliberately absent so a compromised action
+  # in the build toolchain cannot abuse the job token to publish.
+  build:
+    name: Build ${{ matrix.image }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: go-api
+            context: .
+            dockerfile: Dockerfile
+          - image: python-worker
+            context: ai-worker
+            dockerfile: ai-worker/Dockerfile
+          - image: frontend
+            context: frontend
+            dockerfile: frontend/Dockerfile
     steps:
       - uses: actions/checkout@v6
 
@@ -42,118 +57,88 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ghcr.io/${{ github.repository_owner }}/go-api
+          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=sha-
-            type=raw,value=latest,enable={{is_default_branch}}
-
-      - uses: docker/login-action@v4
-        if: github.event_name != 'pull_request'
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: docker/build-push-action@v7
         with:
-          context: .
-          file: Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-  build-python-worker:
-    name: Build python-worker
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: docker/setup-qemu-action@v4
-
-      - uses: docker/setup-buildx-action@v4
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ghcr.io/${{ github.repository_owner }}/python-worker
-          tags: |
-            type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha,prefix=sha-
-            type=raw,value=latest,enable={{is_default_branch}}
-
-      - uses: docker/login-action@v4
-        if: github.event_name != 'pull_request'
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: docker/build-push-action@v7
-        with:
-          context: ai-worker
-          file: ai-worker/Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-  build-frontend:
-    name: Build frontend
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: docker/setup-qemu-action@v4
-
-      - uses: docker/setup-buildx-action@v4
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ghcr.io/${{ github.repository_owner }}/frontend
-          tags: |
-            type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha,prefix=sha-
-            type=raw,value=latest,enable={{is_default_branch}}
-
-      - uses: docker/login-action@v4
-        if: github.event_name != 'pull_request'
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: docker/build-push-action@v7
-        with:
-          context: frontend
-          file: frontend/Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: false
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
-            VITE_API_URL=${{ vars.VITE_API_URL || 'https://api.ravencloak.org' }}
-            VITE_API_BASE_URL=${{ vars.VITE_API_BASE_URL || 'https://api.ravencloak.org/api/v1' }}
-            VITE_LIVEKIT_URL=${{ vars.VITE_LIVEKIT_URL || '' }}
-          tags: ${{ steps.meta.outputs.tags }}
+            ${{ matrix.image == 'frontend' && format('VITE_API_URL={0}', vars.VITE_API_URL || 'https://api.ravencloak.org') || '' }}
+            ${{ matrix.image == 'frontend' && format('VITE_API_BASE_URL={0}', vars.VITE_API_BASE_URL || 'https://api.ravencloak.org/api/v1') || '' }}
+            ${{ matrix.image == 'frontend' && format('VITE_LIVEKIT_URL={0}', vars.VITE_LIVEKIT_URL || '') || '' }}
           labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+
+  # Main-branch / tag-push publish: rebuilds from the GHA build cache
+  # populated by the `build` job and pushes to GHCR. `packages: write` is
+  # scoped to this job only.
+  publish:
+    name: Publish ${{ matrix.image }}
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: go-api
+            context: .
+            dockerfile: Dockerfile
+          - image: python-worker
+            context: ai-worker
+            dockerfile: ai-worker/Dockerfile
+          - image: frontend
+            context: frontend
+            dockerfile: frontend/Dockerfile
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-qemu-action@v4
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v7
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: true
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            ${{ matrix.image == 'frontend' && format('VITE_API_URL={0}', vars.VITE_API_URL || 'https://api.ravencloak.org') || '' }}
+            ${{ matrix.image == 'frontend' && format('VITE_API_BASE_URL={0}', vars.VITE_API_BASE_URL || 'https://api.ravencloak.org/api/v1') || '' }}
+            ${{ matrix.image == 'frontend' && format('VITE_LIVEKIT_URL={0}', vars.VITE_LIVEKIT_URL || '') || '' }}
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,14 +22,15 @@ on:
       - 'docker-compose.yml'
       - '.github/workflows/docker.yml'
 
-permissions:
-  contents: read
-  packages: write
+permissions: {}
 
 jobs:
   build-go-api:
     name: Build go-api
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v6
 
@@ -70,6 +71,9 @@ jobs:
   build-python-worker:
     name: Build python-worker
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v6
 
@@ -110,6 +114,9 @@ jobs:
   build-frontend:
     name: Build frontend
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -10,13 +10,14 @@ on:
     paths:
       - 'frontend/**'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   build:
     name: Lint & Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: frontend
@@ -41,6 +42,8 @@ jobs:
     name: Playwright E2E
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: frontend

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,13 +21,14 @@ on:
       - 'go.mod'
       - 'go.sum'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   build-and-test:
     name: Build & Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -145,6 +146,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/landing.yml
+++ b/.github/workflows/landing.yml
@@ -11,6 +11,8 @@ concurrency:
   group: landing-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   deploy:
     name: Deploy

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -6,6 +6,8 @@ on:
   pull_request_review_comment:
     types: [created]
 
+permissions: {}
+
 jobs:
   opencode:
     if: |

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,6 +16,8 @@ concurrency:
   group: pages-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   build-and-deploy:
     name: Build & Deploy

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,13 +13,14 @@ on:
       - 'proto/**'
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   test:
     name: Lint, Type-check & Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: ai-worker
@@ -64,6 +65,8 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment: smoke
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: ai-worker

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,14 +24,14 @@ on:
   schedule:
     - cron: '0 6 * * 1'  # Weekly on Monday at 06:00 UTC
 
-permissions:
-  contents: read
-  security-events: write
+permissions: {}
 
 jobs:
   trivy-scan:
     name: Trivy Filesystem Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -48,6 +48,8 @@ jobs:
   go-vuln:
     name: Go Vulnerability Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Audits and locks down `permissions:` on all 10 existing workflows. Every workflow now has **top-level `permissions: {}`** plus explicit per-job grants at the minimum each job actually needs.

Implements **OSPS-AC-04.01**, **OSPS-BR-01.01**, and **OSPS-BR-01.03** from the [OpenSSF Baseline L2](https://baseline.openssf.org/versions/2026-02-19) target (see #330).

## Scans

- **`pull_request_target` usage:** none found (BR-01.03 clean)
- **Unsafe `${{ github.event.* }}` interpolation in `run:` blocks:** none found. All references are in `if:` guards, where interpolation is safe.

## Per-job grant matrix

| Workflow | Jobs | Grants |
|---|---|---|
| `ci-required.yml` | `gate` | `contents: read` |
| `claude.yml` | `claude-assist` | unchanged: wide perms for code assistant |
| `docker.yml` | 3 build jobs | `contents: read`, `packages: write` |
| `frontend.yml` | `build`, `e2e` | `contents: read` |
| `go.yml` | `build-and-test`, `lint`, 2 eBPF jobs | `contents: read` |
| `landing.yml` | `deploy` | unchanged: `contents: read`, `deployments: write` |
| `opencode.yml` | `opencode` | unchanged: `id-token: write`, read-only for others |
| `pages.yml` | `build-and-deploy` | unchanged |
| `python.yml` | `test`, `smoke-tests` | `contents: read` |
| `security.yml` | `trivy-scan`, `go-vuln` | `contents: read` (removed job-wide `security-events: write` — no job currently uploads SARIF; re-add when we wire SARIF upload) |

## Test plan

- [ ] All workflows pass YAML parse (verified locally — 10/10 OK)
- [ ] CI runs on this PR and all jobs complete without new permission errors
- [ ] If any job fails with a permissions error, widen that specific job's grant and re-push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to follow the principle of least privilege by establishing empty default permissions at the workflow level and explicitly defining required permissions at the job level only where needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->