### PR TITLE
feat(osps): release pipeline with cosign keyless signing

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,8 @@ name: Docker Build & Push
 on:
   push:
     branches: [main]
-    tags: ['v*.*.*']
+    # Tag builds are handled by release.yml (with cosign signing). This
+    # workflow is for main-branch CI + PR-gate builds only.
     paths:
       - 'Dockerfile'
       - 'ai-worker/Dockerfile'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,327 @@
+name: Release
+
+# Triggered only by pushing a SemVer tag. docker.yml no longer fires on
+# tags so the two workflows do not race.
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-rc*'
+
+permissions: {}
+
+jobs:
+  # -----------------------------------------------------------------------
+  # preflight: assert the tag was cut from main and is SemVer.
+  # -----------------------------------------------------------------------
+  preflight:
+    name: Preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.extract.outputs.version }}
+      tag: ${{ steps.extract.outputs.tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Extract version
+        id: extract
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          TAG="${REF#refs/tags/}"
+          VERSION="${TAG#v}"
+          if ! printf '%s' "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$'; then
+            echo "::error::Tag '$TAG' does not match SemVer vX.Y.Z or vX.Y.Z-rcN"
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Verify tag is reachable from main
+        env:
+          TAG: ${{ steps.extract.outputs.tag }}
+        run: |
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          if ! git merge-base --is-ancestor "$TAG" origin/main; then
+            echo "::error::Tag $TAG is not reachable from origin/main — releases must be cut from main"
+            exit 1
+          fi
+
+  # -----------------------------------------------------------------------
+  # changelog: git-cliff renders the release body from conventional commits.
+  # -----------------------------------------------------------------------
+  changelog:
+    name: Changelog
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: preflight
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Generate release notes
+        uses: orhun/git-cliff-action@c93ef52f3d0ddcdcc9bd5447d98d458a11cd4f72  # v4.7.1
+        with:
+          config: cliff.toml
+          args: --latest --strip header
+        env:
+          OUTPUT: RELEASE_NOTES.md
+
+      - name: Upload release notes
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.0
+        with:
+          name: release-notes
+          path: RELEASE_NOTES.md
+          retention-days: 1
+
+  # -----------------------------------------------------------------------
+  # go-binaries: goreleaser builds Go binary archives + SHA256SUMS and
+  # cosign-signs the checksum file.
+  # -----------------------------------------------------------------------
+  go-binaries:
+    name: Go binaries
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: preflight
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
+        with:
+          go-version: '1.26.2'
+          cache: true
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@f713795cb21599bc4e5c4b58cbad1da852d7eeb9  # v3.8.1
+
+      - name: Run goreleaser
+        uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c  # v6
+        with:
+          version: '~> v2'
+          args: release --clean --skip=publish
+
+      - name: Upload binary artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.0
+        with:
+          name: go-binaries
+          path: |
+            dist/*.tar.gz
+            dist/checksums.txt
+            dist/checksums.txt.sig
+            dist/checksums.txt.pem
+          retention-days: 7
+
+  # -----------------------------------------------------------------------
+  # docker-images: build multi-arch images for api / worker / frontend,
+  # push to ghcr.io, and cosign-sign each image digest.
+  # -----------------------------------------------------------------------
+  docker-images:
+    name: Docker (${{ matrix.component }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    needs: preflight
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - component: go-api
+            context: .
+            dockerfile: Dockerfile
+          - component: python-worker
+            context: ai-worker
+            dockerfile: ai-worker/Dockerfile
+          - component: frontend
+            context: frontend
+            dockerfile: frontend/Dockerfile
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4
+
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.component }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ !contains(needs.preflight.outputs.tag, '-rc') }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: true
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: true
+          sbom: true
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@f713795cb21599bc4e5c4b58cbad1da852d7eeb9  # v3.8.1
+
+      - name: Sign image
+        env:
+          IMAGES: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          echo "$IMAGES" | while IFS= read -r image; do
+            [ -z "$image" ] && continue
+            echo "Signing ${image}@${DIGEST}"
+            cosign sign --yes "${image}@${DIGEST}"
+          done
+
+  # -----------------------------------------------------------------------
+  # frontend-bundle: produce a signed tarball of the built frontend
+  # (/dist) so self-hosted users can serve it from any static host.
+  # -----------------------------------------------------------------------
+  frontend-bundle:
+    name: Frontend bundle
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: preflight
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build
+        working-directory: frontend
+        run: npm run build
+        env:
+          VITE_API_URL: ${{ vars.VITE_API_URL || 'https://api.ravencloak.org' }}
+          VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL || 'https://api.ravencloak.org/api/v1' }}
+          VITE_LIVEKIT_URL: ${{ vars.VITE_LIVEKIT_URL || '' }}
+
+      - name: Package bundle
+        env:
+          VERSION: ${{ needs.preflight.outputs.version }}
+        run: |
+          cd frontend
+          tar -czf "../frontend-${VERSION}.tgz" -C dist .
+          cd ..
+          sha256sum "frontend-${VERSION}.tgz" > "frontend-${VERSION}.tgz.sha256"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@f713795cb21599bc4e5c4b58cbad1da852d7eeb9  # v3.8.1
+
+      - name: Sign bundle
+        env:
+          VERSION: ${{ needs.preflight.outputs.version }}
+        run: |
+          cosign sign-blob \
+            --yes \
+            --oidc-issuer=https://token.actions.githubusercontent.com \
+            --output-signature "frontend-${VERSION}.tgz.sig" \
+            --output-certificate "frontend-${VERSION}.tgz.pem" \
+            "frontend-${VERSION}.tgz"
+
+      - name: Upload bundle
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.0
+        with:
+          name: frontend-bundle
+          path: |
+            frontend-*.tgz
+            frontend-*.tgz.sha256
+            frontend-*.tgz.sig
+            frontend-*.tgz.pem
+          retention-days: 7
+
+  # -----------------------------------------------------------------------
+  # publish-release: assemble all artifacts into a single GitHub Release.
+  # -----------------------------------------------------------------------
+  publish-release:
+    name: Publish GitHub Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [preflight, changelog, go-binaries, docker-images, frontend-bundle]
+    permissions:
+      contents: write
+    steps:
+      - name: Download go binaries
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6
+        with:
+          name: go-binaries
+          path: artifacts/binaries
+
+      - name: Download frontend bundle
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6
+        with:
+          name: frontend-bundle
+          path: artifacts/frontend
+
+      - name: Download release notes
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53  # v6
+        with:
+          name: release-notes
+          path: artifacts/notes
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
+        with:
+          tag_name: ${{ needs.preflight.outputs.tag }}
+          name: Release ${{ needs.preflight.outputs.tag }}
+          body_path: artifacts/notes/RELEASE_NOTES.md
+          prerelease: ${{ contains(needs.preflight.outputs.tag, '-rc') }}
+          fail_on_unmatched_files: true
+          files: |
+            artifacts/binaries/*.tar.gz
+            artifacts/binaries/checksums.txt
+            artifacts/binaries/checksums.txt.sig
+            artifacts/binaries/checksums.txt.pem
+            artifacts/frontend/frontend-*.tgz
+            artifacts/frontend/frontend-*.tgz.sha256
+            artifacts/frontend/frontend-*.tgz.sig
+            artifacts/frontend/frontend-*.tgz.pem

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,110 @@
+# GoReleaser configuration for Raven.
+# Builds the Go binaries (cmd/api, cmd/worker), produces SHA256SUMS and
+# tar/zip archives, and signs the checksums manifest with cosign keyless.
+#
+# Invoked by .github/workflows/release.yml on tag push (v*.*.*).
+# GitHub Release creation is delegated to the workflow so Docker images
+# and the frontend bundle can be attached to the same release.
+
+version: 2
+
+project_name: raven
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: raven-api
+    main: ./cmd/api
+    binary: raven-api
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      # Keep the matrix lean — darwin/amd64 dropped since production targets
+      # are linux (cloud + Raspberry Pi) plus Apple Silicon for dev.
+      - goos: darwin
+        goarch: amd64
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
+
+  - id: raven-worker
+    main: ./cmd/worker
+    binary: raven-worker
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: darwin
+        goarch: amd64
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
+
+archives:
+  - id: default
+    ids:
+      - raven-api
+      - raven-worker
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- .Os }}_
+      {{- .Arch }}
+    formats: [tar.gz]
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+    files:
+      - LICENSE
+      - README.md
+      - SECURITY.md
+
+checksum:
+  name_template: "checksums.txt"
+  algorithm: sha256
+
+# cosign keyless signing (OIDC). Produces checksums.txt.sig and
+# checksums.txt.pem recorded in the Rekor transparency log.
+signs:
+  - id: cosign-checksums
+    cmd: cosign
+    signature: "${artifact}.sig"
+    certificate: "${artifact}.pem"
+    args:
+      - "sign-blob"
+      - "--oidc-issuer=https://token.actions.githubusercontent.com"
+      - "--output-certificate=${certificate}"
+      - "--output-signature=${signature}"
+      - "${artifact}"
+      - "--yes"
+    artifacts: checksum
+    output: true
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"
+
+# Let release.yml publish the GitHub Release — goreleaser only builds
+# artifacts and writes them to dist/.
+release:
+  disable: true

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,61 @@
+# Configuration file for git-cliff.
+# Generates the Release body + appends entries to CHANGELOG.md.
+# Expects conventional commits (feat:, fix:, docs:, chore:, ci:, refactor:, deps:).
+
+[changelog]
+# Header shown once at the top of CHANGELOG.md.
+header = """
+# Changelog
+
+All notable changes to Raven. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+versioning per [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+"""
+
+# Body template rendered per release.
+body = """
+{% if version %}\
+## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+## [Unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}\
+- {{ commit.message | split(pat="\\n") | first | trim }}{% if commit.breaking %} **[breaking]**{% endif %}\
+{% endfor %}
+{% endfor %}
+"""
+
+footer = """"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+
+# Classifiers — map conventional prefixes to changelog sections.
+commit_parsers = [
+  { message = "^feat", group = "Features" },
+  { message = "^fix", group = "Bug Fixes" },
+  { message = "^perf", group = "Performance" },
+  { message = "^refactor", group = "Refactors" },
+  { message = "^docs", group = "Documentation" },
+  { message = "^test", group = "Tests" },
+  { message = "^ci", group = "CI / Build" },
+  { message = "^chore", group = "Chores" },
+  { message = "^deps", group = "Dependencies" },
+  { message = "^security|^sec", group = "Security" },
+  { message = "^revert", group = "Reverts" },
+  # Ignore release/merge noise
+  { message = "^release", skip = true },
+  { message = "^Merge ", skip = true },
+]
+
+protect_breaking_commits = false
+filter_commits = false
+tag_pattern = "v[0-9]+\\.[0-9]+\\.[0-9]+(-[a-zA-Z0-9.]+)?"
+skip_tags = ""
+ignore_tags = ""
+topo_order = false
+sort_commits = "oldest"


### PR DESCRIPTION
## Summary

Wires up a tagged-release pipeline that signs every artifact with **cosign keyless** (OIDC → Fulcio → Rekor). Implements **OSPS-BR-02.01**, **OSPS-BR-04.01**, and **OSPS-BR-06.01** from the [OpenSSF Baseline L2](https://baseline.openssf.org/versions/2026-02-19) target (see #330).

## Changes

- **`cliff.toml`** — git-cliff config for conventional-commit changelogs.
- **`.goreleaser.yaml`** — builds `cmd/api` + `cmd/worker` for `linux/{amd64,arm64}` and `darwin/arm64`, produces `checksums.txt`, cosign-signs it.
- **`.github/workflows/release.yml`** — six-job orchestration on tag push:
  1. `preflight` — SemVer check + tag reachable from `main`
  2. `changelog` — git-cliff `--latest` → `RELEASE_NOTES.md`
  3. `go-binaries` — goreleaser (archives + signed checksums)
  4. `docker-images` (matrix: go-api, python-worker, frontend) — multi-arch `linux/amd64+arm64`, push to ghcr.io, cosign-sign digest
  5. `frontend-bundle` — npm build → tgz → SHA256 + cosign signature
  6. `publish-release` — assembles everything into a single GitHub Release
- **`.github/workflows/docker.yml`** — removes `tags: ['v*.*.*']` trigger. Tag-driven builds now flow through `release.yml` to avoid a race. Main-branch + PR builds still go through docker.yml unchanged.

## Security posture

- Top-level `permissions: {}`; per-job grants are minimal (`id-token: write` only where cosign runs).
- All action SHAs pinned.
- Docker buildx is invoked with `provenance: true` and `sbom: true` so each image gets a build-provenance attestation automatically (nice-to-have; does not add up to full SLSA L3).

## Test plan

- [ ] Review `.goreleaser.yaml` — confirm build flags + archive layout match distribution goals (notably: dropping `darwin/amd64`)
- [ ] Merge this PR and then cut a throwaway **`v0.0.0-rc1`** tag to exercise the full pipeline
- [ ] Verify the GH Release page contains: 3 tar.gz (go binaries), checksums.txt + .sig + .pem, frontend tgz + .sha256 + .sig + .pem, auto-generated release notes
- [ ] Verify each image with:
      ```
      cosign verify ghcr.io/ravencloak-org/go-api:v0.0.0-rc1 \
        --certificate-identity-regexp '^https://github.com/ravencloak-org/Raven' \
        --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
      ```
- [ ] Once passing, delete the rc1 release + tag and cut a real `v0.1.0`
- [ ] Document these verify commands in `SECURITY.md` as part of the self-assessment (Phase 5)