### PR TITLE
docs(compliance): add privacy stack — PRIVACY, DPA, DPIA, incident response

### DIFF
--- a/DPA.md
+++ b/DPA.md
@@ -162,9 +162,17 @@ of execution.)*
 ## 11. Return or Deletion
 
 On termination or expiry of the Principal Agreement, Processor shall, at
-Controller's election, **return or delete all personal data within 30
-days**, including all backups, save where retention is required by
-applicable law. Processor shall certify deletion in writing on request.
+Controller's election, **return, delete, or put beyond use all personal
+data within 30 days** of receipt of Controller's instruction. For data
+held in immutable, write-once, or offline backup media, Processor shall
+apply its documented backup lifecycle policy and certify deletion — or
+that the data has been put beyond use — once the backup retention period
+elapses; the backup lifecycle policy specifies the maximum retention
+window and the controls that prevent restoration to an active environment
+in the interim. Retention required by applicable law is excepted, in
+which case Processor shall continue to apply this DPA to the retained
+data until deletion is permitted. Processor shall certify deletion or
+putting beyond use in writing on request.
 
 ## 12. Term and Execution
 
@@ -247,16 +255,26 @@ the authoritative description is `SECURITY.md`.
 The list mirrors `PRIVACY.md` Section 7 and is the authoritative list for
 this DPA. Updates follow the notice procedure in Section 4.
 
-| Sub-processor    | Role                                           | Location |
-| ---------------- | ---------------------------------------------- | -------- |
-| AWS (incl. SES)  | Transactional email delivery                   | US       |
-| PostgreSQL host  | Primary relational + pgvector store            | *(TBD)*  |
-| ClickHouse host  | Analytics and audit-log store                  | *(TBD)*  |
-| Valkey host      | Cache and asynchronous job queue (Asynq)       | *(TBD)*  |
-| SeaweedFS host   | Object storage (attachments, voice audio)      | *(TBD)*  |
-| SuperTokens      | Authentication and session management          | *(TBD)*  |
-| LiveKit          | Real-time voice transport                      | *(TBD)*  |
-| PostHog          | Product analytics                              | *(TBD)*  |
-| Anthropic *(BYOK)* | LLM inference (configured by Customer)       | US       |
-| OpenAI *(BYOK)*    | LLM inference (configured by Customer)       | US       |
-| Cohere *(BYOK)*    | Embeddings / reranking (configured by Customer) | US/CA  |
+> **REVIEW WITH COUNSEL — DRAFT.** Hosting region and applicable transfer
+> mechanism for self-hosted-infrastructure rows are deployment-time
+> decisions and are not yet finalised; rows marked *(TBD — pending
+> hosting decision)* must be completed and counsel-validated before this
+> Annex is offered to a Customer. Transfer mechanisms are listed where
+> the row is known; SCCs Module 2 (controller-to-processor) or Module 3
+> (processor-to-processor) apply by default for transfers out of the
+> EU/EEA, complemented by the UK IDTA and Swiss FADP addenda per
+> Section 5.
+
+| Sub-processor    | Role                                           | Location | Transfer mechanism |
+| ---------------- | ---------------------------------------------- | -------- | ------------------ |
+| AWS (incl. SES)  | Transactional email delivery                   | US       | EU SCCs + UK IDTA + Swiss addendum |
+| PostgreSQL host  | Primary relational + pgvector store            | *(TBD — pending hosting decision)* | *(TBD — counsel to confirm)* |
+| ClickHouse host  | Analytics and audit-log store                  | *(TBD — pending hosting decision)* | *(TBD — counsel to confirm)* |
+| Valkey host      | Cache and asynchronous job queue (Asynq)       | *(TBD — pending hosting decision)* | *(TBD — counsel to confirm)* |
+| SeaweedFS host   | Object storage (attachments, voice audio)      | *(TBD — pending hosting decision)* | *(TBD — counsel to confirm)* |
+| SuperTokens      | Authentication and session management          | *(TBD — pending self-hosted vs managed decision)* | *(TBD — counsel to confirm)* |
+| LiveKit          | Real-time voice transport                      | *(TBD — pending self-hosted vs LiveKit Cloud decision)* | *(TBD — counsel to confirm)* |
+| PostHog          | Product analytics                              | EU (PostHog Cloud EU) or US (PostHog Cloud US) — *deployment selects region* | EU SCCs + UK IDTA + Swiss addendum (US region) / N/A (EU region) |
+| Anthropic *(BYOK)* | LLM inference (configured by Customer)       | US       | Customer is the controlling party for the BYOK contract |
+| OpenAI *(BYOK)*    | LLM inference (configured by Customer)       | US       | Customer is the controlling party for the BYOK contract |
+| Cohere *(BYOK)*    | Embeddings / reranking (configured by Customer) | US / CA | Customer is the controlling party for the BYOK contract |

