### PR TITLE
fix(scripts): address Semgrep IFS + subprocess findings (#359)

### DIFF
--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -60,7 +60,10 @@ if [ "${#INPUTS[@]}" -eq 0 ]; then
   exit 1
 fi
 
-IFS=','; INPUT_CSV="${INPUTS[*]}"; unset IFS
+# Join INPUTS with ',' inside a subshell so the IFS change is scoped to
+# this single command and never leaks into the caller's environment.
+# See semgrep rule bash.lang.security.ifs-tampering.ifs-tampering.
+INPUT_CSV="$(IFS=','; printf '%s' "${INPUTS[*]}")"
 
 log "Merging coverage from: $INPUT_CSV"
 go tool covdata textfmt -i="$INPUT_CSV" -o="$OUT_DIR/cov.out"

--- a/scripts/dev-agent.py
+++ b/scripts/dev-agent.py
@@ -46,9 +46,16 @@ SYSTEM_PROMPT = textwrap.dedent(f"""
 def run_bash(command: str, timeout: int = 60) -> str:
     """Execute a shell command and return combined stdout+stderr."""
     try:
+        # This helper is the backend for Anthropic's `bash_20250124` tool,
+        # which issues free-form shell strings (pipes, redirection, `cd &&`,
+        # here-docs). Running without `shell=True` would break the tool
+        # contract. The script is a developer-only CLI that requires an
+        # ANTHROPIC_API_KEY in the local env and is never exposed to
+        # untrusted input -- any "injection" here is already the LLM choosing
+        # what to run, which is the entire point of the bash tool.
         result = subprocess.run(
             command,
-            shell=True,
+            shell=True,  # nosemgrep: python.lang.security.audit.subprocess-shell-true.subprocess-shell-true -- dev-only CLI; Anthropic bash tool contract requires shell string execution
             capture_output=True,
             text=True,
             timeout=timeout,


### PR DESCRIPTION
## Summary

Resolves two Semgrep findings in \`scripts/\` surfaced by the report-only SAST job (refs #359).

### \`scripts/coverage.sh:63\` - \`bash.lang.security.ifs-tampering.ifs-tampering\`

Before:
\`\`\`bash
IFS=','; INPUT_CSV="${INPUTS[*]}"; unset IFS
\`\`\`
After (command substitution scopes IFS to a subshell; outer IFS is never mutated):
\`\`\`bash
INPUT_CSV="\$(IFS=','; printf '%s' "\${INPUTS[*]}")"
\`\`\`
Verified: \`bash -c '...'\` shows outer IFS remains the default \`\$' \\t\\n'\` after the join, and the CSV comes out identical (\`a,b,c\` for \`(a b c)\`).

### \`scripts/dev-agent.py:51\` - \`python.lang.security.audit.subprocess-shell-true.subprocess-shell-true\`

\`run_bash\` is the backend for Anthropic's \`bash_20250124\` tool -- the Claude model hands it free-form shell strings (pipes, redirection, \`cd &&\`, here-docs). Running without \`shell=True\` would break the tool contract, so the list-form refactor is not viable here.

This is a developer-only CLI gated on a local \`ANTHROPIC_API_KEY\` -- it never receives untrusted input; the only "command injector" is the LLM itself, which is the intended design. Suppressed with an inline \`# nosemgrep: python.lang.security.audit.subprocess-shell-true.subprocess-shell-true -- <why>\` annotation plus an explanatory block comment above the \`subprocess.run\` call.

## Gates

- [x] \`bash -n scripts/coverage.sh\` - OK
- [x] \`shellcheck scripts/coverage.sh\` - rc=0 (no findings)
- [x] \`python3 -m py_compile scripts/dev-agent.py\` - OK
- [x] \`ruff check scripts/\` - all checks passed
- [x] Smoke test: \`run_bash("echo hello && echo world | tr a-z A-Z")\` returns \`hello\\nWORLD\` (shell features still work)
- [x] DCO sign-off present, no AI attribution

## Test plan

- [ ] CI Semgrep job no longer flags either finding
- [ ] \`make cover\` (or \`scripts/coverage.sh\`) still produces the merged CSV input and HTML/summary report