### PR TITLE
feat(api): single-user mode flag for Raven Local (M11/03, closes #419)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -188,15 +188,17 @@ func main() {
 		defer ebpfManager.Stop()
 	}
 
-	// Initialise the SuperTokens Go SDK. This must happen before any route
-	// registration so that supertokens.Middleware can intercept /auth/* paths.
-	if err := auth.InitSuperTokens(auth.SuperTokensInitConfig{
-		ConnectionURI: cfg.SuperTokens.ConnectionURI,
-		APIKey:        cfg.SuperTokens.APIKey,
-		APIDomain:     cfg.SuperTokens.APIDomain,
-		WebsiteDomain: cfg.SuperTokens.WebsiteDomain,
-	}); err != nil {
-		log.Fatalf("failed to initialize SuperTokens: %v", err)
+	// Initialise the SuperTokens Go SDK. Skipped in single-user mode where no
+	// external auth service is required or expected.
+	if !cfg.Server.SingleUser {
+		if err := auth.InitSuperTokens(auth.SuperTokensInitConfig{
+			ConnectionURI: cfg.SuperTokens.ConnectionURI,
+			APIKey:        cfg.SuperTokens.APIKey,
+			APIDomain:     cfg.SuperTokens.APIDomain,
+			WebsiteDomain: cfg.SuperTokens.WebsiteDomain,
+		}); err != nil {
+			log.Fatalf("failed to initialize SuperTokens: %v", err)
+		}
 	}
 
 	// TMDB client for demo seed endpoint.
@@ -506,6 +508,14 @@ func main() {
 	// Excluded from rate limiting.
 	router.GET("/healthz", middleware.Deadline(1*time.Second), handler.HealthCheck)
 
+	// Frontend config endpoint — public, unauthenticated. Returns feature flags
+	// that the frontend reads on boot to decide behaviour (e.g. single-user mode).
+	router.GET("/api/v1/config", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{
+			"single_user": cfg.Server.SingleUser,
+		})
+	})
+
 	// One-click unsubscribe — public, authenticated via a signed token embedded
 	// in the link (RFC 8058). Placed outside /api/v1 so email clients can hit
 	// it without triggering CORS/auth middleware.
