### PR TITLE
fix(security): triage asyncpg-sqli Semgrep findings (#359)

### DIFF
--- a/ai-worker/raven_worker/retrieval/vector_search.py
+++ b/ai-worker/raven_worker/retrieval/vector_search.py
@@ -49,6 +49,7 @@ async def vector_search(
         embedding_dims=len(query_embedding),
     )
 
+    # nosemgrep: python.lang.security.audit.sqli.asyncpg-sqli -- hard-coded SQL, $N placeholders
     rows = await conn.fetch(
         _VECTOR_SEARCH_SQL,
         embedding_str,

--- a/ai-worker/raven_worker/services/semantic_cache.py
+++ b/ai-worker/raven_worker/services/semantic_cache.py
@@ -88,6 +88,7 @@ class SemanticCache:
 
             async with self._pool.acquire() as conn, conn.transaction():
                 await conn.execute("SELECT set_config('app.current_org_id', $1, true)", org_id)
+                # nosemgrep: python.lang.security.audit.sqli.asyncpg-sqli -- hard-coded SQL, $N placeholders  # noqa: E501
                 row = await conn.fetchrow(
                     _LOOKUP_SQL, embedding_str, org_id, kb_id, self._threshold
                 )
@@ -160,6 +161,7 @@ class SemanticCache:
 
             async with self._pool.acquire() as conn, conn.transaction():
                 await conn.execute("SELECT set_config('app.current_org_id', $1, true)", org_id)
+                # nosemgrep: python.lang.security.audit.sqli.asyncpg-sqli -- hard-coded SQL, $N placeholders  # noqa: E501
                 await conn.execute(
                     _STORE_SQL,
                     cache_id,


### PR DESCRIPTION
Closes part of #359 (Semgrep `python.lang.security.audit.sqli.asyncpg-sqli`).

## Per-finding verdict

| Location | Verdict | Reason |
|---|---|---|
| `ai-worker/raven_worker/retrieval/vector_search.py:52` | **Suppressed (false positive)** | SQL lives in module constant `_VECTOR_SEARCH_SQL`; every user-supplied value (embedding, org_id, kb_ids, limit) is passed via `$1..$4` placeholders to `conn.fetch()`. No interpolation. |
| `ai-worker/raven_worker/services/semantic_cache.py:91` | **Suppressed (false positive)** | SQL in constant `_LOOKUP_SQL`; embedding, org_id, kb_id, threshold passed via `$1..$4` placeholders to `conn.fetchrow()`. |
| `ai-worker/raven_worker/services/semantic_cache.py:163` | **Suppressed (false positive)** | SQL in constant `_STORE_SQL`; all 8 values pass via `$1..$8` placeholders to `conn.execute()`. |

The Semgrep rule flags any asyncpg call whose SQL argument is a variable (not a string literal), regardless of whether values are actually parameterised. Inline `# nosemgrep` annotations with a one-line rationale are applied at each call site.

No real injection exists: no f-strings, no string concatenation, no dynamic identifiers.

## Test plan

- [x] `cd ai-worker && uv run ruff check` -> All checks passed
- [x] `uv run ruff format --check` -> 65 files already formatted
- [x] `uv run mypy raven_worker` -> no issues in 35 source files
- [x] `uv run pytest -q` -> 247 passed, 3 skipped