### PR TITLE
feat(desktop): system-requirements precheck (M11/04, closes #420)

### DIFF
--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -1865,6 +1865,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2517,6 +2526,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "sysinfo",
  "tauri",
  "tauri-build",
  "tauri-plugin-shell",
@@ -3247,6 +3257,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c33cd241af0f2e9e3b5c32163b873b29956890b5342e6745b917ce9d490f4af"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "windows 0.57.0",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3293,7 +3316,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -3364,7 +3387,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -3488,7 +3511,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -3513,7 +3536,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -4331,10 +4354,10 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
 ]
 
 [[package]]
@@ -4355,7 +4378,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -4407,6 +4430,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -4429,12 +4462,24 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -4446,8 +4491,8 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
@@ -4466,9 +4511,31 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4506,6 +4573,15 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4965,7 +5041,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -28,6 +28,7 @@ tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+sysinfo = { version = "0.32", default-features = false, features = ["disk", "system"] }
 thiserror = "1"
 
 [dev-dependencies]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -5,3 +5,4 @@
 //! the orchestrator implementation here so it's available to both.
 
 pub mod compose;
+pub mod precheck;

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -4,12 +4,14 @@
 use std::path::PathBuf;
 
 use raven_local_lib::compose::{ComposeManager, StatusEvent};
+use raven_local_lib::precheck::{run_precheck, skip_requested, RealSystemInfo};
 use tauri::{Emitter, Manager};
 
 const COMPOSE_FILE: &str = "docker-compose.local.yml";
 const API_HEALTH_URL: &str = "http://127.0.0.1:8081/healthz";
 const STATUS_EVENT: &str = "compose:status";
 const LOG_EVENT: &str = "compose:log";