@@ -517,7 +527,10 @@ func main() {
 
 	// SuperTokens SDK routes — catch-all for /auth/* so the SDK middleware
 	// can intercept signinup, session/refresh, callback, etc.
-	router.Any("/auth/*path", handler.SuperTokensMiddleware())
+	// Not registered in single-user mode (no SuperTokens; no auth flows).
+	if !cfg.Server.SingleUser {
+		router.Any("/auth/*path", handler.SuperTokensMiddleware())
+	}
 
 	// Protected API routes — JWT validation applied per-group, not globally.
 	// This allows health checks and other public endpoints to remain unauthenticated.
@@ -531,9 +544,16 @@ func main() {
 	// WriteTimeout — acceptable for default-CRUD route groups.
 	api := router.Group("/api/v1")
 
-	authProvider := auth.NewSuperTokensProvider()
-	api.Use(middleware.SessionMiddleware(authProvider))
-	api.Use(middleware.UserLookup(&userLookupAdapter{repo: userRepo}))
+	// Single-user mode: inject synthetic local session without SuperTokens.
+	// Multi-user mode: verify session via SuperTokens and resolve DB user.
+	var authProvider auth.Provider
+	if cfg.Server.SingleUser {
+		api.Use(middleware.SingleUserMiddleware())
+	} else {
+		authProvider = auth.NewSuperTokensProvider()
+		api.Use(middleware.SessionMiddleware(authProvider))
+		api.Use(middleware.UserLookup(&userLookupAdapter{repo: userRepo}))
+	}
 	// Per-user and per-org flat rate limits (config-driven defaults).
 	api.Use(middleware.ByUserID(rl, cfg.RateLimit.DefaultUserLimit))
 	api.Use(middleware.ByOrgID(rl, cfg.RateLimit.DefaultOrgLimit))
@@ -857,19 +877,22 @@ func main() {
 	// Auth callback — outside the session-protected /api/v1 group.
 	// We verify the session directly via the SuperTokens SDK rather than
 	// relying on SessionMiddleware (cookies may not be available yet).
+	// Not registered in single-user mode — there is no sign-in flow.
 	demoJoiner := service.NewDemoOrgJoiner(orgSvc, wsSvc)
 	authHandler := handler.NewAuthHandler(userSvc, demoJoiner)
-	router.GET("/api/v1/auth/callback", func(c *gin.Context) {
-		info, err := authProvider.VerifySession(c.Request)
-		if err != nil || info == nil {
-			c.AbortWithStatusJSON(401, gin.H{"error": "invalid_session"})
-			return
-		}
-		c.Set(string(middleware.ContextKeyExternalID), info.ExternalID)
-		c.Set(string(middleware.ContextKeyEmail), info.Email)
-		c.Set(string(middleware.ContextKeyUserName), info.Name)
-		authHandler.Callback(c)
-	})
+	if !cfg.Server.SingleUser {
+		router.GET("/api/v1/auth/callback", func(c *gin.Context) {
+			info, err := authProvider.VerifySession(c.Request)
+			if err != nil || info == nil {
+				c.AbortWithStatusJSON(401, gin.H{"error": "invalid_session"})
+				return
+			}
+			c.Set(string(middleware.ContextKeyExternalID), info.ExternalID)
+			c.Set(string(middleware.ContextKeyEmail), info.Email)
+			c.Set(string(middleware.ContextKeyUserName), info.Name)
+			authHandler.Callback(c)
+		})
+	}
 
 	// Create HTTP server
 	addr := fmt.Sprintf(":%d", cfg.Server.Port)

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,13 +1,12 @@
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import { useAuthStore } from './stores/auth'
+import { useServerConfigStore } from './stores/server-config'
 import { posthogPlugin } from './plugins/posthog'
 import { initSuperTokens } from './plugins/supertokens'
 import App from './App.vue'
 import router from './router'
 import './assets/main.css'
-
-initSuperTokens()
 
 const app = createApp(App)
 const pinia = createPinia()
@@ -15,8 +14,22 @@ app.use(pinia)
 app.use(router)
 app.use(posthogPlugin, { router })
 
-// Initialise Keycloak before mounting so the auth store is ready when the
-// router guard evaluates.  With check-sso the app mounts regardless of
-// whether the user is logged in — the router guard handles redirects.
-const authStore = useAuthStore()
-authStore.init().then(() => app.mount('#app'))
+// Fetch server feature flags before mounting so the router guard has them.
+const serverConfig = useServerConfigStore()
+serverConfig.load().then(() => {
+  // In single-user (Raven Local) mode SuperTokens is not running on the server;
+  // skip SDK initialisation to avoid unnecessary network requests to /auth/*.
+  if (!serverConfig.singleUser) {
+    initSuperTokens()
+  }
+
+  const authStore = useAuthStore()
+  if (serverConfig.singleUser) {
+    // Single-user mode: no real session — treat as always authenticated.
+    authStore.setLocalMode()
+    app.mount('#app')
+  } else {
+    // Multi-user mode: initialise session check before mounting.
+    authStore.init().then(() => app.mount('#app'))
+  }
+})

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import { useAuthStore } from '../stores/auth'
+import { useServerConfigStore } from '../stores/server-config'
 
 const router = createRouter({
   history: createWebHistory(),
@@ -7,6 +8,8 @@ const router = createRouter({
     {
       path: '/',
       redirect: () => {
+        const serverConfig = useServerConfigStore()
+        if (serverConfig.singleUser) return '/dashboard'
         const auth = useAuthStore()
         return auth.isAuthenticated ? '/dashboard' : '/login'
       },
@@ -155,7 +158,17 @@ const router = createRouter({
 })
 
 router.beforeEach(async (to) => {
+  const serverConfig = useServerConfigStore()
   const auth = useAuthStore()
+
+  // In single-user (Raven Local) mode there is no login flow — the app always
+  // boots directly to the dashboard. Skip the login/callback pages entirely.
+  if (serverConfig.singleUser) {
+    if (to.path === '/login' || to.path === '/callback' || to.path === '/onboarding') {
+      return '/dashboard'
+    }
+    return
+  }
 
   if (to.path === '/login' || to.path === '/callback') return
   if (to.path.startsWith('/legal/')) return

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -59,6 +59,19 @@ export const useAuthStore = defineStore('auth', () => {
     sessionStorage.setItem('raven_org_id', id)
   }
 
+  /**
+   * Called in single-user (Raven Local) mode to mark the session as
+   * authenticated without going through SuperTokens. The backend injects
+   * the local user / org via SingleUserMiddleware so no real token is needed.
+   */
+  function setLocalMode() {
+    sessionExists.value = true
+    // Use the fixed local org UUID from the single-user migration seed.
+    const localOrgId = '00000000-0000-0000-0000-000000000001'
+    orgId.value = localOrgId
+    sessionStorage.setItem('raven_org_id', localOrgId)
+  }
+
   return {
     sessionExists,
     orgId,
@@ -69,5 +82,6 @@ export const useAuthStore = defineStore('auth', () => {
     handleCallback,
     logout,
     setOrgId,
+    setLocalMode,
   }
 })

--- a/frontend/src/stores/server-config.ts
+++ b/frontend/src/stores/server-config.ts
@@ -1,0 +1,34 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+interface ServerConfig {
+  single_user: boolean
+}
+
+/**
+ * Holds server-side feature flags fetched from GET /api/v1/config on boot.
+ * Consumed by the router guard to skip the login flow in single-user mode.
+ */
+export const useServerConfigStore = defineStore('serverConfig', () => {
+  const singleUser = ref(false)
+  const loaded = ref(false)
+
+  async function load() {
+    if (loaded.value) return
+    try {
+      const res = await fetch(
+        `${import.meta.env.VITE_API_BASE_URL}/api/v1/config`,
+      )
+      if (res.ok) {
+        const data: ServerConfig = await res.json()
+        singleUser.value = data.single_user ?? false
+      }
+    } catch {
+      // Network error — assume multi-user mode (safe default).
+      singleUser.value = false
+    }
+    loaded.value = true
+  }
+
+  return { singleUser, loaded, load }
+})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -245,6 +245,12 @@ type ServerConfig struct {
 	AIWorkerTimeout          time.Duration `mapstructure:"ai_worker_timeout"`
 	AIWorkerBreakerThreshold uint32        `mapstructure:"ai_worker_breaker_threshold"`
 	AIWorkerBreakerCooldown  time.Duration `mapstructure:"ai_worker_breaker_cooldown"`
+
+	// SingleUser enables single-user (Raven Local / desktop) mode. When true,
+	// SessionMiddleware injects a synthetic session for user_id=local,
+	// org_id=local without contacting SuperTokens. The /auth/* routes are not
+	// registered. Default false (standard multi-user mode).
+	SingleUser bool `mapstructure:"single_user"`
 }
 
 // DatabaseConfig holds database connection settings.
@@ -283,6 +289,7 @@ func Load() (*Config, error) {
 	v.SetDefault("server.ai_worker_timeout", "5s")
 	v.SetDefault("server.ai_worker_breaker_threshold", 5)
 	v.SetDefault("server.ai_worker_breaker_cooldown", "30s")
+	v.SetDefault("server.single_user", false)
 	v.SetDefault("grpc.worker_addr", "localhost:50051")
 	v.SetDefault("otel.endpoint", "")
 	v.SetDefault("otel.service_name", "raven-api")
@@ -419,6 +426,7 @@ func Load() (*Config, error) {
 	_ = v.BindEnv("server.ai_worker_timeout", "RAVEN_AI_WORKER_TIMEOUT")
 	_ = v.BindEnv("server.ai_worker_breaker_threshold", "RAVEN_AI_WORKER_BREAKER_THRESHOLD")
 	_ = v.BindEnv("server.ai_worker_breaker_cooldown", "RAVEN_AI_WORKER_BREAKER_COOLDOWN")
+	_ = v.BindEnv("server.single_user", "RAVEN_SINGLE_USER")
 	_ = v.BindEnv("clickhouse.host", "RAVEN_CLICKHOUSE_HOST")
 	_ = v.BindEnv("clickhouse.port", "RAVEN_CLICKHOUSE_PORT")
 	_ = v.BindEnv("clickhouse.database", "RAVEN_CLICKHOUSE_DATABASE")

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -55,6 +55,31 @@ func SessionMiddleware(provider auth.Provider) gin.HandlerFunc {
 	}
 }
 
+// SingleUserMiddleware returns a Gin handler that injects a synthetic
+// "local" session without calling SuperTokens. Use this in place of
+// SessionMiddleware+UserLookup when RAVEN_SINGLE_USER=true.
+//
+// It sets all context keys that downstream handlers expect so that no
+// handler code needs a separate single-user branch.
+func SingleUserMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Fixed well-known values for the single-user persona.
+		// The migration seeds matching rows in organizations and users.
+		const (
+			localOrgID  = "00000000-0000-0000-0000-000000000001"
+			localUserID = "00000000-0000-0000-0000-000000000002"
+		)
+		c.Set(string(ContextKeyUserID), localUserID)
+		c.Set(string(ContextKeyOrgID), localOrgID)
+		c.Set(string(ContextKeyOrgRole), "org_admin")
+		c.Set(string(ContextKeyWorkspaceRole), "admin")
+		c.Set(string(ContextKeyEmail), "local@raven.localhost")
+		c.Set(string(ContextKeyUserName), "Local User")
+		c.Set(string(ContextKeyExternalID), "local")
+		c.Next()
+	}
+}
+
 // UserResolver is the interface for looking up users by external ID.
 // Returns empty userID when the user is not found (not an error).
 type UserResolver interface {

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -72,6 +72,67 @@ func TestSessionMiddleware_InvalidSession(t *testing.T) {
 	}
 }
 
+func TestSingleUserMiddleware_SetsLocalIdentity(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(middleware.SingleUserMiddleware())
+	r.GET("/test", func(c *gin.Context) {
+		c.JSON(200, gin.H{
+			"user_id": c.GetString(string(middleware.ContextKeyUserID)),
+			"org_id":  c.GetString(string(middleware.ContextKeyOrgID)),
+			"role":    c.GetString(string(middleware.ContextKeyOrgRole)),
+			"email":   c.GetString(string(middleware.ContextKeyEmail)),
+		})
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/test", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+
+	body := w.Body.String()
+	if !contains(body, "00000000-0000-0000-0000-000000000002") {
+		t.Errorf("expected local user_id in response body, got: %s", body)
+	}
+	if !contains(body, "00000000-0000-0000-0000-000000000001") {
+		t.Errorf("expected local org_id in response body, got: %s", body)
+	}
+	if !contains(body, "org_admin") {
+		t.Errorf("expected org_admin role in response body, got: %s", body)
+	}
+}
+
+func TestSingleUserMiddleware_NoAuthHeaderRequired(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(middleware.SingleUserMiddleware())
+	r.GET("/test", func(c *gin.Context) { c.Status(200) })
+
+	// No Authorization header, no cookies — must still succeed.
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/test", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Errorf("expected 200 with no auth headers, got %d", w.Code)
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(sub) == 0 ||
+		func() bool {
+			for i := 0; i <= len(s)-len(sub); i++ {
+				if s[i:i+len(sub)] == sub {
+					return true
+				}
+			}
+			return false
+		}())
+}
+
 func TestRequireOrg_WithOrg(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()

--- a/internal/middleware/single_user_integration_test.go
+++ b/internal/middleware/single_user_integration_test.go
@@ -1,0 +1,116 @@
+package middleware_test
+
+// single_user_integration_test.go validates that SingleUserMiddleware correctly
+// injects the local session and that authenticated endpoints work without any
+// auth headers when single-user mode is active.
+//
+// These tests do not require Docker or a real database — they use an in-process
+// Gin router with mock handlers to verify the middleware chain behaviour.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/ravencloak-org/Raven/internal/middleware"
+)
+
+// buildSingleUserRouter simulates what main.go does in single-user mode:
+// SingleUserMiddleware replaces SessionMiddleware+UserLookup.
+func buildSingleUserRouter() *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+
+	api := r.Group("/api/v1")
+	api.Use(middleware.SingleUserMiddleware())
+	{
+		api.GET("/me", func(c *gin.Context) {
+			c.JSON(http.StatusOK, gin.H{
+				"user_id": c.GetString(string(middleware.ContextKeyUserID)),
+				"org_id":  c.GetString(string(middleware.ContextKeyOrgID)),
+				"email":   c.GetString(string(middleware.ContextKeyEmail)),
+			})
+		})
+
+		api.POST("/chat", func(c *gin.Context) {
+			orgID := c.GetString(string(middleware.ContextKeyOrgID))
+			if orgID == "" {
+				c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "no org"})
+				return
+			}
+			c.JSON(http.StatusOK, gin.H{"ok": true})
+		})
+	}
+
+	return r
+}
+
+const (
+	wantLocalUserID = "00000000-0000-0000-0000-000000000002"
+	wantLocalOrgID  = "00000000-0000-0000-0000-000000000001"
+)
+
+// TestSingleUserMode_GetMe_Returns200WithoutAuthHeaders verifies that an
+// authenticated endpoint returns 200 and the local identity without any
+// Authorization header or session cookie.
+func TestSingleUserMode_GetMe_Returns200WithoutAuthHeaders(t *testing.T) {
+	r := buildSingleUserRouter()
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/me", nil)
+	// Deliberately no Authorization header, no Cookie.
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if body["user_id"] != wantLocalUserID {
+		t.Errorf("user_id = %q, want %q", body["user_id"], wantLocalUserID)
+	}
+	if body["org_id"] != wantLocalOrgID {
+		t.Errorf("org_id = %q, want %q", body["org_id"], wantLocalOrgID)
+	}
+	if body["email"] != "local@raven.localhost" {
+		t.Errorf("email = %q, want %q", body["email"], "local@raven.localhost")
+	}
+}
+
+// TestSingleUserMode_PostChat_Returns200WithoutAuthHeaders verifies that a
+// representative POST endpoint returns 200 in single-user mode with no headers.
+func TestSingleUserMode_PostChat_Returns200WithoutAuthHeaders(t *testing.T) {
+	r := buildSingleUserRouter()
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/chat", http.NoBody)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestSingleUserMode_ContextKeys_AllSet verifies that all expected context keys
+// are populated by SingleUserMiddleware so downstream middleware (RequireOrg,
+// RequireOrgRole, etc.) does not abort.
+func TestSingleUserMode_ContextKeys_AllSet(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(middleware.SingleUserMiddleware())
+	r.Use(middleware.RequireOrg())
+	r.GET("/guarded", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/guarded", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("RequireOrg blocked single-user request: got %d, want 200", w.Code)
+	}
+}

--- a/migrations/00038_add_local_singleuser_seed.sql
+++ b/migrations/00038_add_local_singleuser_seed.sql
@@ -1,0 +1,40 @@
+-- migrations/00038_add_local_singleuser_seed.sql
+-- +goose Up
+-- +goose StatementBegin
+
+-- Idempotent seed for single-user (Raven Local / desktop) mode.
+-- Safe to apply on multi-user deployments — only inserts if rows do not exist.
+-- The fixed UUIDs are reserved for the local persona and never created by the
+-- application in multi-user mode.
+
+INSERT INTO organizations (id, name, slug, status, settings, created_at, updated_at)
+VALUES (
+    '00000000-0000-0000-0000-000000000001',
+    'Local',
+    'local',
+    'active',
+    '{}',
+    NOW(),
+    NOW()
+)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO users (id, org_id, email, display_name, external_id, auth_provider, status, created_at, updated_at)
+VALUES (
+    '00000000-0000-0000-0000-000000000002',
+    '00000000-0000-0000-0000-000000000001',
+    'local@raven.localhost',
+    'Local User',
+    'local',
+    'single_user',
+    'active',
+    NOW(),
+    NOW()
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- Intentionally empty — removing the local user/org could break in-flight data
+-- and is unnecessary even when rolling back to multi-user mode.


### PR DESCRIPTION
## Summary

Adds `RAVEN_SINGLE_USER` env var. When true:

- `SessionMiddleware` is replaced by `SingleUserMiddleware` which injects a synthetic session for `user_id=00000000-0000-0000-0000-000000000002`, `org_id=00000000-0000-0000-0000-000000000001` — no SuperTokens calls, no auth headers required
- `/auth/*` routes and `/api/v1/auth/callback` are not registered
- SuperTokens SDK init is skipped entirely
- Migration `00038_add_local_singleuser_seed.sql` idempotently seeds the `local` user + org on first boot
- `GET /api/v1/config` (new, public) returns `{"single_user": bool}` for frontend consumption
- Frontend reads `/api/v1/config` on boot, skips SuperTokens init and login splash when `single_user=true`

Multi-user mode (`RAVEN_SINGLE_USER=false`, the default) is **unchanged** — all existing tests still pass.

Closes #419 — refs M11.

## Test plan

- [x] Unit: `TestSingleUserMiddleware_SetsLocalIdentity` — middleware sets correct UUIDs
- [x] Unit: `TestSingleUserMiddleware_NoAuthHeaderRequired` — 200 with zero auth headers
- [x] Integration: `TestSingleUserMode_GetMe_Returns200WithoutAuthHeaders` — full middleware chain
- [x] Integration: `TestSingleUserMode_PostChat_Returns200WithoutAuthHeaders`
- [x] Integration: `TestSingleUserMode_ContextKeys_AllSet` — `RequireOrg` passes in single-user mode
- [x] All existing middleware/internal tests pass (`go test ./internal/... -short`)
- [ ] Manual: `RAVEN_SINGLE_USER=true docker compose up` → dashboard loads without login page