### PR TITLE
ci(sast): wire Semgrep + hadolint + actionlint + no-unsanitized

### DIFF
--- a/.github/workflows/lint-infra.yml
+++ b/.github/workflows/lint-infra.yml
@@ -1,0 +1,70 @@
+name: Infra Lint
+
+# Lint the non-app-code surfaces that the Go / Python / frontend CI jobs
+# don't cover: Dockerfiles (hadolint) and GitHub Actions workflow YAML
+# (actionlint). Kept in its own workflow so Dockerfile edits don't
+# trigger the whole security scan battery.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'Dockerfile'
+      - 'ai-worker/Dockerfile'
+      - 'frontend/Dockerfile'
+      - '.github/workflows/*.yml'
+      - '.github/workflows/*.yaml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'Dockerfile'
+      - 'ai-worker/Dockerfile'
+      - 'frontend/Dockerfile'
+      - '.github/workflows/*.yml'
+      - '.github/workflows/*.yaml'
+
+permissions: {}
+
+jobs:
+  hadolint:
+    name: Hadolint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        dockerfile:
+          - Dockerfile
+          - ai-worker/Dockerfile
+          - frontend/Dockerfile
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+
+      - name: Hadolint ${{ matrix.dockerfile }}
+        uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf  # v3
+        with:
+          dockerfile: ${{ matrix.dockerfile }}
+          # DL3008 (apt pin versions) + DL3018 (apk pin versions) are
+          # noisy on base-image-derived Dockerfiles; enable later once
+          # we version-pin systematically.
+          ignore: DL3008,DL3018
+          failure-threshold: warning
+
+  actionlint:
+    name: Actionlint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+
+      - name: Actionlint + shellcheck
+        uses: reviewdog/action-actionlint@e0207a28405ecad11953ba625a95d92f7889572a  # v1
+        with:
+          reporter: github-pr-check
+          fail_level: warning

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,65 @@
+name: Semgrep
+
+# Umbrella SAST. One tool, every source-producing language (Go, Python,
+# JavaScript, TypeScript, Vue) + shell + Dockerfile + YAML. Complements
+# CodeQL (which is deeper but slower) with a faster first-pass of
+# community rules from p/ci, p/security-audit, p/owasp-top-ten, and
+# p/secrets.
+#
+# Satisfies the OpenSSF Best Practices `static_analysis` criterion at
+# the "one SAST tool per language" bar even in the absence of CodeQL
+# for a given language.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # 03:17 UTC Mondays — offset from every other security workflow.
+    - cron: '17 3 * * 1'
+
+permissions: {}
+
+jobs:
+  semgrep:
+    name: Semgrep scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: '3.12'
+
+      - name: Install Semgrep
+        run: pip install "semgrep==1.*"
+
+      - name: Scan
+        # --config=auto pulls Semgrep's maintained community rule packs
+        # that match the languages detected in the repo. --sarif
+        # produces SARIF for the Code Scanning upload; --error makes
+        # findings fail the job.
+        run: |
+          semgrep scan \
+            --config=p/default \
+            --config=p/security-audit \
+            --config=p/owasp-top-ten \
+            --config=p/secrets \
+            --sarif --output=semgrep.sarif \
+            --error
+        env:
+          SEMGREP_RULES_CACHE_DIR: /tmp/semgrep-rules
+
+      - name: Upload SARIF to Code Scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@865f5f5c36632f18690a3d569fa0a764f2da0c3e  # v3
+        with:
+          sarif_file: semgrep.sarif
+          category: semgrep

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,6 +1,7 @@
 import js from '@eslint/js'
 import tseslint from 'typescript-eslint'
 import pluginVue from 'eslint-plugin-vue'
+import pluginNoUnsanitized from 'eslint-plugin-no-unsanitized'
 import eslintConfigPrettier from 'eslint-config-prettier'
 import globals from 'globals'
 
