### PR TITLE
ci(lint): fix golangci-lint v2 schema (move exclude-rules) + pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Run golangci-lint when staged changes touch Go files.
+# Catches lint violations before they reach the remote and CI.
+#
+# Install once per clone (alongside the pre-push hook):
+#   git config core.hooksPath .githooks
+#
+# Bypass (NOT recommended): git commit --no-verify
+
+set -euo pipefail
+
+# No staged Go files? Skip silently.
+if ! git diff --cached --name-only --diff-filter=AM | grep -qE '\.go$'; then
+    exit 0
+fi
+
+if ! command -v golangci-lint >/dev/null 2>&1; then
+    cat >&2 <<'EOF'
+WARNING: golangci-lint not found in PATH; skipping pre-commit lint check.
+
+Install it so this hook can protect your commits:
+  brew install golangci-lint               # macOS
+  go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+
+EOF
+    exit 0
+fi
+
+echo "Running golangci-lint on the repository..." >&2
+if ! golangci-lint run ./...; then
+    cat >&2 <<'EOF'
+
+Refusing to commit: golangci-lint reported issues above.
+
+Fix the reported violations, then commit again. To bypass (e.g. for a
+work-in-progress checkpoint commit) use:
+  git commit --no-verify
+…but CI will still reject the push.
+
+EOF
+    exit 1
+fi
+
+exit 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,32 +26,29 @@ linters:
         - name: error-strings
         - name: increment-decrement
         - name: var-naming
+  exclusions:
+    rules:
+      # Tests using net/http.NewRequest with httptest servers — ctx propagation
+      # is moot for these short-lived requests. New non-test code MUST use
+      # NewRequestWithContext (linter still enforces).
+      - path: _test\.go$
+        linters:
+          - noctx
+      # Pre-existing fire-and-forget goroutines (async log delivery, async
+      # cache invalidation) intentionally detach from the request lifecycle.
+      # contextcheck cannot tell intentional detachment from accidental;
+      # narrow file-level exemptions until a follow-up audit reworks each
+      # site to use a long-lived background ctx.
+      - path: internal/service/(security|document|billing)\.go$
+        linters:
+          - contextcheck
+      - path: internal/repository/semantic_cache\.go$
+        linters:
+          - contextcheck
+      - path: internal/jobs/airbyte_sync\.go$
+        linters:
+          - contextcheck
 
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
-  exclude-rules:
-    # Tests using net/http.NewRequest with httptest servers — ctx propagation
-    # is moot for these short-lived requests. New non-test code MUST use
-    # NewRequestWithContext (linter still enforces).
-    - path: _test\.go$
-      linters:
-        - noctx
-    # Pre-existing fire-and-forget goroutines (async log delivery, async
-    # cache invalidation) intentionally detach from the request lifecycle.
-    # contextcheck cannot tell intentional detachment from accidental;
-    # narrow file-level exemptions until a follow-up audit reworks each
-    # site to use a long-lived background ctx.
-    - path: internal/service/(security|document|billing)\.go$
-      linters:
-        - contextcheck
-    - path: internal/repository/semantic_cache\.go$
-      linters:
-        - contextcheck
-    - path: internal/jobs/airbyte_sync\.go$
-      linters:
-        - contextcheck
-    # webhooks_test.go uses http.NewRequest extensively for delivery
-    # simulation; covered by the _test.go rule above but included here
-    # as documentation of the known site.
-    # internal/ee/webhooks/webhooks_test.go — see above

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,13 +38,20 @@ Use `type/descriptor` format:
 
 ## Local hooks
 
-The repo ships a pre-push hook that mirrors the DCO CI check. Install it once per clone:
+The repo ships two hooks under `.githooks/` that mirror CI checks. Install both at once with:
 
 ```bash
 git config core.hooksPath .githooks
 ```
 
-After that, every `git push` runs `.githooks/pre-push`, which rejects the push if any commit being sent lacks a `Signed-off-by:` trailer. To retroactively sign off a branch:
+| Hook | Runs | Checks |
+|------|------|--------|
+| `pre-commit` | every `git commit` | `golangci-lint run ./...` when staged changes include `.go` files |
+| `pre-push` | every `git push` | every commit being sent carries a `Signed-off-by:` trailer |
+
+`pre-commit` skips silently if `golangci-lint` is not installed; install it via `brew install golangci-lint` (macOS) or `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest`.
+
+To retroactively sign off a branch that was made before the hook existed:
 
 ```bash
 git rebase origin/main --exec 'git commit --amend --no-edit -s'


### PR DESCRIPTION
## Summary

PR #411 landed `.golangci.yml` with `exclude-rules` under `issues:`, which golangci-lint v2 (2.11.4) rejects at schema-validate time:

```
jsonschema: "issues" does not validate with "/properties/issues/additionalProperties":
  additional properties 'exclude-rules' not allowed
```

Lint CI is currently red on `main` and on every open PR built from it.

## Fix

- Move the four exclusion rules from `issues.exclude-rules` to `linters.exclusions.rules` (the v2 home). Same content, new location.
- Add `.githooks/pre-commit` that runs `golangci-lint run ./...` when staged changes touch `.go` files (skips silently if `golangci-lint` is missing). Companion to the existing `pre-push` DCO hook.
- `CLAUDE.md` documents the install (`git config core.hooksPath .githooks`) and the hooks table.

## Test plan

- [x] `python3 -c 'yaml.safe_load(open(\".golangci.yml\"))'` parses cleanly
- [x] `linters.exclusions.rules` contains the four pre-existing exemptions
- [x] `issues.exclude-rules` no longer present
- [ ] CI lint job passes (no schema validation error)