### PR TITLE
ci: bump actions/setup-go v6.0.0 → v6.4.0 (node20 → node24)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Setup Go
         if: matrix.language == 'go'
-        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version: '1.26.2'
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version: '1.26.2'
           cache: true


### PR DESCRIPTION
Post-v0.3.0 release run emitted:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: `actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00`.

[GitHub deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/): Node 20 goes away on June 2, 2026.

## Fix

`actions/setup-go` v6.4.0 (commit `4a3601121dd01d1626a1e23e37211e3254c1c06c`) runs on node24. Bumped every pinned reference:

```
.github/workflows/codeql.yml
.github/workflows/release.yml
```

Verified by fetching `action.yml` at v6.4.0 — `runs.using: 'node24'`.

## Remaining node20 warning

`actions/download-artifact` latest is v6, still node20. No node24 release upstream yet. Leaving it pinned; will revisit once `v7` drops or by June 2 set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` as an opt-in.

## Audit

Other JS actions already on node24 at their pinned SHAs: `actions/checkout`, `actions/setup-node`, `actions/setup-python`, `actions/upload-artifact`, all `docker/*`, `goreleaser/goreleaser-action`.

## Test plan

- [ ] Post-merge Go CI / release workflows run without the Node 20 deprecation warning