### PR TITLE
fix(pages): exclude docs/superpowers and docs/compliance from Jekyll

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -49,6 +49,13 @@ exclude:
   - contracts/
   - update-check/
 
+  # Working documents that embed Vue / shell / CI templates using `{{ }}`
+  # and `{% %}`. Kramdown's code fences do not shield these from Jekyll's
+  # Liquid pass, so they crash the Pages build. These files are engineering
+  # specs / plans / the OSPS self-assessment, not user-facing documentation.
+  - docs/superpowers/
+  - docs/compliance/
+
   # Build / config files — not meant for Pages rendering
   - "*.sh"
   - "Makefile"


### PR DESCRIPTION
## Summary

Follow-up to #343. Pages kept failing because markdown under these paths embeds Vue template syntax and workflow `${{ ... }}` examples that Liquid parses even inside code fences.

Failing files observed: `docs/compliance/osps-l2-2026-02-19.md` (cosign + `gh api` examples), `docs/superpowers/plans/2026-04-10-wave3-mvp-features.md` (Vue component examples), `docs/superpowers/plans/2026-04-16-demo-kb.md` (unterminated `{{`).

These directories hold engineering specs, plans, and the OSPS self-assessment — not user-facing documentation. They remain viewable via GitHub directly; they just shouldn't go through Jekyll.

## Test plan

- [ ] Merge and confirm `pages-build-deployment` goes green on next main push
- [ ] Visit https://ravencloak-org.github.io/Raven and confirm README + docs are still rendered