@@ -9,6 +10,15 @@ export default tseslint.config(
   js.configs.recommended,
   ...tseslint.configs.recommended,
   ...pluginVue.configs['flat/recommended'],
+  // eslint-plugin-no-unsanitized blocks direct innerHTML / outerHTML /
+  // insertAdjacentHTML writes, which are the primary DOM-XSS vectors once
+  // the Vue template compiler is out of the loop (escape hatches, web-
+  // component code, etc.). The broader rule set historically provided by
+  // eslint-plugin-security is covered by the Semgrep workflow in
+  // .github/workflows/semgrep.yml (p/owasp-top-ten + p/security-audit),
+  // because upstream eslint-plugin-security hasn't migrated off the
+  // removed context.getSourceCode API and breaks on ESLint 10.
+  pluginNoUnsanitized.configs.recommended,
   {
     languageOptions: {
       globals: {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,6 +27,7 @@
         "@vue/tsconfig": "^0.9.0",
         "eslint": "^10.2.0",
         "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-no-unsanitized": "^4.1.2",
         "eslint-plugin-vue": "^10.8.0",
         "globals": "^17.5.0",
         "happy-dom": "^20.9.0",
@@ -2286,6 +2287,16 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-no-unsanitized": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-unsanitized/-/eslint-plugin-no-unsanitized-4.1.5.tgz",
+      "integrity": "sha512-MSB4hXPVFQrI8weqzs6gzl7reP2k/qSjtCoL2vUMSDejIIq9YL1ZKvq5/ORBXab/PvfBBrWO2jWviYpL+4Ghfg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "eslint": "^9 || ^10"
       }
     },
     "node_modules/eslint-plugin-vue": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,6 +34,7 @@
     "@vue/tsconfig": "^0.9.0",
     "eslint": "^10.2.0",
     "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-no-unsanitized": "^4.1.2",
     "eslint-plugin-vue": "^10.8.0",
     "globals": "^17.5.0",
     "happy-dom": "^20.9.0",

--- a/frontend/src/components/chat-widget/RavenChat.ce.ts
+++ b/frontend/src/components/chat-widget/RavenChat.ce.ts
@@ -153,6 +153,11 @@ export class RavenChat extends HTMLElement {
       ? `<img class="rc-header-avatar" src="${this._escapeHtml(this._avatarUrl)}" alt="Assistant avatar" />`
       : `<div class="rc-header-avatar"></div>`
 
+    // The only external input in this template is this._avatarUrl, and it is
+    // passed through this._escapeHtml above. chatStyles() returns a literal
+    // string built from this._themeColor which is also escaped at property-set
+    // time. Every other interpolation is a compile-time constant.
+    // eslint-disable-next-line no-unsanitized/property
     shadow.innerHTML = `
       <style>${chatStyles(this._themeColor)}</style>
 
@@ -421,6 +426,9 @@ export class RavenChat extends HTMLElement {
     const muteBtn = this.shadowRoot!.querySelector('.rc-voice-mute') as HTMLElement | null
     if (muteBtn) {
       muteBtn.classList.toggle('muted', muted)
+      // ICON_MIC / ICON_MIC_OFF are module-level SVG string constants with no
+      // interpolated user input. Safe to assign to innerHTML.
+      // eslint-disable-next-line no-unsanitized/property
       muteBtn.innerHTML = muted ? ICON_MIC_OFF : ICON_MIC
       muteBtn.setAttribute('aria-label', muted ? 'Unmute microphone' : 'Mute microphone')
     }


### PR DESCRIPTION
Closes the remaining SAST coverage gaps called out by the OpenSSF Best Practices `static_analysis` criterion. CodeQL + golangci-lint + ruff + mypy + vue-tsc already cover the compiled/type-checked languages; this PR adds the cross-cutting and infra tools.

## New workflows

- **`.github/workflows/semgrep.yml`** — Semgrep community rule packs (`p/default`, `p/security-audit`, `p/owasp-top-ten`, `p/secrets`) scan every source language and upload SARIF to Code Scanning. Runs on PR, push to main, and weekly (Mon 03:17 UTC, staggered from the other security workflows).
- **`.github/workflows/lint-infra.yml`** — hadolint (matrix over `Dockerfile`, `ai-worker/Dockerfile`, `frontend/Dockerfile`) and actionlint (GitHub Actions YAML + shellcheck on `run` blocks). Path-filtered so Docker / workflow edits trigger it and nothing else does.

## Frontend ESLint

- **`eslint-plugin-no-unsanitized`** — blocks direct `.innerHTML` / `.outerHTML` / `.insertAdjacentHTML` writes. Two pre-existing sites in `RavenChat.ce.ts` (template + SVG icon) now have inline disables with justifications.
- **`eslint-plugin-security`** was originally planned but upstream still uses `context.getSourceCode`, which ESLint 10 removed, so it crashes at lint time. Semgrep's `p/owasp-top-ten` + `p/security-audit` packs cover the same ground; we can revisit ESLint-side once upstream ships an ESLint-10-compatible release.

## OSPS / OpenSSF Best Practices status_analysis

With this PR, every language-producing surface in the repo has at least one FLOSS SAST tool:

| Surface | Tool |
|---|---|
| Go | CodeQL + golangci-lint (govet, staticcheck, gosec, revive, ineffassign) + govulncheck |
| Python | CodeQL + ruff + mypy + Semgrep |
| JS / TS / Vue | CodeQL + ESLint + no-unsanitized + Semgrep |
| Shell | actionlint (via shellcheck on workflow run blocks) |
| Dockerfile | hadolint + Trivy |
| GH Actions YAML | actionlint |
| IaC (compose / migrations) | Trivy + Semgrep (YAML/SQL rule packs) |
| Secrets (belt-and-braces) | gitleaks + Semgrep `p/secrets` |

## Test plan

- [x] `frontend: npm run lint` passes with the new plugin
- [x] `frontend: npx vue-tsc --noEmit` passes
- [x] `frontend: npm run test:unit` passes (128/128)
- [x] Both new workflow YAMLs parse
- [ ] First CI run on this PR exercises Semgrep + hadolint + actionlint + ESLint
- [ ] Any findings Semgrep flags on the main tree are triaged (fix or justify with `nosem` comments in a follow-up PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added infrastructure linting workflow to CI pipeline.
  * Added security scanning workflow with multiple rule sets.
  * Enhanced code quality checks for DOM manipulation safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->