### PR TITLE
ci: tighten claude/opencode triggers to reduce Skipped check noise

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,13 +1,16 @@
 name: Claude Code
 
 on:
-  # Manual: tag @claude in any comment/review to get help
+  # Manual: tag @claude in any PR/issue comment, or in a new issue body/title.
+  # GitHub fires `issue_comment` for both issue and PR conversation comments,
+  # so that single trigger covers @claude mentions on PRs as well. We do NOT
+  # subscribe to `pull_request_review` / `pull_request_review_comment` —
+  # those events register the workflow as a `Skipped` check on every review
+  # activity. Trade-off: @claude mentions inside an inline review comment or
+  # a review-submission body won't trigger the bot — re-mention @claude in
+  # the regular PR conversation to invoke it.
   issue_comment:
     types: [created]
-  pull_request_review_comment:
-    types: [created]
-  pull_request_review:
-    types: [submitted]
   issues:
     types: [opened, assigned]
 
@@ -18,8 +21,6 @@ jobs:
     name: Claude (on-demand)
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,9 +1,11 @@
 name: opencode
 
 on:
+  # /oc and /opencode are only meaningful in PR/issue conversation comments.
+  # `issue_comment` covers both, so we drop `pull_request_review_comment` —
+  # it was registering this workflow as a `Skipped` check on every inline
+  # review-comment event without being a useful invocation surface for /oc.
   issue_comment:
-    types: [created]
-  pull_request_review_comment:
     types: [created]
 
 permissions: {}


### PR DESCRIPTION
## Summary

Both `claude.yml` and `opencode.yml` are comment-triggered: they only act when `@claude` (or `/oc`) appears in a comment. But their previous `on:` trigger sets fired on every PR review / inline-review-comment event, registering each workflow as a candidate run, evaluating the `if:` to false, and emitting a **Skipped** check on every PR. Cosmetic, but it clutters the checks panel.

This PR drops the trigger types that don't carry useful invocation surfaces.

## Trigger lists

### `claude.yml` — BEFORE (4 triggers)
- `issue_comment: [created]`
- `pull_request_review_comment: [created]`
- `pull_request_review: [submitted]`
- `issues: [opened, assigned]`

### `claude.yml` — AFTER (2 triggers)
- `issue_comment: [created]` *(covers both issue comments AND PR conversation comments — same GitHub event)*
- `issues: [opened, assigned]`

### `opencode.yml` — BEFORE (2 triggers)
- `issue_comment: [created]`
- `pull_request_review_comment: [created]`

### `opencode.yml` — AFTER (1 trigger)
- `issue_comment: [created]`

## Why each removed trigger is safe

- `pull_request_review_comment` (inline code-review comments): not subscribed by `opencode`'s slash commands at all. For `claude.yml`, `@claude` mentions placed *inside an inline review comment* will no longer invoke the bot — re-mention `@claude` in a regular PR conversation comment instead. (Tradeoff acknowledged; in practice almost all `@claude` invocations on this repo happen as PR conversation comments, which `issue_comment` covers.)
- `pull_request_review` (review-summary body): same reasoning — `@claude` in a "Submit Review" summary won't invoke; users should drop a top-level PR comment instead.

`issue_comment` is the workhorse: GitHub fires it for both issue comments AND PR conversation comments, so the primary invocation path stays intact for both bots.

## Test plan

- [ ] After merge, open any PR / push a commit and confirm `Claude Code` and `opencode` no longer appear as Skipped checks.
- [ ] Drop a `@claude help` comment on a PR conversation thread and confirm Claude responds.
- [ ] Drop a `/oc` comment on a PR conversation thread and confirm opencode responds.
- [ ] Open a new issue with `@claude` in the body and confirm Claude is invoked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined GitHub Actions workflow event triggers and documentation for improved configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->