### PR TITLE
docs(wiki): add Raven Local (M11) to roadmap + architecture page

### DIFF
--- a/docs/wiki/Raven-Local.md
+++ b/docs/wiki/Raven-Local.md
@@ -1,0 +1,78 @@
+# Raven Local (Desktop)
+
+A self-contained desktop edition of Raven for users who want everything to run locally — no cloud, no telemetry by default, no multi-tenancy. Built as a thin [Tauri](https://tauri.app/) shell over the existing Docker compose, with [Ollama](https://ollama.com/) bundled as a local LLM provider.
+
+> **Status:** Active development under [milestone M11](https://github.com/ravencloak-org/Raven/milestone/14). Track progress on the [project board](https://github.com/orgs/ravencloak-org/projects/2).
+
+## Why
+
+Raven's cloud SaaS is the primary product, but the architecture has always been edge-deployable (the same stack runs on a Raspberry Pi). Raven Local turns that into a one-click experience for:
+
+- Privacy-conscious users who don't want any data leaving their machine
+- Regulated industries with on-prem mandates
+- Hobbyists and developers who want to experiment locally before committing to cloud
+- A clean funnel from "try locally" → "self-hosted prod" → "managed SaaS"
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Tauri shell (Rust + native window)                         │
+│  ├─ Compose orchestrator (start / stop / health / logs)     │
+│  ├─ System-requirements precheck (RAM, CPU, disk)           │
+│  ├─ Tray / menubar status                                   │
+│  ├─ Auto-updater                                            │
+│  └─ Native window → http://127.0.0.1:<api-port>             │
+└────────────────────────┬────────────────────────────────────┘
+                         │  manages
+                         ▼
+┌─────────────────────────────────────────────────────────────┐
+│  Docker compose (existing services)                         │
+│  ├─ Go API (Gin) ── single-user mode = true                 │
+│  ├─ Python AI worker (gRPC)                                 │
+│  ├─ PostgreSQL 18 + pgvector                                │
+│  ├─ Valkey + Asynq                                          │
+│  ├─ Vue.js frontend                                         │
+│  └─ Ollama (sidecar — local LLM)                            │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Key design decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Tauri over Electron | ~10× smaller footprint, native performance, Rust security model |
+| Bundle existing compose, don't rewrite services | Same binary as the SaaS; lower maintenance burden |
+| Single-user mode = config flag | One env var (`RAVEN_SINGLE_USER=true`) bypasses auth + pins to default workspace |
+| Ollama as a BYOK provider | Reuses the existing AI worker provider abstraction |
+| Unsigned installers in M11; signing in M12 | Faster ship; signed-and-notarized binaries follow |
+
+## Hardware requirements
+
+| | Minimum | Recommended |
+|--|---------|-------------|
+| RAM | 8 GB | 16 GB+ |
+| Disk (free) | 20 GB | 50 GB |
+| CPU cores | 4 | 8+ |
+| GPU | optional | recommended for larger Ollama models |
+
+The system-requirements precheck ([#420](https://github.com/ravencloak-org/Raven/issues/420)) warns the user before launch if they're below minimum.
+
+## Upgrade path
+
+A user who outgrows Raven Local — needs multiple users, remote access, scaling — can graduate to:
+
+1. **Self-hosted Raven** — same compose, run it on a server, switch off `RAVEN_SINGLE_USER`, point users at the host's URL.
+2. **Raven Cloud (managed SaaS)** — export the workspace from Raven Local, import into the hosted offering.
+
+The data model is identical across all three; the differences are deployment topology and the auth flag.
+
+## Telemetry
+
+Raven Local ships with telemetry **off by default**. The optional opt-in (added in [#424](https://github.com/ravencloak-org/Raven/issues/424)) sends only anonymous usage counters (e.g., "Ollama model downloaded") via the existing OpenObserve pipeline pointed at our public endpoint. No content, no prompts, no PII.
+
+## See also
+
+- [Architecture-Overview](Architecture-Overview.md) — the underlying Raven architecture (cloud + self-hosted + local share this)
+- [Hardware-Requirements](Hardware-Requirements.md) — the broader Raven hardware story
+- [Roadmap](Roadmap.md) — milestone-level plan

--- a/docs/wiki/Roadmap.md
+++ b/docs/wiki/Roadmap.md
@@ -12,6 +12,7 @@
 | **Phase 5: Cloud Managed** | AWS Terraform, hosted offering, pricing, i18n, a11y | Future |
 | **Raven Pro: Enterprise Connectors** | Airbyte-powered data connectors, on-prem/hybrid deployment, data classification, ClickHouse + QBit vectors at scale | Future |
 | **Edge Optimization** | eBPF-based XDP pre-filtering, kernel-level observability, security audit trail | Future (post-Phase 2) |
+| **Raven Local (Desktop)** | Tauri-based one-click installer bundling the existing stack with Ollama as a local LLM provider. Single-user mode, no service rewrite. | M11 — active |
 
 ## Phase 1 -- MVP (Chatbot)
 
@@ -76,6 +77,31 @@ Low-level Linux kernel optimizations using eBPF. See `docs/research/ebpf-edge-op
 **1. XDP Pre-filtering (Rate Limiting Offload)** — Drop/throttle traffic at the NIC before TCP stack.
 **2. Kernel-level Observability (Zero-agent Metrics)** — CPU, memory, syscall metrics via kprobes/tracepoints.
 **3. Security Audit Trail (Process + Syscall Monitoring)** — Trace sys_execve and socket calls for GDPR/SOC2.
+
+## Raven Local (Desktop) — M11
+
+A privacy-first desktop edition of Raven for users who want everything to run locally.
+
+**Approach:** Tauri shell wrapping the existing Docker compose. Ollama is bundled as a sidecar so users can pick a local LLM (or supply BYOK keys for cloud providers). No rewrite of the Go API, AI worker, or frontend — single-user mode is a config flag.
+
+**Phase 0 (foundation):**
+- [#417](https://github.com/ravencloak-org/Raven/issues/417) Tauri shell skeleton
+- [#418](https://github.com/ravencloak-org/Raven/issues/418) Compose orchestrator (lifecycle from Tauri)
+- [#419](https://github.com/ravencloak-org/Raven/issues/419) Single-user mode flag
+- [#420](https://github.com/ravencloak-org/Raven/issues/420) System-requirements precheck
+
+**Phase 1 (MVP):**
+- [#421](https://github.com/ravencloak-org/Raven/issues/421) Ollama bundled service + BYOK provider
+- [#422](https://github.com/ravencloak-org/Raven/issues/422) First-run wizard
+- [#423](https://github.com/ravencloak-org/Raven/issues/423) Installer packaging (.dmg / .msi / .AppImage)
+
+**Phase 2 (polish):**
+- [#424](https://github.com/ravencloak-org/Raven/issues/424) Settings panel
+- [#425](https://github.com/ravencloak-org/Raven/issues/425) Tray/menubar status app
+- [#426](https://github.com/ravencloak-org/Raven/issues/426) Auto-update channel
+- [#427](https://github.com/ravencloak-org/Raven/issues/427) CI: cross-platform build + artefact upload
+
+See [Raven-Local](Raven-Local.md) for the architecture overview and the [M11 project board](https://github.com/orgs/ravencloak-org/projects/2) for live status.
 
 ## Milestones
 


### PR DESCRIPTION
## Summary

Documents the new M11 milestone (Raven Local — Tauri desktop edition) on the wiki and roadmap.

- \`docs/wiki/Roadmap.md\` — adds a row to the Phase Overview table and a "Raven Local (Desktop) — M11" section linking to issues #417-#427 and the [project board](https://github.com/orgs/ravencloak-org/projects/2)
- \`docs/wiki/Raven-Local.md\` — new page covering architecture (Tauri + compose + Ollama), key design decisions, hardware requirements, upgrade path, and telemetry posture

Refs M11.

## Test plan

- [x] Markdown renders cleanly
- [ ] Wiki sync workflow picks up the new page on merge