### PR TITLE
fix(ci): repair Semgrep SARIF output + bump CodeQL action to v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -69,7 +69,7 @@ jobs:
           cache: true
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@865f5f5c36632f18690a3d569fa0a764f2da0c3e  # v3
+        uses: github/codeql-action/init@b25d0ebf40e5b63ee81e1bd6e5d2a12b7c2aeb61  # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -77,9 +77,9 @@ jobs:
 
       - name: Autobuild
         if: matrix.build-mode == 'autobuild'
-        uses: github/codeql-action/autobuild@865f5f5c36632f18690a3d569fa0a764f2da0c3e  # v3
+        uses: github/codeql-action/autobuild@b25d0ebf40e5b63ee81e1bd6e5d2a12b7c2aeb61  # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@865f5f5c36632f18690a3d569fa0a764f2da0c3e  # v3
+        uses: github/codeql-action/analyze@b25d0ebf40e5b63ee81e1bd6e5d2a12b7c2aeb61  # v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -50,19 +50,23 @@ jobs:
         # build-side signal out of the hot path while the existing
         # backlog is triaged in follow-up issues.
         run: |
+          # --sarif-output writes ONLY SARIF to the file; --text prints a
+          # human-readable summary to stdout without corrupting the file.
+          # Using --output with --sarif writes both formats to the same
+          # destination and the SARIF becomes unparseable.
           semgrep scan \
             --config=p/default \
             --config=p/security-audit \
             --config=p/owasp-top-ten \
             --config=p/secrets \
-            --sarif --output=semgrep.sarif \
+            --sarif-output=semgrep.sarif \
             --text --no-error
         env:
           SEMGREP_RULES_CACHE_DIR: /tmp/semgrep-rules
 
       - name: Upload SARIF to Code Scanning
         if: always()
-        uses: github/codeql-action/upload-sarif@865f5f5c36632f18690a3d569fa0a764f2da0c3e  # v3
+        uses: github/codeql-action/upload-sarif@b25d0ebf40e5b63ee81e1bd6e5d2a12b7c2aeb61  # v4
         with:
           sarif_file: semgrep.sarif
           category: semgrep


### PR DESCRIPTION
Two workflow fixes surfaced by the Semgrep run on `main` ([run 24817162250](https://github.com/ravencloak-org/Raven/actions/runs/24817162250/job/72633778256)):

## 1. SARIF corruption
The scan step used `--sarif --output=semgrep.sarif` alongside `--text`. Semgrep merged both output modes into the same destination, so the SARIF file started with the box-drawing scan-status banner instead of `{`. `codeql-action/upload-sarif` rejected it:
> Error: Invalid SARIF. JSON syntax error: Unexpected token '┌'

Fix: use the dedicated `--sarif-output=semgrep.sarif` flag so SARIF writes to the file and `--text` prints to stdout unaffected.

## 2. CodeQL action v3 → v4
The action emits a deprecation warning — v3 goes away December 2026 ([changelog](https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/)). Bumped all four references (`init`, `autobuild`, `analyze` in `codeql.yml`; `upload-sarif` in `semgrep.yml`) to v4 commit `b25d0ebf40e5b63ee81e1bd6e5d2a12b7c2aeb61`.

## Test plan

- [ ] Semgrep workflow on this PR produces a valid SARIF file (no JSON parse error)
- [ ] CodeQL workflow on this PR runs all three matrix jobs without deprecation warnings
- [ ] Code Scanning at `/security/code-scanning` receives the semgrep category uploads