--- a/DPA.md
+++ b/DPA.md
@@ -1,0 +1,262 @@
+# Data Processing Addendum (DPA)
+
+> **STATUS:** DRAFT — pending review by qualified counsel. Do not rely on
+> this document as legal advice or execute it without qualified review. The
+> DRAFT banner must be removed by counsel before this template is offered
+> to customers.
+
+**Effective date:** 2026-05-08 *(placeholder — to be confirmed by counsel)*
+
+This Data Processing Addendum ("DPA") supplements the Master Services
+Agreement, Order Form, or other binding written agreement (the "Principal
+Agreement") between the customer ("Customer") and Ravencloak Org
+("Processor") under which Processor provides the cloud-hosted variant of the
+Raven platform (the "Services"). It is intended to satisfy the requirements
+of GDPR Article 28, the UK GDPR, the Swiss FADP, and the DPDP Act, 2023.
+
+In the event of conflict between this DPA and the Principal Agreement, this
+DPA prevails for matters relating to processing of personal data.
+
+## 1. Parties
+
+| Role             | Party                                                      |
+| ---------------- | ---------------------------------------------------------- |
+| Controller       | Customer (as identified in the Principal Agreement)        |
+| Processor        | Ravencloak Org — Jobin Lawrance, India                     |
+| Processor contact| <jobinlawrance@gmail.com> (Data Protection / Grievance Officer) |
+
+## 2. Subject Matter and Duration (GDPR Art. 28(3))
+
+- **Subject matter:** processing of personal data submitted by Customer or
+  its end users in the course of receiving the Services.
+- **Duration:** the term of the Principal Agreement, plus any post-termination
+  period required for return or deletion of data under Section 11 below.
+- **Nature and purpose of processing:** delivery, operation, support, and
+  security of the Services.
+- **Types of personal data:** as listed in `PRIVACY.md` Section 4 and
+  enumerated in Annex I.
+- **Categories of data subjects:** Customer's authorised users, Customer's
+  end users (where Customer makes the Services available to them), and any
+  third parties whose personal data is included in content submitted to the
+  Services.
+
+## 3. Processor Obligations (Art. 28(3)(a)–(h))
+
+Processor shall:
+
+1. Process personal data only on documented instructions from Controller,
+   including with regard to international transfers, unless required by
+   Union, Member State, or Indian law to do otherwise (in which case
+   Processor shall inform Controller of that legal requirement before
+   processing, unless that law prohibits such notice);
+2. Ensure that persons authorised to process the personal data have
+   committed themselves to confidentiality or are under an appropriate
+   statutory obligation of confidentiality;
+3. Take all measures required pursuant to Article 32 (security of
+   processing) — see Annex II;
+4. Respect the conditions for engaging sub-processors set out in Section 4;
+5. Taking into account the nature of the processing, assist Controller by
+   appropriate technical and organisational measures, in so far as possible,
+   in fulfilling Controller's obligation to respond to data-subject rights
+   requests under GDPR Chapter III;
+6. Assist Controller in ensuring compliance with Articles 32 to 36 (security,
+   breach notification, DPIAs, prior consultation), taking into account the
+   nature of processing and information available to Processor;
+7. At Controller's choice, delete or return all personal data after the end
+   of the provision of Services, and delete existing copies unless retention
+   is required by applicable law — see Section 11;
+8. Make available to Controller all information necessary to demonstrate
+   compliance with Article 28, and allow for and contribute to audits
+   conducted by Controller or another auditor mandated by Controller — see
+   Section 9.
+
+## 4. Sub-Processors
+
+Controller grants Processor a **general written authorisation** to engage
+sub-processors, subject to the following:
+
+- Processor maintains an up-to-date list of sub-processors in Annex III of
+  this DPA, mirrored from `PRIVACY.md` Section 7.
+- Processor will give Controller **at least 30 days' prior notice** before
+  appointing or replacing a sub-processor. Notice will be delivered via
+  in-product banner and the project changelog.
+- Controller may **object** to a proposed sub-processor on reasonable data
+  protection grounds within the notice period. If the parties cannot reach
+  agreement, Controller may terminate the affected portion of the Services
+  without penalty.
+- Processor remains fully liable to Controller for the performance of each
+  sub-processor's obligations.
+- Each sub-processor is bound by data-protection terms substantially
+  equivalent to those in this DPA.
+
+## 5. International Transfers
+
+Where personal data is transferred from the EU/EEA, the United Kingdom, or
+Switzerland to a country not subject to an adequacy decision, the parties
+incorporate by reference:
+
+- The **EU Standard Contractual Clauses** (Commission Implementing Decision
+  (EU) 2021/914 of 4 June 2021), Module 2 (controller-to-processor) or
+  Module 3 (processor-to-processor) as applicable;
+- The **UK International Data Transfer Addendum** to the EU SCCs (issued
+  under section 119A of the Data Protection Act 2018);
+- The **Swiss FADP addendum** to the EU SCCs.
+
+The optional Clause 7 docking clause is included. The supervisory authority
+under Clause 13 is the Irish Data Protection Commission unless otherwise
+agreed in writing. Annex I and Annex II of the SCCs are completed by Annex I
+and Annex II of this DPA respectively.
+
+## 6. Security Measures
+
+Processor implements appropriate technical and organisational measures
+("TOMs") as set out in Annex II and in `SECURITY.md`. Processor will not
+materially diminish the protection afforded by those measures during the
+term.
+
+## 7. Personal-Data Breach Notification
+
+Processor shall notify Controller of any personal-data breach without undue
+delay, and in any event **within 48 hours** of becoming aware of it. The
+notification shall, to the extent then known, contain the information
+required by GDPR Article 33(3). Processor shall provide reasonable
+cooperation in Controller's discharge of its own breach-notification
+obligations to supervisory authorities and data subjects.
+
+The 48-hour processor-to-controller window is intentionally tighter than the
+72-hour controller-to-supervisory-authority window so Controller retains
+adequate time to assess and notify.
+
+The full incident-response runbook is at `docs/security/incident-response.md`.
+
+## 8. Data-Subject Requests
+
+Processor shall, taking into account the nature of the processing, assist
+Controller by appropriate technical and organisational measures (in so far
+as possible) for the fulfilment of Controller's obligation to respond to
+requests for exercising data-subject rights under GDPR Chapter III and the
+DPDP Act. Processor shall promptly forward any request received directly
+from a data subject to Controller and shall not respond to that request
+itself except on documented instructions from Controller.
+
+## 9. Audits
+
+- Processor shall make available, on request, the most recent third-party
+  attestations or certifications it holds (for example, when available, SOC
+  2 Type II or ISO 27001), together with any summary penetration-test
+  reports.
+- Controller may conduct an **on-site audit** no more than once per year
+  (and additionally following a personal-data breach), on **at least 30
+  days' prior written notice**, during business hours, in a manner that does
+  not unreasonably disrupt Processor's operations. The audit must be
+  conducted under reasonable confidentiality obligations and at Controller's
+  own cost.
+- Processor will reasonably address any material findings.
+
+## 10. Liability
+
+Liability under this DPA is governed by the limitation-of-liability terms
+in the Principal Agreement. *(Stub — to be aligned with the MSA at the time
+of execution.)*
+
+## 11. Return or Deletion
+
+On termination or expiry of the Principal Agreement, Processor shall, at
+Controller's election, **return or delete all personal data within 30
+days**, including all backups, save where retention is required by
+applicable law. Processor shall certify deletion in writing on request.
+
+## 12. Term and Execution
+
+This DPA enters into force on the latest signature date below and remains in
+force for the duration of the Principal Agreement and any post-termination
+period required by Section 11.
+
+| Party        | Name | Title | Date | Signature |
+| ------------ | ---- | ----- | ---- | --------- |
+| Controller   |      |       |      |           |
+| Processor    |      |       |      |           |
+
+---
+
+## Annex I — Details of Processing
+
+### A. List of Parties
+
+As set out in Section 1.
+
+### B. Description of Processing
+
+- **Categories of data subjects:** Customer's authorised users; Customer's
+  end users; third parties referenced in submitted content.
+- **Categories of personal data:** as enumerated in `PRIVACY.md` Section 4.
+- **Special categories of data:** not solicited; may be incidentally present
+  in user-submitted content (Section 6 of `PRIVACY.md`).
+- **Frequency of transfer:** continuous, for the duration of the Services.
+- **Nature of processing:** hosting, storage, retrieval, indexing,
+  embedding, inference, transmission, and deletion as required to operate
+  the Services.
+- **Purpose of processing:** delivery, operation, support, and security of
+  the Services.
+- **Duration of processing:** for the term of the Principal Agreement and
+  any retention period required by Section 11.
+
+### C. Competent Supervisory Authority
+
+Irish Data Protection Commission unless otherwise agreed in writing for the
+EU Module; ICO for the UK addendum; FDPIC for the Swiss addendum; the Data
+Protection Board of India for DPDP-Act matters.
+
+---
+
+## Annex II — Technical and Organisational Measures (TOMs)
+
+The measures below are implemented at the platform level. They reflect
+Raven's documented security posture as of the effective date of this DPA;
+the authoritative description is `SECURITY.md`.
+
+- **Build integrity.** SLSA Level 3 provenance for all release artefacts;
+  OSPS Level 2 process compliance; signed releases.
+- **Source integrity.** All contributions require DCO sign-off; protected
+  branches; required reviews; CodeQL, Semgrep, and Gitleaks in CI;
+  Dependabot updates with auto-merge of low-risk patches.
+- **Encryption at rest.** PostgreSQL data is encrypted at rest using
+  filesystem-level / managed-service-equivalent of TDE; SeaweedFS volumes
+  are encrypted at rest; secrets are stored in a managed secrets backend.
+- **Encryption in transit.** TLS 1.2+ on all external endpoints; mTLS
+  between internal services where supported.
+- **Access control.** Role-based access control across the application
+  surface; PostgreSQL row-level security (RLS) for tenant isolation;
+  least-privilege IAM for cloud resources; SuperTokens-managed sessions
+  with MFA enrolment available.
+- **Audit logging.** Application audit events streamed to OpenObserve and
+  ClickHouse with tamper-evident retention.
+- **Vulnerability management.** Continuous dependency scanning, regular
+  third-party review, and a documented disclosure path under `SECURITY.md`.
+- **Personnel.** All personnel with access to production are subject to
+  confidentiality obligations and access reviews.
+- **Incident response.** Documented runbook at
+  `docs/security/incident-response.md`, with quarterly tabletop exercises.
+- **Business continuity.** Daily backups of PostgreSQL with point-in-time
+  recovery; periodic restore testing.
+
+---
+
+## Annex III — Sub-Processors
+
+The list mirrors `PRIVACY.md` Section 7 and is the authoritative list for
+this DPA. Updates follow the notice procedure in Section 4.
+
+| Sub-processor    | Role                                           | Location |
+| ---------------- | ---------------------------------------------- | -------- |
+| AWS (incl. SES)  | Transactional email delivery                   | US       |
+| PostgreSQL host  | Primary relational + pgvector store            | *(TBD)*  |
+| ClickHouse host  | Analytics and audit-log store                  | *(TBD)*  |
+| Valkey host      | Cache and asynchronous job queue (Asynq)       | *(TBD)*  |
+| SeaweedFS host   | Object storage (attachments, voice audio)      | *(TBD)*  |
+| SuperTokens      | Authentication and session management          | *(TBD)*  |
+| LiveKit          | Real-time voice transport                      | *(TBD)*  |
+| PostHog          | Product analytics                              | *(TBD)*  |
+| Anthropic *(BYOK)* | LLM inference (configured by Customer)       | US       |
+| OpenAI *(BYOK)*    | LLM inference (configured by Customer)       | US       |
+| Cohere *(BYOK)*    | Embeddings / reranking (configured by Customer) | US/CA  |

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,211 @@
+# Privacy Notice
+
+> **STATUS:** DRAFT — pending review by qualified counsel. Do not rely on this
+> document as legal advice. Until the DRAFT banner is removed by counsel, this
+> notice must not be linked from public-facing surfaces or relied upon to
+> satisfy any statutory disclosure obligation.
+
+**Effective date:** 2026-05-08 *(placeholder — to be confirmed by counsel)*
+
+This Privacy Notice explains how the Ravencloak organisation ("Ravencloak",
+"we", "us") processes personal data in connection with the cloud-hosted
+variant of the Raven platform. It is written to satisfy the transparency
+obligations of the EU General Data Protection Regulation (GDPR) Articles 13
+and 14, the UK GDPR, the Swiss Federal Act on Data Protection (FADP), and
+India's Digital Personal Data Protection Act, 2023 ("DPDP Act").
+
+## 1. Scope and Deployment Model
+
+Raven is offered in two deployment modes, and the controller relationship
+differs between them:
+
+- **Self-hosted.** When a customer deploys Raven on their own infrastructure,
+  that customer is the **data controller** (or "data fiduciary" under DPDP)
+  for end-user personal data processed within their instance. Ravencloak does
+  not have access to that data and is not a processor in respect of it. This
+  notice does not govern self-hosted deployments; the operating customer must
+  publish their own privacy notice.
+- **Cloud-hosted (Ravencloak SaaS).** Where Ravencloak operates the platform
+  on behalf of a customer, Ravencloak acts as **processor** (or "data
+  processor" under DPDP) on the customer's behalf, save for a narrow set of
+  controller activities (account administration, billing, security
+  monitoring) covered by this notice.
+
+## 2. Identity of the Controller
+
+| Field                  | Value                                            |
+| ---------------------- | ------------------------------------------------ |
+| Controller             | Jobin Lawrance, trading as Ravencloak Org        |
+| Place of establishment | India                                            |
+| Postal address         | *(to be added by counsel)*                       |
+| General contact        | <jobinlawrance@gmail.com>                        |
+
+A formal entity registration and registered office will be added prior to
+removal of the DRAFT banner.
+
+## 3. Data Protection Officer / Grievance Officer
+
+Pursuant to GDPR Article 37 (where applicable) and DPDP Act Sections 10 and
+13, the following individual is designated as the contact for data protection
+queries and grievances:
+
+| Field   | Value                          |
+| ------- | ------------------------------ |
+| Name    | Jobin Lawrance                 |
+| Role    | Data Protection / Grievance Officer |
+| Email   | <jobinlawrance@gmail.com>      |
+
+The DPO/Grievance Officer is the single point of contact for data subjects
+and supervisory authorities. A dedicated alias (`privacy@ravencloak.org`)
+will replace the personal address once provisioned.
+
+## 4. Categories of Personal Data Processed
+
+In the cloud-hosted variant, Ravencloak processes the following categories
+of personal data:
+
+- **Account and authentication identifiers** — email address, hashed
+  credentials, SuperTokens session tokens, IP address, user agent, MFA
+  enrolment metadata.
+- **Conversation content** — text prompts, model responses, attached
+  documents, retrieval-augmented generation (RAG) embeddings derived from
+  customer content.
+- **Voice audio** — short-form audio captured by the LiveKit voice agent
+  feature, plus its derived transcripts and embeddings.
+- **Telemetry and product analytics** — page views, feature usage events,
+  error traces, and similar product analytics emitted by the
+  `internal/posthog` package and stored in ClickHouse and PostHog.
+- **Operational telemetry** — logs, traces, and metrics shipped to
+  OpenObserve for incident response and performance management.
+- **Billing data** — name, billing address, tax identifiers, payment-method
+  metadata (full card numbers are not stored by Ravencloak).
+- **Support correspondence** — anything a user voluntarily includes when
+  contacting the team.
+
+## 5. Lawful Bases for Processing (GDPR Art. 6)
+
+| Processing activity                          | Lawful basis                                       |
+| -------------------------------------------- | -------------------------------------------------- |
+| Provision of the contracted service          | Performance of a contract — Art. 6(1)(b)           |
+| Account security, fraud and abuse prevention | Legitimate interests — Art. 6(1)(f)                |
+| Service telemetry and product improvement    | Legitimate interests — Art. 6(1)(f)                |
+| Marketing communications                     | Consent — Art. 6(1)(a)                             |
+| Voice recording beyond the default retention | Consent — Art. 6(1)(a)                             |
+| Compliance with legal obligations            | Legal obligation — Art. 6(1)(c)                    |
+
+For users in India, the corresponding lawful grounds under DPDP Act Sections
+4 and 7 (consent, legitimate uses) are relied upon.
+
+## 6. Special Categories of Personal Data (GDPR Art. 9)
+
+Ravencloak does not solicit special-category data. Voice transcripts may
+incidentally capture such data if a user volunteers it; the platform does
+not infer health, biometric identification, sexual orientation, or political
+opinions from voice signals. Where a customer chooses to process special
+categories of data through the platform, the customer is responsible for
+identifying an appropriate Article 9(2) condition.
+
+## 7. Sub-Processors
+
+The cloud-hosted variant relies on the following sub-processors. Each
+sub-processor's privacy notice should be consulted for the data they process
+on our behalf. Where the customer brings their own LLM key (BYOK), the
+provider acts as a sub-processor of the customer, not of Ravencloak.
+
+| Sub-processor    | Role                                           | Privacy policy           |
+| ---------------- | ---------------------------------------------- | ------------------------ |
+| AWS (incl. SES)  | Transactional email delivery (US transfer)     | *(URL placeholder)*      |
+| PostgreSQL host  | Primary relational + pgvector store            | *(URL placeholder)*      |
+| ClickHouse host  | Analytics and audit-log store                  | *(URL placeholder)*      |
+| Valkey host      | Cache and asynchronous job queue (Asynq)       | *(URL placeholder)*      |
+| SeaweedFS host   | Object storage (attachments, voice audio)      | *(URL placeholder)*      |
+| SuperTokens      | Authentication and session management          | *(URL placeholder)*      |
+| LiveKit          | Real-time voice transport for the voice agent  | *(URL placeholder)*      |
+| PostHog          | Product analytics                              | *(URL placeholder)*      |
+| Anthropic *(BYOK)* | LLM inference where the customer configures it | *(URL placeholder)*    |
+| OpenAI *(BYOK)*    | LLM inference where the customer configures it | *(URL placeholder)*    |
+| Cohere *(BYOK)*    | Embeddings and reranking where configured      | *(URL placeholder)*    |
+
+The current authoritative list of sub-processors is mirrored in Annex III of
+the Data Processing Addendum (`DPA.md`).
+
+## 8. International Data Transfers
+
+Personal data may be transferred outside the data subject's country of
+residence — most notably to the United States in connection with AWS SES,
+and potentially to other jurisdictions where BYOK LLM providers operate.
+Where such transfers occur, Ravencloak relies on:
+
+- The European Commission's **Standard Contractual Clauses** (Decision
+  2021/914) for transfers from the EU/EEA;
+- The **UK International Data Transfer Addendum** for transfers from the
+  United Kingdom; and
+- The **Swiss FADP addendum** for transfers from Switzerland.
+
+A copy of the executed clauses is available on request to the DPO.
+
+## 9. Retention
+
+| Category                          | Default retention                                                  |
+| --------------------------------- | ------------------------------------------------------------------ |
+| Account and authentication data   | Lifetime of the account, plus 30 days after deletion request       |
+| Conversation content              | Configurable per workspace; default retention set by the customer  |
+| Voice audio                       | 30 days, unless the caller opts in to extended retention           |
+| Voice transcripts and embeddings  | Tied to the parent conversation's retention setting                |
+| Operational telemetry (logs)      | 90 days                                                            |
+| Product analytics events          | 13 months                                                          |
+| Billing records                   | 7 years (statutory accounting retention)                           |
+
+Customers can shorten any of the above for their workspace via configuration.
+
+## 10. Your Rights
+
+Subject to applicable law, data subjects have the rights set out in GDPR
+Articles 15–22 and DPDP Act Chapter III, namely:
+
+- **Access** their personal data (Art. 15 / DPDP §11);
+- **Rectify** inaccurate data (Art. 16 / DPDP §12);
+- **Erase** their data (Art. 17 / DPDP §12);
+- **Restrict** processing (Art. 18);
+- **Portability** of data they provided (Art. 20);
+- **Object** to processing based on legitimate interests (Art. 21);
+- **Withdraw consent** at any time, without affecting prior lawful processing
+  (Art. 7(3) / DPDP §6(4));
+- **Lodge a complaint** with the competent supervisory authority — for EU
+  residents, their national DPA (e.g. CNIL, ICO); for Indian residents, the
+  Data Protection Board of India.
+
+To exercise any right, open a private GitHub issue against
+`ravencloak-org/Raven` or email the DPO at <jobinlawrance@gmail.com>.
+Ravencloak responds to verifiable requests within **30 days**, extendable
+once where strictly necessary under Article 12(3).
+
+## 11. Children
+
+The Raven platform is not directed at individuals under 18 years of age.
+Ravencloak does not knowingly collect personal data from minors. Where a
+parent or guardian believes their child has provided personal data, they
+should contact the DPO so the data can be erased.
+
+## 12. Security
+
+Technical and organisational measures are described in `SECURITY.md` and
+mirrored in Annex II of the Data Processing Addendum (`DPA.md`). Ravencloak
+maintains SLSA Level 3 build provenance, OSPS Level 2 process compliance,
+encryption at rest and in transit, role-based access control with row-level
+security, and centralised audit logging.
+
+## 13. Changes to This Notice
+
+Material changes will be announced at least 30 days in advance via in-product
+notice and via the project changelog. The "Effective date" at the top of
+this notice will reflect the date of the most recent material revision.
+
+## 14. Contact
+
+| Purpose                                | Contact                                |
+| -------------------------------------- | -------------------------------------- |
+| Privacy queries / DPO / Grievance      | <jobinlawrance@gmail.com>              |
+| Security vulnerability reports         | <security@ravencloak.org> (preferred), <jobinlawrance@gmail.com> (fallback) |
+| Supervisory authority complaints (EU)  | Your national Data Protection Authority |
+| Data Protection Board (India)          | <https://www.dpdp.gov.in/> *(placeholder)* |

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -112,19 +112,25 @@ sub-processor's privacy notice should be consulted for the data they process
 on our behalf. Where the customer brings their own LLM key (BYOK), the
 provider acts as a sub-processor of the customer, not of Ravencloak.
 
-| Sub-processor    | Role                                           | Privacy policy           |
-| ---------------- | ---------------------------------------------- | ------------------------ |
-| AWS (incl. SES)  | Transactional email delivery (US transfer)     | *(URL placeholder)*      |
-| PostgreSQL host  | Primary relational + pgvector store            | *(URL placeholder)*      |
-| ClickHouse host  | Analytics and audit-log store                  | *(URL placeholder)*      |
-| Valkey host      | Cache and asynchronous job queue (Asynq)       | *(URL placeholder)*      |
-| SeaweedFS host   | Object storage (attachments, voice audio)      | *(URL placeholder)*      |
-| SuperTokens      | Authentication and session management          | *(URL placeholder)*      |
-| LiveKit          | Real-time voice transport for the voice agent  | *(URL placeholder)*      |
-| PostHog          | Product analytics                              | *(URL placeholder)*      |
-| Anthropic *(BYOK)* | LLM inference where the customer configures it | *(URL placeholder)*    |
-| OpenAI *(BYOK)*    | LLM inference where the customer configures it | *(URL placeholder)*    |
-| Cohere *(BYOK)*    | Embeddings and reranking where configured      | *(URL placeholder)*    |
+> URLs below are the vendors' published privacy/DPA notices at the time of
+> drafting. Counsel must verify each URL is current and points to the
+> correct controlling document before the DRAFT banner on this notice is
+> removed. Self-hosted-infrastructure rows depend on the deployment-time
+> hosting choice and are tagged for counsel review.
+
+| Sub-processor    | Role                                           | Privacy / DPA notice |
+| ---------------- | ---------------------------------------------- | -------------------- |
+| AWS (incl. SES)  | Transactional email delivery (US transfer)     | <https://aws.amazon.com/privacy/> &nbsp;·&nbsp; <https://aws.amazon.com/compliance/gdpr-center/> |
+| PostgreSQL host  | Primary relational + pgvector store            | DPA available on request — *REVIEW WITH COUNSEL once hosting provider confirmed* |
+| ClickHouse host  | Analytics and audit-log store                  | DPA available on request — *REVIEW WITH COUNSEL once hosting provider confirmed* |
+| Valkey host      | Cache and asynchronous job queue (Asynq)       | DPA available on request — *REVIEW WITH COUNSEL once hosting provider confirmed* |
+| SeaweedFS host   | Object storage (attachments, voice audio)      | DPA available on request — *REVIEW WITH COUNSEL once hosting provider confirmed* |
+| SuperTokens      | Authentication and session management          | <https://supertokens.com/legal/privacy-policy> *(verify before publication)* |
+| LiveKit          | Real-time voice transport for the voice agent  | <https://livekit.io/legal/privacy-policy> *(verify before publication)* |
+| PostHog          | Product analytics                              | <https://posthog.com/privacy> &nbsp;·&nbsp; <https://posthog.com/dpa> |
+| Anthropic *(BYOK)* | LLM inference where the customer configures it | <https://www.anthropic.com/legal/privacy> |
+| OpenAI *(BYOK)*    | LLM inference where the customer configures it | <https://openai.com/policies/privacy-policy/> |
+| Cohere *(BYOK)*    | Embeddings and reranking where configured      | <https://cohere.com/privacy> |
 
 The current authoritative list of sub-processors is mirrored in Annex III of
 the Data Processing Addendum (`DPA.md`).
@@ -175,10 +181,28 @@ Articles 15–22 and DPDP Act Chapter III, namely:
   residents, their national DPA (e.g. CNIL, ICO); for Indian residents, the
   Data Protection Board of India.
 
-To exercise any right, open a private GitHub issue against
-`ravencloak-org/Raven` or email the DPO at <jobinlawrance@gmail.com>.
-Ravencloak responds to verifiable requests within **30 days**, extendable
-once where strictly necessary under Article 12(3).
+To exercise any right, email the DPO at <jobinlawrance@gmail.com>. A
+dedicated privacy intake address (`privacy@ravencloak.org`) and web form
+will replace the personal mailbox once provisioned; until then, the DPO
+mailbox is the sole intake channel.
+
+GitHub issues, pull requests, and discussions are **not** an authorised
+intake channel for data-subject rights requests; messages sent through
+those channels will be redirected to the DPO mailbox without being acted
+upon, to protect requester confidentiality and to satisfy our identity-
+verification controls.
+
+Each request must be capable of verification. Where a request is unclear
+or where Ravencloak has reasonable doubts about the identity of the
+requester, Ravencloak will request the minimum additional information
+necessary to confirm identity before acting (GDPR Art. 12(6)). All access
+to the resulting case file is restricted to the DPO and personnel
+specifically authorised to assist with the response. Ravencloak responds
+to verifiable requests within **30 days** of receipt, extendable by up to
+two further months where strictly necessary having regard to the
+complexity and number of requests (GDPR Art. 12(3)); any extension and
+its reasons are notified to the requester within the initial 30-day
+window.
 
 ## 11. Children
 

--- a/docs/compliance/dpia-template.md
+++ b/docs/compliance/dpia-template.md
@@ -1,0 +1,174 @@
+# Data Protection Impact Assessment (DPIA) — Template
+
+> **STATUS:** DRAFT — pending review by qualified counsel. This template is
+> intended as a working artefact for internal use; it must not be presented
+> to a supervisory authority as a completed DPIA without legal review.
+
+This document provides a template for conducting a Data Protection Impact
+Assessment (DPIA) under GDPR Article 35, aligned with guidance from the UK
+Information Commissioner's Office (ICO), the French CNIL, and the European
+Data Protection Board's WP248 rev.01. Where the processing also falls
+within the DPDP Act, 2023, this template should be supplemented with any
+"Data Protection Impact Assessment" or "Significant Data Fiduciary"
+obligations that the Indian rules introduce.
+
+A completed DPIA should be filed in the DPIA register at
+`docs/compliance/dpia-register.md`. The register file is intentionally not
+created in this PR — it will be added in the next compliance round.
+
+---
+
+## When a DPIA Is Required
+
+A DPIA is mandatory when processing is likely to result in a **high risk to
+the rights and freedoms** of natural persons (GDPR Art. 35(1)). It is
+**always** required in the cases listed in Article 35(3), including:
+
+- Systematic and extensive evaluation based on automated processing,
+  including profiling, that produces legal or similarly significant effects;
+- Large-scale processing of special-category or criminal-conviction data;
+- Systematic monitoring of a publicly accessible area on a large scale.
+
+In addition, the **ICO's mandatory list** and **CNIL's "list of processing
+operations subject to a DPIA"** include indicators such as: use of innovative
+technology, biometric or genetic data, location tracking, processing of
+data concerning vulnerable people, and combining datasets from different
+sources.
+
+If two or more WP248 criteria apply, a DPIA is presumptively required.
+Document the determination either way.
+
+---
+
+## Step 1 — Identify the Need
+
+| Field                                           | Value |
+| ----------------------------------------------- | ----- |
+| Processing activity                             |       |
+| Owner (business)                                |       |
+| Owner (engineering)                             |       |
+| Date of assessment                              |       |
+| DPIA reference                                  |       |
+| Linked GitHub issue / RFC                       |       |
+| Trigger (Art. 35(3) / WP248 / ICO / CNIL list)  |       |
+
+Briefly explain what the processing involves and why a DPIA was triggered.
+
+## Step 2 — Describe the Processing
+
+Cover scope, context, and purpose:
+
+- **Nature of processing:** what is collected, who has access, how long it
+  is retained, where it is stored, how it flows. Include a **data-flow
+  diagram** (placeholder — embed a diagram from the architecture
+  documentation).
+- **Scope:** volume and variety of data, geography, duration, frequency,
+  number of data subjects.
+- **Context:** relationship with data subjects, their reasonable
+  expectations, prior public concerns, sectoral codes of practice.
+- **Purpose:** the legitimate aim, expected benefits, and lawful basis.
+
+## Step 3 — Consultation Process
+
+| Stakeholder                | Consulted? | Date | Notes |
+| -------------------------- | ---------- | ---- | ----- |
+| DPO / Grievance Officer    |            |      |       |
+| Engineering lead           |            |      |       |
+| Security lead              |            |      |       |
+| Product / business sponsor |            |      |       |
+| External processor(s)      |            |      |       |
+| Data subjects (sample)     |            |      |       |
+| Supervisory authority      |            |      |       |
+
+Where the views of data subjects cannot be sought, document the reason.
+
+## Step 4 — Necessity and Proportionality
+
+- Is the processing necessary to achieve the stated purpose? Could the
+  purpose be achieved with less data or less intrusive means?
+- What is the lawful basis under GDPR Art. 6, and any Art. 9 condition for
+  special-category data?
+- What is the lawful ground under DPDP Act §§ 4–7 for users in India?
+- How is the data minimisation principle satisfied?
+- What is the retention period and how is it enforced?
+- How are data-subject rights operationalised?
+- Are international transfers in scope, and which transfer mechanism is
+  used (SCCs, UK IDTA, Swiss FADP addendum)?
+
+## Step 5 — Identify and Assess Risks
+
+For each identified risk, assess **likelihood** and **severity** on the
+scales below, then plot in the matrix.
+
+- **Likelihood:** Remote / Possible / Probable
+- **Severity:** Minimal / Significant / Severe
+
+| #   | Risk to data subjects                                 | Likelihood | Severity | Inherent rating |
+| --- | ----------------------------------------------------- | ---------- | -------- | --------------- |
+| R1  |                                                       |            |          |                 |
+| R2  |                                                       |            |          |                 |
+| R3  |                                                       |            |          |                 |
+
+Risks to consider include: illegitimate access, unauthorised modification,
+loss of data, re-identification, function creep, discrimination, loss of
+control, chilling effects on free expression, and incidental capture of
+special-category data.
+
+### Likelihood × Severity Matrix
+
+|              | Minimal | Significant | Severe |
+| ------------ | ------- | ----------- | ------ |
+| Remote       | Low     | Low         | Medium |
+| Possible     | Low     | Medium      | High   |
+| Probable     | Medium  | High        | High   |
+
+## Step 6 — Identify Measures to Mitigate
+
+For each risk in Step 5, identify mitigations and the resulting **residual
+rating**.
+
+| #   | Mitigation                                            | Effect on likelihood | Effect on severity | Residual rating | Owner |
+| --- | ----------------------------------------------------- | -------------------- | ------------------ | --------------- | ----- |
+| R1  |                                                       |                      |                    |                 |       |
+| R2  |                                                       |                      |                    |                 |       |
+| R3  |                                                       |                      |                    |                 |       |
+
+If any residual risk remains **High**, **prior consultation with the
+supervisory authority** under GDPR Article 36 is required before processing
+begins.
+
+## Step 7 — Sign-Off and Record Outcomes
+
+| Role                          | Name | Date | Decision |
+| ----------------------------- | ---- | ---- | -------- |
+| DPO / Grievance Officer       |      |      |          |
+| Engineering lead              |      |      |          |
+| Product sponsor               |      |      |          |
+
+Document any prior consultation submitted to a supervisory authority and
+the response received. Record the planned review date — DPIAs are living
+documents and must be revisited when the processing changes materially.
+
+---
+
+## Worked Example Reference — Voice Agent Feature
+
+The Raven voice agent (LiveKit-backed) is the canonical worked example for
+this template, because:
+
+- **Voice is biometric-adjacent.** Even where the platform does not perform
+  voice-print identification, the audio payload itself can support
+  identification and is treated as high-risk.
+- **AI inference on personal data.** Speech is transcribed, embedded, and
+  fed into LLM inference, which is a form of automated processing producing
+  effects on data subjects.
+- **Incidental special-category data.** Callers may volunteer health,
+  political, or other Article 9 data; the system must not treat that as
+  expected input.
+- **Cross-border transfers.** BYOK LLM providers may sit in the US.
+
+A DPIA on this feature should explicitly address: retention defaults
+(30 days, opt-in extension), erasure flows for both raw audio and derived
+embeddings, the boundary between Ravencloak's processor role and
+Customer's controller role, and prior consultation triggers if any
+residual risk remains High.

--- a/docs/security/incident-response.md
+++ b/docs/security/incident-response.md
@@ -107,15 +107,25 @@ personal-data breach notification (WP250 rev.01).
 
 ### T+48h → T+72h: Statutory Notifications
 
+> **REVIEW WITH COUNSEL — DRAFT.** The DPDP Act filing path, recipient,
+> and prescribed notification form below are illustrative pending counsel
+> sign-off. The exact route, addressee, and form may vary with the final
+> DPDP rules and any sectoral guidance in force at the time of the
+> incident. Do not rely on the language below in a live incident before
+> counsel has confirmed the current path; treat it as a starting checklist
+> only.
+
 1. Where Ravencloak is acting as **controller** for the affected data, file
    a **GDPR Article 33** notification with the lead supervisory authority
    within **72 hours of awareness**, unless the breach is unlikely to result
    in a risk to the rights and freedoms of natural persons. Document the
    decision either way.
-2. For data subjects in India, file the **DPDP Act §8(6)** notification with
-   the **Data Protection Board of India** and notify each affected
-   **data principal** in accordance with the form prescribed by the Indian
-   rules.
+2. For data subjects in India, prepare a **DPDP Act § 8(6)** notification
+   to the **Data Protection Board of India** and to each affected **data
+   principal**. The exact recipient, prescribed form, and timing must be
+   confirmed by counsel against the DPDP rules in force at the time of
+   the incident before the notice is dispatched. *(See the REVIEW WITH
+   COUNSEL note above.)*
 3. Where the risk to data subjects is high, prepare and dispatch a
    **GDPR Article 34** communication to affected data subjects without
    undue delay.

--- a/docs/security/incident-response.md
+++ b/docs/security/incident-response.md
@@ -1,0 +1,216 @@
+# Incident Response Runbook
+
+> **STATUS:** DRAFT — pending review by qualified counsel. The notification
+> templates, statutory timers, and regulatory addressees in this runbook
+> must be confirmed by counsel before this document is relied upon during
+> a live incident.
+
+This runbook governs Ravencloak's response to security incidents affecting
+the Raven platform, including personal-data breaches subject to GDPR
+Article 33 and DPDP Act Section 8. It complements `SECURITY.md` (the public
+disclosure path), `PRIVACY.md` (the controller-facing notice), `DPA.md`
+(the contractual processor-to-controller flow), and `GOVERNANCE.md` (the
+escalation chain).
+
+## Scope
+
+This runbook applies to:
+
+- **Confidentiality, integrity, or availability incidents** affecting the
+  cloud-hosted Raven platform or its supporting infrastructure;
+- **Personal-data breaches** as defined in GDPR Article 4(12) and DPDP Act
+  Section 2(1)(p);
+- **Supply-chain compromises** affecting Raven's build, signing, or
+  distribution pipeline;
+- **Suspected insider misuse** of production systems or production data.
+
+It does **not** govern self-hosted deployments operated by customers; in
+those cases, the customer is the controller and runs their own runbook.
+
+## Severity Classification
+
+| Severity | Definition | Examples |
+| -------- | ---------- | -------- |
+| **SEV-1** | Confirmed personal-data breach with risk to rights/freedoms; full or partial production outage; supply-chain compromise; loss of cryptographic material | Database exfiltration confirmed; signing key compromise; ransomware on production host; mass account takeover |
+| **SEV-2** | Probable personal-data breach pending forensic confirmation; degraded but not down service; compromise of a non-production credential with production access; isolated account takeover | Suspicious S3-equivalent egress detected; insider misuse suspected; high-volume authentication anomaly |
+| **SEV-3** | Security-relevant event with no confirmed data exposure; isolated customer-impacting bug under investigation | OSSF Scorecard regression; CVE in a deployed dependency without confirmed exploit; single-tenant misconfiguration discovered and contained |
+
+The **on-call Incident Commander** sets the initial severity at T+0 and
+revises it as evidence develops. Severity is recorded in the incident
+ticket and never silently downgraded.
+
+## Roles
+
+| Role                     | Responsibility                                                      | Default holder                |
+| ------------------------ | ------------------------------------------------------------------- | ----------------------------- |
+| Incident Commander (IC)  | Overall coordination, severity calls, decisions of record           | On-call engineer              |
+| Comms Lead               | Customer-facing communications, status page, regulator letters      | Founder / delegated comms     |
+| Tech Lead                | Containment, forensic capture, remediation, post-incident review    | On-call engineer              |
+| Legal / Privacy Lead     | Statutory notifications, supervisory-authority engagement, records  | Data Protection Officer       |
+
+A single individual may temporarily hold more than one role at the early
+stages of a small organisation; role separation is mandatory before any
+external notification leaves the building.
+
+## Detection Sources
+
+- **OpenObserve alerts** — application traces, logs, security rules.
+- **Beszel host metrics** — host-level anomalies on AWS hosts.
+- **OSSF Scorecard regressions** — CI-driven supply-chain signal.
+- **CodeQL / Semgrep / Gitleaks** — pre-merge and scheduled scans.
+- **Third-party reports** — disclosures via the GitHub Security Advisory
+  channel and the `security@ravencloak.org` alias defined in `SECURITY.md`.
+- **Customer reports** — support correspondence escalated to the IC.
+- **Sub-processor notifications** — breach notices received from any
+  sub-processor listed in Annex III of `DPA.md`.
+
+## Response Timeline
+
+The clock starts at **T+0**, defined as the first moment a member of the
+on-call rotation has actual or constructive awareness that an incident has
+occurred. "Awareness" is interpreted in line with WP29 Guidelines on
+personal-data breach notification (WP250 rev.01).
+
+### T+0 → T+1 hour: Triage, Contain, Classify
+
+1. Open an incident ticket and a private war-room channel.
+2. Assign IC, Tech Lead, Comms Lead, and Privacy Lead.
+3. Establish initial severity.
+4. Take **immediate containment actions** that do not destroy evidence:
+   rotate credentials, revoke sessions, isolate hosts, block egress.
+5. Snapshot affected hosts and database state; preserve logs in
+   write-locked storage.
+6. Begin a single source-of-truth incident timeline; every action logged
+   with timestamp and actor.
+
+### T+1h → T+24h: Investigate, Preserve, Scope
+
+1. Conduct evidence-led investigation: who, what, when, how, blast radius.
+2. Determine whether **personal data** is implicated and, if so, the
+   categories, volume, and affected jurisdictions.
+3. Determine whether the incident is a "personal-data breach" requiring
+   notification under GDPR Article 33, the DPDP Act, or any sectoral law.
+4. Communicate ongoing status to internal stakeholders at least every four
+   hours during a SEV-1.
+
+### T+24h → T+48h: Processor → Controller Notice and Customer Communications
+
+1. Where Ravencloak processes data on behalf of customers, deliver the
+   **48-hour processor-to-controller notice** required by Section 7 of
+   `DPA.md`. The notice covers, to the extent then known, the elements
+   required by GDPR Article 33(3).
+2. Send appropriate customer communications via the status page, in-product
+   banner, and direct email where indicated.
+3. Coordinate with the Privacy Lead on the wording of any external
+   statement so that it is consistent with the regulator filing planned
+   for the next phase.
+
+### T+48h → T+72h: Statutory Notifications
+
+1. Where Ravencloak is acting as **controller** for the affected data, file
+   a **GDPR Article 33** notification with the lead supervisory authority
+   within **72 hours of awareness**, unless the breach is unlikely to result
+   in a risk to the rights and freedoms of natural persons. Document the
+   decision either way.
+2. For data subjects in India, file the **DPDP Act §8(6)** notification with
+   the **Data Protection Board of India** and notify each affected
+   **data principal** in accordance with the form prescribed by the Indian
+   rules.
+3. Where the risk to data subjects is high, prepare and dispatch a
+   **GDPR Article 34** communication to affected data subjects without
+   undue delay.
+4. Update sub-processors and downstream parties as required.
+
+### T+72h → T+30d: Post-Incident Review
+
+1. Complete a written **root-cause analysis (RCA)** with a five-whys or
+   equivalent technique.
+2. File **remediation tickets** with owners and due dates.
+3. Conduct a **post-incident review** within ten business days of
+   resolution; the review is blameless and produces written corrective
+   actions.
+4. Update the runbook, detection rules, and tabletop scenarios with
+   lessons learned.
+5. File the closed incident record in the incident archive.
+
+## Notification Templates
+
+### Regulator letter (GDPR Art. 33)
+
+> Subject: Personal-Data Breach Notification — Ravencloak Org — \[Reference]
+>
+> Pursuant to Article 33 of Regulation (EU) 2016/679, Ravencloak Org
+> notifies the \[supervisory authority] of a personal-data breach that came
+> to our attention on \[date/time, UTC].
+>
+> 1. Nature of the breach: \[description, categories and approximate number
+>    of data subjects, categories and approximate number of records].
+> 2. Contact point: Data Protection Officer, \[name, email].
+> 3. Likely consequences for data subjects: \[assessment].
+> 4. Measures taken or proposed: \[containment, mitigation, communication].
+>
+> Where information is not yet available, it will be provided in phases
+> without further undue delay.
+
+### Customer email (processor → controller, per DPA Section 7)
+
+> Subject: \[SEV-?] Personal-Data Breach Notification — \[Reference]
+>
+> Dear \[Customer],
+>
+> Ravencloak Org is writing to notify you, in our capacity as processor
+> under our Data Processing Addendum, of a personal-data breach affecting
+> your tenant of the Raven platform. Awareness occurred at \[time, UTC].
+>
+> What we know now: \[summary]. What we do not yet know: \[summary].
+> Containment actions taken: \[summary]. Next update: \[time].
+>
+> Please direct any questions to \[DPO contact]. We will continue to update
+> you as our investigation progresses.
+
+## Tools and Runbook Commands
+
+> The exact queries below are illustrative. Validate against the live
+> schema and adjust before running in production.
+
+- **ClickHouse audit-log triage**
+
+  ```sql
+  SELECT timestamp, actor_id, action, resource, source_ip
+  FROM audit_events
+  WHERE timestamp >= now() - INTERVAL 24 HOUR
+    AND (action LIKE '%export%' OR action LIKE '%delete%')
+  ORDER BY timestamp DESC
+  LIMIT 1000;
+  ```
+
+- **OpenObserve correlation** — pivot on the `incident_id` tag attached to
+  all telemetry generated during a war-room session; export the full trace
+  bundle to write-locked storage.
+
+- **Container forensics** — capture the filesystem and process list of any
+  container of interest before terminating it; tag the snapshot with the
+  incident reference and chain-of-custody metadata.
+
+- **Credential rotation** — rotate database, object-storage, and signing
+  credentials per the runbook in `SECURITY.md`. Revoke SuperTokens sessions
+  for affected tenants where session-token compromise is suspected.
+
+## Tabletop Exercise Cadence
+
+Tabletop exercises are conducted **quarterly**. Each exercise rehearses one
+of: a SEV-1 personal-data breach, a SEV-1 supply-chain compromise, a SEV-2
+insider misuse case, or a sub-processor-originated breach. The Privacy Lead
+participates in every exercise. Exercise outputs are filed alongside live
+incidents in the archive and are an input to the annual review of this
+runbook.
+
+## Related Documents
+
+- `SECURITY.md` — public disclosure path and supported versions.
+- `GOVERNANCE.md` — escalation, decision rights, and project governance.
+- `PRIVACY.md` — the public privacy notice referenced in customer comms.
+- `DPA.md` — the processor-to-controller breach notification clause and
+  sub-processor list.
+- `docs/compliance/dpia-template.md` — the DPIA template used to evaluate
+  changes before they reach production.


### PR DESCRIPTION
## Summary

GDPR + DPDP posture stack. Four documents, all marked **DRAFT** pending counsel review — do not link or publish before legal sign-off.

- **`PRIVACY.md`** — public notice satisfying GDPR Art. 13/14 and DPDP §5. Names DPO/grievance officer, lists sub-processors, defines retention defaults.
- **`DPA.md`** — Data Processing Addendum template per GDPR Art. 28 with EU SCCs (2021/914) + UK IDTA + Swiss FADP addenda by reference, 48-hour processor breach SLA, audit rights, sub-processor table, three annexes.
- **`docs/compliance/dpia-template.md`** — Art. 35 template (7-step process, ICO/CNIL aligned), worked example for the voice agent feature.
- **`docs/security/incident-response.md`** — breach runbook with T+0 → T+30d timeline, regulator notification templates, severity ladder, OpenObserve/ClickHouse forensics commands.

## Test plan
- [ ] Counsel reviews each document and removes the DRAFT banner before linking publicly
- [ ] Sub-processor list reconciled with actual production stack at review time
- [ ] DPIA template exercised on the voice agent feature to validate fit
- [ ] Incident-response runbook tabletop tested before relying on it
- [ ] DPDP grievance officer details replaced with finalised contact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Data Processing Addendum (DPA) outlining data handling obligations and international transfer mechanisms
  * Added Privacy Notice documenting personal data practices, user rights, and retention policies
  * Added Data Protection Impact Assessment (DPIA) template and Incident Response procedures for transparency into compliance and security operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->