### PR TITLE
fix(security): address CodeQL findings — weak hash + credential log

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -213,7 +213,7 @@ func main() {
 	})
 
 	// Build rate limiter using config-driven limits.
-	rl := middleware.NewRateLimiter(valkeyClient, slog.Default())
+	rl := middleware.NewRateLimiter(valkeyClient, slog.Default(), cfg.RateLimit.APIKeyHashSecret)
 	tierResolver := middleware.NewValkeyTierResolver(valkeyClient, slog.Default())
 	tierCfg := middleware.TierConfig{
 		Free: middleware.TierLimits{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -219,6 +219,13 @@ type RateLimitConfig struct {
 
 	// Widget limits — stricter for public chatbot widget endpoints.
 	WidgetRPM int `mapstructure:"widget_rpm"`
+
+	// APIKeyHashSecret is the HMAC-SHA-256 key used to derive Valkey bucket
+	// identifiers from raw API keys. Must be a stable, secret value in
+	// production so that bucket IDs are consistent across nodes and cannot
+	// be reversed via a rainbow-table lookup of plain SHA-256. Provide via
+	// RAVEN_RATELIMIT_APIKEY_HASH_SECRET.
+	APIKeyHashSecret string `mapstructure:"apikey_hash_secret"`
 }
 
 // ServerConfig holds HTTP server settings.
@@ -285,6 +292,7 @@ func Load() (*Config, error) {
 	v.SetDefault("ratelimit.enterprise_general_rpm", 6000)
 	v.SetDefault("ratelimit.enterprise_completion_rpm", -1) // unlimited
 	v.SetDefault("ratelimit.widget_rpm", 30)
+	v.SetDefault("ratelimit.apikey_hash_secret", "")
 	v.SetDefault("queue.concurrency", 10)
 	v.SetDefault("queue.max_retry", 5)
 	v.SetDefault("seaweedfs.master_url", "http://seaweedfs-master:9333")
@@ -416,6 +424,7 @@ func Load() (*Config, error) {
 	_ = v.BindEnv("ratelimit.enterprise_general_rpm", "RAVEN_RATELIMIT_ENTERPRISE_GENERAL_RPM")
 	_ = v.BindEnv("ratelimit.enterprise_completion_rpm", "RAVEN_RATELIMIT_ENTERPRISE_COMPLETION_RPM")
 	_ = v.BindEnv("ratelimit.widget_rpm", "RAVEN_RATELIMIT_WIDGET_RPM")
+	_ = v.BindEnv("ratelimit.apikey_hash_secret", "RAVEN_RATELIMIT_APIKEY_HASH_SECRET")
 	_ = v.BindEnv("otel.endpoint", "RAVEN_OTEL_ENDPOINT")
 	_ = v.BindEnv("otel.service_name", "RAVEN_OTEL_SERVICE_NAME")
 	_ = v.BindEnv("otel.enabled", "RAVEN_OTEL_ENABLED")

--- a/internal/middleware/ratelimit.go
+++ b/internal/middleware/ratelimit.go
@@ -2,7 +2,9 @@ package middleware
 
 import (
 	"context"
+	"crypto/hmac"
 	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -59,19 +61,34 @@ end
 return {count, -1, oldest}
 `
 
-// RateLimiter holds the Valkey client and logger used by rate-limit middleware.
+// RateLimiter holds the Valkey client, logger, and API-key HMAC secret used by
+// rate-limit middleware. The HMAC secret is used to derive bucket keys for
+// API-key-scoped limits so that raw keys never hit Valkey and the bucket
+// identifier cannot be reversed by a rainbow-table lookup of plain SHA-256.
 type RateLimiter struct {
-	client redis.Cmdable
-	logger *slog.Logger
+	client  redis.Cmdable
+	logger  *slog.Logger
+	hmacKey []byte
 }
 
 // NewRateLimiter constructs a RateLimiter from any redis.Cmdable (real client
 // or miniredis stub).
-func NewRateLimiter(client redis.Cmdable, logger *slog.Logger) *RateLimiter {
+//
+// apiKeyHashSecret is used as the HMAC-SHA-256 key for hashing raw API keys
+// into Valkey bucket identifiers. It MUST be set to a stable, secret value in
+// production (e.g. from RAVEN_RATELIMIT_APIKEY_HASH_SECRET) so that bucket
+// identifiers are consistent across processes and nodes. If empty, a warning
+// is logged and a zero-length key is used — acceptable only for dev/tests
+// where API-key hashing is not security-critical (buckets still work, but
+// the hash is reversible via brute force).
+func NewRateLimiter(client redis.Cmdable, logger *slog.Logger, apiKeyHashSecret string) *RateLimiter {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &RateLimiter{client: client, logger: logger}
+	if apiKeyHashSecret == "" {
+		logger.Warn("rate limiter: apiKeyHashSecret is empty — API-key bucket hashes are not keyed; set RAVEN_RATELIMIT_APIKEY_HASH_SECRET in production")
+	}
+	return &RateLimiter{client: client, logger: logger, hmacKey: []byte(apiKeyHashSecret)}
 }
 
 // rateLimitResult is the decoded response from the Lua script.
@@ -234,11 +251,14 @@ func RateLimitMiddleware(rl *RateLimiter, limit int, keyFn func(*gin.Context) st
 	}
 }
 
-// apiKeyHash returns the SHA-256 hex digest of an API key, used as the Valkey
-// key suffix so that raw secrets are never stored in Valkey.
-func apiKeyHash(apiKey string) string {
-	h := sha256.Sum256([]byte(apiKey))
-	return fmt.Sprintf("%x", h)
+// apiKeyHash returns the HMAC-SHA-256 hex digest of an API key using the
+// rate-limiter's per-deployment secret as the HMAC key, used as the Valkey
+// key suffix so that raw secrets are never stored in Valkey and the bucket
+// identifier is not reversible via a rainbow table of plain SHA-256.
+func (rl *RateLimiter) apiKeyHash(apiKey string) string {
+	m := hmac.New(sha256.New, rl.hmacKey)
+	m.Write([]byte(apiKey))
+	return hex.EncodeToString(m.Sum(nil))
 }
 
 // ByAPIKey returns a Gin middleware that rate-limits by API key.
@@ -254,7 +274,7 @@ func ByAPIKey(rl *RateLimiter, limit int) gin.HandlerFunc {
 		if !ok || key == "" {
 			return ""
 		}
-		return keyPrefixAPIKey + apiKeyHash(key)
+		return keyPrefixAPIKey + rl.apiKeyHash(key)
 	}, keyPrefixAPIKey+"fallback:")
 }
 

--- a/internal/middleware/ratelimit_test.go
+++ b/internal/middleware/ratelimit_test.go
@@ -2,9 +2,10 @@ package middleware
 
 import (
 	"context"
+	"crypto/hmac"
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -22,7 +23,7 @@ func newTestRateLimiter(t *testing.T) (*RateLimiter, *miniredis.Miniredis) {
 	t.Helper()
 	mr := miniredis.RunT(t)
 	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
-	rl := NewRateLimiter(client, nil)
+	rl := NewRateLimiter(client, nil, "test-hmac-secret")
 	return rl, mr
 }
 
@@ -343,9 +344,11 @@ func TestByAPIKey(t *testing.T) {
 	}
 
 	// Assert that the raw key was NOT stored in Valkey, and that the hashed
-	// form IS present — confirming ByAPIKey hashes the key before use.
-	hash := sha256.Sum256([]byte(rawKey))
-	expectedValkeyKey := keyPrefixAPIKey + fmt.Sprintf("%x", hash)
+	// form IS present — confirming ByAPIKey hashes the key before use with
+	// HMAC-SHA-256 keyed by the rate-limiter's secret.
+	m := hmac.New(sha256.New, []byte("test-hmac-secret"))
+	m.Write([]byte(rawKey))
+	expectedValkeyKey := keyPrefixAPIKey + hex.EncodeToString(m.Sum(nil))
 
 	allKeys := mr.Keys()
 	for _, k := range allKeys {

--- a/scripts/test-keycloak-realm.py
+++ b/scripts/test-keycloak-realm.py
@@ -18,6 +18,20 @@ PASS = 0
 FAIL = 0
 
 
+def _redact(value: str) -> str:
+    """Mask all but the first 4 characters of a potentially-sensitive value.
+
+    Used when surfacing credential-shaped data in assertion failure messages
+    so CodeQL (py/clear-text-logging-sensitive-data) and reviewers do not see
+    raw secrets in CI logs. Placeholders like "${ENV_VAR}" pass through.
+    """
+    if not value or value.startswith("${"):
+        return value
+    if len(value) <= 4:
+        return "<REDACTED>"
+    return value[:4] + "<REDACTED>"
+
+
 def check(description, condition, detail=""):
     global PASS, FAIL
     if condition:
@@ -196,7 +210,7 @@ def main():
         check(
             "raven-api secret is a placeholder (not a real value)",
             secret.startswith("${") or secret == "",
-            f"got '{secret}'",
+            f"got '{_redact(secret)}'",
         )
     # Broad scan for common secret patterns
     suspicious = []
@@ -212,7 +226,7 @@ def main():
                 val_end = lower.index('"', val_start)
                 val = raw[val_start:val_end]
                 if val and not val.startswith("${"):
-                    suspicious.append(f"{keyword}={val}")
+                    suspicious.append(f"{keyword}={_redact(val)}")
     check("no hardcoded password/secret_key/api_key/private_key values", len(suspicious) == 0,
           f"found: {suspicious}")
 


### PR DESCRIPTION
## Summary

Addresses two CodeQL findings from #359:

1. **`go/weak-sensitive-data-hashing`** (`internal/middleware/ratelimit.go:240`)
   - **Before:** `apiKeyHash` used plain SHA-256 of the raw API key as the Valkey bucket identifier. CodeQL flags unsalted/unkeyed hashes of secrets because the hash is reversible by a rainbow-table / brute-force lookup of the hex digest.
   - **After:** switched to **HMAC-SHA-256** keyed by a per-deployment secret (`RAVEN_RATELIMIT_APIKEY_HASH_SECRET`, surfaced as `RateLimit.APIKeyHashSecret`). `apiKeyHash` is now a method on `RateLimiter` so the HMAC key flows in via `NewRateLimiter(client, logger, apiKeyHashSecret)`. If the secret is empty we log a warning — acceptable only in dev/tests.
   - Tests updated to derive the expected Valkey key via HMAC with the same test secret.

2. **`py/clear-text-logging-sensitive-data`** (`scripts/test-keycloak-realm.py:31`)
   - **Before:** assertion-failure messages interpolated raw client secrets / passwords / API keys into stdout (e.g. `f\"got '{secret}'\"` and `suspicious.append(f\"{keyword}={val}\")`).
   - **After:** added a `_redact()` helper that masks all but the first 4 characters of credential-shaped values (placeholders like `${VAR}` pass through). Both call sites now route through `_redact`.
   - Kept the script in tree — it's still useful for validating the realm JSON structure (no credentials involved in a passing run); only the failure paths ever included raw values.

## Why HMAC and not just a stronger hash

Per the issue guidance, the hash is only used as a rate-limit bucket key (collision prevention / lookup), not compared against a stored hash. Plain SHA-256 would arguably be sufficient, but CodeQL's heuristic flags it because the input is sensitive. HMAC-SHA-256 both silences the finding and gives genuine defence-in-depth: an attacker who exfiltrates Valkey bucket names no longer gets a plain SHA-256 digest they can feed to a rainbow table — they need the per-deployment HMAC secret.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -short ./...` (all packages green)
- [x] `golangci-lint run ./...` (clean)
- [x] `ruff check scripts/test-keycloak-realm.py` (clean)
- [ ] CodeQL re-scan in CI closes both alerts

## Operational note

`RAVEN_RATELIMIT_APIKEY_HASH_SECRET` should be added to the production env (any high-entropy secret — 32+ bytes). Without it, the limiter still works but logs a warning on startup. Existing API-key buckets will be invalidated on first rollout (they're sliding-window counters, so one minute of cold buckets is the only impact).

Refs #359