### PR TITLE
ci(slsa): upgrade container attestations to SLSA Build Level 3

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -90,6 +90,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write      # Sigstore OIDC for keyless signing
+      attestations: write  # GitHub attestation store
     strategy:
       fail-fast: false
       matrix:
@@ -128,7 +130,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v7
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v7
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
@@ -142,3 +146,27 @@ jobs:
             ${{ matrix.image == 'frontend' && format('VITE_LIVEKIT_URL={0}', vars.VITE_LIVEKIT_URL || '') || '' }}
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
+          provenance: false
+          sbom: false
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          image: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}@${{ steps.build.outputs.digest }}
+          format: spdx-json
+          output-file: sbom-${{ matrix.image }}.spdx.json
+
+      - name: Attest SBOM
+        uses: actions/attest-sbom@v3
+        with:
+          subject-name: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          sbom-path: sbom-${{ matrix.image }}.spdx.json
+          push-to-registry: true
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-name: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,6 +141,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write   # GitHub attestation store
     strategy:
       fail-fast: false
       matrix:
@@ -193,8 +194,30 @@ jobs:
           cache-to: type=gha,mode=max
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          provenance: true
-          sbom: true
+          provenance: false
+          sbom: false
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0
+        with:
+          image: ghcr.io/${{ github.repository_owner }}/${{ matrix.component }}@${{ steps.build.outputs.digest }}
+          format: spdx-json
+          output-file: sbom-${{ matrix.component }}.spdx.json
+
+      - name: Attest SBOM
+        uses: actions/attest-sbom@51e74621a501c89df81fc1391c5a8f4cfc9fab2f  # v3
+        with:
+          subject-name: ghcr.io/${{ github.repository_owner }}/${{ matrix.component }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          sbom-path: sbom-${{ matrix.component }}.spdx.json
+          push-to-registry: true
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@43d14bc2b83dec42d39ecae14e916627a18bb661  # v3
+        with:
+          subject-name: ghcr.io/${{ github.repository_owner }}/${{ matrix.component }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
 
       - name: Install cosign
         uses: sigstore/cosign-installer@f713795cb21599bc4e5c4b58cbad1da852d7eeb9  # v3.8.1

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   <a href="https://github.com/ravencloak-org/Raven/actions/workflows/python.yml"><img src="https://github.com/ravencloak-org/Raven/actions/workflows/python.yml/badge.svg" alt="Python CI" /></a>
   <a href="https://github.com/ravencloak-org/Raven/actions/workflows/docker.yml"><img src="https://github.com/ravencloak-org/Raven/actions/workflows/docker.yml/badge.svg" alt="Docker Build" /></a>
   <a href="https://github.com/ravencloak-org/Raven/actions/workflows/security.yml"><img src="https://github.com/ravencloak-org/Raven/actions/workflows/security.yml/badge.svg" alt="Security" /></a>
+  <a href="docs/security/slsa-verification.md"><img src="https://slsa.dev/images/gh-badge-level3.svg" alt="SLSA 3" /></a>
   <a href="https://codecov.io/gh/ravencloak-org/Raven"><img src="https://codecov.io/gh/ravencloak-org/Raven/branch/main/graph/badge.svg" alt="Coverage" /></a>
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License: Apache 2.0" /></a>
   <a href="https://baseline.openssf.org/versions/2026-02-19"><img src="https://img.shields.io/badge/OpenSSF%20Baseline-L2%20target-blue" alt="OpenSSF Baseline L2" /></a>

--- a/docs/security/slsa-verification.md
+++ b/docs/security/slsa-verification.md
@@ -1,0 +1,126 @@
+# Verifying SLSA Build Provenance for Raven Container Images
+
+Every container image published by this repository to GHCR carries two
+cryptographic attestations:
+
+- **SLSA v1 build provenance** — who built the image, from which commit,
+  on which workflow, at what time.
+- **SPDX SBOM** — the full software bill of materials for the image.
+
+Both are signed keylessly via [Sigstore](https://www.sigstore.dev/) using
+GitHub OIDC and anchored in the public [Rekor](https://docs.sigstore.dev/logging/overview/)
+transparency log. Attestations are stored both in the GitHub attestation
+store and as OCI referrers alongside the image in GHCR.
+
+Images covered: `ghcr.io/ravencloak-org/{go-api,python-worker,frontend}`.
+Attestations exist for every image pushed from `main` or a `v*.*.*` tag on
+or after the commit that landed this feature.
+
+## Verify with `gh` (GitHub CLI)
+
+Primary path — no extra install beyond `gh`.
+
+**Provenance:**
+
+```
+gh attestation verify \
+  oci://ghcr.io/ravencloak-org/go-api:latest \
+  --owner ravencloak-org \
+  --predicate-type https://slsa.dev/provenance/v1
+```
+
+**SBOM:**
+
+```
+gh attestation verify \
+  oci://ghcr.io/ravencloak-org/go-api:latest \
+  --owner ravencloak-org \
+  --predicate-type https://spdx.dev/Document/v2.3
+```
+
+Substitute `go-api` with `python-worker` or `frontend` for the other two
+images, and replace `latest` with any tag or `sha256:` digest you want to
+verify.
+
+## Verify with `cosign`
+
+For environments without `gh`:
+
+**Provenance:**
+
+```
+cosign verify-attestation \
+  --type slsaprovenance1 \
+  --certificate-identity-regexp \
+    'https://github.com/ravencloak-org/Raven/.github/workflows/docker.yml@.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/ravencloak-org/go-api:latest
+```
+
+**SBOM:**
+
+```
+cosign verify-attestation \
+  --type spdxjson \
+  --certificate-identity-regexp \
+    'https://github.com/ravencloak-org/Raven/.github/workflows/docker.yml@.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/ravencloak-org/go-api:latest
+```
+
+## Always Verify by Digest in Production
+
+Tags like `:latest` are mutable. For any real supply-chain check, pin to
+the image's immutable `sha256:` digest. Resolve a tag to a digest with
+either of:
+
+```
+crane digest ghcr.io/ravencloak-org/go-api:latest
+```
+
+```
+docker buildx imagetools inspect ghcr.io/ravencloak-org/go-api:latest --format '{{json .Manifest.Digest}}'
+```
+
+Then verify the digest directly:
+
+```
+gh attestation verify \
+  oci://ghcr.io/ravencloak-org/go-api@sha256:<digest> \
+  --owner ravencloak-org \
+  --predicate-type https://slsa.dev/provenance/v1
+```
+
+`cosign verify-attestation` accepts the same `<image>@sha256:<digest>`
+form.
+
+## What Verification Proves
+
+- The image was built from `ravencloak-org/Raven` by the `docker.yml`
+  workflow on a GitHub-hosted runner.
+- The commit SHA in the provenance matches a real commit on this repo.
+- The image digest you pull is byte-for-byte the one that was attested.
+- The SBOM was produced by the same build.
+
+## What Verification Does NOT Prove
+
+- That the image is free of known vulnerabilities — that is what Trivy and
+  `govulncheck` in `.github/workflows/security.yml` cover.
+- That the build is bit-for-bit reproducible.
+- Runtime integrity. Attestation is a build-time guarantee.
+
+## Notes
+
+- `actions/attest-sbom@v3` supports SPDX only; the SBOM attestation uses
+  `spdx-json`. A CycloneDX variant is not produced.
+- If you verify an image pushed before this feature landed, both commands
+  will fail with "no attestation found". That is expected.
+- If `gh attestation verify` fails with an auth error, run `gh auth login`
+  and ensure the account has read access to `ravencloak-org/Raven`.
+
+## References
+
+- [SLSA v1.0 specification](https://slsa.dev/spec/v1.0/)
+- [GitHub artifact attestations](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)
+- [`gh attestation verify` manual](https://cli.github.com/manual/gh_attestation_verify)
+- [`cosign verify-attestation` docs](https://docs.sigstore.dev/cosign/verifying/verify/)

--- a/docs/security/slsa-verification.md
+++ b/docs/security/slsa-verification.md
@@ -52,7 +52,7 @@ For environments without `gh`:
 cosign verify-attestation \
   --type slsaprovenance1 \
   --certificate-identity-regexp \
-    'https://github.com/ravencloak-org/Raven/.github/workflows/docker.yml@.*' \
+    'https://github.com/ravencloak-org/Raven/.github/workflows/(docker|release)\.yml@.*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   ghcr.io/ravencloak-org/go-api:latest
 ```
@@ -63,7 +63,7 @@ cosign verify-attestation \
 cosign verify-attestation \
   --type spdxjson \
   --certificate-identity-regexp \
-    'https://github.com/ravencloak-org/Raven/.github/workflows/docker.yml@.*' \
+    'https://github.com/ravencloak-org/Raven/.github/workflows/(docker|release)\.yml@.*' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   ghcr.io/ravencloak-org/go-api:latest
 ```
@@ -96,8 +96,9 @@ form.
 
 ## What Verification Proves
 
-- The image was built from `ravencloak-org/Raven` by the `docker.yml`
-  workflow on a GitHub-hosted runner.
+- The image was built from `ravencloak-org/Raven` by either the
+  `docker.yml` workflow (main-branch pushes) or the `release.yml`
+  workflow (tag releases), on a GitHub-hosted runner.
 - The commit SHA in the provenance matches a real commit on this repo.
 - The image digest you pull is byte-for-byte the one that was attested.
 - The SBOM was produced by the same build.
@@ -117,6 +118,9 @@ form.
   will fail with "no attestation found". That is expected.
 - If `gh attestation verify` fails with an auth error, run `gh auth login`
   and ensure the account has read access to `ravencloak-org/Raven`.
+- Re-pushing an image with an unchanged digest will add a new referrer
+  manifest rather than dedupe. `gh attestation verify` picks the first
+  valid attestation, so this is benign.
 
 ## References
 

--- a/docs/security/slsa-verification.md
+++ b/docs/security/slsa-verification.md
@@ -22,7 +22,7 @@ Primary path — no extra install beyond `gh`.
 
 **Provenance:**
 
-```
+```bash
 gh attestation verify \
   oci://ghcr.io/ravencloak-org/go-api:latest \
   --owner ravencloak-org \
@@ -31,7 +31,7 @@ gh attestation verify \
 
 **SBOM:**
 
-```
+```bash
 gh attestation verify \
   oci://ghcr.io/ravencloak-org/go-api:latest \
   --owner ravencloak-org \
@@ -48,7 +48,7 @@ For environments without `gh`:
 
 **Provenance:**
 
-```
+```bash
 cosign verify-attestation \
   --type slsaprovenance1 \
   --certificate-identity-regexp \
@@ -59,7 +59,7 @@ cosign verify-attestation \
 
 **SBOM:**
 
-```
+```bash
 cosign verify-attestation \
   --type spdxjson \
   --certificate-identity-regexp \
@@ -74,17 +74,17 @@ Tags like `:latest` are mutable. For any real supply-chain check, pin to
 the image's immutable `sha256:` digest. Resolve a tag to a digest with
 either of:
 
-```
+```bash
 crane digest ghcr.io/ravencloak-org/go-api:latest
 ```
 
-```
+```bash
 docker buildx imagetools inspect ghcr.io/ravencloak-org/go-api:latest --format '{{json .Manifest.Digest}}'
 ```
 
 Then verify the digest directly:
 
-```
+```bash
 gh attestation verify \
   oci://ghcr.io/ravencloak-org/go-api@sha256:<digest> \
   --owner ravencloak-org \
@@ -114,13 +114,19 @@ form.
 
 - `actions/attest-sbom@v3` supports SPDX only; the SBOM attestation uses
   `spdx-json`. A CycloneDX variant is not produced.
-- If you verify an image pushed before this feature landed, both commands
+- If you verify an image pushed before this feature landed (PR
+  [#352](https://github.com/ravencloak-org/Raven/pull/352)), both commands
   will fail with "no attestation found". That is expected.
 - If `gh attestation verify` fails with an auth error, run `gh auth login`
   and ensure the account has read access to `ravencloak-org/Raven`.
 - Re-pushing an image with an unchanged digest will add a new referrer
   manifest rather than dedupe. `gh attestation verify` picks the first
   valid attestation, so this is benign.
+- The SBOM is attached to the multi-arch **manifest-list digest**, so a
+  single SBOM covers all platforms for a given tag. Syft runs against one
+  platform when generating it, so platform-specific contents (e.g. arm64
+  vs. amd64 system libs) may not be fully enumerated. Per-platform SBOM
+  attestation is a tracked follow-up.
 
 ## References
 


### PR DESCRIPTION
Closes #346.

## Summary

Upgrades container image attestations to **SLSA Build Level 3** using GitHub-native keyless attest actions. Stacks cleanly on #341's cosign-sign flow — does not replace it.

- **`.github/workflows/docker.yml` (`publish` job)** — main-branch images gain provenance + SBOM attestations for the first time. Adds `id-token: write` + `attestations: write`; flips `build-push-action` to `provenance: false` + `sbom: false` so the L3 attest actions are the single source.
- **`.github/workflows/release.yml` (`docker-images` job)** — tag-release images get L3 attestations alongside the existing cosign signature. Same three-step append; buildkit inline provenance/SBOM (L2) turned off. Cosign sign preserved intentionally for one release as belt-and-braces while consumers migrate.
- **`docs/security/slsa-verification.md`** — consumer verification guide covering both workflows (cosign identity regex matches `(docker|release)\.yml`), both predicate types (`https://slsa.dev/provenance/v1`, `https://spdx.dev/Document/v2.3`), and digest-pinning guidance.
- **`README.md`** — SLSA 3 badge.

## Design notes

- **Asymmetric action pinning.** `docker.yml` uses tag pins (`@v3`, `@v7`); `release.yml` uses SHA pins with `# v3` comments. Each file follows its own pre-existing convention. Harmonising pinning policy across workflows is out of scope; should be a separate PR.
- **Matrix variable naming.** `docker.yml` uses `matrix.image`; `release.yml` uses `matrix.component`. Preserved as-is.
- **No composite action.** At N=2 duplication is ~20 lines per workflow; reusable action would trade that for one more layer of indirection. Revisit at N≥3.

## Dry-run evidence

The pattern was end-to-end verified on the superseded branch `ci/slsa-provenance` (run [24636605043](https://github.com/ravencloak-org/Raven/actions/runs/24636605043)) against `go-api` and `python-worker`: 4/4 attestations (2 predicate types × 2 images) verified with `gh attestation verify`. The predicate types in the verification doc were validated empirically on those real attestations.

## Test plan

- [x] `actionlint .github/workflows/docker.yml .github/workflows/release.yml` passes.
- [x] Spec-compliance review passed.
- [x] Code-quality review passed after one fix round (broadened cosign regex from `docker.yml` to `(docker|release)\.yml`).
- [ ] Post-merge: first main-branch push produces 2 attestations per image, verifiable with `gh attestation verify`.
- [ ] First tag release produces 2 attestations per image AND the existing cosign signature.

## Supersedes

- Closed PR #345 (stale against the post-#341 layout).
- Closed issues #331, #332, #333 (scope changed, consolidated into #346).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Container images now include cryptographic attestations for Software Bill of Materials (SBOM) and build provenance, enabling verification of image authenticity and integrity.

* **Documentation**
  * Added guide for verifying signed container image attestations using GitHub CLI or Cosign, including instructions for pinning to immutable image digests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->