### PR TITLE
docs(compliance): add CoC, governance, security.txt, OSSF Scorecard

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,44 @@
+name: Scorecard supply-chain security
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@05b42c624433fc40578a4040d5cf5e36ddca8cde  # v2.4.2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4
+        with:
+          sarif_file: results.sarif

--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,0 +1,8 @@
+# Raven security contact information per RFC 9116 (https://www.rfc-editor.org/rfc/rfc9116).
+Contact: https://github.com/ravencloak-org/Raven/security/advisories/new
+Contact: mailto:security@ravencloak.org
+Expires: 2027-05-08T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://raw.githubusercontent.com/ravencloak-org/Raven/main/.well-known/security.txt
+Policy: https://github.com/ravencloak-org/Raven/blob/main/SECURITY.md
+Acknowledgments: https://github.com/ravencloak-org/Raven/security/advisories

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,68 @@
+# Code of Conduct
+
+Raven adopts the [Contributor Covenant, version 2.1][cc21] as its code of
+conduct. Every contributor, maintainer, and community member is expected to
+abide by it whenever participating in the project's online and offline spaces.
+
+The full text of the policy is published at:
+
+<https://www.contributor-covenant.org/version/2/1/code-of-conduct/>
+
+The translations and FAQ are at:
+
+<https://www.contributor-covenant.org/translations/>
+<https://www.contributor-covenant.org/faq/>
+
+## Reporting
+
+Concerns about conduct in any Raven space (this repository, GitHub
+Discussions, issue trackers, pull requests, chat channels, in-person events
+operating under the Raven name, and any future official forums) should be
+sent privately to the maintainers via:
+
+- Email: `security@ravencloak.org` (preferred)
+- Email: `jobinlawrance@gmail.com` (fallback until `security@ravencloak.org` is
+  fully provisioned)
+- GitHub private vulnerability reporting if the matter overlaps with a
+  security report:
+  <https://github.com/ravencloak-org/Raven/security/advisories/new>
+
+Reports are received only by the named maintainers in
+[`MAINTAINERS.md`](./MAINTAINERS.md). Reporters may request that their
+identity be kept confidential within the maintainer team.
+
+## Enforcement
+
+Maintainers are responsible for clarifying and enforcing this code of
+conduct. They may take any action they deem appropriate in response to a
+report, up to and including a permanent ban from the project's spaces. The
+[Contributor Covenant 2.1 enforcement guidelines][cc21-enforce] describe the
+ladder of corrective actions used.
+
+Decisions and any sanction applied are documented privately within the
+maintainer team. Public disclosure of a sanction is at the maintainers'
+discretion and only with care for the privacy of the reporter and any
+subjects involved.
+
+## Scope
+
+This code of conduct applies within all Raven spaces and also applies when
+an individual is officially representing Raven in public spaces (for
+example, using an official email address, posting via an official social
+media account, or acting as an appointed representative at an online or
+offline event).
+
+## Attribution
+
+This document is adapted from the Contributor Covenant, version 2.1,
+available at <https://www.contributor-covenant.org/version/2/1/code-of-conduct/>.
+Contributor Covenant is licensed under
+[Creative Commons Attribution 4.0 International][cc-by-4].
+
+---
+
+Last updated: 2026-05-08.
+
+[cc21]: https://www.contributor-covenant.org/version/2/1/code-of-conduct/
+[cc21-enforce]: https://www.contributor-covenant.org/version/2/1/code-of-conduct/#enforcement-guidelines
+[cc-by-4]: https://creativecommons.org/licenses/by/4.0/

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,108 @@
+# Governance
+
+This document describes how the Raven project is governed: who decides what,
+how decisions are made, how maintainers are added and removed, and how
+releases and security incidents are handled. It complements
+[`CONTRIBUTING.md`](./CONTRIBUTING.md), [`SECURITY.md`](./SECURITY.md), and
+[`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md), and supersedes none of them.
+
+## Mission
+
+Raven is an open-source, self-hostable, multi-tenant knowledge base platform
+with AI-powered chat, voice, and WhatsApp channels. The project's goal is
+to give teams a production-grade retrieval-augmented generation platform
+without vendor lock-in, runnable on a single Docker Compose host or on
+edge hardware such as a Raspberry Pi, with data ownership end-to-end.
+
+## Roles
+
+Four roles operate within the project. Anyone may move between roles as
+their participation grows.
+
+| Role | Responsibilities | How to become one |
+|---|---|---|
+| **User** | Runs Raven, reports bugs, files feature requests, asks questions. | Use the project. |
+| **Contributor** | Submits pull requests, helps in discussions, improves docs. | Open a PR; sign-off via DCO. |
+| **Committer** | Reviews and approves pull requests within an area of expertise. Cannot merge to `main`. | Sustained, high-quality contribution recognised by an existing maintainer. |
+| **Maintainer** | Final review and merge authority. Sets technical direction. Listed in [`MAINTAINERS.md`](./MAINTAINERS.md). | Nominated by an existing maintainer; approved per the rules below. |
+
+The current list of maintainers and their areas of ownership is published in
+[`MAINTAINERS.md`](./MAINTAINERS.md). The lead maintainer at the time of
+writing is Jobin Lawrance (`@jobinlawrance`).
+
+## Decision making
+
+Decisions are made by lazy consensus where possible and explicit maintainer
+approval where required.
+
+| Change type | Required approvals |
+|---|---|
+| Typo fixes, dependency bumps, low-risk refactors | One maintainer review. Lazy consensus: 24 hours with no objection. |
+| Feature additions, behaviour changes | One maintainer review and an explicit "approve". |
+| Architectural change, public API change, breaking change | Two maintainer reviews. Discussion documented in an issue or ADR before merge. |
+| Security-impacting change | Two maintainer reviews, one of whom is the security lead. Disclosure handled per [`SECURITY.md`](./SECURITY.md). |
+| Governance change (this file, `MAINTAINERS.md`, license, code of conduct) | Two maintainer reviews and a 14-day public comment window on the PR. |
+
+If maintainers disagree and consensus cannot be reached within seven days,
+the lead maintainer breaks the tie. The decision and its rationale are
+recorded in the originating issue or PR.
+
+## Adding and removing maintainers
+
+A new maintainer is nominated by an existing maintainer in a private channel
+and confirmed by the lead maintainer. The nomination is then announced in a
+public issue for transparency. New maintainers receive merge access and are
+added to [`MAINTAINERS.md`](./MAINTAINERS.md) in the same PR.
+
+A maintainer may step down at any time by opening a PR that removes their
+entry from [`MAINTAINERS.md`](./MAINTAINERS.md). Involuntary removal
+requires two maintainer approvals and a 30-day public notice on a tracking
+issue, during which the affected maintainer may respond. A removal that is
+the result of a code-of-conduct or security finding follows the process in
+the relevant document and may be expedited.
+
+A maintainer who has not contributed for 12 consecutive months is
+automatically considered emeritus. Emeritus maintainers retain credit but
+relinquish merge authority; they may return to active status by opening a
+PR.
+
+## Releases
+
+Releases are cut from `main` and tagged via the
+[`release.yml`](./.github/workflows/release.yml) workflow. The project ships
+Go binaries, Docker images, and (where applicable) the frontend bundle. All
+release artefacts are produced with SLSA Level 3 build provenance per
+[`docs/security/slsa-verification.md`](./docs/security/slsa-verification.md)
+and target the OpenSSF Baseline (`docs/compliance/`) self-assessment.
+
+`main` is always release-shaped: every PR squash-merges, must pass the
+required-status checks defined in
+[`.github/workflows/ci-required.yml`](./.github/workflows/ci-required.yml),
+and may not bypass hooks (`--no-verify` is not permitted). Release versions
+follow semantic versioning. Pre-1.0, minor versions may contain breaking
+changes; these are called out in the release notes.
+
+## Security escalation
+
+Suspected vulnerabilities, leaked credentials, and incidents follow the
+private channels and SLAs documented in [`SECURITY.md`](./SECURITY.md).
+Public disclosure happens through the GitHub Security Advisory and the
+release notes of the fixed version. The security lead may merge a
+security-only fix to `main` with a single maintainer review when speed is
+necessary; the second review is performed post-merge and recorded in the
+advisory.
+
+## Code of conduct
+
+All participants in Raven spaces are bound by the
+[Code of Conduct](./CODE_OF_CONDUCT.md). Reports are handled by the
+maintainer team via the channels documented there.
+
+## Amendments
+
+This document may be amended by a pull request approved per the "Governance
+change" row in the [Decision making](#decision-making) table.
+
+---
+
+Last updated: 2026-05-08.

--- a/README.md
+++ b/README.md
@@ -16,12 +16,13 @@
   <a href="https://codecov.io/gh/ravencloak-org/Raven"><img src="https://codecov.io/gh/ravencloak-org/Raven/branch/main/graph/badge.svg" alt="Coverage" /></a>
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License: Apache 2.0" /></a>
   <a href="https://baseline.openssf.org/versions/2026-02-19"><img src="https://img.shields.io/badge/OpenSSF%20Baseline-L2%20target-blue" alt="OpenSSF Baseline L2" /></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/ravencloak-org/Raven"><img src="https://api.scorecard.dev/projects/github.com/ravencloak-org/Raven/badge" alt="OpenSSF Scorecard" /></a>
   <img src="https://img.shields.io/badge/PRs-welcome-blue" alt="PRs Welcome" />
 </p>
-<p allign="center">
+<p align="center">
   <a href="https://www.bestpractices.dev/projects/12590"><img src="https://www.bestpractices.dev/projects/12590/badge"></a>
 </p>
-</p>
+
 ---
 
 ## What is Raven?


### PR DESCRIPTION
## Summary

Free-tier compliance quick wins. No legal review required.

- **`.well-known/security.txt`** — RFC 9116 vulnerability-disclosure pointer; auto-discovered by scanners.
- **OSSF Scorecard workflow + badge** — weekly supply-chain score on 18 checks, SARIF surfaced in the Security tab.
- **`CODE_OF_CONDUCT.md`** — adopts Contributor Covenant 2.1 by reference (closes a GitHub community-standards gap).
- **`GOVERNANCE.md`** — documents roles, decision-making, and release rules; OSPS-L3 prerequisite.
- **README** — fixes `allign` typo and an orphan `</p>` from the badge block; adds the Scorecard badge.

## Test plan
- [ ] Scorecard SARIF appears in Security tab after first cron run
- [ ] `security.txt` resolves at `https://raw.githubusercontent.com/ravencloak-org/Raven/main/.well-known/security.txt`
- [ ] README renders cleanly on GitHub (badges aligned, no stray tags)
- [ ] GitHub community-standards page shows CoC + Governance ticked