### PR TITLE
fix: main-CI regressions — duplicate RLS assertion + missing gcc in eBPF container

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -200,8 +200,11 @@ jobs:
       - name: Install system dependencies
         run: |
           apt-get update
+          # `gcc` is required because `go test -race` needs cgo, and the
+          # minimal ubuntu:24.04 container doesn't ship a C compiler.
           apt-get install -y --no-install-recommends \
-            clang llvm libbpf-dev linux-tools-$(uname -r) linux-tools-generic \
+            build-essential clang llvm libbpf-dev \
+            linux-tools-$(uname -r) linux-tools-generic \
             ca-certificates curl git docker.io
 
       - uses: actions/setup-go@v6

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -202,10 +202,17 @@ jobs:
           apt-get update
           # `gcc` is required because `go test -race` needs cgo, and the
           # minimal ubuntu:24.04 container doesn't ship a C compiler.
+          # linux-tools-generic covers the bpftool/perf tooling we need and
+          # is always available; the host-kernel-specific package is
+          # attempted separately so a missing package (the Azure-hosted
+          # runner kernel often has no match in noble) doesn't abort the
+          # whole install.
           apt-get install -y --no-install-recommends \
             build-essential clang llvm libbpf-dev \
-            linux-tools-$(uname -r) linux-tools-generic \
+            linux-tools-generic \
             ca-certificates curl git docker.io
+          apt-get install -y --no-install-recommends "linux-tools-$(uname -r)" || \
+            echo "::warning::linux-tools for kernel $(uname -r) unavailable; using linux-tools-generic"
 
       - uses: actions/setup-go@v6
         with:

--- a/internal/repository/rls_test.go
+++ b/internal/repository/rls_test.go
@@ -171,17 +171,13 @@ func TestRLS_MigrationVersion_AllApplied(t *testing.T) {
 
 	// The highest migration version_id should match whichever migration
 	// file sits at the tip of `migrations/`. Bump this when adding a new
-	// migration. Goose tolerates gaps in the numeric sequence (e.g., 00036
-	// is reserved for the parallel semantic-cache PR), so MAX(version_id)
-	// may jump over reserved numbers.
-	// All SQL migrations must be applied.
+	// migration.
 	var maxVersion int64
 	err := pool.QueryRow(ctx,
 		"SELECT MAX(version_id) FROM goose_db_version WHERE is_applied = true",
 	).Scan(&maxVersion)
 	require.NoError(t, err)
 	assert.EqualValues(t, 37, maxVersion, "latest migration version must be applied")
-	assert.EqualValues(t, 36, maxVersion, "all 36 migrations must be applied cleanly")
 
 	// Spot-check critical tables exist.
 	for _, table := range []string{


### PR DESCRIPTION
Both failures on post-#350-merge [run 24786459589](https://github.com/ravencloak-org/Raven/actions/runs/24786459589):

### Build & Test — `TestRLS_MigrationVersion_AllApplied` (job 72531714191)

PR #350's merge produced **two** assertions on `maxVersion`: the newer `EqualValues(t, 37, ...)` I added plus a stale `EqualValues(t, 36, ...)`. Main has migrations 00036 (#351) and 00037 (#350) applied, so `MAX(version_id) = 37` and the second assertion always fails. Removed the stale line.

### eBPF Privileged Test Harness — `go: -race requires cgo` (job 72531714199)

The privileged job runs in a minimal `ubuntu:24.04` container with no C compiler. `go test -race` needs cgo, which needs `gcc`. Added `build-essential` to the apt install list.

## Test plan

- [ ] Both post-merge Go CI jobs go green on main after this lands
- [ ] No new regressions elsewhere (only touched files are `rls_test.go` and `.github/workflows/go.yml`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI environment setup for test container with improved compiler availability and kernel tooling fallback handling.
  * Refined test assertions and documentation for migration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->