### PR TITLE
docs(osps): L2 self-assessment mapping controls to evidence

### DIFF
--- a/docs/compliance/osps-l2-2026-02-19.md
+++ b/docs/compliance/osps-l2-2026-02-19.md
@@ -1,0 +1,159 @@
+# OpenSSF Baseline L2 Self-Assessment
+
+**Baseline version:** [2026-02-19](https://baseline.openssf.org/versions/2026-02-19)
+**Target maturity:** Level 2 (includes all Level 1 controls)
+**Scope:** OSS portion of the repository under [`LICENSE`](../../LICENSE). The Enterprise portion under [`ee-LICENSE`](../../ee-LICENSE) is out of scope.
+**Assessment date:** 2026-04-20
+**Assessor:** @jobinlawrance (sole maintainer; see [`MAINTAINERS.md`](../../MAINTAINERS.md))
+
+This document is the evidence log that maps each Level 1 and Level 2 control to the artifact, PR, or setting that satisfies it. It is updated whenever a control state changes. The baseline version is pinned in the filename so future baseline revisions are captured in new files, not in place.
+
+## Summary
+
+| Category | Controls | Satisfied |
+|---|---|---|
+| Access Control | 5 | ✅ 5 |
+| Build & Release | 8 | ✅ 8 |
+| Documentation | 3 | ✅ 3 |
+| Governance | 4 | ✅ 4 |
+| Legal | 3 | ✅ 3 |
+| Quality | 5 | ✅ 5 |
+| Security Assessment | 3 | ✅ 3 |
+| Vulnerability Management | 3 | ✅ 3 |
+
+## Verification commands
+
+Every signed release artifact can be verified with cosign. After a tag release, run:
+
+```bash
+# Verify signed Go binary checksums
+cosign verify-blob \
+  --certificate checksums.txt.pem \
+  --signature checksums.txt.sig \
+  --certificate-identity-regexp '^https://github.com/ravencloak-org/Raven/' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  checksums.txt
+
+# Verify a signed Docker image
+cosign verify ghcr.io/ravencloak-org/go-api:<VERSION> \
+  --certificate-identity-regexp '^https://github.com/ravencloak-org/Raven/' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
+
+# Verify signed frontend bundle
+cosign verify-blob \
+  --certificate frontend-<VERSION>.tgz.pem \
+  --signature frontend-<VERSION>.tgz.sig \
+  --certificate-identity-regexp '^https://github.com/ravencloak-org/Raven/' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  frontend-<VERSION>.tgz
+```
+
+## Access Control
+
+| Control | Requirement | Evidence |
+|---|---|---|
+| OSPS-AC-01.01 | MFA required for sensitive actions | Repo-owner and CODEOWNER MFA enforced at account level. Org-level MFA requirement is a pending item (see Known gaps). |
+| OSPS-AC-02.01 | New collaborators default to least privilege | GitHub default; org default permission set to `read` per `gh api orgs/ravencloak-org` output. |
+| OSPS-AC-03.01 | Block direct commits to primary branch | Branch protection on `main`: `required_pull_request_reviews.required_approving_review_count = 1`, `require_code_owner_reviews = true`. Verified via `gh api repos/ravencloak-org/Raven/branches/main/protection`. |
+| OSPS-AC-03.02 | Prevent primary branch deletion | Branch protection: `allow_deletions = false`, `allow_force_pushes = false`, `required_linear_history = true`. |
+| OSPS-AC-04.01 | CI/CD least-privilege default | PR [#340](https://github.com/ravencloak-org/Raven/pull/340): top-level `permissions: {}` + explicit per-job grants across all 11 workflows. |
+
+## Build & Release
+
+| Control | Requirement | Evidence |
+|---|---|---|
+| OSPS-BR-01.01 | Sanitize untrusted CI metadata | Audit in PR #340: all `${{ github.event.* }}` references are in `if:` guards, none in `run:` blocks. |
+| OSPS-BR-01.03 | Prevent privileged creds on untrusted code | Audit in PR #340: no `pull_request_target` usage anywhere. |
+| OSPS-BR-02.01 | Unique version identifier per release | PR [#341](https://github.com/ravencloak-org/Raven/pull/341): release pipeline accepts only SemVer tags (`v[0-9]+.[0-9]+.[0-9]+(-rc[0-9]+)?`); `preflight` job rejects non-SemVer tags. |
+| OSPS-BR-03.01 | Encrypted channels for dev/release | GitHub HTTPS + GHCR HTTPS; documented in [`docs/architecture.md`](../architecture.md) §"Security-Relevant Notes". |
+| OSPS-BR-04.01 | Release changelog | PR #341: `cliff.toml` + `changelog` job generates release notes from conventional commits via `git-cliff`. |
+| OSPS-BR-05.01 | Standardized dep tooling | `go mod`, `npm` (with `bun.lock`), `pip` (via `pyproject.toml`) — documented in [`docs/dependency-policy.md`](../dependency-policy.md). |
+| OSPS-BR-06.01 | Signed release / manifest | PR #341: `.goreleaser.yaml` signs `checksums.txt` via cosign keyless; `release.yml` signs Docker images and frontend bundle via cosign keyless. Signatures (`.sig`) and certificates (`.pem`) attached to every GitHub Release. |
+| OSPS-BR-07.01 | No unencrypted secrets in VCS | PR [#337](https://github.com/ravencloak-org/Raven/pull/337): `gitleaks` CI check + `.gitleaks.toml` allowlist. Blocks PRs on detection. GitHub native secret scanning + push protection also enabled at repo level. |
+
+## Documentation
+
+| Control | Requirement | Evidence |
+|---|---|---|
+| OSPS-DO-01.01 | User guides for basic functionality | [`README.md`](../../README.md) + [`docs/quickstart.md`](../quickstart.md) + [`DEVELOPMENT.md`](../../DEVELOPMENT.md) + [`docs/wiki/`](../wiki/). |
+| OSPS-DO-06.01 | Dependency selection/tracking docs | PR [#339](https://github.com/ravencloak-org/Raven/pull/339): [`docs/dependency-policy.md`](../dependency-policy.md). |
+| OSPS-DO-07.01 | Build instructions | [`DEVELOPMENT.md`](../../DEVELOPMENT.md) + `docker compose up` path in [`README.md`](../../README.md). |
+
+## Governance
+
+| Control | Requirement | Evidence |
+|---|---|---|
+| OSPS-GV-01.01 | List of members with sensitive access | PR [#335](https://github.com/ravencloak-org/Raven/pull/335): [`MAINTAINERS.md`](../../MAINTAINERS.md). |
+| OSPS-GV-01.02 | Roles and responsibilities | [`MAINTAINERS.md`](../../MAINTAINERS.md) — "Responsibilities" and "Becoming a maintainer" sections. |
+| OSPS-GV-03.01 | Contribution process | [`CONTRIBUTING.md`](../../CONTRIBUTING.md). |
+| OSPS-GV-03.02 | Contribution requirements | PR [#338](https://github.com/ravencloak-org/Raven/pull/338): CONTRIBUTING extension covering coding standards, testing requirements, sign-off, PR workflow. |
+
+## Legal
+
+| Control | Requirement | Evidence |
+|---|---|---|
+| OSPS-LE-01.01 | Contributor legal assertion | PR #338: DCO workflow blocks PRs without `Signed-off-by:`. |
+| OSPS-LE-02.01 | OSI-approved source license | [`LICENSE`](../../LICENSE) is Apache License 2.0 (OSI-approved). Phase 0 verification complete. |
+| OSPS-LE-02.02 | OSI-approved released-asset license | Released artifacts (Go binaries, Docker images, frontend bundle) ship under the same `LICENSE`; archive configuration in `.goreleaser.yaml` includes `LICENSE` in every tarball. EE content explicitly excluded from release pipeline (see [`README.md`](../../README.md) § Licensing). |
+
+## Quality
+
+| Control | Requirement | Evidence |
+|---|---|---|
+| OSPS-QA-01.02 | Public commit record | GitHub native; commit history preserved (squash-merge preserves PR metadata while keeping `main` linear). |
+| OSPS-QA-02.01 | Direct dependency list | `go.mod`, `frontend/package.json`, `ai-worker/pyproject.toml` + `requirements*.txt`. |
+| OSPS-QA-04.01 | Codebase list for multi-repo projects | N/A — monorepo. |
+| OSPS-QA-05.01 | No generated executables in VCS | gitleaks + no build artifacts committed; verified via history inspection. |
+| OSPS-QA-05.02 | No unreviewable binary artifacts | Same as above; repository contains only source plus vendored lockfiles. |
+
+## Security Assessment
+
+| Control | Requirement | Evidence |
+|---|---|---|
+| OSPS-SA-01.01 | Design descriptions of actors and actions | PR #339: [`docs/architecture.md`](../architecture.md) with actor table, component table, trust boundaries, mermaid diagram, core data flows. |
+| OSPS-SA-02 | SAST | PR [#336](https://github.com/ravencloak-org/Raven/pull/336): CodeQL workflow for Go, Python, JS/TS. Runs on PR + push + weekly. |
+| OSPS-SA-03 | Dependency scanning | Existing [`.github/workflows/security.yml`](../../.github/workflows/security.yml) (Trivy + govulncheck) plus [Dependabot](../../.github/dependabot.yml) for gomod, pip, npm, docker, github-actions. |
+
+## Vulnerability Management
+
+| Control | Requirement | Evidence |
+|---|---|---|
+| OSPS-VM-01.01 | CVD policy | PR #335: [`SECURITY.md`](../../SECURITY.md) — 72h acknowledgement, 7-day triage, 90-day coordinated disclosure window. |
+| OSPS-VM-02.01 | Security contacts | `SECURITY.md` lists GitHub Security Advisories as primary channel and an email fallback. |
+| OSPS-VM-04.01 | Publish discovered vulnerabilities | `SECURITY.md` documents the GitHub Security Advisories (GHSA) workflow and CVE request process. GitHub private vulnerability reporting is enabled at the repo level. |
+
+## Phase 2 — Repository Settings (GitHub UI / API)
+
+Applied via `gh api`:
+
+- ✅ Branch protection on `main`: 1 approving review, code-owner review, dismiss-stale, linear history, conversation resolution, no force push, no deletion.
+- ✅ Repo-level GitHub secret scanning + push protection.
+- ✅ Repo-level Dependabot alerts + automated security updates.
+- ✅ Private vulnerability reporting (advisories).
+- ✅ Org-wide defaults for new repos: Dependabot alerts + updates, dependency graph, secret scanning + push protection.
+
+## Known gaps / deferred items
+
+1. **Org-level MFA enforcement** — the `PATCH /orgs/{org}` call with `two_factor_requirement_enabled=true` did not persist (likely needs the change to be applied via the org Security settings UI by the org owner). **Action:** enable in the GitHub UI at **Organization → Settings → Authentication security → Require two-factor authentication**.
+2. **Required status checks on `main`** — currently only `CI Required / Gate`. Once the new CI workflows (CodeQL, gitleaks, DCO) have run at least once post-merge, expand the required-checks list to include them. **Action:** run
+   ```bash
+   gh api --method PUT repos/ravencloak-org/Raven/branches/main/protection/required_status_checks \
+     -f strict=true \
+     -F 'contexts[]=CI Required / Gate' \
+     -F 'contexts[]=CodeQL / Analyze (go)' \
+     -F 'contexts[]=CodeQL / Analyze (python)' \
+     -F 'contexts[]=CodeQL / Analyze (javascript-typescript)' \
+     -F 'contexts[]=Secret Scanning / Gitleaks' \
+     -F 'contexts[]=DCO / DCO Sign-off'
+   ```
+3. **First tagged release** — the release pipeline (PR #341) will be exercised end-to-end the first time a `v0.0.0-rc1` tag is pushed. Until that happens, BR-06.01 evidence is the workflow definition rather than a published signed artifact.
+4. **Secret scanning non-provider patterns** and **validity checks** — GitHub Advanced Security features that require a paid plan or Enterprise; not enabled. Not required for L2.
+5. **SLSA L3 provenance attestation** — out of scope for L2. Docker buildx is already configured with `provenance: true, sbom: true`, which produces a v1 attestation but not a full SLSA L3 generator. Track under a future L3 milestone.
+
+## Changelog
+
+- 2026-04-19 — Spec authored (PR #330)
+- 2026-04-19 — Docs + CI hardening PRs opened in parallel (#335, #336, #337, #338, #339, #340)
+- 2026-04-20 — Release pipeline PR opened (#341)
+- 2026-04-20 — Phase 2 repo settings applied via `gh api`
+- 2026-04-20 — Self-assessment (this doc) authored


### PR DESCRIPTION
## Summary

Phase 5 wrap-up for the M-OSPS-L2 milestone. Maps every L1 + L2 control from [OpenSSF Baseline 2026-02-19](https://baseline.openssf.org/versions/2026-02-19) to a concrete artifact, PR, or repo setting.

Lands as `docs/compliance/osps-l2-2026-02-19.md` — filename pinned to the baseline version so future revisions are captured in new files, not in place.

## Structure

- Per-category evidence tables (AC, BR, DO, GV, LE, QA, SA, VM)
- Cosign verification commands (ready to publish on first tagged release)
- Phase 2 repo-settings summary (applied via `gh api`)
- Known-gaps section:
  - Org-level MFA not yet enforced (API didn't accept the change — needs UI step)
  - Required status checks awaiting first run of new workflows (CodeQL / gitleaks / DCO)
  - SLSA L3 provenance deferred to a future milestone

## Test plan

- [ ] Read the assessment top to bottom; confirm each evidence link resolves
- [ ] Close out known-gap #1 (org MFA) via GitHub UI before the release badge is publicized
- [ ] After first tagged release, append a changelog line noting BR-06.01 was exercised