### PR TITLE
docs(compliance): close OSPS-L2 Known Gaps — org MFA enforced

### DIFF
--- a/docs/compliance/osps-l2-2026-02-19.md
+++ b/docs/compliance/osps-l2-2026-02-19.md
@@ -52,7 +52,7 @@ cosign verify-blob \
 
 | Control | Requirement | Evidence |
 |---|---|---|
-| OSPS-AC-01.01 | MFA required for sensitive actions | Repo-owner and CODEOWNER MFA enforced at account level. Org-level MFA requirement is a pending item (see Known gaps). |
+| OSPS-AC-01.01 | MFA required for sensitive actions | Enforced at the org level on 2026-04-24. Verified via `gh api orgs/ravencloak-org --jq .two_factor_requirement_enabled` → `true`. Every current and future org member must have 2FA on their GitHub account. |
 | OSPS-AC-02.01 | New collaborators default to least privilege | GitHub default; org default permission set to `read` per `gh api orgs/ravencloak-org` output. |
 | OSPS-AC-03.01 | Block direct commits to primary branch | Branch protection on `main`: `required_pull_request_reviews.required_approving_review_count = 1`, `require_code_owner_reviews = true`. Verified via `gh api repos/ravencloak-org/Raven/branches/main/protection`. |
 | OSPS-AC-03.02 | Prevent primary branch deletion | Branch protection: `allow_deletions = false`, `allow_force_pushes = false`, `required_linear_history = true`. |
@@ -134,21 +134,8 @@ Applied via `gh api`:
 
 ## Known gaps / deferred items
 
-1. **Org-level MFA enforcement** — the `PATCH /orgs/{org}` call with `two_factor_requirement_enabled=true` did not persist (likely needs the change to be applied via the org Security settings UI by the org owner). **Action:** enable in the GitHub UI at **Organization → Settings → Authentication security → Require two-factor authentication**.
-2. **Required status checks on `main`** — currently only `CI Required / Gate`. Once the new CI workflows (CodeQL, gitleaks, DCO) have run at least once post-merge, expand the required-checks list to include them. **Action:** run
-   ```bash
-   gh api --method PUT repos/ravencloak-org/Raven/branches/main/protection/required_status_checks \
-     -f strict=true \
-     -F 'contexts[]=CI Required / Gate' \
-     -F 'contexts[]=CodeQL / Analyze (go)' \
-     -F 'contexts[]=CodeQL / Analyze (python)' \
-     -F 'contexts[]=CodeQL / Analyze (javascript-typescript)' \
-     -F 'contexts[]=Secret Scanning / Gitleaks' \
-     -F 'contexts[]=DCO / DCO Sign-off'
-   ```
-3. **First tagged release** — the release pipeline (PR #341) will be exercised end-to-end the first time a `v0.0.0-rc1` tag is pushed. Until that happens, BR-06.01 evidence is the workflow definition rather than a published signed artifact.
-4. **Secret scanning non-provider patterns** and **validity checks** — GitHub Advanced Security features that require a paid plan or Enterprise; not enabled. Not required for L2.
-5. **SLSA L3 provenance attestation** — out of scope for L2. Docker buildx is already configured with `provenance: true, sbom: true`, which produces a v1 attestation but not a full SLSA L3 generator. Track under a future L3 milestone.
+1. **Secret scanning non-provider patterns** and **validity checks** — GitHub Advanced Security features that require a paid plan or Enterprise; not enabled. Not required for L2.
+2. **SLSA L3 provenance attestation** — out of scope for L2. Container builds carry SLSA Build Level 3 attestations as of #352 and the release pipeline publishes them via `actions/attest-build-provenance`; a formal L3 generator workflow is a future L3 milestone.
 
 ## Changelog
 
@@ -157,3 +144,10 @@ Applied via `gh api`:
 - 2026-04-20 — Release pipeline PR opened (#341)
 - 2026-04-20 — Phase 2 repo settings applied via `gh api`
 - 2026-04-20 — Self-assessment (this doc) authored
+- 2026-04-20 — First signed release cut: `v0.1.0`
+- 2026-04-22 — SLSA Build Level 3 container attestations (#352)
+- 2026-04-23 — SAST tool stack wired (Semgrep, hadolint, actionlint, no-unsanitized) — PRs #357, #358
+- 2026-04-23 — 17-finding baseline SAST triage complete — PRs #360 through #363; remaining Code Scanning alerts dismissed with per-finding reasons on 2026-04-23
+- 2026-04-23 — `v0.3.0` released
+- 2026-04-24 — CodeQL Gate pattern landed (#369); required checks now `[Gate, DCO Sign-off, Gitleaks, CodeQL / Gate]`
+- 2026-04-24 — Org-level MFA enforcement enabled; closes the last Known gap item. Baseline L2 status: **complete**.


### PR DESCRIPTION
Closes #347.

`gh api orgs/ravencloak-org --jq .two_factor_requirement_enabled` → `true`.

## What changed

- **AC-01.01 evidence row** now reads "enforced at the org level on 2026-04-24" with the verification command.
- **Known gaps section** pruned from five items to two non-goals:
  - ✅ Org-level MFA: enforced today.
  - ✅ Required status checks: expanded to `[Gate, DCO Sign-off, Gitleaks, CodeQL / Gate]` via #369.
  - ✅ First tagged release: `v0.1.0` shipped 2026-04-20, `v0.3.0` on 2026-04-23.
  - 🚫 Non-provider secret-scanning patterns: requires GHAS Enterprise.
  - 🔭 Formal SLSA L3 generator workflow: L3-scope follow-up. Container builds already carry SLSA Build Level 3 attestations via #352.
- **Changelog** extended with milestones reached since the original authoring.

## Baseline L2 status

**Complete.** Every L1 + L2 control has an evidence row with either an artifact, a CI job, or a dismissed-with-rationale alert.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated compliance documentation confirming org-level MFA enforcement is now enabled and verified.
  * Added SLSA Build Level 3 build attestation evidence to compliance records.
  * Expanded changelog documenting signed releases, SAST tool implementation, and CodeQL security scanning.
  * Streamlined known gaps section reflecting current security posture and L2 baseline completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->