### PR TITLE
ci(docker): drop self-reference + native arm64 runners on PR gate

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,6 @@ on:
       - 'frontend/Dockerfile'
       - 'frontend/nginx.conf'
       - 'docker-compose.yml'
-      - '.github/workflows/docker.yml'
   pull_request:
     branches: [main]
     paths:
@@ -20,17 +19,23 @@ on:
       - 'frontend/Dockerfile'
       - 'frontend/nginx.conf'
       - 'docker-compose.yml'
-      - '.github/workflows/docker.yml'
+      # NOTE: `.github/workflows/docker.yml` is intentionally NOT a path
+      # filter trigger. Internal edits to this workflow (Dependabot SHA
+      # bumps, refactors) shouldn't fire a 25-minute multi-arch build that
+      # produces no useful signal. Regressions surface on the next push
+      # that actually touches a Dockerfile.
 
 permissions: {}
 
 jobs:
-  # PR-gated build: verifies the image still builds. No registry token, no
-  # push. `packages: write` is deliberately absent so a compromised action
-  # in the build toolchain cannot abuse the job token to publish.
+  # PR-gated build: verifies the image still builds on each native runner.
+  # Previously a single ubuntu-latest job did multi-arch via QEMU and the
+  # arm64 leg with CGO + eBPF took ~20 min. Splitting per arch onto native
+  # runners lifts that to ~5 min critical path. PR-gate doesn't need to
+  # produce a manifest — verifying both arches build cleanly is enough.
   build:
-    name: Build ${{ matrix.image }}
-    runs-on: ubuntu-latest
+    name: Build ${{ matrix.image }} (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
     strategy:
@@ -40,16 +45,41 @@ jobs:
           - image: go-api
             context: .
             dockerfile: Dockerfile
+            platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+          - image: go-api
+            context: .
+            dockerfile: Dockerfile
+            platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
           - image: python-worker
             context: ai-worker
             dockerfile: ai-worker/Dockerfile
+            platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+          - image: python-worker
+            context: ai-worker
+            dockerfile: ai-worker/Dockerfile
+            platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
           - image: frontend
             context: frontend
             dockerfile: frontend/Dockerfile
+            platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+          - image: frontend
+            context: frontend
+            dockerfile: frontend/Dockerfile
+            platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
-
-      - uses: docker/setup-qemu-action@v4
 
       - uses: docker/setup-buildx-action@v4
 
@@ -69,9 +99,11 @@ jobs:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
           push: false
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          platforms: ${{ matrix.platform }}
+          # Per-(image,arch) cache scope — different arches don't share
+          # buildx layers.
+          cache-from: type=gha,scope=${{ matrix.image }}-${{ matrix.arch }}
+          cache-to:   type=gha,scope=${{ matrix.image }}-${{ matrix.arch }},mode=max
           build-args: |
             ${{ matrix.image == 'frontend' && format('VITE_API_URL={0}', vars.VITE_API_URL || 'https://api.ravencloak.org') || '' }}
             ${{ matrix.image == 'frontend' && format('VITE_API_BASE_URL={0}', vars.VITE_API_BASE_URL || 'https://api.ravencloak.org/api/v1') || '' }}


### PR DESCRIPTION
Two compounding issues PR #374 just exposed:

## 1. Self-referential path filter
`.github/workflows/docker.yml` had **itself** in the `paths:` filter. Any Dependabot SHA bump that touches this file (#374 was `actions/attest-build-provenance@v3 → v4`) triggers a full 25-minute multi-arch Docker build of all three images — for zero useful signal, since PR mode is `push: false`.

Fix: removed `.github/workflows/docker.yml` from the path filter. Real Dockerfile / compose changes still trigger; pure workflow edits don't.

## 2. PR-gate still on QEMU
[#367](https://github.com/ravencloak-org/Raven/pull/367) moved `release.yml` to native amd64 + arm64 runners. `docker.yml` stayed on `ubuntu-latest` with `docker/setup-qemu-action` for the arm64 leg. CGO + eBPF under QEMU on `go-api` is the very combination #367 was written to escape.

Fix: same restructure here — 6-entry matrix over (image × arch), each on its native runner:
- `linux/amd64` → `ubuntu-latest`
- `linux/arm64` → `ubuntu-24.04-arm`

Per-arch GHA cache scopes so the two arches don't fight for cache keys.

## Expected timings

| | Before (QEMU) | After (native) |
|---|---|---|
| Critical path | ~25 min | ~5 min |
| Triggered by Dependabot YAML bump? | yes | no |

## What did NOT change

- The `publish` job (runs only on main pushes, signs+attests). Still ubuntu-latest+QEMU. Cheaper to leave alone since main pushes are rare and the publish is push-once-build-once. If main builds become a bottleneck we can mirror this split there too.

## Test plan

- [ ] Open a docs-only PR to verify docker.yml does NOT trigger
- [ ] Open a Dockerfile-touching PR to verify it does, and that all 6 jobs land on the right runners + finish in <8 min total

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Docker build infrastructure updated to run native builds per architecture and simplify build steps.
  * CI gating behavior adjusted so edits to workflow files no longer trigger PR gating.
  * Build cache scoping improved to prevent cross-architecture layer sharing, improving reliability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->