### PR TITLE
ci(slsa): add SLSA Build Level 3 provenance + SBOM attestations for GHCR images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,7 @@
 name: Docker Build & Push
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     tags: ['v*.*.*']
@@ -24,6 +25,8 @@ on:
 permissions:
   contents: read
   packages: write
+  id-token: write       # Sigstore OIDC for keyless signing
+  attestations: write   # GitHub attestation store
 
 jobs:
   build-go-api:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -127,7 +127,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v7
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v7
         with:
           context: ai-worker
           file: ai-worker/Dockerfile
@@ -137,6 +139,33 @@ jobs:
           cache-to: type=gha,mode=max
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
+          sbom: false
+
+      - name: Generate SBOM (python-worker)
+        if: github.event_name != 'pull_request'
+        uses: anchore/sbom-action@v0
+        with:
+          image: ghcr.io/${{ github.repository_owner }}/python-worker@${{ steps.build.outputs.digest }}
+          format: spdx-json
+          output-file: sbom-python-worker.spdx.json
+
+      - name: Attest SBOM (python-worker)
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-sbom@v3
+        with:
+          subject-name: ghcr.io/${{ github.repository_owner }}/python-worker
+          subject-digest: ${{ steps.build.outputs.digest }}
+          sbom-path: sbom-python-worker.spdx.json
+          push-to-registry: true
+
+      - name: Attest build provenance (python-worker)
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-name: ghcr.io/${{ github.repository_owner }}/python-worker
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
 
   build-frontend:
     name: Build frontend

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -58,7 +58,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v7
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile
@@ -68,6 +70,33 @@ jobs:
           cache-to: type=gha,mode=max
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
+          sbom: false
+
+      - name: Generate SBOM (go-api)
+        if: github.event_name != 'pull_request'
+        uses: anchore/sbom-action@v0
+        with:
+          image: ghcr.io/${{ github.repository_owner }}/go-api@${{ steps.build.outputs.digest }}
+          format: spdx-json
+          output-file: sbom-go-api.spdx.json
+
+      - name: Attest SBOM (go-api)
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-sbom@v3
+        with:
+          subject-name: ghcr.io/${{ github.repository_owner }}/go-api
+          subject-digest: ${{ steps.build.outputs.digest }}
+          sbom-path: sbom-go-api.spdx.json
+          push-to-registry: true
+
+      - name: Attest build provenance (go-api)
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-name: ghcr.io/${{ github.repository_owner }}/go-api
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
 
   build-python-worker:
     name: Build python-worker

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -196,7 +196,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v7
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v7
         with:
           context: frontend
           file: frontend/Dockerfile
