### PR TITLE
feat(landing): monochrome+red rebrand, prominent hero logo, fix tab assets and self-host curl URL

### DIFF
--- a/landing/src/app/opengraph-image.tsx
+++ b/landing/src/app/opengraph-image.tsx
@@ -35,7 +35,7 @@ export default async function OG() {
           style={{
             marginTop: 40,
             fontSize: 36,
-            color: '#06b6d4',
+            color: 'rgba(255,255,255,0.7)',
             maxWidth: 980,
             textAlign: 'center',
             fontFamily: 'sans-serif',

--- a/landing/src/components/Hero.tsx
+++ b/landing/src/components/Hero.tsx
@@ -1,16 +1,22 @@
 import { Button } from '@/components/Button'
 import { Container } from '@/components/Container'
+import { Logo } from '@/components/Logo'
 
 const REPO_URL = 'https://github.com/ravencloak-org/Raven'
 
 export function Hero() {
   return (
-    <Container className="pt-20 pb-16 text-center lg:pt-32">
-      <h1 className="mx-auto max-w-4xl font-display text-5xl font-medium tracking-tight text-[var(--color-ink)] sm:text-7xl">
-        Your team&apos;s knowledge,{' '}
-        <span className="relative whitespace-nowrap text-[var(--color-accent)]">
-          <span className="relative">on your infrastructure.</span>
-        </span>
+    <Container className="pt-16 pb-16 text-center lg:pt-24">
+      <Logo
+        variant="mark"
+        markClassName="mx-auto h-32 w-auto md:h-40"
+        className="block"
+      />
+      <p className="raven-wordmark mt-6 text-6xl leading-none tracking-[0.18em] text-[var(--color-ink)] md:text-7xl">
+        RAVEN
+      </p>
+      <h1 className="mx-auto mt-12 max-w-4xl font-display text-4xl font-medium tracking-tight text-[var(--color-ink)] sm:text-6xl">
+        Your team&apos;s knowledge, on your infrastructure.
       </h1>
       <p className="mx-auto mt-6 max-w-2xl text-lg tracking-tight text-[var(--color-body)]">
         A self-hostable, multi-tenant RAG platform with built-in voice, chat, and

--- a/landing/src/components/QuickStart.tsx
+++ b/landing/src/components/QuickStart.tsx
@@ -1,7 +1,8 @@
 import { Container } from '@/components/Container'
 
-const compose = `# 1. Grab the production Compose file
-curl -fsSL https://raven.ravencloak.org/compose.yml -o docker-compose.yml
+const compose = `# 1. Grab the production Compose file (canonical, pinned to main)
+curl -fsSL https://raw.githubusercontent.com/ravencloak-org/Raven/main/docker-compose.yml \\
+  -o docker-compose.yml
 
 # 2. Generate secrets and start
 docker compose up -d

--- a/landing/src/images/screenshots/chat.svg
+++ b/landing/src/images/screenshots/chat.svg
@@ -1,5 +1,31 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 720" fill="none">
-  <rect width="1280" height="720" rx="16" fill="#171717"/>
-  <rect x="440" y="310" width="400" height="40" rx="8" fill="#262626"/>
-  <text x="640" y="338" font-family="system-ui" font-size="16" fill="#737373" text-anchor="middle">AI Chat Interface</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 720" fill="none" role="img" aria-label="Chat surface mockup">
+  <rect width="1280" height="720" rx="16" fill="#0a0a0a"/>
+  <rect x="40" y="40" width="240" height="22" rx="11" fill="#262626"/>
+  <text x="48" y="56" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" fill="#a3a3a3" letter-spacing="0.08em">CHAT  ·  #ENGINEERING</text>
+  <rect x="640" y="100" width="560" height="80" rx="16" fill="#dc2626"/>
+  <rect x="660" y="124" width="380" height="10" rx="5" fill="#fff" opacity="0.85"/>
+  <rect x="660" y="146" width="280" height="10" rx="5" fill="#fff" opacity="0.7"/>
+  <text x="1180" y="194" text-anchor="end" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12" fill="#737373">jobin · 09:41</text>
+  <rect x="80" y="220" width="720" height="220" rx="16" fill="#171717" stroke="#262626" stroke-width="1"/>
+  <rect x="100" y="244" width="600" height="10" rx="5" fill="#e5e5e5"/>
+  <rect x="100" y="266" width="540" height="10" rx="5" fill="#e5e5e5"/>
+  <rect x="100" y="288" width="660" height="10" rx="5" fill="#e5e5e5"/>
+  <rect x="100" y="310" width="420" height="10" rx="5" fill="#a3a3a3"/>
+  <rect x="100" y="350" width="160" height="28" rx="14" fill="#262626"/>
+  <circle cx="118" cy="364" r="6" fill="#dc2626"/>
+  <text x="132" y="368" font-family="ui-monospace, monospace" font-size="12" fill="#fafafa">runbook.md</text>
+  <rect x="276" y="350" width="220" height="28" rx="14" fill="#262626"/>
+  <circle cx="294" cy="364" r="6" fill="#dc2626"/>
+  <text x="308" y="368" font-family="ui-monospace, monospace" font-size="12" fill="#fafafa">migrations/0019.sql</text>
+  <rect x="512" y="350" width="160" height="28" rx="14" fill="#262626"/>
+  <circle cx="530" cy="364" r="6" fill="#dc2626"/>
+  <text x="544" y="368" font-family="ui-monospace, monospace" font-size="12" fill="#fafafa">PR #318</text>
+  <text x="100" y="416" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12" fill="#737373">raven · 09:41 · 3 sources cited</text>
+  <rect x="780" y="480" width="420" height="60" rx="16" fill="#dc2626"/>
+  <rect x="800" y="504" width="240" height="10" rx="5" fill="#fff" opacity="0.85"/>
+  <rect x="800" y="522" width="160" height="8" rx="4" fill="#fff" opacity="0.6"/>
+  <rect x="80" y="620" width="1120" height="56" rx="28" fill="#171717" stroke="#262626" stroke-width="1"/>
+  <text x="120" y="654" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#737373">Reply to thread…</text>
+  <circle cx="1140" cy="648" r="20" fill="#dc2626"/>
+  <path d="M1132 648 L1148 648 M1142 642 L1148 648 L1142 654" stroke="#fff" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/landing/src/images/screenshots/voice.svg
+++ b/landing/src/images/screenshots/voice.svg
@@ -1,5 +1,63 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 720" fill="none">
-  <rect width="1280" height="720" rx="16" fill="#171717"/>
-  <rect x="440" y="310" width="400" height="40" rx="8" fill="#262626"/>
-  <text x="640" y="338" font-family="system-ui" font-size="16" fill="#737373" text-anchor="middle">Voice Agent UI</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 720" fill="none" role="img" aria-label="Voice surface mockup">
+  <rect width="1280" height="720" rx="16" fill="#0a0a0a"/>
+  <rect x="40" y="40" width="200" height="22" rx="11" fill="#262626"/>
+  <text x="48" y="56" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" fill="#a3a3a3" letter-spacing="0.08em">VOICE  ·  LIVE</text>
+  <circle cx="220" cy="51" r="5" fill="#dc2626"/>
+  <circle cx="640" cy="320" r="120" fill="#171717" stroke="#262626" stroke-width="2"/>
+  <circle cx="640" cy="320" r="80" fill="#dc2626"/>
+  <rect x="615" y="280" width="50" height="80" rx="25" fill="#fafafa"/>
+  <path d="M580 360 a60 60 0 0 0 120 0" stroke="#fafafa" stroke-width="6" fill="none"/>
+  <line x1="640" y1="420" x2="640" y2="450" stroke="#fafafa" stroke-width="6"/>
+  <g fill="#fafafa">
+    <rect x="160" y="540" width="6" height="40" rx="3"/>
+    <rect x="180" y="520" width="6" height="80" rx="3"/>
+    <rect x="200" y="490" width="6" height="140" rx="3"/>
+    <rect x="220" y="510" width="6" height="100" rx="3"/>
+    <rect x="240" y="480" width="6" height="160" rx="3"/>
+    <rect x="260" y="450" width="6" height="220" rx="3"/>
+    <rect x="280" y="470" width="6" height="180" rx="3"/>
+    <rect x="300" y="500" width="6" height="120" rx="3"/>
+    <rect x="320" y="520" width="6" height="80" rx="3"/>
+    <rect x="340" y="490" width="6" height="140" rx="3"/>
+    <rect x="360" y="460" width="6" height="200" rx="3"/>
+    <rect x="380" y="430" width="6" height="260" rx="3"/>
+    <rect x="400" y="400" width="6" height="320" rx="3" fill="#dc2626"/>
+    <rect x="420" y="380" width="6" height="360" rx="3" fill="#dc2626"/>
+    <rect x="440" y="370" width="6" height="380" rx="3" fill="#dc2626"/>
+    <rect x="460" y="380" width="6" height="360" rx="3" fill="#dc2626"/>
+    <rect x="480" y="400" width="6" height="320" rx="3" fill="#dc2626"/>
+    <rect x="500" y="430" width="6" height="260" rx="3"/>
+    <rect x="520" y="460" width="6" height="200" rx="3"/>
+    <rect x="540" y="490" width="6" height="140" rx="3"/>
+    <rect x="560" y="520" width="6" height="80" rx="3"/>
+    <rect x="580" y="540" width="6" height="40" rx="3"/>
+    <rect x="600" y="550" width="6" height="20" rx="3"/>
+    <rect x="620" y="540" width="6" height="40" rx="3"/>
+    <rect x="640" y="520" width="6" height="80" rx="3"/>
+    <rect x="660" y="540" width="6" height="40" rx="3"/>
+    <rect x="680" y="550" width="6" height="20" rx="3"/>
+    <rect x="700" y="540" width="6" height="40" rx="3"/>
+    <rect x="720" y="520" width="6" height="80" rx="3"/>
+    <rect x="740" y="490" width="6" height="140" rx="3"/>
+    <rect x="760" y="460" width="6" height="200" rx="3"/>
+    <rect x="780" y="430" width="6" height="260" rx="3"/>
+    <rect x="800" y="400" width="6" height="320" rx="3" fill="#dc2626"/>
+    <rect x="820" y="380" width="6" height="360" rx="3" fill="#dc2626"/>
+    <rect x="840" y="370" width="6" height="380" rx="3" fill="#dc2626"/>
+    <rect x="860" y="380" width="6" height="360" rx="3" fill="#dc2626"/>
+    <rect x="880" y="400" width="6" height="320" rx="3" fill="#dc2626"/>
+    <rect x="900" y="430" width="6" height="260" rx="3"/>
+    <rect x="920" y="460" width="6" height="200" rx="3"/>
+    <rect x="940" y="490" width="6" height="140" rx="3"/>
+    <rect x="960" y="500" width="6" height="120" rx="3"/>
+    <rect x="980" y="470" width="6" height="180" rx="3"/>
+    <rect x="1000" y="450" width="6" height="220" rx="3"/>
+    <rect x="1020" y="480" width="6" height="160" rx="3"/>
+    <rect x="1040" y="510" width="6" height="100" rx="3"/>
+    <rect x="1060" y="490" width="6" height="140" rx="3"/>
+    <rect x="1080" y="520" width="6" height="80" rx="3"/>
+    <rect x="1100" y="540" width="6" height="40" rx="3"/>
+  </g>
+  <rect x="280" y="660" width="720" height="32" rx="16" fill="#171717"/>
+  <text x="640" y="680" text-anchor="middle" font-family="ui-monospace, monospace" font-size="14" fill="#a3a3a3">"who owns the migration runbook?"</text>
 </svg>

--- a/landing/src/images/screenshots/whatsapp.svg
+++ b/landing/src/images/screenshots/whatsapp.svg
@@ -1,5 +1,51 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 720" fill="none">
-  <rect width="1280" height="720" rx="16" fill="#171717"/>
-  <rect x="440" y="310" width="400" height="40" rx="8" fill="#262626"/>
-  <text x="640" y="338" font-family="system-ui" font-size="16" fill="#737373" text-anchor="middle">WhatsApp Conversation</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 720" fill="none" role="img" aria-label="Channels surface mockup">
+  <rect width="1280" height="720" rx="16" fill="#0a0a0a"/>
+  <rect x="40" y="40" width="240" height="22" rx="11" fill="#262626"/>
+  <text x="48" y="56" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" fill="#a3a3a3" letter-spacing="0.08em">CHANNELS  ·  4 ACTIVE</text>
+
+  <!-- WhatsApp tile (top-left) -->
+  <rect x="80" y="120" width="540" height="240" rx="20" fill="#171717" stroke="#262626" stroke-width="1"/>
+  <circle cx="160" cy="200" r="40" fill="#fafafa"/>
+  <text x="160" y="213" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="36" font-weight="700" fill="#0a0a0a">W</text>
+  <text x="220" y="190" font-family="ui-sans-serif, system-ui, sans-serif" font-size="22" font-weight="600" fill="#fafafa">WhatsApp</text>
+  <text x="220" y="220" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#a3a3a3">+91 98XXX XX842</text>
+  <rect x="100" y="280" width="500" height="10" rx="5" fill="#262626"/>
+  <rect x="100" y="300" width="380" height="10" rx="5" fill="#262626"/>
+  <rect x="100" y="320" width="260" height="10" rx="5" fill="#262626"/>
+  <circle cx="580" cy="160" r="6" fill="#dc2626"/>
+  <text x="592" y="164" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12" fill="#dc2626">live</text>
+
+  <!-- Slack tile (top-right) -->
+  <rect x="660" y="120" width="540" height="240" rx="20" fill="#171717" stroke="#262626" stroke-width="1"/>
+  <g transform="translate(720,160)">
+    <rect x="0" y="20" width="40" height="20" rx="10" fill="#fafafa"/>
+    <rect x="20" y="0" width="20" height="40" rx="10" fill="#fafafa"/>
+    <rect x="40" y="20" width="40" height="20" rx="10" fill="#a3a3a3"/>
+    <rect x="40" y="0" width="20" height="40" rx="10" fill="#a3a3a3"/>
+  </g>
+  <text x="800" y="190" font-family="ui-sans-serif, system-ui, sans-serif" font-size="22" font-weight="600" fill="#fafafa">Slack</text>
+  <text x="800" y="220" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#a3a3a3">ravencloak.slack.com · 12 channels</text>
+  <rect x="680" y="280" width="500" height="10" rx="5" fill="#262626"/>
+  <rect x="680" y="300" width="420" height="10" rx="5" fill="#262626"/>
+  <rect x="680" y="320" width="200" height="10" rx="5" fill="#262626"/>
+
+  <!-- Email tile (bottom-left) -->
+  <rect x="80" y="400" width="540" height="240" rx="20" fill="#171717" stroke="#262626" stroke-width="1"/>
+  <rect x="120" y="450" width="80" height="56" rx="6" fill="#fafafa"/>
+  <path d="M120 450 L160 484 L200 450" stroke="#0a0a0a" stroke-width="3" fill="none"/>
+  <text x="220" y="470" font-family="ui-sans-serif, system-ui, sans-serif" font-size="22" font-weight="600" fill="#fafafa">Email</text>
+  <text x="220" y="498" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#a3a3a3">support@ravencloak.org</text>
+  <rect x="100" y="560" width="500" height="10" rx="5" fill="#262626"/>
+  <rect x="100" y="580" width="380" height="10" rx="5" fill="#262626"/>
+  <rect x="100" y="600" width="240" height="10" rx="5" fill="#262626"/>
+
+  <!-- Web tile (bottom-right) -->
+  <rect x="660" y="400" width="540" height="240" rx="20" fill="#171717" stroke="#262626" stroke-width="1"/>
+  <circle cx="720" cy="478" r="36" fill="#fafafa"/>
+  <path d="M684 478 L756 478 M720 442 Q700 478 720 514 M720 442 Q740 478 720 514" stroke="#0a0a0a" stroke-width="2.5" fill="none"/>
+  <text x="780" y="470" font-family="ui-sans-serif, system-ui, sans-serif" font-size="22" font-weight="600" fill="#fafafa">Web</text>
+  <text x="780" y="498" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" fill="#a3a3a3">42 sites · sitemap-driven crawl</text>
+  <rect x="680" y="560" width="500" height="10" rx="5" fill="#262626"/>
+  <rect x="680" y="580" width="320" height="10" rx="5" fill="#262626"/>
+  <rect x="680" y="600" width="280" height="10" rx="5" fill="#262626"/>
 </svg>

--- a/landing/src/styles/tailwind.css
+++ b/landing/src/styles/tailwind.css
@@ -11,8 +11,8 @@
   --color-body: oklch(0.42 0 0);          /* slate-600 */
   --color-bg: oklch(0.98 0.005 75);       /* warm off-white */
   --color-surface: oklch(1 0 0);          /* white */
-  --color-accent: oklch(0.71 0.16 200);   /* cyan-500 */
-  --color-accent-hover: oklch(0.65 0.18 200); /* cyan-600 */
+  --color-accent: oklch(0.578 0.214 27);     /* red-600 (#dc2626) */
+  --color-accent-hover: oklch(0.505 0.213 27); /* red-700 (#b91c1c) */
   --color-border: oklch(0.91 0.005 75);
 
   --font-sans: var(--font-inter), ui-sans-serif, system-ui, sans-serif;


### PR DESCRIPTION
## Summary

Four targeted fixes after the initial Salient rebuild:

**1. Brand: drop cyan, go monochrome with red**
`--color-accent` switches from electric cyan (`oklch 0.71 0.16 200`) to red-600 (`oklch 0.578 0.214 27` / `#dc2626`); hover to red-700. Site is now monochrome (ink + warm off-white) with red as the only accent.

**2. Hero: promote the logo**
The bird mark is now the centrepiece (h-32 / md:h-40, centred), with the **RAVEN** wordmark stacked below in the `ravenicons` font (`text-6xl` / `md:text-7xl`, wide tracking). Headline + pitch + CTAs follow. Drops the previous "on your infrastructure" coloured-span treatment — the logo does the visual work.

**3. SecondaryFeatures tabs: real distinct mocks**
The three SVGs we shipped (Voice/Chat/Channels) were near-identical 340-byte placeholder dark rectangles, so the tab toggle looked broken. Replaced with three visibly distinct mocks:
- `voice.svg` — mic + audio waveform with red-accent peaks
- `chat.svg` — alternating user/assistant bubbles with citation chips
- `whatsapp.svg` — 4-tile channel-source grid (WhatsApp / Slack / Email / Web)

**4. Fix `/compose.yml` 404 in QuickStart**
`QuickStart.tsx` instructed `curl https://raven.ravencloak.org/compose.yml` but no such file ships under `landing/public/`. Point at the canonical GitHub Raw `docker-compose.yml` on `main` — always tracks the actual production Compose, no manual sync.

**OpenGraph image**: tagline colour cyan → `rgba(255,255,255,0.7)` to keep the OG card monochrome.

## Already deployed

Pushed to the `raven-landing` Cloudflare Pages project via `wrangler pages deploy`:
- Production alias: https://raven-landing.pages.dev/
- Preview hash: https://62022760.raven-landing.pages.dev/

`raven.ravencloak.org` still doesn't show this build — the custom-domain CNAME hasn't been pointed at `raven-landing.pages.dev` yet (open follow-up; needs CF dashboard edit or a `Zone:DNS:Edit` token).

## Test plan
- [ ] CI green (lint, typecheck, build, smoke)
- [ ] Click through `https://raven-landing.pages.dev/` — confirm: prominent logo + RAVEN wordmark, no cyan anywhere (red CTAs/buttons/highlights), Voice/Chat/Channels tabs visibly switch
- [ ] On `/self-host/`, copy the QuickStart curl line and verify it resolves to the actual `docker-compose.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated accent color scheme from cyan to red throughout the interface
  * Refined Hero section typography and layout spacing
  * Adjusted OpenGraph image subtitle text color for improved contrast

* **New Features**
  * Added visual logo element to Hero section

* **Updates**
  * Docker Compose configuration now references the production repository

<!-- end of auto-generated comment: release notes by coderabbit.ai -->