### PR TITLE
ci(codeql): add Gate job for required-check semantics (#348)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,44 +3,50 @@ name: CodeQL
 on:
   push:
     branches: [main]
-    paths:
-      - '**/*.go'
-      - '**/*.py'
-      - '**/*.ts'
-      - '**/*.tsx'
-      - '**/*.js'
-      - '**/*.vue'
-      - 'go.mod'
-      - 'go.sum'
-      - 'frontend/package.json'
-      - 'frontend/bun.lock'
-      - 'ai-worker/pyproject.toml'
-      - 'ai-worker/requirements*.txt'
-      - '.github/workflows/codeql.yml'
   pull_request:
     branches: [main]
-    paths:
-      - '**/*.go'
-      - '**/*.py'
-      - '**/*.ts'
-      - '**/*.tsx'
-      - '**/*.js'
-      - '**/*.vue'
-      - 'go.mod'
-      - 'go.sum'
-      - 'frontend/package.json'
-      - 'frontend/bun.lock'
-      - 'ai-worker/pyproject.toml'
-      - 'ai-worker/requirements*.txt'
-      - '.github/workflows/codeql.yml'
   schedule:
     - cron: '23 6 * * 1'
 
 permissions: {}
 
 jobs:
+  changes:
+    name: Detect relevant changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+
+      - name: Filter paths
+        id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  # v3.0.2
+        with:
+          filters: |
+            code:
+              - '**/*.go'
+              - '**/*.py'
+              - '**/*.ts'
+              - '**/*.tsx'
+              - '**/*.js'
+              - '**/*.vue'
+              - 'go.mod'
+              - 'go.sum'
+              - 'frontend/package.json'
+              - 'frontend/bun.lock'
+              - 'ai-worker/pyproject.toml'
+              - 'ai-worker/requirements*.txt'
+              - '.github/workflows/codeql.yml'
+
   analyze:
     name: Analyze (${{ matrix.language }})
+    needs: changes
+    if: needs.changes.outputs.code == 'true' || github.event_name == 'schedule' || github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -83,3 +89,20 @@ jobs:
         uses: github/codeql-action/analyze@b25d0ebf40e5b63ee81e1bd6e5d2a12b7c2aeb61  # v4
         with:
           category: "/language:${{ matrix.language }}"
+
+  gate:
+    name: Gate
+    needs: analyze
+    runs-on: ubuntu-latest
+    if: always() && !cancelled()
+    permissions:
+      contents: read
+    steps:
+      - name: Evaluate CodeQL result
+        run: |
+          result="${{ needs.analyze.result }}"
+          echo "analyze result: $result"
+          case "$result" in
+            success|skipped) exit 0 ;;
+            *) exit 1 ;;
+          esac


### PR DESCRIPTION
## Summary

Restructures `.github/workflows/codeql.yml` so CodeQL can serve as a **required status check** on branch protection without blocking docs-only PRs.

Implements **option 2** (the gate pattern) from #348: keep CodeQL skipped on non-code changes (no perf regression) while still emitting a stable required-check context on every PR to `main`.

## Design

- **Workflow triggers on every PR to `main`** (path filters removed from the `on:` block).
- **New `changes` job** uses `dorny/paths-filter` (pinned by SHA) to detect whether the PR touches Go/Python/JS/TS/Vue/lockfile/`codeql.yml` paths.
- **`analyze` matrix** now has a job-level `if:` gate on the `changes.outputs.code` flag, plus an escape hatch for `schedule` and `push` events (those still always analyze).
- **New `gate` job** with `needs: analyze` and `if: always() && !cancelled()`:
  - `needs.analyze.result == 'success'` -> exit 0 (analysis passed)
  - `needs.analyze.result == 'skipped'` -> exit 0 (docs-only PR, analysis not needed)
  - anything else (`failure`, `cancelled` propagated, etc.) -> exit 1
- Stable context `CodeQL / Gate` is always posted, so branch protection can require it.

## Follow-up (post-merge)

After this PR merges, update branch protection to require the new `Gate` check:

```bash
gh api --method PATCH repos/ravencloak-org/Raven/branches/main/protection/required_status_checks \
  --input - <<JSON
{
  "strict": false,
  "checks": [
    {"context": "Gate"},
    {"context": "DCO Sign-off"},
    {"context": "Gitleaks"},
    {"context": "CodeQL / Gate"}
  ]
}
JSON
```

Doing this **after** merge avoids the patch blocking this very PR.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/codeql.yml'))"` parses cleanly
- [ ] This PR touches `.github/workflows/codeql.yml`, which is in the `paths-filter`, so CodeQL matrix should run and Gate should pass
- [ ] After merge, verify `CodeQL / Gate` appears as a required check
- [ ] Open a docs-only PR and confirm `analyze` is skipped while `Gate` succeeds

Closes #348

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized continuous integration workflow by implementing improved change detection for code-related updates and conditional job execution, reducing unnecessary analysis runs.
  * Enhanced workflow reliability with additional result validation logic to ensure consistent execution outcomes across pipeline stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->