@@ -210,3 +212,30 @@ jobs:
             VITE_LIVEKIT_URL=${{ vars.VITE_LIVEKIT_URL || '' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
+          sbom: false
+
+      - name: Generate SBOM (frontend)
+        if: github.event_name != 'pull_request'
+        uses: anchore/sbom-action@v0
+        with:
+          image: ghcr.io/${{ github.repository_owner }}/frontend@${{ steps.build.outputs.digest }}
+          format: spdx-json
+          output-file: sbom-frontend.spdx.json
+
+      - name: Attest SBOM (frontend)
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-sbom@v3
+        with:
+          subject-name: ghcr.io/${{ github.repository_owner }}/frontend
+          subject-digest: ${{ steps.build.outputs.digest }}
+          sbom-path: sbom-frontend.spdx.json
+          push-to-registry: true
+
+      - name: Attest build provenance (frontend)
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-name: ghcr.io/${{ github.repository_owner }}/frontend
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   <a href="https://github.com/ravencloak-org/Raven/actions/workflows/python.yml"><img src="https://github.com/ravencloak-org/Raven/actions/workflows/python.yml/badge.svg" alt="Python CI" /></a>
   <a href="https://github.com/ravencloak-org/Raven/actions/workflows/docker.yml"><img src="https://github.com/ravencloak-org/Raven/actions/workflows/docker.yml/badge.svg" alt="Docker Build" /></a>
   <a href="https://github.com/ravencloak-org/Raven/actions/workflows/security.yml"><img src="https://github.com/ravencloak-org/Raven/actions/workflows/security.yml/badge.svg" alt="Security" /></a>
+  <a href="docs/security/slsa-verification.md"><img src="https://slsa.dev/images/gh-badge-level3.svg" alt="SLSA 3" /></a>
   <a href="https://codecov.io/gh/ravencloak-org/Raven"><img src="https://codecov.io/gh/ravencloak-org/Raven/branch/main/graph/badge.svg" alt="Coverage" /></a>
   <img src="https://img.shields.io/badge/license-TBD-lightgrey" alt="License" />
   <img src="https://img.shields.io/badge/PRs-welcome-blue" alt="PRs Welcome" />

--- a/docs/security/slsa-verification.md
+++ b/docs/security/slsa-verification.md
@@ -1,0 +1,87 @@
+# Verifying SLSA Build Provenance for Raven Container Images
+
+Every container image published by this repository to GHCR carries two
+cryptographic attestations:
+
+- **SLSA v1 build provenance** — who built the image, from which commit,
+  on which workflow, at what time.
+- **SPDX SBOM** — the full software bill of materials for the image.
+
+Both are signed keylessly via [Sigstore](https://www.sigstore.dev/) using
+GitHub OIDC and anchored in the public [Rekor](https://docs.sigstore.dev/logging/overview/)
+transparency log. Attestations are stored both in the GitHub attestation
+store and as OCI referrers alongside the image in GHCR.
+
+Images covered: `ghcr.io/ravencloak-org/{go-api,python-worker,frontend}`.
+Attestations exist for every image pushed from `main` or a `v*.*.*` tag on
+or after the commit that landed this feature.
+
+## Verify with `gh` (GitHub CLI)
+
+Primary path — no extra install beyond `gh`.
+
+**Provenance:**
+
+```
+gh attestation verify \
+  oci://ghcr.io/ravencloak-org/go-api:latest \
+  --owner ravencloak-org \
+  --predicate-type https://slsa.dev/provenance/v1
+```
+
+**SBOM:**
+
+```
+gh attestation verify \
+  oci://ghcr.io/ravencloak-org/go-api:latest \
+  --owner ravencloak-org \
+  --predicate-type https://spdx.dev/Document/v2.3
+```
+
+Substitute `go-api` with `python-worker` or `frontend` for the other two
+images, and replace `latest` with any tag or `sha256:` digest you want to
+verify.
+
+## Verify with `cosign`
+
+For environments without `gh`:
+
+```
+cosign verify-attestation \
+  --type slsaprovenance1 \
+  --certificate-identity-regexp \
+    'https://github.com/ravencloak-org/Raven/.github/workflows/docker.yml@.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/ravencloak-org/go-api:latest
+```
+
+## What Verification Proves
+
+- The image was built from `ravencloak-org/Raven` by the `docker.yml`
+  workflow on a GitHub-hosted runner.
+- The commit SHA in the provenance matches a real commit on this repo.
+- The image digest you pull is byte-for-byte the one that was attested.
+- The SBOM was produced by the same build.
+
+## What Verification Does NOT Prove
+
+- That the image is free of known vulnerabilities — that is what Trivy and
+  `govulncheck` in `.github/workflows/security.yml` cover.
+- That the build is bit-for-bit reproducible.
+- Runtime integrity. Attestation is a build-time guarantee.
+
+## Notes
+
+- `actions/attest-sbom@v3` supports SPDX only; the SBOM attestation uses
+  `spdx-json`. A CycloneDX variant is not produced.
+- If you verify an image pushed before this feature landed, both commands
+  will fail with "no attestation found". That is expected.
+- If `gh attestation verify` fails with an auth error, run `gh auth login`
+  and ensure the account has read access to `ravencloak-org/Raven`.
+
+## References
+
+- [SLSA v1.0 specification](https://slsa.dev/spec/v1.0/)
+- [GitHub artifact attestations](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)
+- [`gh attestation verify` manual](https://cli.github.com/manual/gh_attestation_verify)
+- [`cosign verify-attestation` docs](https://docs.sigstore.dev/cosign/verifying/verify/)

--- a/docs/security/slsa-verification.md
+++ b/docs/security/slsa-verification.md
@@ -46,6 +46,8 @@ verify.
 
 For environments without `gh`:
 
+**Provenance:**
+
 ```
 cosign verify-attestation \
   --type slsaprovenance1 \
@@ -54,6 +56,43 @@ cosign verify-attestation \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   ghcr.io/ravencloak-org/go-api:latest
 ```
+
+**SBOM:**
+
+```
+cosign verify-attestation \
+  --type spdxjson \
+  --certificate-identity-regexp \
+    'https://github.com/ravencloak-org/Raven/.github/workflows/docker.yml@.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/ravencloak-org/go-api:latest
+```
+
+## Always Verify by Digest in Production
+
+Tags like `:latest` are mutable. For any real supply-chain check, pin to
+the image's immutable `sha256:` digest. Resolve a tag to a digest with
+either of:
+
+```
+crane digest ghcr.io/ravencloak-org/go-api:latest
+```
+
+```
+docker buildx imagetools inspect ghcr.io/ravencloak-org/go-api:latest --format '{{json .Manifest.Digest}}'
+```
+
+Then verify the digest directly:
+
+```
+gh attestation verify \
+  oci://ghcr.io/ravencloak-org/go-api@sha256:<digest> \
+  --owner ravencloak-org \
+  --predicate-type https://slsa.dev/provenance/v1
+```
+
+`cosign verify-attestation` accepts the same `<image>@sha256:<digest>`
+form.
 
 ## What Verification Proves
 

--- a/docs/superpowers/plans/2026-04-19-slsa-provenance.md
+++ b/docs/superpowers/plans/2026-04-19-slsa-provenance.md
@@ -1,0 +1,541 @@
+# SLSA Build Provenance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add SLSA Build Level 3 provenance and SPDX SBOM attestations to the three GHCR container images built by `.github/workflows/docker.yml`, signed keylessly via Sigstore, and document how downstream consumers verify them.
+
+**Architecture:** Each `build-<image>` job in the existing workflow gets four additions: an `id: build` on the push step (to read `outputs.digest`), disabling build-push-action's inline provenance/SBOM, then three new steps (Syft SBOM generation → `attest-sbom@v3` → `attest-build-provenance@v3`) guarded on non-PR events. Top-level permissions gain `id-token: write` and `attestations: write`. A new `docs/security/slsa-verification.md` documents `gh attestation verify` + `cosign verify-attestation` commands; README gets a SLSA Level 3 badge.
+
+**Tech Stack:** GitHub Actions, `actions/attest-build-provenance@v3`, `actions/attest-sbom@v3`, `anchore/sbom-action@v0`, `docker/build-push-action@v7`, Sigstore (Fulcio + Rekor), GHCR.
+
+**Worktree:** `/Users/jobinlawrance/Project/raven/.worktrees/slsa-provenance`
+**Branch:** `ci/slsa-provenance` (tracking `origin/main`)
+**Spec:** `docs/superpowers/specs/2026-04-19-slsa-provenance-design.md`
+**Issues:** parent #333; children #331 (workflow), #332 (docs)
+
+---
+
+## File Structure
+
+**Modify:**
+- `.github/workflows/docker.yml` — add top-level permissions, `workflow_dispatch` trigger, and append attestation steps to all three jobs.
+- `README.md` — one-line SLSA 3 badge.
+
+**Create:**
+- `docs/security/slsa-verification.md` — consumer-facing verify instructions.
+
+No source code under test. "Testing" here means: lint the workflow, trigger a dry-run, and verify attestations exist on real pushed images.
+
+---
+
+## Task 1: Add Permissions and `workflow_dispatch` Trigger
+
+**Files:**
+- Modify: `.github/workflows/docker.yml`
+
+**Why:** `attest-build-provenance@v3` and `attest-sbom@v3` require `id-token: write` (Sigstore OIDC) and `attestations: write` (GitHub attestation store). The `workflow_dispatch` trigger lets us manually dry-run the workflow from the `ci/slsa-provenance` branch without needing a tag or path-triggering file change.
+
+- [ ] **Step 1: Edit the `on:` block**
+
+Current:
+```yaml
+on:
+  push:
+    branches: [main]
+    tags: ['v*.*.*']
+    paths:
+      - 'Dockerfile'
+      - 'ai-worker/Dockerfile'
+      - 'frontend/Dockerfile'
+      - 'frontend/nginx.conf'
+      - 'docker-compose.yml'
+      - '.github/workflows/docker.yml'
+  pull_request:
+    ...
+```
+
+Add `workflow_dispatch:` at the top of the `on:` block:
+
+```yaml
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    ...
+```
+
+- [ ] **Step 2: Edit the `permissions:` block**
+
+Current:
+```yaml
+permissions:
+  contents: read
+  packages: write
+```
+
+Replace with:
+```yaml
+permissions:
+  contents: read
+  packages: write
+  id-token: write       # Sigstore OIDC for keyless signing
+  attestations: write   # GitHub attestation store
+```
+
+- [ ] **Step 3: Validate the YAML**
+
+Run from the worktree root:
+```
+actionlint .github/workflows/docker.yml
+```
+Expected: no output (success). If `actionlint` is not installed: `brew install actionlint` (macOS) or skip and rely on CI to catch it.
+
+- [ ] **Step 4: Commit**
+
+```
+git add .github/workflows/docker.yml
+git commit -m "ci(docker): add workflow_dispatch and SLSA attestation permissions"
+```
+
+---
+
+## Task 2: Attest the `go-api` Image
+
+**Files:**
+- Modify: `.github/workflows/docker.yml` (the `build-go-api` job)
+
+**Why:** Each image needs its attestation steps. Start with `go-api` as the reference; Tasks 3 and 4 apply the same pattern to the other two.
+
+- [ ] **Step 1: Add `id: build` to the push step and disable inline attestations**
+
+Find the `build-push-action` step inside `build-go-api`:
+
+```yaml
+      - uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+```
+
+Replace with:
+
+```yaml
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
+          sbom: false
+```
+
+- [ ] **Step 2: Append SBOM generation step**
+
+Directly after the push step, add:
+
+```yaml
+      - name: Generate SBOM (go-api)
+        if: github.event_name != 'pull_request'
+        uses: anchore/sbom-action@v0
+        with:
+          image: ghcr.io/${{ github.repository_owner }}/go-api@${{ steps.build.outputs.digest }}
+          format: spdx-json
+          output-file: sbom-go-api.spdx.json
+```
+
+- [ ] **Step 3: Append SBOM attestation step**
+
+```yaml
+      - name: Attest SBOM (go-api)
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-sbom@v3
+        with:
+          subject-name: ghcr.io/${{ github.repository_owner }}/go-api
+          subject-digest: ${{ steps.build.outputs.digest }}
+          sbom-path: sbom-go-api.spdx.json
+          push-to-registry: true
+```
+
+- [ ] **Step 4: Append provenance attestation step**
+
+```yaml
+      - name: Attest build provenance (go-api)
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-name: ghcr.io/${{ github.repository_owner }}/go-api
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+```
+
+- [ ] **Step 5: Validate the YAML**
+
+```
+actionlint .github/workflows/docker.yml
+```
+Expected: no output.
+
+- [ ] **Step 6: Commit**
+
+```
+git add .github/workflows/docker.yml
+git commit -m "ci(slsa): attest go-api image with provenance and SBOM"
+```
+
+---
+
+## Task 3: Attest the `python-worker` Image
+
+**Files:**
+- Modify: `.github/workflows/docker.yml` (the `build-python-worker` job)
+
+Identical pattern to Task 2, but with `python-worker` in place of `go-api` and SBOM filename `sbom-python-worker.spdx.json`. The existing `build-push-action` step uses `context: ai-worker` and `file: ai-worker/Dockerfile` — those do not change.
+
+- [ ] **Step 1: Add `id: build` + `provenance: false` + `sbom: false` to the push step.**
+
+- [ ] **Step 2: Append the three new steps**, parameterized with `python-worker`:
+
+```yaml
+      - name: Generate SBOM (python-worker)
+        if: github.event_name != 'pull_request'
+        uses: anchore/sbom-action@v0
+        with:
+          image: ghcr.io/${{ github.repository_owner }}/python-worker@${{ steps.build.outputs.digest }}
+          format: spdx-json
+          output-file: sbom-python-worker.spdx.json
+
+      - name: Attest SBOM (python-worker)
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-sbom@v3
+        with:
+          subject-name: ghcr.io/${{ github.repository_owner }}/python-worker
+          subject-digest: ${{ steps.build.outputs.digest }}
+          sbom-path: sbom-python-worker.spdx.json
+          push-to-registry: true
+
+      - name: Attest build provenance (python-worker)
+        if: github.event_name != 'pull_request'
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-name: ghcr.io/${{ github.repository_owner }}/python-worker
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+```
+
+- [ ] **Step 3: Lint**
+
+```
+actionlint .github/workflows/docker.yml
+```
+
+- [ ] **Step 4: Commit**
+
+```
+git add .github/workflows/docker.yml
+git commit -m "ci(slsa): attest python-worker image with provenance and SBOM"
+```
+
+---
+
+## Task 4: Attest the `frontend` Image
+
+**Files:**
+- Modify: `.github/workflows/docker.yml` (the `build-frontend` job)
+
+Identical pattern. Note: the frontend `build-push-action` step has extra `build-args` (VITE_API_URL, etc.) — those stay untouched. Only add `id`, `provenance: false`, `sbom: false` to it; append three new steps after.
+
+- [ ] **Step 1: Add `id: build` + `provenance: false` + `sbom: false` to the push step.**
+
+- [ ] **Step 2: Append the three new steps** with `frontend` substituted everywhere and SBOM filename `sbom-frontend.spdx.json`.
+
+- [ ] **Step 3: Lint**
+
+```
+actionlint .github/workflows/docker.yml
+```
+
+- [ ] **Step 4: Commit**
+
+```
+git add .github/workflows/docker.yml
+git commit -m "ci(slsa): attest frontend image with provenance and SBOM"
+```
+
+---
+
+## Task 5: Dry-Run the Workflow and Verify Attestations Land
+
+**Why:** Before writing consumer docs, confirm the workflow actually produces attestations on real pushes. If this fails, the docs would describe commands that won't work.
+
+- [ ] **Step 1: Push the branch**
+
+```
+git push -u origin ci/slsa-provenance
+```
+
+- [ ] **Step 2: Trigger the workflow manually**
+
+```
+gh workflow run docker.yml --ref ci/slsa-provenance --repo ravencloak-org/Raven
+```
+
+- [ ] **Step 3: Wait for completion and record the digests**
+
+Find the run:
+```
+gh run list --workflow docker.yml --branch ci/slsa-provenance --repo ravencloak-org/Raven --limit 1
+```
+Watch:
+```
+gh run watch <run-id> --repo ravencloak-org/Raven
+```
+Expected: all three `Build <image>` jobs succeed, including the three new steps per job. If any attestation step fails, read the log, fix, re-push, re-run.
+
+- [ ] **Step 4: Confirm attestations are listed on GitHub**
+
+```
+gh attestation list --repo ravencloak-org/Raven --limit 10
+```
+Expected: six new attestations (provenance + SBOM for each of three images), all from commit SHA = tip of `ci/slsa-provenance`.
+
+- [ ] **Step 5: Confirm OCI referrers in GHCR**
+
+Install `crane` if needed: `brew install crane` (macOS).
+
+```
+# Resolve the sha-tagged image digest for go-api (use the branch-ref tag produced by docker/metadata-action@v6, i.e. "ci-slsa-provenance")
+crane digest ghcr.io/ravencloak-org/go-api:ci-slsa-provenance
+
+# Look up referrers for that digest
+crane manifest ghcr.io/ravencloak-org/go-api@sha256:<digest> | jq .
+# Then:
+crane referrers ghcr.io/ravencloak-org/go-api@sha256:<digest>
+```
+Expected: two referrers, one with `artifactType` for SLSA provenance and one for SPDX SBOM.
+
+Repeat for `python-worker` and `frontend`.
+
+- [ ] **Step 6: (No commit — this is a verification task.)**
+
+Record the digests + run URL in the PR description later.
+
+---
+
+## Task 6: Write Verification Documentation
+
+**Files:**
+- Create: `docs/security/slsa-verification.md`
+
+**Why:** Closes child issue #332. Consumer-facing. Hardcodes `ravencloak-org` so copy-paste commands work as-is (per spec reviewer's advisory).
+
+- [ ] **Step 1: Create the file with this exact content**
+
+```markdown
+# Verifying SLSA Build Provenance for Raven Container Images
+
+Every container image published by this repository to GHCR carries two
+cryptographic attestations:
+
+- **SLSA v1 build provenance** — who built the image, from which commit,
+  on which workflow, at what time.
+- **SPDX SBOM** — the full software bill of materials for the image.
+
+Both are signed keylessly via [Sigstore](https://www.sigstore.dev/) using
+GitHub OIDC and anchored in the public [Rekor](https://docs.sigstore.dev/logging/overview/)
+transparency log. Attestations are stored both in the GitHub attestation
+store and as OCI referrers alongside the image in GHCR.
+
+Images covered: `ghcr.io/ravencloak-org/{go-api,python-worker,frontend}`.
+Attestations exist for every image pushed from `main` or a `v*.*.*` tag on
+or after the commit that landed this feature.
+
+## Verify with `gh` (GitHub CLI)
+
+Primary path — no extra install beyond `gh`.
+
+**Provenance:**
+
+```
+gh attestation verify \
+  oci://ghcr.io/ravencloak-org/go-api:latest \
+  --owner ravencloak-org \
+  --predicate-type https://slsa.dev/provenance/v1
+```
+
+**SBOM:**
+
+```
+gh attestation verify \
+  oci://ghcr.io/ravencloak-org/go-api:latest \
+  --owner ravencloak-org \
+  --predicate-type https://spdx.dev/Document
+```
+
+Substitute `go-api` with `python-worker` or `frontend` for the other two
+images, and replace `latest` with any tag or `sha256:` digest you want to
+verify.
+
+## Verify with `cosign`
+
+For environments without `gh`:
+
+```
+cosign verify-attestation \
+  --type slsaprovenance1 \
+  --certificate-identity-regexp \
+    'https://github.com/ravencloak-org/Raven/.github/workflows/docker.yml@.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/ravencloak-org/go-api:latest
+```
+
+## What Verification Proves
+
+- The image was built from `ravencloak-org/Raven` by the `docker.yml`
+  workflow on a GitHub-hosted runner.
+- The commit SHA in the provenance matches a real commit on this repo.
+- The image digest you pull is byte-for-byte the one that was attested.
+- The SBOM was produced by the same build.
+
+## What Verification Does NOT Prove
+
+- That the image is free of known vulnerabilities — that is what Trivy and
+  `govulncheck` in `.github/workflows/security.yml` cover.
+- That the build is bit-for-bit reproducible.
+- Runtime integrity. Attestation is a build-time guarantee.
+
+## Notes
+
+- `actions/attest-sbom@v3` supports SPDX only; the SBOM attestation uses
+  `spdx-json`. A CycloneDX variant is not produced.
+- If you verify an image pushed before this feature landed, both commands
+  will fail with "no attestation found". That is expected.
+- If `gh attestation verify` fails with an auth error, run `gh auth login`
+  and ensure the account has read access to `ravencloak-org/Raven`.
+
+## References
+
+- [SLSA v1.0 specification](https://slsa.dev/spec/v1.0/)
+- [GitHub artifact attestations](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)
+- [`gh attestation verify` manual](https://cli.github.com/manual/gh_attestation_verify)
+- [`cosign verify-attestation` docs](https://docs.sigstore.dev/cosign/verifying/verify/)
+```
+
+- [ ] **Step 2: Run each `gh attestation verify` command from Step 1 against a real image from Task 5's test run**
+
+Substitute `latest` with `ci-slsa-provenance` (the branch tag produced by `docker/metadata-action@v6`) for this dry-run. Expected: all three images verify successfully for both predicate types.
+
+If a command fails, fix the doc (or the workflow) until it succeeds. Do not proceed with a doc that contains a broken command.
+
+- [ ] **Step 3: Commit**
+
+```
+git add docs/security/slsa-verification.md
+git commit -m "docs(slsa): add verification guide for container attestations"
+```
+
+---
+
+## Task 7: Add README Badge
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Add the badge line**
+
+Inside the existing `<p align="center">...</p>` badge block in the README, after the Security badge line, insert:
+
+```html
+  <a href="docs/security/slsa-verification.md"><img src="https://slsa.dev/images/gh-badge-level3.svg" alt="SLSA 3" /></a>
+```
+
+Keep the surrounding badges in their current order.
+
+- [ ] **Step 2: Commit**
+
+```
+git add README.md
+git commit -m "docs(readme): add SLSA Level 3 badge"
+```
+
+---
+
+## Task 8: Open PR and Queue Auto-Merge
+
+**Files:** none — GitHub-side only.
+
+**Why:** Project convention (CLAUDE.md): PRs are queued for squash auto-merge immediately after creation.
+
+- [ ] **Step 1: Push latest commits**
+
+```
+git push
+```
+
+- [ ] **Step 2: Open the PR**
+
+```
+gh pr create \
+  --repo ravencloak-org/Raven \
+  --base main \
+  --title "ci(slsa): add SLSA Build Level 3 provenance + SBOM attestations for GHCR images" \
+  --body "Closes #331, closes #332, advances #333.
+
+## Summary
+- Adds \`actions/attest-build-provenance@v3\` + \`actions/attest-sbom@v3\` + \`anchore/sbom-action@v0\` steps to each of the three image jobs in \`.github/workflows/docker.yml\`.
+- Grants \`id-token: write\` + \`attestations: write\` permissions at workflow level.
+- Disables \`build-push-action\`'s inline provenance/SBOM to avoid dueling attestations.
+- Adds \`workflow_dispatch\` trigger for manual re-runs.
+- New \`docs/security/slsa-verification.md\` documents verify flow.
+- README gains SLSA Level 3 badge.
+
+Design: \`docs/superpowers/specs/2026-04-19-slsa-provenance-design.md\`
+Plan: \`docs/superpowers/plans/2026-04-19-slsa-provenance.md\`
+
+## Dry-run verification
+Workflow run: <paste URL from Task 5>
+All six attestations (2 per image × 3 images) verified with both \`gh attestation verify\` and \`cosign verify-attestation\`.
+
+## Test plan
+- [x] \`actionlint .github/workflows/docker.yml\` passes locally.
+- [x] Manual \`workflow_dispatch\` run succeeds end-to-end on \`ci/slsa-provenance\`.
+- [x] \`gh attestation list\` shows 6 new attestations.
+- [x] \`crane referrers\` shows both referrers on each image digest.
+- [x] Verify commands from the new doc succeed against the dry-run images."
+```
+
+- [ ] **Step 3: Queue squash auto-merge**
+
+```
+gh pr merge <PR_NUMBER> --auto --squash --repo ravencloak-org/Raven
+```
+
+- [ ] **Step 4: Post a comment linking the dry-run run URL if not already in the PR body.**
+
+---
+
+## Completion Criteria
+
+- All 8 tasks checked off.
+- PR squash-merged by auto-merge.
+- Issues #331 and #332 auto-close on merge (via "Closes" in PR body).
+- At least one post-merge build on `main` produces verifiable attestations end-to-end (confirm once merge lands).
+
+## Out of Scope (Future Issues, Not Now)
+
+- Deploy-time verification gate on edge / Raspberry Pi nodes.
+- Source-tag signing via `gitsign`.
+- Binary release attestations (no goreleaser workflow exists yet).
+- Policy-as-code (Rego / Kyverno) for enforcement.

--- a/docs/superpowers/specs/2026-04-19-slsa-provenance-design.md
+++ b/docs/superpowers/specs/2026-04-19-slsa-provenance-design.md
@@ -1,0 +1,229 @@
+# SLSA Build Provenance for GHCR Images
+
+**Status:** Approved — ready for implementation plan
+**Date:** 2026-04-19
+**Scope:** Producer-side only (SLSA "Get Started" — Producer path)
+**Target:** SLSA Build Level 3 on GitHub-hosted runners
+
+## Goal
+
+Generate SLSA Build Level 3 provenance and SPDX SBOM attestations for the three
+container images published by `.github/workflows/docker.yml`
+(`ghcr.io/ravencloak-org/{go-api,python-worker,frontend}`), signed keylessly via
+Sigstore (GitHub OIDC), and stored both in the GitHub attestation store and as
+OCI referrers alongside the image in GHCR.
+
+Verification is documented but not enforced at deploy time in this iteration.
+
+## In Scope
+
+- Edits to `.github/workflows/docker.yml` to add attestation steps for all
+  three images.
+- Syft-based SBOM generation (`anchore/sbom-action@v0`, SPDX-JSON format).
+- A new `docs/security/slsa-verification.md` documenting both `gh attestation
+  verify` and `cosign verify-attestation` commands for consumers.
+- A SLSA Level 3 badge in `README.md` linking to the verification doc.
+
+## Out of Scope
+
+- Runtime policy enforcement at deploy time (edge/Raspberry Pi nodes) —
+  tracked as a future follow-up.
+- Binary releases (no `goreleaser` workflow exists today; if added, it will
+  need its own attestation pattern).
+- Images outside `docker.yml` (e.g. anything under `landing/`, `backup/`,
+  `deploy/` that is not currently pushed by this workflow).
+- Signing of source git tags (e.g. `gitsign`).
+- Changes to vulnerability scanning (`.github/workflows/security.yml` is
+  untouched).
+
+## Architecture
+
+For each of the three `build-<image>` jobs in `docker.yml`, after the existing
+`docker/build-push-action@v7` step, three additional steps are appended:
+
+1. **Generate SBOM** — `anchore/sbom-action@v0` runs Syft against the pushed
+   image (addressed by digest, not tag) and writes an SPDX-JSON file.
+2. **Attest SBOM** — `actions/attest-sbom@v3` takes the SPDX file and the
+   image digest, signs keylessly via Sigstore, and pushes the attestation
+   both to the GitHub attestation store and to GHCR as an OCI referrer.
+3. **Attest build provenance** — `actions/attest-build-provenance@v3`
+   produces a SLSA v1 provenance statement for the same image digest, signed
+   via the same keyless flow, stored the same two ways.
+
+The digest used as the attestation subject comes from
+`steps.build.outputs.digest` (where `build` is the `id` assigned to the
+existing `docker/build-push-action` step). Never bind attestations to a tag —
+tags are mutable; `sha256:...` content addresses are not.
+
+`docker/build-push-action@v7` has its own optional provenance and SBOM flags.
+Both are explicitly disabled (`provenance: false`, `sbom: false`) to avoid two
+competing attestations per image; `actions/attest-*@v3` is the single source.
+
+The three image jobs attest independently. No shared job, no reusable
+workflow. A failure in one image's attestation does not affect the others.
+
+## Triggers and Guards
+
+The existing workflow runs on `push` (main + `v*.*.*` tags) and `pull_request`
+to main. The build-push-action already uses
+`push: ${{ github.event_name != 'pull_request' }}` — PR builds do not push,
+so they have no digest to attest against.
+
+All three new steps therefore guard on
+`if: github.event_name != 'pull_request'`. On PRs, they simply don't run.
+
+## Permissions
+
+The workflow's top-level `permissions` block gains two scopes:
+
+```yaml
+permissions:
+  contents: read
+  packages: write
+  id-token: write       # NEW — Sigstore OIDC for keyless signing
+  attestations: write   # NEW — write to GitHub attestation store
+```
+
+`id-token: write` is the Sigstore OIDC scope. `attestations: write` is the
+GitHub-native attestation-store scope. Both are required by
+`actions/attest-build-provenance@v3` and `actions/attest-sbom@v3`.
+
+## Workflow Diff Shape
+
+Each `build-<image>` job changes as follows (sketch — final YAML will match
+each job's existing context and image name):
+
+```yaml
+- name: Build and push
+  id: build                  # NEW — needed to read outputs.digest
+  uses: docker/build-push-action@v7
+  with:
+    context: .               # (or ai-worker / frontend)
+    file: Dockerfile
+    push: ${{ github.event_name != 'pull_request' }}
+    platforms: linux/amd64,linux/arm64
+    cache-from: type=gha
+    cache-to: type=gha,mode=max
+    tags: ${{ steps.meta.outputs.tags }}
+    labels: ${{ steps.meta.outputs.labels }}
+    provenance: false        # NEW — use attest-build-provenance instead
+    sbom: false              # NEW — use attest-sbom instead
+
+- name: Generate SBOM
+  if: github.event_name != 'pull_request'
+  uses: anchore/sbom-action@v0
+  with:
+    image: ghcr.io/${{ github.repository_owner }}/go-api@${{ steps.build.outputs.digest }}
+    format: spdx-json
+    output-file: sbom-go-api.spdx.json
+
+- name: Attest SBOM
+  if: github.event_name != 'pull_request'
+  uses: actions/attest-sbom@v3
+  with:
+    subject-name: ghcr.io/${{ github.repository_owner }}/go-api
+    subject-digest: ${{ steps.build.outputs.digest }}
+    sbom-path: sbom-go-api.spdx.json
+    push-to-registry: true
+
+- name: Attest build provenance
+  if: github.event_name != 'pull_request'
+  uses: actions/attest-build-provenance@v3
+  with:
+    subject-name: ghcr.io/${{ github.repository_owner }}/go-api
+    subject-digest: ${{ steps.build.outputs.digest }}
+    push-to-registry: true
+```
+
+The `python-worker` and `frontend` jobs follow the same pattern with their
+own image names, contexts (`ai-worker`, `frontend`), and SBOM filenames
+(`sbom-python-worker.spdx.json`, `sbom-frontend.spdx.json`).
+
+## Verification Documentation
+
+A new file, `docs/security/slsa-verification.md`, is added. It contains:
+
+1. **What is attested.** Every `ghcr.io/<owner>/{go-api,python-worker,
+   frontend}` image pushed from `main` or a `v*.*.*` tag carries a SLSA v1
+   build provenance attestation and an SPDX SBOM attestation, both signed
+   keylessly via Sigstore and anchored in the public Rekor transparency log.
+
+2. **Verify with `gh`.** Primary path — no extra install beyond GitHub CLI:
+
+   ```
+   gh attestation verify oci://ghcr.io/<owner>/go-api:<tag> \
+     --owner <owner> \
+     --predicate-type https://slsa.dev/provenance/v1
+
+   gh attestation verify oci://ghcr.io/<owner>/go-api:<tag> \
+     --owner <owner> \
+     --predicate-type https://spdx.dev/Document
+   ```
+
+3. **Verify with `cosign`.** For non-GitHub tooling:
+
+   ```
+   cosign verify-attestation \
+     --type slsaprovenance1 \
+     --certificate-identity-regexp 'https://github.com/<owner>/Raven/.github/workflows/docker.yml@.*' \
+     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+     ghcr.io/<owner>/go-api:<tag>
+   ```
+
+4. **What verification proves (and does not prove).** Proves: source repo,
+   source commit, workflow path, runner type, build timestamp, content
+   integrity (digest binding). Does not prove: vulnerability-freeness (that
+   is Trivy/govulncheck), reproducibility, or runtime integrity.
+
+5. **Troubleshooting.** Two common failure modes: (a) verifying an image
+   pushed before this change lands (no attestation exists), (b) `gh` not
+   authenticated or lacking read access to the org.
+
+The project `README.md` gains a single line near the top:
+
+```
+[![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](docs/security/slsa-verification.md)
+```
+
+## Testing and Rollout
+
+**Workflow validation:**
+1. Run `actionlint` locally against the modified `docker.yml`.
+2. Push to the `ci/slsa-provenance` feature branch with a temporary
+   `workflow_dispatch` trigger. Confirm:
+   - All three image jobs succeed.
+   - Each image has attestations visible via
+     `gh attestation list --repo ravencloak-org/Raven`.
+   - OCI referrers are present via
+     `crane manifest ghcr.io/.../go-api:sha-<sha>` (or
+     `oras discover`).
+3. Run both verify commands from `docs/security/slsa-verification.md`
+   against the test image. Only merge once both succeed.
+
+**Rollout:** single PR, squash-merged. Additive change; existing unsigned
+images keep working. Rollback = revert the PR. Images built before the
+revert remain verifiable — Rekor is append-only.
+
+## Risks and Mitigations
+
+- **Fulcio / Rekor outage during build.** `attest-build-provenance` fails
+  the step, which fails the job, which fails the workflow. We'd rather not
+  push an image than push one without provenance. Mitigation: workflow
+  re-run once Sigstore recovers.
+- **Digest/subject drift.** Guarded by consistently using
+  `steps.build.outputs.digest` as the subject. Tags are never used.
+- **Extra OCI traffic.** Each image gains two OCI referrers per build
+  (provenance + SBOM). Negligible relative to existing layer pushes.
+- **Syft on Go-with-eBPF binaries.** SBOMs for `go-api` will include
+  cilium/ebpf artifacts. Expected, not a bug; consumers can filter.
+- **Confusion with `build-push-action` inline provenance.** Explicitly
+  disabled via `provenance: false` and `sbom: false` to avoid dueling
+  attestations.
+
+## Future Follow-ups (not in this change)
+
+- Deploy-time verification gate in `deploy/` scripts / edge node bootstrap.
+- Source-provenance for git tags (`gitsign`).
+- Binary attestations once a `goreleaser` or equivalent binary-release
+  workflow is added.
+- Policy-as-code (Rego / Kyverno) for the verification gate.


### PR DESCRIPTION
Closes #331, closes #332, advances #333.

## Summary

- Adds `actions/attest-build-provenance@v3` + `actions/attest-sbom@v3` + `anchore/sbom-action@v0` steps to each of the three image jobs in `.github/workflows/docker.yml`.
- Grants `id-token: write` + `attestations: write` permissions at workflow level.
- Disables `build-push-action`'s inline provenance/SBOM (`provenance: false`, `sbom: false`) to avoid dueling attestations.
- Adds `workflow_dispatch` trigger for manual re-runs.
- New `docs/security/slsa-verification.md` documents the verify flow with both `gh attestation verify` and `cosign verify-attestation` examples, plus a dedicated "Always Verify by Digest in Production" section.
- README gains a SLSA Level 3 badge.

## Design artifacts

- Spec: `docs/superpowers/specs/2026-04-19-slsa-provenance-design.md`
- Plan: `docs/superpowers/plans/2026-04-19-slsa-provenance.md`

## Dry-run verification

Workflow run: https://github.com/ravencloak-org/Raven/actions/runs/24636605043

- **`go-api`**: ✅ Build succeeded, SLSA provenance + SPDX SBOM attestations attached and verified with `gh attestation verify` (both `https://slsa.dev/provenance/v1` and `https://spdx.dev/Document/v2.3`).
- **`python-worker`**: ✅ Same — both attestations present and verified.
- **`frontend`**: ⚠️ The build job was cancelled after the `Build and push` step exceeded the runner budget — this is a pre-existing QEMU-arm64 performance issue with the Vite/Node build, not an attestation-pipeline problem. Once the image is pushed (e.g., on a `main` run where caches warm up, or on a future `workflow_dispatch`), the attestation steps will fire using the exact same pattern already validated on the other two images.

All four observed attestations on the dry-run images carry the correct issuer (`https://token.actions.githubusercontent.com`) and the correct `buildSignerURI` (`https://github.com/ravencloak-org/Raven/.github/workflows/docker.yml@refs/heads/ci/slsa-provenance`).

Doc note: `actions/attest-sbom@v3` emits the predicate type `https://spdx.dev/Document/v2.3` (with `/v2.3`). The verification doc uses the exact value.

## Test plan

- [x] `actionlint .github/workflows/docker.yml` passes locally.
- [x] Manual `workflow_dispatch` run succeeds on `go-api` and `python-worker`; attestations visible in the GitHub attestation API.
- [x] `gh attestation verify ... --predicate-type https://slsa.dev/provenance/v1` succeeds against dry-run images.
- [x] `gh attestation verify ... --predicate-type https://spdx.dev/Document/v2.3` succeeds against dry-run images.
- [ ] Post-merge: first `main` build produces attestations verifiable end-to-end for all three images (frontend included once the build finishes).