### PR TITLE
feat(m9): cross-channel conversation memory + PostHog (#258)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -335,7 +335,13 @@ func main() {
 	hsClient := hyperswitch.NewClient(cfg.Hyperswitch.BaseURL, cfg.Hyperswitch.APIKey)
 	billingSvc := service.NewBillingService(billingRepo, pool, hsClient, cfg.Hyperswitch.WebhookSecret)
 	chatRepo := repository.NewChatRepository(pool)
-	chatSvc := service.NewChatService(chatRepo, grpcClient, pool)
+	// Cross-channel conversation memory (issue #258): shares the
+	// conversation_sessions table with #257. The migration
+	// (00037_conversation_sessions.sql) is introduced by #257 — this
+	// branch reads/writes the table but does not create it.
+	conversationRepo := repository.NewConversationRepository(pool)
+	conversationSvc := service.NewConversationService(conversationRepo, posthogClient)
+	chatSvc := service.NewChatService(chatRepo, grpcClient, pool).WithConversationMemory(conversationSvc)
 	voiceRepo := repository.NewVoiceRepository(pool)
 	// Instantiate shared LiveKit client for WebRTC room management and token generation.
 	lkClient := lk.NewClient(lk.Config{
@@ -430,6 +436,7 @@ func main() {
 	securityHandler := handler.NewSecurityHandler(securitySvc)
 	strangerHandler := handler.NewStrangerHandler(strangerSvc)
 	identityHandler := handler.NewIdentityHandler(identitySvc)
+	conversationHandler := handler.NewConversationHandler(conversationSvc)
 	notifHandler := handler.NewNotificationHandler(notifSvc)
 	webhookHandler := handler.NewWebhookHandler(webhookSvc)
 	chatHandler := handler.NewChatHandler(chatSvc)
@@ -641,6 +648,14 @@ func main() {
 			identity.POST("/track", middleware.RequireOrgRole("org_member"), identityHandler.Track)
 			identity.GET("", middleware.RequireOrgRole("org_member"), identityHandler.ListIdentities)
 			identity.DELETE("/:id", middleware.RequireOrgRole("org_admin"), identityHandler.DeleteIdentity)
+		}
+
+		// --- Cross-channel conversation memory (#258): user-scoped history
+		// shared between chat, voice, and WebRTC channels. ---
+		conv := api.Group("/orgs/:org_id/kbs/:kb_id/conversations")
+		{
+			conv.GET("", middleware.RequireOrgRole("org_member"), conversationHandler.List)
+			conv.GET("/:session_id", middleware.RequireOrgRole("org_member"), conversationHandler.Get)
 		}
 
 		// --- Notification config and log routes (nested under org, admin only) ---

--- a/frontend/src/api/conversations.ts
+++ b/frontend/src/api/conversations.ts
@@ -1,0 +1,78 @@
+// Cross-channel conversation memory API — issue #258.
+// Depends on the conversation_sessions table shared with #257.
+
+export type ConversationChannel = 'chat' | 'voice' | 'webrtc'
+
+export interface ConversationTurn {
+  role: string
+  content: string
+  ts: string
+}
+
+export interface ConversationSession {
+  id: string
+  org_id: string
+  kb_id: string
+  user_id: string
+  channel: ConversationChannel
+  messages: ConversationTurn[]
+  started_at: string
+  ended_at?: string
+  summary?: string
+}
+
+export interface ConversationSessionSummary {
+  id: string
+  org_id: string
+  kb_id: string
+  user_id: string
+  channel: ConversationChannel
+  started_at: string
+  ended_at?: string
+  message_count: number
+  summary?: string
+}
+
+export interface ConversationListResponse {
+  sessions: ConversationSessionSummary[]
+  total: number
+  limit: number
+  offset: number
+}
+
+async function authFetch(path: string, init?: RequestInit): Promise<Response> {
+  const base = import.meta.env.VITE_API_BASE_URL ?? '/api/v1'
+  return fetch(base + path, {
+    ...init,
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      ...init?.headers,
+    },
+  })
+}
+
+export async function listConversations(
+  orgId: string,
+  kbId: string,
+  limit = 5,
+  offset = 0,
+): Promise<ConversationListResponse> {
+  const res = await authFetch(
+    `/orgs/${encodeURIComponent(orgId)}/kbs/${encodeURIComponent(kbId)}/conversations?limit=${limit}&offset=${offset}`,
+  )
+  if (!res.ok) throw new Error(`listConversations failed: ${res.status}`)
+  return res.json()
+}
+
+export async function getConversation(
+  orgId: string,
+  kbId: string,
+  sessionId: string,
+): Promise<ConversationSession> {
+  const res = await authFetch(
+    `/orgs/${encodeURIComponent(orgId)}/kbs/${encodeURIComponent(kbId)}/conversations/${encodeURIComponent(sessionId)}`,
+  )
+  if (!res.ok) throw new Error(`getConversation failed: ${res.status}`)
+  return res.json()
+}

--- a/frontend/src/components/conversations/RecentConversationsCard.vue
+++ b/frontend/src/components/conversations/RecentConversationsCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import {
   listConversations,
   getConversation,
@@ -72,7 +72,23 @@ function closeTranscript() {
   selected.value = null
 }
 
-onMounted(load)
+// Keep the transcript open on Escape the same way a native <dialog> would —
+// without the implied modal semantics (see #349 CodeRabbit review thread).
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === 'Escape' && selected.value) {
+    closeTranscript()
+  }
+}
+
+onMounted(() => {
+  void load()
+  window.addEventListener('keydown', onKeydown)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', onKeydown)
+})
+
 watch(() => [props.orgId, props.kbId], () => {
   sessions.value = []
   selected.value = null
@@ -129,14 +145,14 @@ watch(() => [props.orgId, props.kbId], () => {
       </li>
     </ul>
 
-    <div
+    <section
       v-if="selected"
       class="recent-conversations__transcript"
-      role="dialog"
-      aria-modal="true"
+      role="region"
+      aria-labelledby="recent-conv-transcript-heading"
     >
       <header class="recent-conversations__transcript-header">
-        <h4>Transcript</h4>
+        <h4 id="recent-conv-transcript-heading">Transcript</h4>
         <button type="button" @click="closeTranscript">Close</button>
       </header>
       <p v-if="loadingTranscript">Loading transcript…</p>
@@ -152,7 +168,7 @@ watch(() => [props.orgId, props.kbId], () => {
           <time class="recent-conversations__turn-ts">{{ fmtDate(t.ts) }}</time>
         </li>
       </ol>
-    </div>
+    </section>
   </section>
 </template>
 

--- a/frontend/src/components/conversations/RecentConversationsCard.vue
+++ b/frontend/src/components/conversations/RecentConversationsCard.vue
@@ -1,0 +1,289 @@
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import {
+  listConversations,
+  getConversation,
+  type ConversationSession,
+  type ConversationSessionSummary,
+} from '../../api/conversations'
+
+const props = defineProps<{
+  orgId: string
+  kbId: string
+}>()
+
+const loading = ref(false)
+const error = ref<string | null>(null)
+const sessions = ref<ConversationSessionSummary[]>([])
+const selected = ref<ConversationSession | null>(null)
+const loadingTranscript = ref(false)
+
+const returningGreeting = computed(() => {
+  if (!sessions.value.length) return null
+  const latest = sessions.value[0]
+  const topic = latest.summary ?? `your last ${latest.channel} conversation`
+  return `Welcome back! Last time you asked about ${topic}.`
+})
+
+const channelIcon = (c: string): string => {
+  switch (c) {
+    case 'chat': return 'message-square'
+    case 'voice': return 'phone'
+    case 'webrtc': return 'video'
+    default: return 'circle'
+  }
+}
+
+const fmtDate = (iso: string): string => {
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
+    })
+  } catch {
+    return iso
+  }
+}
+
+async function load() {
+  loading.value = true
+  error.value = null
+  try {
+    const resp = await listConversations(props.orgId, props.kbId, 5, 0)
+    sessions.value = resp.sessions
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function openSession(id: string) {
+  loadingTranscript.value = true
+  try {
+    selected.value = await getConversation(props.orgId, props.kbId, id)
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    loadingTranscript.value = false
+  }
+}
+
+function closeTranscript() {
+  selected.value = null
+}
+
+onMounted(load)
+watch(() => [props.orgId, props.kbId], () => {
+  sessions.value = []
+  selected.value = null
+  void load()
+})
+</script>
+
+<template>
+  <section class="recent-conversations" aria-labelledby="recent-conv-heading">
+    <header class="recent-conversations__header">
+      <h3 id="recent-conv-heading">Recent conversations</h3>
+      <button
+        type="button"
+        class="recent-conversations__refresh"
+        :disabled="loading"
+        @click="load"
+      >
+        {{ loading ? 'Loading…' : 'Refresh' }}
+      </button>
+    </header>
+
+    <p v-if="returningGreeting" class="recent-conversations__greeting">
+      {{ returningGreeting }}
+    </p>
+
+    <p v-if="error" class="recent-conversations__error" role="alert">
+      {{ error }}
+    </p>
+
+    <p v-if="!loading && !error && sessions.length === 0" class="recent-conversations__empty">
+      No past sessions yet. Start a chat or voice call and it will appear here.
+    </p>
+
+    <ul v-if="sessions.length" class="recent-conversations__list">
+      <li
+        v-for="s in sessions"
+        :key="s.id"
+        class="recent-conversations__item"
+      >
+        <button
+          type="button"
+          class="recent-conversations__item-btn"
+          @click="openSession(s.id)"
+        >
+          <span :data-icon="channelIcon(s.channel)" class="recent-conversations__icon">
+            {{ s.channel }}
+          </span>
+          <span class="recent-conversations__meta">
+            <span class="recent-conversations__date">{{ fmtDate(s.started_at) }}</span>
+            <span class="recent-conversations__count">{{ s.message_count }} messages</span>
+          </span>
+          <span v-if="s.summary" class="recent-conversations__summary">{{ s.summary }}</span>
+        </button>
+      </li>
+    </ul>
+
+    <div
+      v-if="selected"
+      class="recent-conversations__transcript"
+      role="dialog"
+      aria-modal="true"
+    >
+      <header class="recent-conversations__transcript-header">
+        <h4>Transcript</h4>
+        <button type="button" @click="closeTranscript">Close</button>
+      </header>
+      <p v-if="loadingTranscript">Loading transcript…</p>
+      <ol v-else class="recent-conversations__turns">
+        <li
+          v-for="(t, idx) in selected.messages"
+          :key="idx"
+          :data-role="t.role"
+          class="recent-conversations__turn"
+        >
+          <span class="recent-conversations__turn-role">{{ t.role }}</span>
+          <p class="recent-conversations__turn-content">{{ t.content }}</p>
+          <time class="recent-conversations__turn-ts">{{ fmtDate(t.ts) }}</time>
+        </li>
+      </ol>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.recent-conversations {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-radius: 12px;
+  background: var(--surface-1, #fff);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+.recent-conversations__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+}
+.recent-conversations__header h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+.recent-conversations__refresh {
+  background: transparent;
+  border: none;
+  color: var(--color-primary, #2563eb);
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+.recent-conversations__greeting {
+  margin: 0;
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
+  background: var(--surface-2, #f4f6fb);
+  font-size: 0.9rem;
+}
+.recent-conversations__error {
+  color: #b91c1c;
+  font-size: 0.9rem;
+}
+.recent-conversations__empty {
+  color: var(--text-muted, #6b7280);
+  font-size: 0.9rem;
+}
+.recent-conversations__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.recent-conversations__item-btn {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.25rem 0.75rem;
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--border, #e5e7eb);
+  border-radius: 10px;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+}
+.recent-conversations__item-btn:hover,
+.recent-conversations__item-btn:focus-visible {
+  border-color: var(--color-primary, #2563eb);
+  outline: none;
+}
+.recent-conversations__icon {
+  grid-row: span 2;
+  align-self: start;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  background: var(--surface-2, #f4f6fb);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.recent-conversations__meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  color: var(--text-muted, #6b7280);
+}
+.recent-conversations__summary {
+  grid-column: 2;
+  font-size: 0.9rem;
+  color: var(--text-default, #111827);
+}
+.recent-conversations__transcript {
+  margin-top: 0.75rem;
+  padding: 0.75rem;
+  border-radius: 10px;
+  border: 1px solid var(--border, #e5e7eb);
+}
+.recent-conversations__transcript-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.recent-conversations__turns {
+  list-style: none;
+  padding: 0;
+  margin: 0.5rem 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.recent-conversations__turn {
+  padding: 0.5rem 0.6rem;
+  border-radius: 8px;
+  background: var(--surface-2, #f4f6fb);
+}
+.recent-conversations__turn[data-role='assistant'] {
+  background: var(--surface-3, #eef2ff);
+}
+.recent-conversations__turn-role {
+  display: inline-block;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted, #6b7280);
+}
+.recent-conversations__turn-content {
+  margin: 0.15rem 0;
+  font-size: 0.95rem;
+  white-space: pre-wrap;
+}
+.recent-conversations__turn-ts {
+  font-size: 0.75rem;
+  color: var(--text-muted, #6b7280);
+}
+</style>

--- a/frontend/src/pages/knowledge-bases/KBDetailPage.vue
+++ b/frontend/src/pages/knowledge-bases/KBDetailPage.vue
@@ -2,6 +2,7 @@
 import { nextTick, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useKnowledgeBasesStore } from '../../stores/knowledge-bases'
+import RecentConversationsCard from '../../components/conversations/RecentConversationsCard.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -600,6 +601,10 @@ function statusBadgeClass(status: string): string {
           </button>
         </div>
         <p class="mt-1.5 text-xs text-gray-400">Press Enter to send · Shift+Enter for new line</p>
+      </section>
+
+      <section class="mt-6">
+        <RecentConversationsCard :org-id="orgId" :kb-id="kbId" />
       </section>
     </div>
   </div>

--- a/internal/handler/chat.go
+++ b/internal/handler/chat.go
@@ -66,6 +66,14 @@ func (h *ChatHandler) StreamCompletion(c *gin.Context) {
 		return
 	}
 
+	// Populate the stable authenticated user identifier (JWT `sub` claim)
+	// from the session context when present. This is what the cross-channel
+	// conversation memory layer (#258) keys on; it is never read from the
+	// JSON body to avoid client-supplied impersonation.
+	if uid := c.GetString(string(middleware.ContextKeyExternalID)); uid != "" {
+		req.UserID = uid
+	}
+
 	// Set SSE headers before starting the stream.
 	c.Header("Content-Type", "text/event-stream")
 	c.Header("Cache-Control", "no-cache")

--- a/internal/handler/conversation.go
+++ b/internal/handler/conversation.go
@@ -1,0 +1,120 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/ravencloak-org/Raven/internal/middleware"
+	"github.com/ravencloak-org/Raven/internal/model"
+	"github.com/ravencloak-org/Raven/pkg/apierror"
+)
+
+// ConversationServicer is the slice of ConversationService the handler needs.
+type ConversationServicer interface {
+	ListForUser(ctx context.Context, orgID, kbID, userID string, limit, offset int) (*model.ConversationListResponse, error)
+	GetTranscript(ctx context.Context, orgID, kbID, sessionID, userID string) (*model.ConversationSession, error)
+}
+
+// ConversationHandler exposes cross-channel conversation history.
+type ConversationHandler struct {
+	svc ConversationServicer
+}
+
+// NewConversationHandler creates a new ConversationHandler.
+func NewConversationHandler(svc ConversationServicer) *ConversationHandler {
+	return &ConversationHandler{svc: svc}
+}
+
+// List handles GET /api/v1/orgs/:org_id/kbs/:kb_id/conversations.
+// Returns the authenticated user's paginated session history for the KB.
+//
+// @Summary     List user's conversation sessions for a KB
+// @Tags        conversations
+// @Produce     json
+// @Security    BearerAuth
+// @Param       org_id path  string true  "Organisation ID"
+// @Param       kb_id  path  string true  "Knowledge base ID"
+// @Param       limit  query int    false "Page size (default 20, max 100)"
+// @Param       offset query int    false "Offset (default 0)"
+// @Success     200 {object} model.ConversationListResponse
+// @Failure     401 {object} apierror.AppError
+// @Router      /orgs/{org_id}/kbs/{kb_id}/conversations [get]
+func (h *ConversationHandler) List(c *gin.Context) {
+	orgID, userID, ok := extractOrgAndUser(c)
+	if !ok {
+		return
+	}
+	kbID := c.Param("kb_id")
+	if kbID == "" {
+		_ = c.Error(apierror.NewBadRequest("kb_id is required"))
+		c.Abort()
+		return
+	}
+
+	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "20"))
+	offset, _ := strconv.Atoi(c.DefaultQuery("offset", "0"))
+
+	resp, err := h.svc.ListForUser(c.Request.Context(), orgID, kbID, userID, limit, offset)
+	if err != nil {
+		_ = c.Error(err)
+		c.Abort()
+		return
+	}
+	c.JSON(http.StatusOK, resp)
+}
+
+// Get handles GET /api/v1/orgs/:org_id/kbs/:kb_id/conversations/:session_id.
+// Returns the full transcript for a session owned by the authenticated user.
+//
+// @Summary     Get conversation transcript
+// @Tags        conversations
+// @Produce     json
+// @Security    BearerAuth
+// @Param       org_id     path string true "Organisation ID"
+// @Param       kb_id      path string true "Knowledge base ID"
+// @Param       session_id path string true "Session ID"
+// @Success     200 {object} model.ConversationSession
+// @Failure     401 {object} apierror.AppError
+// @Failure     404 {object} apierror.AppError
+// @Router      /orgs/{org_id}/kbs/{kb_id}/conversations/{session_id} [get]
+func (h *ConversationHandler) Get(c *gin.Context) {
+	orgID, userID, ok := extractOrgAndUser(c)
+	if !ok {
+		return
+	}
+	kbID := c.Param("kb_id")
+	sessionID := c.Param("session_id")
+	if kbID == "" || sessionID == "" {
+		_ = c.Error(apierror.NewBadRequest("kb_id and session_id are required"))
+		c.Abort()
+		return
+	}
+
+	sess, err := h.svc.GetTranscript(c.Request.Context(), orgID, kbID, sessionID, userID)
+	if err != nil {
+		_ = c.Error(err)
+		c.Abort()
+		return
+	}
+	c.JSON(http.StatusOK, sess)
+}
+
+// extractOrgAndUser reads orgID and the authenticated user's stable
+// identifier (JWT `sub` claim, stored in ContextKeyExternalID by SuperTokens)
+// from the Gin context. Responds with 401 when either is missing.
+func extractOrgAndUser(c *gin.Context) (orgID, userID string, ok bool) {
+	orgID, ok = extractOrgID(c)
+	if !ok {
+		return "", "", false
+	}
+	userID = c.GetString(string(middleware.ContextKeyExternalID))
+	if userID == "" {
+		_ = c.Error(apierror.NewUnauthorized("authenticated user required"))
+		c.Abort()
+		return "", "", false
+	}
+	return orgID, userID, true
+}

--- a/internal/handler/conversation.go
+++ b/internal/handler/conversation.go
@@ -56,6 +56,14 @@ func (h *ConversationHandler) List(c *gin.Context) {
 
 	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "20"))
 	offset, _ := strconv.Atoi(c.DefaultQuery("offset", "0"))
+	// Mirror the clamp in internal/handler/chat.go GetHistory/ListSessions so
+	// callers get defensive pagination at the HTTP edge as well as the repo.
+	if limit <= 0 || limit > 100 {
+		limit = 20
+	}
+	if offset < 0 {
+		offset = 0
+	}
 
 	resp, err := h.svc.ListForUser(c.Request.Context(), orgID, kbID, userID, limit, offset)
 	if err != nil {

--- a/internal/model/chat.go
+++ b/internal/model/chat.go
@@ -81,12 +81,21 @@ type ChatMessage struct {
 
 // ChatCompletionRequest is the request body for POST /v1/chat/:kb_id/completions.
 type ChatCompletionRequest struct {
-	Query    string            `json:"query" binding:"required"`
-	SessionID string           `json:"session_id,omitempty"`
-	Model    string            `json:"model,omitempty"`
-	Provider string            `json:"provider,omitempty"`
-	Filters  map[string]string `json:"filters,omitempty"`
-	Stream   bool              `json:"stream"`
+	Query     string            `json:"query" binding:"required"`
+	SessionID string            `json:"session_id,omitempty"`
+	Model     string            `json:"model,omitempty"`
+	Provider  string            `json:"provider,omitempty"`
+	Filters   map[string]string `json:"filters,omitempty"`
+	Stream    bool              `json:"stream"`
+	// UserID is the stable authenticated user identifier (JWT `sub` claim).
+	// Populated server-side by the handler from the request context — never
+	// trusted from the client body. Used to pull cross-channel conversation
+	// memory from the conversation_sessions table (issue #258).
+	UserID string `json:"-"`
+	// ConversationSessionID is the caller's active cross-channel
+	// conversation_sessions row id (when one has been started). Also populated
+	// server-side by the handler / voice code path.
+	ConversationSessionID string `json:"-"`
 }
 
 // ChatSource describes a source chunk that contributed to the AI response.

--- a/internal/model/conversation.go
+++ b/internal/model/conversation.go
@@ -1,0 +1,92 @@
+// Package model defines shared domain types.
+//
+// This file models cross-channel conversation memory — the user-centric
+// history shared between chat, voice, and WebRTC sessions. The underlying
+// conversation_sessions table is introduced by issue #257's migration
+// (00037_conversation_sessions.sql). This PR consumes that schema.
+package model
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// ConversationChannel enumerates the supported conversation channels.
+const (
+	// ConvChannelChat is the text-based chat widget channel.
+	ConvChannelChat = "chat"
+	// ConvChannelVoice is the PSTN / voice telephony channel.
+	ConvChannelVoice = "voice"
+	// ConvChannelWebRTC is the browser WebRTC voice/video channel.
+	ConvChannelWebRTC = "webrtc"
+)
+
+// MaxConversationHistoryTurns is the maximum number of turns surfaced to
+// the AI worker on a new message. Five keeps the prompt overhead under
+// roughly 1500 tokens.
+const MaxConversationHistoryTurns = 5
+
+// ConversationTurn is a single user or assistant message persisted inside
+// a ConversationSession.messages JSONB column.
+type ConversationTurn struct {
+	Role      string    `json:"role"`
+	Content   string    `json:"content"`
+	Timestamp time.Time `json:"ts"`
+}
+
+// ConversationSession is the cross-channel session keyed by the stable
+// authenticated user ID (JWT sub claim).
+type ConversationSession struct {
+	ID        string             `json:"id"`
+	OrgID     string             `json:"org_id"`
+	KBID      string             `json:"kb_id"`
+	UserID    string             `json:"user_id"`
+	Channel   string             `json:"channel"`
+	Messages  []ConversationTurn `json:"messages"`
+	StartedAt time.Time          `json:"started_at"`
+	EndedAt   *time.Time         `json:"ended_at,omitempty"`
+	Summary   *string            `json:"summary,omitempty"`
+}
+
+// ConversationSessionSummary is the lightweight row returned by list endpoints.
+type ConversationSessionSummary struct {
+	ID           string     `json:"id"`
+	OrgID        string     `json:"org_id"`
+	KBID         string     `json:"kb_id"`
+	UserID       string     `json:"user_id"`
+	Channel      string     `json:"channel"`
+	StartedAt    time.Time  `json:"started_at"`
+	EndedAt      *time.Time `json:"ended_at,omitempty"`
+	MessageCount int        `json:"message_count"`
+	Summary      *string    `json:"summary,omitempty"`
+}
+
+// ConversationListResponse is the paginated response for GET /conversations.
+type ConversationListResponse struct {
+	Sessions []ConversationSessionSummary `json:"sessions"`
+	Total    int                          `json:"total"`
+	Limit    int                          `json:"limit"`
+	Offset   int                          `json:"offset"`
+}
+
+// MarshalMessages serialises the ConversationTurn slice for JSONB storage.
+// Returns "[]" for nil/empty slices so the DB column keeps a valid JSON array.
+func MarshalMessages(turns []ConversationTurn) ([]byte, error) {
+	if len(turns) == 0 {
+		return []byte("[]"), nil
+	}
+	return json.Marshal(turns)
+}
+
+// UnmarshalMessages parses a JSONB column payload into ConversationTurn slices.
+// Empty / null payloads yield a nil slice.
+func UnmarshalMessages(raw []byte) ([]ConversationTurn, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	var out []ConversationTurn
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/internal/model/conversation.go
+++ b/internal/model/conversation.go
@@ -26,6 +26,11 @@ const (
 // roughly 1500 tokens.
 const MaxConversationHistoryTurns = 5
 
+// DefaultConversationListLimit is the default page size for conversation
+// session list endpoints (distinct from MaxConversationHistoryTurns which
+// bounds turns, not sessions).
+const DefaultConversationListLimit = 20
+
 // ConversationTurn is a single user or assistant message persisted inside
 // a ConversationSession.messages JSONB column.
 type ConversationTurn struct {

--- a/internal/repository/conversation.go
+++ b/internal/repository/conversation.go
@@ -126,11 +126,14 @@ func (r *ConversationRepository) AppendMessage(
 }
 
 // EndSession stamps ended_at = NOW() on the session. Idempotent: subsequent
-// calls are a no-op.
+// calls are a no-op. Returns (ended=true, nil) only when this call actually
+// transitioned a row from open to ended; (ended=false, nil) when the row was
+// already ended. Returns ErrConversationNotFound if the row does not exist.
 func (r *ConversationRepository) EndSession(
 	ctx context.Context,
 	orgID, sessionID string,
-) error {
+) (bool, error) {
+	var ended bool
 	err := db.WithOrgID(ctx, r.pool, orgID, func(tx pgx.Tx) error {
 		tag, e := tx.Exec(ctx,
 			`UPDATE conversation_sessions
@@ -141,37 +144,41 @@ func (r *ConversationRepository) EndSession(
 		if e != nil {
 			return e
 		}
-		if tag.RowsAffected() == 0 {
-			// Either unknown session or already ended — treat as not found only
-			// when the row truly doesn't exist.
-			var exists bool
-			if err := tx.QueryRow(ctx,
-				`SELECT EXISTS(SELECT 1 FROM conversation_sessions WHERE id = $1 AND org_id = $2)`,
-				sessionID, orgID,
-			).Scan(&exists); err != nil {
-				return err
-			}
-			if !exists {
-				return ErrConversationNotFound
-			}
+		if tag.RowsAffected() > 0 {
+			ended = true
+			return nil
+		}
+		// Either unknown session or already ended — treat as not found only
+		// when the row truly doesn't exist.
+		var exists bool
+		if err := tx.QueryRow(ctx,
+			`SELECT EXISTS(SELECT 1 FROM conversation_sessions WHERE id = $1 AND org_id = $2)`,
+			sessionID, orgID,
+		).Scan(&exists); err != nil {
+			return err
+		}
+		if !exists {
+			return ErrConversationNotFound
 		}
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("ConversationRepository.EndSession: %w", err)
+		return false, fmt.Errorf("ConversationRepository.EndSession: %w", err)
 	}
-	return nil
+	return ended, nil
 }
 
 // GetRecentByUser returns the most recent sessions for a given user on a KB
-// ordered by started_at DESC. Limit <= 0 means use a default of 5.
+// ordered by started_at DESC. Limit <= 0 means use the default session-count
+// limit (DefaultConversationListLimit); this is a session count, not a turn
+// count.
 func (r *ConversationRepository) GetRecentByUser(
 	ctx context.Context,
 	orgID, kbID, userID string,
 	limit int,
 ) ([]model.ConversationSession, error) {
 	if limit <= 0 {
-		limit = model.MaxConversationHistoryTurns
+		limit = model.DefaultConversationListLimit
 	}
 
 	var out []model.ConversationSession
@@ -242,7 +249,7 @@ func (r *ConversationRepository) ListByUser(
 	limit, offset int,
 ) ([]model.ConversationSessionSummary, int, error) {
 	if limit <= 0 || limit > 100 {
-		limit = 20
+		limit = model.DefaultConversationListLimit
 	}
 	if offset < 0 {
 		offset = 0

--- a/internal/repository/conversation.go
+++ b/internal/repository/conversation.go
@@ -1,0 +1,300 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/ravencloak-org/Raven/internal/db"
+	"github.com/ravencloak-org/Raven/internal/model"
+)
+
+// ErrConversationNotFound is returned when the requested conversation session
+// does not exist or is not visible to the current org.
+var ErrConversationNotFound = errors.New("conversation session not found")
+
+// ConversationRepository persists and queries cross-channel conversation
+// sessions. The underlying conversation_sessions table (introduced by #257)
+// is org-scoped and protected by Postgres RLS via db.WithOrgID.
+type ConversationRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewConversationRepository creates a new ConversationRepository.
+func NewConversationRepository(pool *pgxpool.Pool) *ConversationRepository {
+	return &ConversationRepository{pool: pool}
+}
+
+const conversationCols = `id, org_id, kb_id, user_id, channel,
+	COALESCE(messages, '[]'::jsonb) AS messages,
+	started_at, ended_at, summary`
+
+func scanConversation(row pgx.Row) (*model.ConversationSession, error) {
+	var s model.ConversationSession
+	var msgRaw []byte
+	var summary *string
+	if err := row.Scan(
+		&s.ID, &s.OrgID, &s.KBID, &s.UserID, &s.Channel,
+		&msgRaw, &s.StartedAt, &s.EndedAt, &summary,
+	); err != nil {
+		return nil, err
+	}
+	turns, err := model.UnmarshalMessages(msgRaw)
+	if err != nil {
+		return nil, fmt.Errorf("decode messages: %w", err)
+	}
+	s.Messages = turns
+	s.Summary = summary
+	return &s, nil
+}
+
+// CreateSession inserts a new conversation session and returns the stored row.
+// messages is the initial turn payload (may be empty).
+func (r *ConversationRepository) CreateSession(
+	ctx context.Context,
+	orgID, kbID, userID, channel string,
+	initialMessages []model.ConversationTurn,
+) (*model.ConversationSession, error) {
+	if orgID == "" || kbID == "" || userID == "" || channel == "" {
+		return nil, fmt.Errorf("CreateSession: missing required identifiers")
+	}
+
+	msgsJSON, err := model.MarshalMessages(initialMessages)
+	if err != nil {
+		return nil, fmt.Errorf("CreateSession marshal: %w", err)
+	}
+
+	var session *model.ConversationSession
+	err = db.WithOrgID(ctx, r.pool, orgID, func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx,
+			`INSERT INTO conversation_sessions
+				(org_id, kb_id, user_id, channel, messages)
+			 VALUES ($1, $2, $3, $4, $5)
+			 RETURNING `+conversationCols,
+			orgID, kbID, userID, channel, msgsJSON,
+		)
+		var e error
+		session, e = scanConversation(row)
+		return e
+	})
+	if err != nil {
+		return nil, fmt.Errorf("ConversationRepository.CreateSession: %w", err)
+	}
+	return session, nil
+}
+
+// AppendMessage atomically pushes a new ConversationTurn onto the messages
+// JSONB array. Returns the updated session. Uses jsonb_build_array +
+// || concatenation so the update is a single SQL statement.
+func (r *ConversationRepository) AppendMessage(
+	ctx context.Context,
+	orgID, sessionID string,
+	turn model.ConversationTurn,
+) (*model.ConversationSession, error) {
+	turnJSON, err := json.Marshal(turn)
+	if err != nil {
+		return nil, fmt.Errorf("AppendMessage marshal: %w", err)
+	}
+
+	var session *model.ConversationSession
+	err = db.WithOrgID(ctx, r.pool, orgID, func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx,
+			`UPDATE conversation_sessions
+			 SET messages = COALESCE(messages, '[]'::jsonb) || jsonb_build_array($3::jsonb)
+			 WHERE id = $1 AND org_id = $2
+			 RETURNING `+conversationCols,
+			sessionID, orgID, string(turnJSON),
+		)
+		s, e := scanConversation(row)
+		if errors.Is(e, pgx.ErrNoRows) {
+			return ErrConversationNotFound
+		}
+		if e != nil {
+			return e
+		}
+		session = s
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("ConversationRepository.AppendMessage: %w", err)
+	}
+	return session, nil
+}
+
+// EndSession stamps ended_at = NOW() on the session. Idempotent: subsequent
+// calls are a no-op.
+func (r *ConversationRepository) EndSession(
+	ctx context.Context,
+	orgID, sessionID string,
+) error {
+	err := db.WithOrgID(ctx, r.pool, orgID, func(tx pgx.Tx) error {
+		tag, e := tx.Exec(ctx,
+			`UPDATE conversation_sessions
+			 SET ended_at = NOW()
+			 WHERE id = $1 AND org_id = $2 AND ended_at IS NULL`,
+			sessionID, orgID,
+		)
+		if e != nil {
+			return e
+		}
+		if tag.RowsAffected() == 0 {
+			// Either unknown session or already ended — treat as not found only
+			// when the row truly doesn't exist.
+			var exists bool
+			if err := tx.QueryRow(ctx,
+				`SELECT EXISTS(SELECT 1 FROM conversation_sessions WHERE id = $1 AND org_id = $2)`,
+				sessionID, orgID,
+			).Scan(&exists); err != nil {
+				return err
+			}
+			if !exists {
+				return ErrConversationNotFound
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("ConversationRepository.EndSession: %w", err)
+	}
+	return nil
+}
+
+// GetRecentByUser returns the most recent sessions for a given user on a KB
+// ordered by started_at DESC. Limit <= 0 means use a default of 5.
+func (r *ConversationRepository) GetRecentByUser(
+	ctx context.Context,
+	orgID, kbID, userID string,
+	limit int,
+) ([]model.ConversationSession, error) {
+	if limit <= 0 {
+		limit = model.MaxConversationHistoryTurns
+	}
+
+	var out []model.ConversationSession
+	err := db.WithOrgID(ctx, r.pool, orgID, func(tx pgx.Tx) error {
+		rows, e := tx.Query(ctx,
+			`SELECT `+conversationCols+`
+			 FROM conversation_sessions
+			 WHERE org_id = $1 AND kb_id = $2 AND user_id = $3
+			 ORDER BY started_at DESC
+			 LIMIT $4`,
+			orgID, kbID, userID, limit,
+		)
+		if e != nil {
+			return e
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			s, e2 := scanConversation(rows)
+			if e2 != nil {
+				return e2
+			}
+			out = append(out, *s)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, fmt.Errorf("ConversationRepository.GetRecentByUser: %w", err)
+	}
+	return out, nil
+}
+
+// GetByID fetches a single session and verifies the user owns it. Returns
+// ErrConversationNotFound when the row is missing or owned by another user.
+func (r *ConversationRepository) GetByID(
+	ctx context.Context,
+	orgID, sessionID, userID string,
+) (*model.ConversationSession, error) {
+	var session *model.ConversationSession
+	err := db.WithOrgID(ctx, r.pool, orgID, func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx,
+			`SELECT `+conversationCols+`
+			 FROM conversation_sessions
+			 WHERE id = $1 AND org_id = $2 AND user_id = $3`,
+			sessionID, orgID, userID,
+		)
+		s, e := scanConversation(row)
+		if errors.Is(e, pgx.ErrNoRows) {
+			return ErrConversationNotFound
+		}
+		if e != nil {
+			return e
+		}
+		session = s
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("ConversationRepository.GetByID: %w", err)
+	}
+	return session, nil
+}
+
+// ListByUser returns paginated session summaries for a user on a KB.
+// Uses jsonb_array_length to compute message count in-SQL.
+func (r *ConversationRepository) ListByUser(
+	ctx context.Context,
+	orgID, kbID, userID string,
+	limit, offset int,
+) ([]model.ConversationSessionSummary, int, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 20
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	var summaries []model.ConversationSessionSummary
+	var total int
+
+	err := db.WithOrgID(ctx, r.pool, orgID, func(tx pgx.Tx) error {
+		if e := tx.QueryRow(ctx,
+			`SELECT COUNT(*) FROM conversation_sessions
+			 WHERE org_id = $1 AND kb_id = $2 AND user_id = $3`,
+			orgID, kbID, userID,
+		).Scan(&total); e != nil {
+			return fmt.Errorf("count: %w", e)
+		}
+
+		rows, e := tx.Query(ctx,
+			`SELECT id, org_id, kb_id, user_id, channel,
+			        started_at, ended_at,
+			        jsonb_array_length(COALESCE(messages, '[]'::jsonb)) AS message_count,
+			        summary
+			 FROM conversation_sessions
+			 WHERE org_id = $1 AND kb_id = $2 AND user_id = $3
+			 ORDER BY started_at DESC
+			 LIMIT $4 OFFSET $5`,
+			orgID, kbID, userID, limit, offset,
+		)
+		if e != nil {
+			return fmt.Errorf("list query: %w", e)
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var s model.ConversationSessionSummary
+			var summary *string
+			if e2 := rows.Scan(
+				&s.ID, &s.OrgID, &s.KBID, &s.UserID, &s.Channel,
+				&s.StartedAt, &s.EndedAt, &s.MessageCount, &summary,
+			); e2 != nil {
+				return fmt.Errorf("scan: %w", e2)
+			}
+			s.Summary = summary
+			summaries = append(summaries, s)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, 0, fmt.Errorf("ConversationRepository.ListByUser: %w", err)
+	}
+	if summaries == nil {
+		summaries = []model.ConversationSessionSummary{}
+	}
+	return summaries, total, nil
+}

--- a/internal/service/chat.go
+++ b/internal/service/chat.go
@@ -178,23 +178,7 @@ func (s *ChatService) StreamCompletion(ctx context.Context, orgID, kbID string, 
 	// recent turns across chat/voice/webrtc sessions on this KB and forward
 	// them to the AI worker. Best-effort — failures are logged but do not
 	// break completion.
-	historyTurnsInjected := 0
-	isReturningUser := false
-	if s.convMem != nil && req.UserID != "" {
-		history, hErr := s.convMem.RecentHistory(ctx, orgID, kbID, req.UserID, model.MaxConversationHistoryTurns)
-		if hErr == nil && len(history) > 0 {
-			if raw, mErr := json.Marshal(history); mErr == nil {
-				filters["conversation_history"] = string(raw)
-				historyTurnsInjected = len(history)
-				isReturningUser = true
-			}
-		}
-		// Best-effort: append the user turn to the cross-channel memory.
-		if _, rErr := s.convMem.RecordMessage(ctx, orgID, req.ConversationSessionID, req.UserID, kbID, model.ConvChannelChat, "user", req.Query, isReturningUser, historyTurnsInjected); rErr != nil {
-			// swallow — analytics / memory must never break the stream
-			_ = rErr
-		}
-	}
+	convSessionID, historyTurnsInjected, isReturningUser := s.primeConversationMemory(ctx, orgID, kbID, req, filters)
 
 	provider := req.Provider
 	if provider == "" {
@@ -301,6 +285,10 @@ func (s *ChatService) StreamCompletion(ctx context.Context, orgID, kbID string, 
 			}
 			return
 		}
+
+		// Persist the assistant turn into cross-channel memory so other
+		// channels see a complete transcript. Best-effort.
+		s.recordAssistantMemoryTurn(ctx, orgID, kbID, req.UserID, convSessionID, fullText, isReturningUser, historyTurnsInjected)
 
 		// Emit done event.
 		msgID := ""
@@ -494,3 +482,65 @@ func strPtr(s string) *string {
 	}
 	return &s
 }
+
+// primeConversationMemory pulls cross-channel history, stuffs it into the
+// AI-worker filters, lazily creates a conversation_sessions row when none
+// exists, and appends the user's turn to that row. Returns the session ID
+// to reuse for the matching assistant turn, the number of history turns
+// injected, and whether the user is returning.
+//
+// All interactions are best-effort: any failure is swallowed so conversation
+// memory never breaks the chat stream.
+func (s *ChatService) primeConversationMemory(
+	ctx context.Context,
+	orgID, kbID string,
+	req *model.ChatCompletionRequest,
+	filters map[string]string,
+) (convSessionID string, historyTurnsInjected int, isReturningUser bool) {
+	convSessionID = req.ConversationSessionID
+	if s.convMem == nil || req.UserID == "" {
+		return convSessionID, 0, false
+	}
+
+	if history, hErr := s.convMem.RecentHistory(ctx, orgID, kbID, req.UserID, model.MaxConversationHistoryTurns); hErr == nil && len(history) > 0 {
+		if raw, mErr := json.Marshal(history); mErr == nil {
+			filters["conversation_history"] = string(raw)
+			historyTurnsInjected = len(history)
+			isReturningUser = true
+		}
+	}
+
+	// Lazily start a cross-channel conversation_sessions row when the caller
+	// hasn't supplied one. Without this, AppendMessage would silently fail
+	// with ErrConversationNotFound and the whole memory feature would be a
+	// no-op (see PR #349 CodeRabbit review).
+	if convSessionID == "" {
+		if sess, sErr := s.convMem.StartSession(ctx, orgID, kbID, req.UserID, model.ConvChannelChat); sErr == nil && sess != nil {
+			convSessionID = sess.ID
+		}
+	}
+
+	if convSessionID != "" {
+		if _, rErr := s.convMem.RecordMessage(ctx, orgID, convSessionID, req.UserID, kbID, model.ConvChannelChat, "user", req.Query, isReturningUser, historyTurnsInjected); rErr != nil {
+			_ = rErr // swallow — memory must never break the stream
+		}
+	}
+	return convSessionID, historyTurnsInjected, isReturningUser
+}
+
+// recordAssistantMemoryTurn mirrors primeConversationMemory's user-turn
+// AppendMessage for the assistant reply. Best-effort; failures are swallowed.
+func (s *ChatService) recordAssistantMemoryTurn(
+	ctx context.Context,
+	orgID, kbID, userID, convSessionID, content string,
+	isReturningUser bool,
+	historyTurnsInjected int,
+) {
+	if s.convMem == nil || userID == "" || convSessionID == "" {
+		return
+	}
+	if _, rErr := s.convMem.RecordMessage(ctx, orgID, convSessionID, userID, kbID, model.ConvChannelChat, "assistant", content, isReturningUser, historyTurnsInjected); rErr != nil {
+		_ = rErr
+	}
+}
+

--- a/internal/service/chat.go
+++ b/internal/service/chat.go
@@ -61,11 +61,25 @@ type AIWorkerClient interface {
 	Worker() pb.AIWorkerClient
 }
 
+// ConversationMemory is the cross-channel conversation memory integration
+// point. It injects user-scoped history into the gRPC call and records the
+// turn for later cross-channel recall. All methods are best-effort — failures
+// must not break chat completion.
+type ConversationMemory interface {
+	RecentHistory(ctx context.Context, orgID, kbID, userID string, maxTurns int) ([]model.ConversationTurn, error)
+	IsReturningUser(ctx context.Context, orgID, kbID, userID string) (bool, error)
+	RecordMessage(ctx context.Context, orgID, sessionID, userID, kbID, channel, role, content string, isReturningUser bool, historyTurnsInjected int) (*model.ConversationSession, error)
+	StartSession(ctx context.Context, orgID, kbID, userID, channel string) (*model.ConversationSession, error)
+}
+
 // ChatService contains business logic for chat completions with SSE streaming.
 type ChatService struct {
 	chatRepo   ChatRepository
 	grpcClient AIWorkerClient
 	pool       *pgxpool.Pool
+	// convMem is optional: when non-nil and the caller has an authenticated
+	// user, the service pulls cross-channel history and records the turn.
+	convMem ConversationMemory
 }
 
 // NewChatService creates a new ChatService.
@@ -76,6 +90,13 @@ func NewChatService(chatRepo *repository.ChatRepository, grpcClient *rpcClient.C
 // NewChatServiceWithDeps creates a ChatService with explicit interface dependencies (for testing).
 func NewChatServiceWithDeps(chatRepo ChatRepository, grpcClient AIWorkerClient, pool *pgxpool.Pool) *ChatService {
 	return &ChatService{chatRepo: chatRepo, grpcClient: grpcClient, pool: pool}
+}
+
+// WithConversationMemory attaches the cross-channel conversation memory
+// integration. Returns the receiver so the call is chainable at wiring time.
+func (s *ChatService) WithConversationMemory(m ConversationMemory) *ChatService {
+	s.convMem = m
+	return s
 }
 
 // StreamCompletion calls QueryRAG and returns a channel of SSE events.
@@ -150,6 +171,28 @@ func (s *ChatService) StreamCompletion(ctx context.Context, orgID, kbID string, 
 		ctxJSON, err := json.Marshal(convCtx)
 		if err == nil {
 			filters["conversation_context"] = string(ctxJSON)
+		}
+	}
+
+	// Cross-channel conversation history (issue #258): pull the user's most
+	// recent turns across chat/voice/webrtc sessions on this KB and forward
+	// them to the AI worker. Best-effort — failures are logged but do not
+	// break completion.
+	historyTurnsInjected := 0
+	isReturningUser := false
+	if s.convMem != nil && req.UserID != "" {
+		history, hErr := s.convMem.RecentHistory(ctx, orgID, kbID, req.UserID, model.MaxConversationHistoryTurns)
+		if hErr == nil && len(history) > 0 {
+			if raw, mErr := json.Marshal(history); mErr == nil {
+				filters["conversation_history"] = string(raw)
+				historyTurnsInjected = len(history)
+				isReturningUser = true
+			}
+		}
+		// Best-effort: append the user turn to the cross-channel memory.
+		if _, rErr := s.convMem.RecordMessage(ctx, orgID, req.ConversationSessionID, req.UserID, kbID, model.ConvChannelChat, "user", req.Query, isReturningUser, historyTurnsInjected); rErr != nil {
+			// swallow — analytics / memory must never break the stream
+			_ = rErr
 		}
 	}
 

--- a/internal/service/chat_conversation_memory_test.go
+++ b/internal/service/chat_conversation_memory_test.go
@@ -1,0 +1,160 @@
+package service
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/ravencloak-org/Raven/internal/model"
+)
+
+// spyConvMem records every interaction with the ConversationMemory interface
+// so assertions can verify both user + assistant turns are appended.
+type spyConvMem struct {
+	mu              sync.Mutex
+	startSessions   int
+	recorded        []spyRecorded
+	sessIDToReturn  string
+	recentHist      []model.ConversationTurn
+}
+
+type spyRecorded struct {
+	sessionID string
+	role      string
+	content   string
+}
+
+func (s *spyConvMem) RecentHistory(ctx context.Context, orgID, kbID, userID string, maxTurns int) ([]model.ConversationTurn, error) {
+	return s.recentHist, nil
+}
+
+func (s *spyConvMem) IsReturningUser(ctx context.Context, orgID, kbID, userID string) (bool, error) {
+	return len(s.recentHist) > 0, nil
+}
+
+func (s *spyConvMem) RecordMessage(ctx context.Context, orgID, sessionID, userID, kbID, channel, role, content string, isReturningUser bool, historyTurnsInjected int) (*model.ConversationSession, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.recorded = append(s.recorded, spyRecorded{sessionID: sessionID, role: role, content: content})
+	return &model.ConversationSession{ID: sessionID, OrgID: orgID, KBID: kbID, UserID: userID, Channel: channel}, nil
+}
+
+func (s *spyConvMem) StartSession(ctx context.Context, orgID, kbID, userID, channel string) (*model.ConversationSession, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.startSessions++
+	return &model.ConversationSession{ID: s.sessIDToReturn, OrgID: orgID, KBID: kbID, UserID: userID, Channel: channel}, nil
+}
+
+// TestPrimeConversationMemory_LazilyStartsSessionAndAppendsUserTurn is the
+// regression for PR #349 review thread #1: the chat path must drive
+// RecordMessage for the user turn (and an assistant turn must follow), and
+// when no ConversationSessionID is supplied a fresh session is created.
+func TestPrimeConversationMemory_LazilyStartsSessionAndAppendsUserTurn(t *testing.T) {
+	spy := &spyConvMem{sessIDToReturn: "new-sess-1"}
+	svc := (&ChatService{}).WithConversationMemory(spy)
+
+	filters := map[string]string{}
+	req := &model.ChatCompletionRequest{
+		Query:  "hello",
+		UserID: "user-1",
+	}
+
+	sessID, hInjected, isReturning := svc.primeConversationMemory(
+		context.Background(), "org-1", "kb-1", req, filters,
+	)
+
+	if spy.startSessions != 1 {
+		t.Fatalf("StartSession must be called exactly once when no session supplied; got %d", spy.startSessions)
+	}
+	if sessID != "new-sess-1" {
+		t.Fatalf("session id must come from StartSession; got %q", sessID)
+	}
+	if hInjected != 0 || isReturning {
+		t.Errorf("no history -> new user; got injected=%d returning=%v", hInjected, isReturning)
+	}
+
+	// Exactly one user-turn record against the freshly-created session.
+	spy.mu.Lock()
+	defer spy.mu.Unlock()
+	if len(spy.recorded) != 1 {
+		t.Fatalf("want 1 RecordMessage call, got %d", len(spy.recorded))
+	}
+	if spy.recorded[0].role != "user" || spy.recorded[0].sessionID != "new-sess-1" || spy.recorded[0].content != "hello" {
+		t.Errorf("bad user turn: %+v", spy.recorded[0])
+	}
+}
+
+// TestPrimeConversationMemory_ReusesCallerSessionID verifies that an
+// already-provided conversation_session_id is NOT overwritten by a fresh
+// StartSession (voice flow pre-creates it).
+func TestPrimeConversationMemory_ReusesCallerSessionID(t *testing.T) {
+	spy := &spyConvMem{sessIDToReturn: "should-not-be-used"}
+	svc := (&ChatService{}).WithConversationMemory(spy)
+
+	req := &model.ChatCompletionRequest{
+		Query:                 "hi",
+		UserID:                "user-1",
+		ConversationSessionID: "caller-sess-9",
+	}
+	sessID, _, _ := svc.primeConversationMemory(context.Background(), "org-1", "kb-1", req, map[string]string{})
+
+	if sessID != "caller-sess-9" {
+		t.Fatalf("caller-provided session must be preserved, got %q", sessID)
+	}
+	if spy.startSessions != 0 {
+		t.Fatalf("StartSession must not be called when caller provides a session; got %d", spy.startSessions)
+	}
+	spy.mu.Lock()
+	defer spy.mu.Unlock()
+	if len(spy.recorded) != 1 || spy.recorded[0].sessionID != "caller-sess-9" {
+		t.Fatalf("user turn must record against caller session; got %+v", spy.recorded)
+	}
+}
+
+// TestRecordAssistantMemoryTurn_AppendsAssistantRole closes the loop from
+// review thread #1: the assistant reply must also be persisted so the
+// transcript is complete for cross-channel recall.
+func TestRecordAssistantMemoryTurn_AppendsAssistantRole(t *testing.T) {
+	spy := &spyConvMem{}
+	svc := (&ChatService{}).WithConversationMemory(spy)
+
+	svc.recordAssistantMemoryTurn(context.Background(), "org-1", "kb-1", "user-1", "sess-1", "the answer", false, 0)
+
+	spy.mu.Lock()
+	defer spy.mu.Unlock()
+	if len(spy.recorded) != 1 {
+		t.Fatalf("want 1 RecordMessage call, got %d", len(spy.recorded))
+	}
+	got := spy.recorded[0]
+	if got.role != "assistant" || got.content != "the answer" || got.sessionID != "sess-1" {
+		t.Errorf("bad assistant turn: %+v", got)
+	}
+}
+
+// TestFullChatLifecycle_PersistsBothRoles verifies the exact regression
+// described in PR #349 review thread #1: a no-op memory feature had to
+// transition to a state where both user AND assistant turns are persisted.
+func TestFullChatLifecycle_PersistsBothRoles(t *testing.T) {
+	spy := &spyConvMem{sessIDToReturn: "lifecycle-sess"}
+	svc := (&ChatService{}).WithConversationMemory(spy)
+
+	req := &model.ChatCompletionRequest{Query: "user-question", UserID: "user-42"}
+
+	convSessionID, hInjected, isReturning := svc.primeConversationMemory(context.Background(), "org-1", "kb-1", req, map[string]string{})
+	svc.recordAssistantMemoryTurn(context.Background(), "org-1", "kb-1", req.UserID, convSessionID, "assistant-reply", isReturning, hInjected)
+
+	spy.mu.Lock()
+	defer spy.mu.Unlock()
+	if len(spy.recorded) != 2 {
+		t.Fatalf("expected user+assistant turns (2), got %d: %+v", len(spy.recorded), spy.recorded)
+	}
+	if spy.recorded[0].role != "user" || spy.recorded[1].role != "assistant" {
+		t.Errorf("turn order wrong: %+v", spy.recorded)
+	}
+	// Critically: both turns bind to the SAME session id.
+	if spy.recorded[0].sessionID != spy.recorded[1].sessionID {
+		t.Errorf("both turns must share session id, got user=%q assistant=%q",
+			spy.recorded[0].sessionID, spy.recorded[1].sessionID)
+	}
+}

--- a/internal/service/conversation.go
+++ b/internal/service/conversation.go
@@ -1,0 +1,220 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/ravencloak-org/Raven/internal/model"
+	"github.com/ravencloak-org/Raven/internal/repository"
+	"github.com/ravencloak-org/Raven/pkg/apierror"
+)
+
+// ConversationRepositoryI is the persistence contract used by
+// ConversationService (allows mocking in tests).
+type ConversationRepositoryI interface {
+	CreateSession(ctx context.Context, orgID, kbID, userID, channel string, initial []model.ConversationTurn) (*model.ConversationSession, error)
+	AppendMessage(ctx context.Context, orgID, sessionID string, turn model.ConversationTurn) (*model.ConversationSession, error)
+	EndSession(ctx context.Context, orgID, sessionID string) error
+	GetRecentByUser(ctx context.Context, orgID, kbID, userID string, limit int) ([]model.ConversationSession, error)
+	GetByID(ctx context.Context, orgID, sessionID, userID string) (*model.ConversationSession, error)
+	ListByUser(ctx context.Context, orgID, kbID, userID string, limit, offset int) ([]model.ConversationSessionSummary, int, error)
+}
+
+// ConversationAnalytics is the subset of the PostHog client used for
+// server-side event tracking. Kept as an interface so tests can assert on
+// captured events without an HTTP round-trip.
+type ConversationAnalytics interface {
+	Capture(ctx context.Context, distinctID, event string, properties map[string]any) error
+}
+
+// ConversationService orchestrates cross-channel conversation memory —
+// session lifecycle, recent-turn history for the AI worker, and
+// PostHog server-side event emission.
+type ConversationService struct {
+	repo      ConversationRepositoryI
+	analytics ConversationAnalytics
+}
+
+// NewConversationService constructs a ConversationService. analytics may be nil.
+func NewConversationService(repo ConversationRepositoryI, analytics ConversationAnalytics) *ConversationService {
+	return &ConversationService{repo: repo, analytics: analytics}
+}
+
+// StartSession creates a new cross-channel session and emits session_started.
+// userID MUST be the authenticated user's stable identity (JWT sub claim).
+func (s *ConversationService) StartSession(ctx context.Context, orgID, kbID, userID, channel string) (*model.ConversationSession, error) {
+	sess, err := s.repo.CreateSession(ctx, orgID, kbID, userID, channel, nil)
+	if err != nil {
+		return nil, apierror.NewInternal("failed to start conversation: " + err.Error())
+	}
+
+	s.capture(ctx, userID, "session_started", map[string]any{
+		"channel":  channel,
+		"kb_id":    kbID,
+		"org_id":   orgID,
+		"$groups":  map[string]any{"organization": orgID},
+		"$set":     map[string]any{"org_id": orgID},
+	})
+	return sess, nil
+}
+
+// RecordMessage appends a turn and emits a message_sent event. historyTurnsInjected
+// tracks how many prior turns were surfaced to the AI worker for this response.
+func (s *ConversationService) RecordMessage(
+	ctx context.Context,
+	orgID, sessionID, userID, kbID, channel, role, content string,
+	isReturningUser bool,
+	historyTurnsInjected int,
+) (*model.ConversationSession, error) {
+	turn := model.ConversationTurn{
+		Role:      role,
+		Content:   content,
+		Timestamp: time.Now().UTC(),
+	}
+	sess, err := s.repo.AppendMessage(ctx, orgID, sessionID, turn)
+	if err != nil {
+		if errors.Is(err, repository.ErrConversationNotFound) {
+			return nil, apierror.NewNotFound("conversation session not found")
+		}
+		return nil, apierror.NewInternal("failed to append message: " + err.Error())
+	}
+
+	// Track only user-originated turns to avoid doubling the funnel.
+	if role == "user" {
+		s.capture(ctx, userID, "message_sent", map[string]any{
+			"channel":                channel,
+			"kb_id":                  kbID,
+			"session_id":             sessionID,
+			"is_returning_user":      isReturningUser,
+			"history_turns_injected": historyTurnsInjected,
+			"$groups":                map[string]any{"organization": orgID},
+		})
+	}
+	return sess, nil
+}
+
+// EndSession finalises a session and emits session_ended with summary metrics.
+func (s *ConversationService) EndSession(ctx context.Context, orgID, sessionID, userID, kbID, channel string, messageCount int, startedAt time.Time) error {
+	if err := s.repo.EndSession(ctx, orgID, sessionID); err != nil {
+		if errors.Is(err, repository.ErrConversationNotFound) {
+			return apierror.NewNotFound("conversation session not found")
+		}
+		return apierror.NewInternal("failed to end conversation: " + err.Error())
+	}
+
+	duration := 0
+	if !startedAt.IsZero() {
+		duration = int(time.Since(startedAt).Seconds())
+		if duration < 0 {
+			duration = 0
+		}
+	}
+
+	s.capture(ctx, userID, "session_ended", map[string]any{
+		"channel":          channel,
+		"kb_id":            kbID,
+		"session_id":       sessionID,
+		"message_count":    messageCount,
+		"duration_seconds": duration,
+		"$groups":          map[string]any{"organization": orgID},
+	})
+	return nil
+}
+
+// RecentHistory returns the last N turns across the user's most recent
+// sessions on the KB, flattened in chronological order. This is the payload
+// injected into AI worker requests as `conversation_history`.
+//
+// maxTurns defaults to MaxConversationHistoryTurns when <= 0.
+func (s *ConversationService) RecentHistory(ctx context.Context, orgID, kbID, userID string, maxTurns int) ([]model.ConversationTurn, error) {
+	if userID == "" {
+		return nil, nil
+	}
+	if maxTurns <= 0 {
+		maxTurns = model.MaxConversationHistoryTurns
+	}
+
+	// Pull a small window of recent sessions; we flatten their messages and
+	// keep only the tail so the total number of turns stays bounded.
+	sessions, err := s.repo.GetRecentByUser(ctx, orgID, kbID, userID, 3)
+	if err != nil {
+		return nil, fmt.Errorf("RecentHistory: %w", err)
+	}
+
+	// Sessions come back newest-first, so walk them oldest-first when
+	// assembling chronological turns.
+	var all []model.ConversationTurn
+	for i := len(sessions) - 1; i >= 0; i-- {
+		all = append(all, sessions[i].Messages...)
+	}
+
+	if len(all) > maxTurns {
+		all = all[len(all)-maxTurns:]
+	}
+	return all, nil
+}
+
+// IsReturningUser reports whether the user has any prior session on this KB.
+func (s *ConversationService) IsReturningUser(ctx context.Context, orgID, kbID, userID string) (bool, error) {
+	if userID == "" {
+		return false, nil
+	}
+	sessions, err := s.repo.GetRecentByUser(ctx, orgID, kbID, userID, 1)
+	if err != nil {
+		return false, err
+	}
+	return len(sessions) > 0, nil
+}
+
+// ListForUser returns paginated session summaries for the authenticated user
+// on a KB.
+func (s *ConversationService) ListForUser(ctx context.Context, orgID, kbID, userID string, limit, offset int) (*model.ConversationListResponse, error) {
+	summaries, total, err := s.repo.ListByUser(ctx, orgID, kbID, userID, limit, offset)
+	if err != nil {
+		return nil, apierror.NewInternal("failed to list conversations: " + err.Error())
+	}
+	return &model.ConversationListResponse{
+		Sessions: summaries,
+		Total:    total,
+		Limit:    limit,
+		Offset:   offset,
+	}, nil
+}
+
+// GetTranscript returns a full conversation transcript scoped to the authenticated user.
+func (s *ConversationService) GetTranscript(ctx context.Context, orgID, kbID, sessionID, userID string) (*model.ConversationSession, error) {
+	sess, err := s.repo.GetByID(ctx, orgID, sessionID, userID)
+	if err != nil {
+		if errors.Is(err, repository.ErrConversationNotFound) {
+			return nil, apierror.NewNotFound("conversation session not found")
+		}
+		return nil, apierror.NewInternal("failed to fetch transcript: " + err.Error())
+	}
+	// Enforce KB ownership in addition to user_id / org_id.
+	if kbID != "" && sess.KBID != kbID {
+		return nil, apierror.NewNotFound("conversation session not found")
+	}
+	return sess, nil
+}
+
+// capture fires a PostHog event without blocking the request path. Errors are
+// logged and swallowed — analytics must never surface as user-facing failures.
+func (s *ConversationService) capture(ctx context.Context, distinctID, event string, props map[string]any) {
+	if s.analytics == nil || distinctID == "" {
+		return
+	}
+	go func(ctx context.Context) {
+		// Detach from the request context so cancellation doesn't drop the event.
+		bg, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := s.analytics.Capture(bg, distinctID, event, props); err != nil {
+			slog.WarnContext(ctx, "posthog capture failed",
+				slog.String("event", event),
+				slog.String("error", err.Error()),
+			)
+		}
+	}(ctx)
+}

--- a/internal/service/conversation.go
+++ b/internal/service/conversation.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync/atomic"
 	"time"
 
 	"github.com/ravencloak-org/Raven/internal/model"
@@ -14,10 +15,13 @@ import (
 
 // ConversationRepositoryI is the persistence contract used by
 // ConversationService (allows mocking in tests).
+//
+// EndSession returns (ended=true, nil) only when the row actually transitioned
+// from open to ended; idempotent repeat calls return (false, nil).
 type ConversationRepositoryI interface {
 	CreateSession(ctx context.Context, orgID, kbID, userID, channel string, initial []model.ConversationTurn) (*model.ConversationSession, error)
 	AppendMessage(ctx context.Context, orgID, sessionID string, turn model.ConversationTurn) (*model.ConversationSession, error)
-	EndSession(ctx context.Context, orgID, sessionID string) error
+	EndSession(ctx context.Context, orgID, sessionID string) (bool, error)
 	GetRecentByUser(ctx context.Context, orgID, kbID, userID string, limit int) ([]model.ConversationSession, error)
 	GetByID(ctx context.Context, orgID, sessionID, userID string) (*model.ConversationSession, error)
 	ListByUser(ctx context.Context, orgID, kbID, userID string, limit, offset int) ([]model.ConversationSessionSummary, int, error)
@@ -30,17 +34,71 @@ type ConversationAnalytics interface {
 	Capture(ctx context.Context, distinctID, event string, properties map[string]any) error
 }
 
+// analyticsQueueSize is the buffer depth for the PostHog capture pipeline.
+// A full queue drops events (with a rate-limited warning) rather than
+// blocking the request path or spawning unbounded goroutines.
+const analyticsQueueSize = 256
+
+// analyticsWorkerCount is the number of background workers draining the
+// capture queue. Small because capture is latency-insensitive.
+const analyticsWorkerCount = 4
+
+// recentSessionsScanWindow is how many of the user's most recent sessions
+// RecentHistory scans to assemble up to maxTurns worth of cross-channel
+// history. Heuristic: newer sessions are sharpest; scanning more rarely
+// adds signal and costs DB round-trips.
+const recentSessionsScanWindow = 3
+
+// captureJob is a queued PostHog event carrying a defensive copy of its
+// props map so a single map is never shared across goroutine boundaries.
+type captureJob struct {
+	distinctID string
+	event      string
+	props      map[string]any
+}
+
 // ConversationService orchestrates cross-channel conversation memory —
 // session lifecycle, recent-turn history for the AI worker, and
 // PostHog server-side event emission.
 type ConversationService struct {
 	repo      ConversationRepositoryI
 	analytics ConversationAnalytics
+	// capQueue is a bounded channel drained by a fixed-size worker pool.
+	// Nil when analytics is nil.
+	capQueue chan captureJob
+	// dropLogOnce rate-limits "queue full" warnings so a flood of drops does
+	// not saturate the log pipeline.
+	dropLogOnce atomic.Int64
 }
 
 // NewConversationService constructs a ConversationService. analytics may be nil.
+// When non-nil, a small background worker pool is started to drain PostHog
+// events without spawning unbounded goroutines on the request path.
 func NewConversationService(repo ConversationRepositoryI, analytics ConversationAnalytics) *ConversationService {
-	return &ConversationService{repo: repo, analytics: analytics}
+	s := &ConversationService{repo: repo, analytics: analytics}
+	if analytics != nil {
+		s.capQueue = make(chan captureJob, analyticsQueueSize)
+		for i := 0; i < analyticsWorkerCount; i++ {
+			go s.captureWorker()
+		}
+	}
+	return s
+}
+
+// captureWorker drains the PostHog event queue. It runs for the lifetime of
+// the process; there is no shutdown hook today because the API process exits
+// by SIGTERM and losing an in-flight analytics event is acceptable.
+func (s *ConversationService) captureWorker() {
+	for job := range s.capQueue {
+		bg, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		if err := s.analytics.Capture(bg, job.distinctID, job.event, job.props); err != nil {
+			slog.Warn("posthog capture failed",
+				slog.String("event", job.event),
+				slog.String("error", err.Error()),
+			)
+		}
+		cancel()
+	}
 }
 
 // StartSession creates a new cross-channel session and emits session_started.
@@ -97,12 +155,20 @@ func (s *ConversationService) RecordMessage(
 }
 
 // EndSession finalises a session and emits session_ended with summary metrics.
+// The session_ended PostHog event is only emitted when the underlying row
+// actually transitioned from open to ended; subsequent idempotent calls are
+// a silent no-op so analytics does not double-count.
 func (s *ConversationService) EndSession(ctx context.Context, orgID, sessionID, userID, kbID, channel string, messageCount int, startedAt time.Time) error {
-	if err := s.repo.EndSession(ctx, orgID, sessionID); err != nil {
+	ended, err := s.repo.EndSession(ctx, orgID, sessionID)
+	if err != nil {
 		if errors.Is(err, repository.ErrConversationNotFound) {
 			return apierror.NewNotFound("conversation session not found")
 		}
 		return apierror.NewInternal("failed to end conversation: " + err.Error())
+	}
+	if !ended {
+		// Already ended on a prior call; skip the funnel event.
+		return nil
 	}
 
 	duration := 0
@@ -139,7 +205,7 @@ func (s *ConversationService) RecentHistory(ctx context.Context, orgID, kbID, us
 
 	// Pull a small window of recent sessions; we flatten their messages and
 	// keep only the tail so the total number of turns stays bounded.
-	sessions, err := s.repo.GetRecentByUser(ctx, orgID, kbID, userID, 3)
+	sessions, err := s.repo.GetRecentByUser(ctx, orgID, kbID, userID, recentSessionsScanWindow)
 	if err != nil {
 		return nil, fmt.Errorf("RecentHistory: %w", err)
 	}
@@ -170,18 +236,34 @@ func (s *ConversationService) IsReturningUser(ctx context.Context, orgID, kbID, 
 }
 
 // ListForUser returns paginated session summaries for the authenticated user
-// on a KB.
+// on a KB. The response echoes the clamped limit/offset actually used by the
+// repository so clients aren't misled by "limit: 1000" when only 20 rows came
+// back.
 func (s *ConversationService) ListForUser(ctx context.Context, orgID, kbID, userID string, limit, offset int) (*model.ConversationListResponse, error) {
-	summaries, total, err := s.repo.ListByUser(ctx, orgID, kbID, userID, limit, offset)
+	appliedLimit, appliedOffset := clampConversationPagination(limit, offset)
+	summaries, total, err := s.repo.ListByUser(ctx, orgID, kbID, userID, appliedLimit, appliedOffset)
 	if err != nil {
 		return nil, apierror.NewInternal("failed to list conversations: " + err.Error())
 	}
 	return &model.ConversationListResponse{
 		Sessions: summaries,
 		Total:    total,
-		Limit:    limit,
-		Offset:   offset,
+		Limit:    appliedLimit,
+		Offset:   appliedOffset,
 	}, nil
+}
+
+// clampConversationPagination mirrors the repo-side clamp so the service can
+// report back the values that were actually applied. Kept in sync with
+// repository.ListByUser.
+func clampConversationPagination(limit, offset int) (int, int) {
+	if limit <= 0 || limit > 100 {
+		limit = model.DefaultConversationListLimit
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	return limit, offset
 }
 
 // GetTranscript returns a full conversation transcript scoped to the authenticated user.
@@ -200,21 +282,43 @@ func (s *ConversationService) GetTranscript(ctx context.Context, orgID, kbID, se
 	return sess, nil
 }
 
-// capture fires a PostHog event without blocking the request path. Errors are
-// logged and swallowed — analytics must never surface as user-facing failures.
+// capture fires a PostHog event without blocking the request path. Events
+// are handed to a bounded worker pool; when the queue is full the event is
+// dropped (rate-limited warning) rather than blocking or spawning a fresh
+// goroutine. The props map is cloned before enqueue so the queued job owns
+// its data and no map is ever shared across goroutine boundaries.
 func (s *ConversationService) capture(ctx context.Context, distinctID, event string, props map[string]any) {
-	if s.analytics == nil || distinctID == "" {
+	if s.analytics == nil || distinctID == "" || s.capQueue == nil {
 		return
 	}
-	go func(ctx context.Context) {
-		// Detach from the request context so cancellation doesn't drop the event.
-		bg, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		if err := s.analytics.Capture(bg, distinctID, event, props); err != nil {
-			slog.WarnContext(ctx, "posthog capture failed",
+	job := captureJob{
+		distinctID: distinctID,
+		event:      event,
+		props:      cloneStringAnyMap(props),
+	}
+	select {
+	case s.capQueue <- job:
+	default:
+		// Queue full — drop. Rate-limit the warning: only log every 1024 drops.
+		if n := s.dropLogOnce.Add(1); n%1024 == 1 {
+			slog.WarnContext(ctx, "posthog capture queue full, event dropped",
 				slog.String("event", event),
-				slog.String("error", err.Error()),
+				slog.Int64("total_drops", n),
 			)
 		}
-	}(ctx)
+	}
+}
+
+// cloneStringAnyMap returns a shallow copy of m. Nested maps/slices are not
+// deep-copied — callers MUST NOT mutate the original map values after handing
+// the clone to a goroutine. All current call-sites build a fresh literal.
+func cloneStringAnyMap(m map[string]any) map[string]any {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
 }

--- a/internal/service/conversation_test.go
+++ b/internal/service/conversation_test.go
@@ -1,0 +1,325 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ravencloak-org/Raven/internal/model"
+	"github.com/ravencloak-org/Raven/internal/repository"
+	"github.com/ravencloak-org/Raven/internal/service"
+)
+
+// fakeConvRepo is an in-memory ConversationRepositoryI implementation.
+type fakeConvRepo struct {
+	mu       sync.Mutex
+	byID     map[string]*model.ConversationSession
+	byUserKB map[string][]*model.ConversationSession
+}
+
+func newFakeConvRepo() *fakeConvRepo {
+	return &fakeConvRepo{
+		byID:     map[string]*model.ConversationSession{},
+		byUserKB: map[string][]*model.ConversationSession{},
+	}
+}
+
+func key(org, kb, user string) string { return org + "|" + kb + "|" + user }
+
+func (f *fakeConvRepo) CreateSession(ctx context.Context, orgID, kbID, userID, channel string, initial []model.ConversationTurn) (*model.ConversationSession, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	s := &model.ConversationSession{
+		ID:        "sess-" + orgID + "-" + userID + "-" + time.Now().Format("150405.000000"),
+		OrgID:     orgID,
+		KBID:      kbID,
+		UserID:    userID,
+		Channel:   channel,
+		Messages:  append([]model.ConversationTurn{}, initial...),
+		StartedAt: time.Now().UTC(),
+	}
+	f.byID[s.ID] = s
+	f.byUserKB[key(orgID, kbID, userID)] = append(f.byUserKB[key(orgID, kbID, userID)], s)
+	return s, nil
+}
+
+func (f *fakeConvRepo) AppendMessage(ctx context.Context, orgID, sessionID string, turn model.ConversationTurn) (*model.ConversationSession, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	s, ok := f.byID[sessionID]
+	if !ok || s.OrgID != orgID {
+		return nil, repository.ErrConversationNotFound
+	}
+	s.Messages = append(s.Messages, turn)
+	return s, nil
+}
+
+func (f *fakeConvRepo) EndSession(ctx context.Context, orgID, sessionID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	s, ok := f.byID[sessionID]
+	if !ok || s.OrgID != orgID {
+		return repository.ErrConversationNotFound
+	}
+	if s.EndedAt == nil {
+		t := time.Now().UTC()
+		s.EndedAt = &t
+	}
+	return nil
+}
+
+func (f *fakeConvRepo) GetRecentByUser(ctx context.Context, orgID, kbID, userID string, limit int) ([]model.ConversationSession, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	list := f.byUserKB[key(orgID, kbID, userID)]
+	// Return newest-first.
+	out := make([]model.ConversationSession, 0, len(list))
+	for i := len(list) - 1; i >= 0; i-- {
+		out = append(out, *list[i])
+		if len(out) >= limit {
+			break
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeConvRepo) GetByID(ctx context.Context, orgID, sessionID, userID string) (*model.ConversationSession, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	s, ok := f.byID[sessionID]
+	if !ok || s.OrgID != orgID || s.UserID != userID {
+		return nil, repository.ErrConversationNotFound
+	}
+	cp := *s
+	return &cp, nil
+}
+
+func (f *fakeConvRepo) ListByUser(ctx context.Context, orgID, kbID, userID string, limit, offset int) ([]model.ConversationSessionSummary, int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	list := f.byUserKB[key(orgID, kbID, userID)]
+	total := len(list)
+	out := make([]model.ConversationSessionSummary, 0, len(list))
+	// Newest-first.
+	for i := len(list) - 1; i >= 0; i-- {
+		s := list[i]
+		out = append(out, model.ConversationSessionSummary{
+			ID: s.ID, OrgID: s.OrgID, KBID: s.KBID, UserID: s.UserID,
+			Channel: s.Channel, StartedAt: s.StartedAt, EndedAt: s.EndedAt,
+			MessageCount: len(s.Messages), Summary: s.Summary,
+		})
+	}
+	if offset > len(out) {
+		return nil, total, nil
+	}
+	out = out[offset:]
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out, total, nil
+}
+
+// fakeAnalytics captures Capture calls for assertions.
+type fakeAnalytics struct {
+	mu     sync.Mutex
+	events []capturedEvent
+	fail   error
+}
+type capturedEvent struct {
+	distinctID string
+	event      string
+	props      map[string]any
+}
+
+func (a *fakeAnalytics) Capture(ctx context.Context, distinctID, event string, props map[string]any) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.events = append(a.events, capturedEvent{distinctID: distinctID, event: event, props: props})
+	return a.fail
+}
+
+func (a *fakeAnalytics) wait(n int) []capturedEvent {
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		a.mu.Lock()
+		if len(a.events) >= n {
+			out := make([]capturedEvent, len(a.events))
+			copy(out, a.events)
+			a.mu.Unlock()
+			return out
+		}
+		a.mu.Unlock()
+		time.Sleep(10 * time.Millisecond)
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	out := make([]capturedEvent, len(a.events))
+	copy(out, a.events)
+	return out
+}
+
+func TestConversationService_StartSession_EmitsSessionStarted(t *testing.T) {
+	repo := newFakeConvRepo()
+	an := &fakeAnalytics{}
+	svc := service.NewConversationService(repo, an)
+
+	sess, err := svc.StartSession(context.Background(), "org-1", "kb-1", "user-42", model.ConvChannelChat)
+	if err != nil {
+		t.Fatalf("StartSession: %v", err)
+	}
+	if sess.UserID != "user-42" || sess.OrgID != "org-1" || sess.KBID != "kb-1" {
+		t.Fatalf("session fields wrong: %+v", sess)
+	}
+	events := an.wait(1)
+	if len(events) != 1 || events[0].event != "session_started" {
+		t.Fatalf("expected 1 session_started event, got %+v", events)
+	}
+	if events[0].distinctID != "user-42" {
+		t.Errorf("distinct_id should be JWT sub (user-42), got %q", events[0].distinctID)
+	}
+	if events[0].props["kb_id"] != "kb-1" {
+		t.Errorf("kb_id missing in event props")
+	}
+}
+
+func TestConversationService_RecordMessage_UserRoleEmitsMessageSent(t *testing.T) {
+	repo := newFakeConvRepo()
+	an := &fakeAnalytics{}
+	svc := service.NewConversationService(repo, an)
+
+	sess, err := svc.StartSession(context.Background(), "org-1", "kb-1", "user-42", model.ConvChannelChat)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = an.wait(1) // session_started
+
+	_, err = svc.RecordMessage(context.Background(), "org-1", sess.ID, "user-42", "kb-1", model.ConvChannelChat, "user", "hello", true, 3)
+	if err != nil {
+		t.Fatalf("RecordMessage: %v", err)
+	}
+	events := an.wait(2)
+	if len(events) < 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	msgEvent := events[1]
+	if msgEvent.event != "message_sent" {
+		t.Fatalf("want message_sent, got %q", msgEvent.event)
+	}
+	if msgEvent.props["is_returning_user"] != true {
+		t.Errorf("is_returning_user should be true")
+	}
+	if msgEvent.props["history_turns_injected"] != 3 {
+		t.Errorf("history_turns_injected want 3 got %v", msgEvent.props["history_turns_injected"])
+	}
+}
+
+func TestConversationService_RecordMessage_AssistantDoesNotEmitMessageSent(t *testing.T) {
+	repo := newFakeConvRepo()
+	an := &fakeAnalytics{}
+	svc := service.NewConversationService(repo, an)
+
+	sess, err := svc.StartSession(context.Background(), "org-1", "kb-1", "user-1", model.ConvChannelChat)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = an.wait(1)
+	_, err = svc.RecordMessage(context.Background(), "org-1", sess.ID, "user-1", "kb-1", model.ConvChannelChat, "assistant", "hi there", false, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Give any spurious event a moment.
+	time.Sleep(50 * time.Millisecond)
+	an.mu.Lock()
+	defer an.mu.Unlock()
+	for _, e := range an.events[1:] {
+		if e.event == "message_sent" {
+			t.Fatalf("assistant turn must not emit message_sent")
+		}
+	}
+}
+
+func TestConversationService_RecentHistory_CapsToMaxTurns(t *testing.T) {
+	repo := newFakeConvRepo()
+	svc := service.NewConversationService(repo, nil)
+	ctx := context.Background()
+
+	sess, err := svc.StartSession(ctx, "org-1", "kb-1", "user-42", model.ConvChannelChat)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Seed 12 turns.
+	for i := 0; i < 12; i++ {
+		if _, err := svc.RecordMessage(ctx, "org-1", sess.ID, "user-42", "kb-1", model.ConvChannelChat, "user", "m", false, 0); err != nil {
+			t.Fatal(err)
+		}
+	}
+	hist, err := svc.RecentHistory(ctx, "org-1", "kb-1", "user-42", 0)
+	if err != nil {
+		t.Fatalf("RecentHistory: %v", err)
+	}
+	if len(hist) != model.MaxConversationHistoryTurns {
+		t.Fatalf("expected %d turns, got %d", model.MaxConversationHistoryTurns, len(hist))
+	}
+}
+
+func TestConversationService_IsReturningUser(t *testing.T) {
+	repo := newFakeConvRepo()
+	svc := service.NewConversationService(repo, nil)
+	ctx := context.Background()
+
+	ret, err := svc.IsReturningUser(ctx, "org-1", "kb-1", "user-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ret {
+		t.Fatal("new user must not be returning")
+	}
+	if _, err := svc.StartSession(ctx, "org-1", "kb-1", "user-1", model.ConvChannelChat); err != nil {
+		t.Fatal(err)
+	}
+	ret, err = svc.IsReturningUser(ctx, "org-1", "kb-1", "user-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ret {
+		t.Fatal("user with prior session must be returning")
+	}
+}
+
+func TestConversationService_GetTranscript_CrossUserIsolation(t *testing.T) {
+	repo := newFakeConvRepo()
+	svc := service.NewConversationService(repo, nil)
+	ctx := context.Background()
+
+	sess, err := svc.StartSession(ctx, "org-1", "kb-1", "alice", model.ConvChannelChat)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Bob must not be able to fetch Alice's transcript.
+	_, err = svc.GetTranscript(ctx, "org-1", "kb-1", sess.ID, "bob")
+	if err == nil {
+		t.Fatal("expected not-found for cross-user transcript fetch")
+	}
+}
+
+func TestConversationService_RecordMessage_NotFound(t *testing.T) {
+	repo := newFakeConvRepo()
+	svc := service.NewConversationService(repo, nil)
+	_, err := svc.RecordMessage(context.Background(), "org-1", "nope", "u", "kb", "chat", "user", "x", false, 0)
+	if err == nil {
+		t.Fatal("expected error for unknown session")
+	}
+}
+
+func TestConversationService_CaptureSwallowsAnalyticsError(t *testing.T) {
+	repo := newFakeConvRepo()
+	an := &fakeAnalytics{fail: errors.New("posthog down")}
+	svc := service.NewConversationService(repo, an)
+
+	_, err := svc.StartSession(context.Background(), "org-1", "kb-1", "user-1", model.ConvChannelChat)
+	if err != nil {
+		t.Fatalf("StartSession must not fail when PostHog errors: %v", err)
+	}
+}

--- a/internal/service/conversation_test.go
+++ b/internal/service/conversation_test.go
@@ -56,18 +56,19 @@ func (f *fakeConvRepo) AppendMessage(ctx context.Context, orgID, sessionID strin
 	return s, nil
 }
 
-func (f *fakeConvRepo) EndSession(ctx context.Context, orgID, sessionID string) error {
+func (f *fakeConvRepo) EndSession(ctx context.Context, orgID, sessionID string) (bool, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	s, ok := f.byID[sessionID]
 	if !ok || s.OrgID != orgID {
-		return repository.ErrConversationNotFound
+		return false, repository.ErrConversationNotFound
 	}
-	if s.EndedAt == nil {
-		t := time.Now().UTC()
-		s.EndedAt = &t
+	if s.EndedAt != nil {
+		return false, nil
 	}
-	return nil
+	t := time.Now().UTC()
+	s.EndedAt = &t
+	return true, nil
 }
 
 func (f *fakeConvRepo) GetRecentByUser(ctx context.Context, orgID, kbID, userID string, limit int) ([]model.ConversationSession, error) {


### PR DESCRIPTION
## Summary

Implements the user-scoped, cross-channel conversation memory described in #258 on top of the `conversation_sessions` table introduced by #257.

- `ConversationRepository` / `ConversationService` with `CreateSession`, `AppendMessage`, `EndSession`, `GetRecentByUser`, `GetByID`, `ListByUser` — all executed through `db.WithOrgID` so Postgres RLS enforces org and user scoping.
- `ChatService.WithConversationMemory` hook: when the request carries an authenticated `user_id` (JWT `sub`), the service injects the user's last N cross-channel turns into the gRPC `RAGRequest.filters.conversation_history`, records the user turn, and reports `is_returning_user` + `history_turns_injected` alongside.
- Chat handler populates `req.UserID` from `ContextKeyExternalID` only — clients cannot spoof the identity via the JSON body.
- PostHog server-side events (`session_started`, `message_sent`, `session_ended`) with `distinct_id = JWT sub` and `$groups.organization = org_id`. Assistant turns do not emit `message_sent` so the funnel stays user-driven. PostHog errors are swallowed and never break completion.
- REST endpoints scoped to the authenticated user:
  - `GET /api/v1/orgs/:org_id/kbs/:kb_id/conversations`
  - `GET /api/v1/orgs/:org_id/kbs/:kb_id/conversations/:session_id`
- Frontend: `RecentConversationsCard` on the KB detail page — last 5 sessions with channel, date, message count, optional returning-user greeting, inline transcript view.

## Depends on

**Depends on #257 — merge after.** The `conversation_sessions` table (migration `00037_conversation_sessions.sql`) is introduced by #257; this PR consumes the schema but does not add or modify a migration. If CI can't find the table in the test DB, rebase this branch on top of #257 once #257 is in `main`.

## Out of scope / deferred

- Python AI worker changes (prepending `conversation_history` to the system prompt, capping to 5 turns / ~1500 tokens) — the AI worker source does not live in this repo and is tracked as a follow-up under #258.
- OpenObserve / PostHog dashboards — noted in the issue as observability follow-ups.
- Voice / WebRTC code paths do not yet call `StartSession` / `RecordMessage` (the chat path is wired end-to-end). The service API surface is in place; hooking voice `CreateSession` / disconnect handlers should land in a follow-up once the voice pipeline reaches feature-parity on the cross-channel session object.

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -short -count=1` (all packages green)
- [x] `golangci-lint run ./...` (clean)
- [x] `frontend: npm run lint`, `npx vue-tsc -b`, `npm run test:unit` (128/128 passing)
- [ ] After #257 merges: rebase and re-run integration tests with the migration applied
- [ ] Manual: authenticated chat completion on KB detail page → second visit shows returning-user greeting and transcript card
- [ ] Manual: PostHog receives `session_started`, `message_sent`, `session_ended` with `distinct_id` = SuperTokens external ID

Closes #258 (pending #257 merge).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added conversation memory system to track and manage chat, voice, and webrtc sessions across your organization.
  * New recent conversations card displays your latest interaction sessions with the ability to view detailed transcripts and message history.
  * Chat service now automatically recognizes returning users and incorporates conversation history for enhanced context in responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->