### PR TITLE
fix(pages): exclude source trees and configs from Jekyll build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,15 +21,59 @@ defaults:
       layout: default
 
 exclude:
+  # Local / generated / agent state
   - .worktrees/
   - .claude/
+  - .entire/
+  - .serena/
+  - .mcp_data/
+  - .idea/
+  - .wrangler/
   - ai-worker/.venv/
   - frontend/node_modules/
   - frontend/dist/
+  - node-compile-cache/
+
+  # Source code trees (not documentation)
+  - cmd/
+  - internal/
+  - pkg/
+  - proto/
+  - ai-worker/
+  - frontend/
+  - landing/
+  - migrations/
+  - deploy/
+  - tests/
+  - backup/
+  - contracts/
+  - update-check/
+
+  # Build / config files — not meant for Pages rendering
   - "*.sh"
-  - Makefile
-  - go.mod
-  - go.sum
+  - "Makefile"
+  - "Makefile.edge"
+  - "Dockerfile"
+  - "docker-compose*.yml"
+  - "go.mod"
+  - "go.sum"
+  - "bun.lock"
+  - ".env.*"
+  - ".air.toml"
+  - ".codecov.yml"
+  - ".coderabbit.yaml"
+  - ".dockerignore"
+  - ".gitignore"
+  - ".gitleaks.toml"
+  - ".goreleaser.yaml"
+  - ".golangci.yml"
+  - ".mergify.yml"
+  - ".trivyignore"
+  - ".mcp.json"
+  - "cliff.toml"
+  - "ee-LICENSE"
+  - "ee-README.md"
+  - "index.html"
 
 header_pages:
   - docs/project-status.md


### PR DESCRIPTION
## Summary

The \`pages-build-deployment\` workflow has been red on \`main\` since each OSPS merge. Root cause: Jekyll processes every \`.yml\`/\`.yaml\` file as a Liquid template, and the Ansible playbooks under \`deploy/\` use Jinja \`{{ }}\` which collides with Liquid and crashes the build.

Example failure: [run 24637617424 / job 72035774509](https://github.com/ravencloak-org/Raven/actions/runs/24637617424/job/72035774509).

## Fix

Expands \`_config.yml\` \`exclude:\` list to cover every non-documentation tree. Pages still renders \`README.md\`, \`LICENSE\`, \`SECURITY.md\`, \`MAINTAINERS.md\`, \`CONTRIBUTING.md\`, \`DEVELOPMENT.md\`, and everything under \`docs/\`.

## Test plan

- [ ] Merge and verify the next \`pages-build-deployment\` run on main goes green
- [ ] Visit https://ravencloak-org.github.io/Raven and confirm the rendered docs are intact (README + docs/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated site build configuration to exclude additional directories and files, improving build efficiency and preventing unnecessary content processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->