### PR TITLE
chore: sync Serena config and add Stash MCP docs to CLAUDE.md

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -3,15 +3,18 @@ project_name: "raven"
 
 
 # list of languages for which language servers are started; choose from:
-#   al                  bash                clojure             cpp                 csharp
-#   csharp_omnisharp    dart                elixir              elm                 erlang
-#   fortran             fsharp              go                  groovy              haskell
-#   java                julia               kotlin              lua                 markdown
-#   matlab              nix                 pascal              perl                php
-#   php_phpactor        powershell          python              python_jedi         r
-#   rego                ruby                ruby_solargraph     rust                scala
-#   swift               terraform           toml                typescript          typescript_vts
-#   vue                 yaml                zig
+#   al                  ansible             bash                clojure             cpp
+#   cpp_ccls            crystal             csharp              csharp_omnisharp    dart
+#   elixir              elm                 erlang              fortran             fsharp
+#   go                  groovy              haskell             haxe                hlsl
+#   java                json                julia               kotlin              lean4
+#   lua                 luau                markdown            matlab              msl
+#   nix                 ocaml               pascal              perl                php
+#   php_phpactor        powershell          python              python_jedi         python_ty
+#   r                   rego                ruby                ruby_solargraph     rust
+#   scala               solidity            swift               systemverilog       terraform
+#   toml                typescript          typescript_vts      vue                 yaml
+#   zig
 #   (This list may be outdated. For the current list, see values of Language enum here:
 #   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
 #   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
@@ -68,53 +71,17 @@ read_only: false
 
 # list of tool names to exclude.
 # This extends the existing exclusions (e.g. from the global configuration)
-#
-# Below is the complete list of tools for convenience.
-# To make sure you have the latest list of tools, and to view their descriptions, 
-# execute `uv run scripts/print_tool_overview.py`.
-#
-#  * `activate_project`: Activates a project by name.
-#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
-#  * `create_text_file`: Creates/overwrites a file in the project directory.
-#  * `delete_lines`: Deletes a range of lines within a file.
-#  * `delete_memory`: Deletes a memory from Serena's project-specific memory store.
-#  * `execute_shell_command`: Executes a shell command.
-#  * `find_referencing_code_snippets`: Finds code snippets in which the symbol at the given location is referenced.
-#  * `find_referencing_symbols`: Finds symbols that reference the symbol at the given location (optionally filtered by type).
-#  * `find_symbol`: Performs a global (or local) search for symbols with/containing a given name/substring (optionally filtered by type).
-#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
-#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
-#  * `initial_instructions`: Gets the initial instructions for the current project.
-#     Should only be used in settings where the system prompt cannot be set,
-#     e.g. in clients you have no control over, like Claude Desktop.
-#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
-#  * `insert_at_line`: Inserts content at a given line in a file.
-#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
-#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
-#  * `list_memories`: Lists memories in Serena's project-specific memory store.
-#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
-#  * `prepare_for_new_conversation`: Provides instructions for preparing for a new conversation (in order to continue with the necessary context).
-#  * `read_file`: Reads a file within the project directory.
-#  * `read_memory`: Reads the memory with the given name from Serena's project-specific memory store.
-#  * `remove_project`: Removes a project from the Serena configuration.
-#  * `replace_lines`: Replaces a range of lines within a file with new content.
-#  * `replace_symbol_body`: Replaces the full definition of a symbol.
-#  * `restart_language_server`: Restarts the language server, may be necessary when edits not through Serena happen.
-#  * `search_for_pattern`: Performs a search for a pattern in the project.
-#  * `summarize_changes`: Provides instructions for summarizing the changes made to the codebase.
-#  * `switch_modes`: Activates modes by providing a list of their names
-#  * `think_about_collected_information`: Thinking tool for pondering the completeness of collected information.
-#  * `think_about_task_adherence`: Thinking tool for determining whether the agent is still on track with the current task.
-#  * `think_about_whether_you_are_done`: Thinking tool for determining whether the task is truly completed.
-#  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 excluded_tools: []
 
 # list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
 # This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 included_optional_tools: []
 
 # fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
 # This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 fixed_tools: []
 
 # list of mode names to that are always to be included in the set of active modes