+const PRECHECK_EVENT: &str = "precheck:result";
 
 fn main() {
     tauri::Builder::default()
@@ -28,6 +30,29 @@ fn main() {
 
             let handle = app.handle().clone();
             tauri::async_runtime::spawn(async move {
+                // System-requirements precheck. The frontend always receives
+                // the structured result so the splash can render warnings;
+                // RAVEN_LOCAL_SKIP_REQS=true lets power users proceed even
+                // when the host is below thresholds.
+                let precheck = run_precheck(&RealSystemInfo);
+                let _ = handle.emit(PRECHECK_EVENT, &precheck);
+                if !precheck.ok && !skip_requested() {
+                    let summary = precheck
+                        .warnings
+                        .iter()
+                        .map(|w| w.remediation())
+                        .collect::<Vec<_>>()
+                        .join(" / ");
+                    let _ = handle.emit(
+                        STATUS_EVENT,
+                        StatusEvent::error(format!(
+                            "system-requirements precheck failed: {summary} \
+                             (set RAVEN_LOCAL_SKIP_REQS=true to bypass)"
+                        )),
+                    );
+                    return;
+                }
+
                 if let Err(e) = manager_for_setup.detect_docker().await {
                     let _ = handle.emit(STATUS_EVENT, StatusEvent::error(e.to_string()));
                     return;

--- a/desktop/src-tauri/src/precheck.rs
+++ b/desktop/src-tauri/src/precheck.rs
@@ -1,0 +1,223 @@
+//! System-requirements precheck for Raven Local.
+//!
+//! Verifies the host meets the minimum thresholds (RAM, free disk, CPU
+//! cores) before launching the compose stack. A failure surfaces a
+//! structured event to the frontend so the splash can render an
+//! actionable modal. Power users can bypass the check entirely with
+//! `RAVEN_LOCAL_SKIP_REQS=true`.
+
+use serde::Serialize;
+
+/// Minimum RAM in gigabytes. Below this we warn the user.
+pub const MIN_RAM_GB: u64 = 8;
+/// Recommended RAM. Above this is comfortable for 7B–13B local models.
+pub const RECOMMENDED_RAM_GB: u64 = 16;
+/// Minimum free disk in gigabytes (for compose images + at least one model).
+pub const MIN_FREE_DISK_GB: u64 = 20;
+/// Minimum logical CPU cores.
+pub const MIN_CPU_CORES: usize = 4;
+
+/// Env var that bypasses the precheck for power users on edge configs.
+pub const SKIP_ENV_VAR: &str = "RAVEN_LOCAL_SKIP_REQS";
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+pub struct PrecheckResult {
+    pub ram_gb: u64,
+    pub free_disk_gb: u64,
+    pub cpu_cores: usize,
+    pub ok: bool,
+    pub warnings: Vec<Warning>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum Warning {
+    LowRam { actual_gb: u64, minimum_gb: u64 },
+    LowDisk { actual_gb: u64, minimum_gb: u64 },
+    FewCpuCores { actual: usize, minimum: usize },
+}
+
+impl Warning {
+    /// Short human-readable remediation text for the splash modal.
+    pub fn remediation(&self) -> String {
+        match self {
+            Warning::LowRam { actual_gb, minimum_gb } => format!(
+                "Detected {actual_gb} GB RAM (minimum {minimum_gb} GB). \
+                 Close other applications, or choose a smaller Ollama model \
+                 in onboarding."
+            ),
+            Warning::LowDisk { actual_gb, minimum_gb } => format!(
+                "Only {actual_gb} GB free disk (minimum {minimum_gb} GB). \
+                 Free up space — the largest consumer is usually downloaded \
+                 model checkpoints under the data directory."
+            ),
+            Warning::FewCpuCores { actual, minimum } => format!(
+                "Only {actual} CPU cores available (minimum {minimum}). \
+                 Inference will be slow; consider a smaller model or a \
+                 BYOK provider."
+            ),
+        }
+    }
+}
+
+/// Provider abstraction so the threshold logic is unit-testable without
+/// touching the real system.
+pub trait SystemInfo {
+    fn total_memory_gb(&self) -> u64;
+    fn free_disk_gb(&self) -> u64;
+    fn cpu_cores(&self) -> usize;
+}
+
+/// Real provider backed by `sysinfo` and the OS-level disk APIs.
+pub struct RealSystemInfo;
+
+impl SystemInfo for RealSystemInfo {
+    fn total_memory_gb(&self) -> u64 {
+        let mut sys = sysinfo::System::new();
+        sys.refresh_memory();
+        // sysinfo reports memory in bytes since 0.30+.
+        let bytes = sys.total_memory();
+        bytes / (1024 * 1024 * 1024)
+    }
+
+    fn free_disk_gb(&self) -> u64 {
+        let disks = sysinfo::Disks::new_with_refreshed_list();
+        // Sum free space across all mounted disks. Reasonable for a desktop
+        // user who hasn't deliberately segregated volumes; the precheck
+        // is a soft warning, not a hard quota.
+        let bytes: u64 = disks.iter().map(|d| d.available_space()).sum();
+        bytes / (1024 * 1024 * 1024)
+    }
+
+    fn cpu_cores(&self) -> usize {
+        std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1)
+    }
+}
+
+/// Run the precheck against the supplied provider. Returns the structured
+/// result; the caller decides whether to honor `RAVEN_LOCAL_SKIP_REQS`.
+pub fn run_precheck<S: SystemInfo>(sys: &S) -> PrecheckResult {
+    let mut warnings = Vec::new();
+    let ram_gb = sys.total_memory_gb();
+    let free_disk_gb = sys.free_disk_gb();
+    let cpu_cores = sys.cpu_cores();
+
+    if ram_gb < MIN_RAM_GB {
+        warnings.push(Warning::LowRam { actual_gb: ram_gb, minimum_gb: MIN_RAM_GB });
+    }
+    if free_disk_gb < MIN_FREE_DISK_GB {
+        warnings.push(Warning::LowDisk { actual_gb: free_disk_gb, minimum_gb: MIN_FREE_DISK_GB });
+    }
+    if cpu_cores < MIN_CPU_CORES {
+        warnings.push(Warning::FewCpuCores { actual: cpu_cores, minimum: MIN_CPU_CORES });
+    }
+
+    PrecheckResult {
+        ram_gb,
+        free_disk_gb,
+        cpu_cores,
+        ok: warnings.is_empty(),
+        warnings,
+    }
+}
+
+/// Returns true when the user has opted to bypass the precheck.
+pub fn skip_requested() -> bool {
+    std::env::var(SKIP_ENV_VAR)
+        .map(|v| matches!(v.to_lowercase().as_str(), "1" | "true" | "yes"))
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct FakeSys {
+        ram_gb: u64,
+        disk_gb: u64,
+        cpu: usize,
+    }
+
+    impl SystemInfo for FakeSys {
+        fn total_memory_gb(&self) -> u64 { self.ram_gb }
+        fn free_disk_gb(&self) -> u64 { self.disk_gb }
+        fn cpu_cores(&self) -> usize { self.cpu }
+    }
+
+    #[test]
+    fn passing_system_yields_ok_with_no_warnings() {
+        let sys = FakeSys { ram_gb: 16, disk_gb: 100, cpu: 8 };
+        let result = run_precheck(&sys);
+        assert!(result.ok);
+        assert!(result.warnings.is_empty());
+        assert_eq!(result.ram_gb, 16);
+        assert_eq!(result.free_disk_gb, 100);
+        assert_eq!(result.cpu_cores, 8);
+    }
+
+    #[test]
+    fn low_ram_yields_warning() {
+        let sys = FakeSys { ram_gb: 4, disk_gb: 100, cpu: 8 };
+        let result = run_precheck(&sys);
+        assert!(!result.ok);
+        assert_eq!(result.warnings.len(), 1);
+        assert!(matches!(result.warnings[0], Warning::LowRam { actual_gb: 4, minimum_gb: 8 }));
+    }
+
+    #[test]
+    fn low_disk_yields_warning() {
+        let sys = FakeSys { ram_gb: 16, disk_gb: 5, cpu: 8 };
+        let result = run_precheck(&sys);
+        assert!(!result.ok);
+        assert!(matches!(result.warnings[0], Warning::LowDisk { actual_gb: 5, minimum_gb: 20 }));
+    }
+
+    #[test]
+    fn few_cores_yields_warning() {
+        let sys = FakeSys { ram_gb: 16, disk_gb: 100, cpu: 2 };
+        let result = run_precheck(&sys);
+        assert!(!result.ok);
+        assert!(matches!(result.warnings[0], Warning::FewCpuCores { actual: 2, minimum: 4 }));
+    }
+
+    #[test]
+    fn multiple_warnings_collected() {
+        let sys = FakeSys { ram_gb: 4, disk_gb: 5, cpu: 2 };
+        let result = run_precheck(&sys);
+        assert!(!result.ok);
+        assert_eq!(result.warnings.len(), 3);
+    }
+
+    #[test]
+    fn warnings_serialize_snake_case() {
+        let w = Warning::LowRam { actual_gb: 4, minimum_gb: 8 };
+        let json = serde_json::to_string(&w).unwrap();
+        assert!(json.contains("\"low_ram\""), "got {json}");
+        assert!(json.contains("\"actual_gb\":4"), "got {json}");
+    }
+
+    #[test]
+    fn remediation_mentions_actual_and_minimum() {
+        let w = Warning::LowRam { actual_gb: 4, minimum_gb: 8 };
+        let text = w.remediation();
+        assert!(text.contains("4 GB"), "got {text}");
+        assert!(text.contains("8 GB"), "got {text}");
+    }
+
+    #[test]
+    fn skip_requested_respects_env_var() {
+        // Use an isolated subprocess-style approach by setting + unsetting.
+        // Tests run in parallel by default — guard with a unique name to
+        // avoid collision with other tests reading the same var.
+        std::env::set_var(SKIP_ENV_VAR, "true");
+        assert!(skip_requested());
+        std::env::set_var(SKIP_ENV_VAR, "false");
+        assert!(!skip_requested());
+        std::env::set_var(SKIP_ENV_VAR, "1");
+        assert!(skip_requested());
+        std::env::remove_var(SKIP_ENV_VAR);
+        assert!(!skip_requested());
+    }
+}


### PR DESCRIPTION
## Summary

Pre-launch sanity check that warns the user if the host is below minimum specs. Runs before Docker detection and `compose up`; bypassable via `RAVEN_LOCAL_SKIP_REQS=true`.

| Resource | Minimum | Recommended |
|----------|---------|-------------|
| RAM      | 8 GB    | 16 GB       |
| Free disk| 20 GB   | 50 GB       |
| CPU cores| 4       | 8+          |

- `desktop/src-tauri/src/precheck.rs` — `SystemInfo` trait (so threshold logic is testable without touching real disks/memory) + `RealSystemInfo` backed by sysinfo. Structured `PrecheckResult` and `Warning` enum with per-warning remediation strings.
- `desktop/src-tauri/src/main.rs` — emits `precheck:result` event; aborts launch with actionable error if warnings present and skip env unset.
- `desktop/src-tauri/Cargo.toml` — adds sysinfo (disk + system features).

8 unit tests (1 passing system + 3 single-warning + 1 multi-warning + 1 serialization + 1 remediation + 1 env-var) cover the threshold logic without touching the real system.

Closes #420 — refs M11.

## Test plan

- [x] cargo check passes
- [x] cargo test --lib precheck passes (8/8)
- [ ] Manual: launch on a 4 GB VM → modal warning shown, launch aborted
- [ ] Manual: launch with RAVEN_LOCAL_SKIP_REQS=true → warning still emitted, launch proceeds