@@ -125,11 +92,14 @@ fixed_tools: []
 # Set this to a list of mode names to always include the respective modes for this project.
 base_modes:
 
-# list of mode names that are to be activated by default.
-# The full set of modes to be activated is base_modes + default_modes.
-# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
 # Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
 # This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
 default_modes:
 
 # initial prompt for the project. It will always be given to the LLM upon activating the project
@@ -153,3 +123,19 @@ read_only_memory_patterns: []
 # Extends the list from the global configuration, merging the two lists.
 # Example: ["_archive/.*", "_episodes/.*"]
 ignored_memory_patterns: []
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,3 +34,42 @@ Use `type/descriptor` format:
 - **Squash merge only** — never regular merge or rebase-merge
 - **Never use `--no-verify`** — all hooks must pass
 - **Never amend published commits** — create new commits instead
+
+## Memory: Stash MCP
+
+Raven uses the Stash MCP server (`mcp__stash__*`) for persistent, cross-session memory. Treat it as the source of truth for project history, working rules, and decisions.
+
+### Session-start protocol
+
+1. `mcp__stash__init` — idempotent; ensures `/self` scaffold exists.
+2. `mcp__stash__get_context` on `/projects/raven` — pick up any in-progress focus.
+3. `mcp__stash__recall` with a query relevant to the user's first message, scoped to `/projects/raven` (recursive — covers all sub-namespaces). If the user's message is generic, also recall from `/users/jobinlawrance`.
+4. If recall returns nothing on a topic, say so explicitly — do NOT answer from training data and pretend to remember.
+
+### Namespace map
+
+- `/users/jobinlawrance` — Jobin's profile, hardware, environment, payment/region constraints.
+- `/projects/raven` — tech stack, edge-deployment requirements, compliance posture, Phase 2 features.
+- `/projects/raven/auth` — Keycloak current state, Zitadel post-mortem, pluggable-auth direction.
+- `/projects/raven/ai-worker` — Python gRPC service (port 50051), parsing, embeddings, RAG, voice.
+- `/projects/raven/infra` — Compose variants, deployment, observability (OpenObserve + Beszel).
+- `/projects/raven/milestones` — delivered + active queue (currently M9: #256, #257, #258).
+- `/projects/raven/feedback` — standing rules: squash merge, no AI attribution, lint-before-push, testing gates, open-PR dependency, milestone protocol, respect tech choices.
+
+### When to write
+
+Call `mcp__stash__remember` (with the matching namespace) any time:
+
+- A decision is finalised — technical, product, or process.
+- The user states a preference, constraint, or correction.
+- A milestone or issue changes state (started, blocked, shipped).
+- You discover a non-obvious fact about the codebase, infra, or a third-party tool that future sessions would have to rediscover.
+- You complete a session — write a one-line summary of what was done.
+
+Use `mcp__stash__create_goal` for milestone-level intent and `mcp__stash__create_failure` for things that didn't work (e.g. the Zitadel decision). Use `mcp__stash__set_context` on `/projects/raven` when starting focused work, so the next session can pick up via `get_context`.
+
+### Discipline
+
+- Before writing to a namespace, verify it exists with `list_namespaces`. If missing, `create_namespace` first.
+- Write complete self-contained sentences in `remember` — readable with zero prior context.
+- Don't double-write the same fact to both `MEMORY.md` (built-in auto-memory) and Stash. Built-in memory holds terse rules loaded every turn; Stash holds project history, episodes, and goal/failure tracking queried on demand.


### PR DESCRIPTION
## Summary
- Pulls upstream Serena project-config template updates (more language servers, replaces the inline tool list with a doc link, adds new keys `added_modes` and `additional_workspace_folders`).
- Adds a **Memory: Stash MCP** section to `CLAUDE.md` documenting the session-start protocol, namespace map, write rules, and discipline notes so future Claude Code sessions follow the same conventions.

These were uncommitted local changes from a prior session — capturing them before starting unrelated marketing-site work.

## Test plan
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to support expanded tool management and workspace flexibility options.

* **Documentation**
  * Enhanced internal documentation with improved guidance and protocols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->