### PR TITLE
feat: Ollama bundled service + BYOK provider (M11/05, closes #421)

### DIFF
--- a/ai-worker/pyproject.toml
+++ b/ai-worker/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
     "pytest>=9.0.3",
     "pytest-asyncio>=0.25.0",
     "pytest-cov>=6.0.0",
+    "respx>=0.21.1",
     "ruff>=0.9.0",
 ]
 

--- a/ai-worker/raven_worker/providers/ollama_provider.py
+++ b/ai-worker/raven_worker/providers/ollama_provider.py
@@ -1,0 +1,95 @@
+"""Ollama embedding provider for Raven Local.
+
+Talks to a local Ollama daemon's ``/api/embeddings`` endpoint. Used in
+single-user (desktop) mode where embeddings stay on the host.
+
+Implements the :class:`~raven_worker.providers.base.EmbeddingProvider` protocol.
+"""
+
+from __future__ import annotations
+
+import httpx
+import structlog
+
+from raven_worker.providers.base import EmbeddingProvider
+
+logger = structlog.get_logger(__name__)
+
+# Default model and dimensions for nomic-embed-text — the bundled local
+# embedding model spec'd for Raven Local.
+_DEFAULT_MODEL = "nomic-embed-text"
+_DEFAULT_DIMENSIONS = 768
+_DEFAULT_BASE_URL = "http://ollama:11434"
+_DEFAULT_TIMEOUT_S = 30.0
+
+
+class ModelNotPulledError(RuntimeError):
+    """Raised when Ollama returns 404 / 'model not found'.
+
+    Callers can map this to a user-facing 'pull this model' affordance
+    instead of a generic 5xx.
+    """
+
+    def __init__(self, model: str) -> None:
+        super().__init__(f"ollama model not pulled: {model}")
+        self.model = model
+
+
+class OllamaEmbeddingProvider:
+    """Generate embeddings using a locally-running Ollama daemon.
+
+    No API key is required — connectivity is to a local sidecar within the
+    Raven Local docker compose network.
+
+    Implements the :class:`~raven_worker.providers.base.EmbeddingProvider` protocol.
+    """
+
+    def __init__(
+        self,
+        model: str = _DEFAULT_MODEL,
+        dimensions: int = _DEFAULT_DIMENSIONS,
+        base_url: str | None = None,
+    ) -> None:
+        self._model = model
+        self._dimensions = dimensions
+        self._base_url = (base_url or _DEFAULT_BASE_URL).rstrip("/")
+        self._client = httpx.AsyncClient(timeout=_DEFAULT_TIMEOUT_S)
+
+    @property
+    def model_name(self) -> str:
+        return self._model
+
+    @property
+    def dimensions(self) -> int:
+        return self._dimensions
+
+    async def embed(self, text: str) -> list[float]:
+        """Generate an embedding for ``text`` via Ollama's REST API."""
+        resp = await self._client.post(
+            f"{self._base_url}/api/embeddings",
+            json={"model": self._model, "prompt": text},
+        )
+        if resp.status_code == 404 and "not found" in resp.text.lower():
+            logger.warning(
+                "ollama_embed_model_not_pulled",
+                model=self._model,
+                base_url=self._base_url,
+            )
+            raise ModelNotPulledError(self._model)
+        if resp.status_code >= 400:
+            logger.error(
+                "ollama_embed_failed",
+                status=resp.status_code,
+                model=self._model,
+                base_url=self._base_url,
+                body=resp.text[:300],
+            )
+            raise RuntimeError(
+                f"ollama embed failed: status={resp.status_code} body={resp.text[:300]!r}"
+            )
+        return resp.json()["embedding"]
+
+
+# Verify the protocol is satisfied at import time so type errors surface
+# during test collection, not at first runtime call.
+_: EmbeddingProvider = OllamaEmbeddingProvider()

--- a/ai-worker/raven_worker/providers/registry.py
+++ b/ai-worker/raven_worker/providers/registry.py
@@ -19,7 +19,12 @@ logger = structlog.get_logger(__name__)
 _provider_cache: dict[tuple[str, str, str], EmbeddingProvider] = {}
 
 # Supported provider names (must match the ``llm_provider`` enum in Postgres)
-_SUPPORTED_PROVIDERS = {"openai", "cohere", "anthropic"}
+_SUPPORTED_PROVIDERS = {"openai", "cohere", "anthropic", "ollama"}
+
+# Providers that don't require an API key — the local Ollama sidecar in
+# Raven Local has no auth surface. The registry skips ``decrypt_api_key``
+# when the provider is in this set so an empty encrypted blob is fine.
+_KEYLESS_PROVIDERS = {"ollama"}
 
 
 async def get_provider_for_request(
@@ -96,11 +101,14 @@ async def get_provider_for_request(
     if row is None:
         raise ValueError(f"No active '{provider_lower}' provider config found for org '{org_id}'")
 
-    api_key = decrypt_api_key(
-        encrypted=bytes(row["api_key_encrypted"]),
-        iv=bytes(row["api_key_iv"]),
-        key_b64=settings.encryption_key,
-    )
+    if provider_lower in _KEYLESS_PROVIDERS:
+        api_key = ""
+    else:
+        api_key = decrypt_api_key(
+            encrypted=bytes(row["api_key_encrypted"]),
+            iv=bytes(row["api_key_iv"]),
+            key_b64=settings.encryption_key,
+        )
     base_url: str | None = row["base_url"]
 
     provider = _build_provider(provider_lower, api_key, model, base_url)
@@ -149,6 +157,12 @@ def _build_provider(
         from raven_worker.providers.anthropic_provider import AnthropicEmbeddingProvider
 
         return AnthropicEmbeddingProvider(api_key=api_key, model=model)
+
+    if provider_name == "ollama":
+        from raven_worker.providers.ollama_provider import OllamaEmbeddingProvider
+
+        # Ollama doesn't take an api_key; it talks to a local sidecar.
+        return OllamaEmbeddingProvider(model=model, base_url=base_url)
 
     raise ValueError(f"Unsupported provider: '{provider_name}'")
 

--- a/ai-worker/tests/test_ollama_provider.py
+++ b/ai-worker/tests/test_ollama_provider.py
@@ -1,0 +1,83 @@
+"""Tests for the Ollama embedding provider used in Raven Local."""
+
+from __future__ import annotations
+
+import pytest
+import respx
+from httpx import Response
+
+from raven_worker.providers.ollama_provider import (
+    ModelNotPulledError,
+    OllamaEmbeddingProvider,
+)
+
+
+@pytest.fixture
+def provider() -> OllamaEmbeddingProvider:
+    return OllamaEmbeddingProvider(
+        base_url="http://ollama:11434",
+        model="nomic-embed-text",
+    )
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_embed_returns_vector(provider: OllamaEmbeddingProvider) -> None:
+    route = respx.post("http://ollama:11434/api/embeddings").mock(
+        return_value=Response(200, json={"embedding": [0.1, 0.2, 0.3]})
+    )
+    vec = await provider.embed("hello world")
+    assert vec == [0.1, 0.2, 0.3]
+    assert route.called
+    body = route.calls.last.request.read().decode()
+    assert '"model":"nomic-embed-text"' in body
+    assert '"prompt":"hello world"' in body
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_embed_raises_typed_error_when_model_missing(
+    provider: OllamaEmbeddingProvider,
+) -> None:
+    """Ollama returns 404 with a 'model not found' body when the model
+    hasn't been pulled. The provider raises ModelNotPulledError so callers
+    can offer a 'pull this model' affordance instead of a generic 5xx."""
+    respx.post("http://ollama:11434/api/embeddings").mock(
+        return_value=Response(
+            404,
+            json={"error": "model 'nomic-embed-text' not found, try pulling it first"},
+        )
+    )
+    with pytest.raises(ModelNotPulledError) as exc:
+        await provider.embed("x")
+    assert exc.value.model == "nomic-embed-text"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_embed_raises_on_other_http_error(
+    provider: OllamaEmbeddingProvider,
+) -> None:
+    respx.post("http://ollama:11434/api/embeddings").mock(
+        return_value=Response(503, text="overloaded")
+    )
+    with pytest.raises(RuntimeError, match="ollama embed failed"):
+        await provider.embed("x")
+
+
+def test_provider_advertises_known_dimension(
+    provider: OllamaEmbeddingProvider,
+) -> None:
+    assert provider.dimensions == 768
+    assert provider.model_name == "nomic-embed-text"
+
+
+def test_provider_strips_trailing_slash_in_base_url() -> None:
+    p = OllamaEmbeddingProvider(base_url="http://ollama:11434/")
+    # _base_url is private but observable via the request URL in respx tests.
+    assert p._base_url == "http://ollama:11434"
+
+
+def test_provider_uses_default_base_url_when_omitted() -> None:
+    p = OllamaEmbeddingProvider()
+    assert p._base_url == "http://ollama:11434"

--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -2523,6 +2523,7 @@ dependencies = [
 name = "raven-local"
 version = "0.1.0"
 dependencies = [
+ "futures-util",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -2532,6 +2533,7 @@ dependencies = [
  "tauri-plugin-shell",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -2618,6 +2620,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -2637,12 +2640,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots",
 ]
@@ -2677,7 +2682,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -4234,6 +4239,19 @@ dependencies = [
  "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/desktop/docker-compose.local.yml
+++ b/desktop/docker-compose.local.yml
@@ -1,15 +1,46 @@
 # Raven Local — desktop-tailored docker compose.
 #
-# This is a placeholder that includes the repo's primary compose file.
-# Issue #421 will replace this with a desktop-tailored variant that
-# adds an Ollama sidecar service and sets RAVEN_SINGLE_USER=true defaults.
-#
-# Used by the Tauri shell's compose orchestrator (desktop/src-tauri/src/compose.rs).
-# When the Tauri app is packaged, this file is bundled as a resource and
-# the orchestrator runs `docker compose -f docker-compose.local.yml up -d`
-# from the resource directory.
+# Adds an Ollama sidecar to the standard Raven stack and forces
+# RAVEN_SINGLE_USER=true on the API. Bundled by the Tauri shell as a
+# resource and started/stopped by `desktop/src-tauri/src/compose.rs`.
 
 include:
   - ../docker-compose.yml
 
-# TODO(#421): add Ollama sidecar service + RAVEN_SINGLE_USER=true defaults
+services:
+  # Local LLM — serves both chat completions (OpenAI-compatible /v1/*)
+  # and embeddings (/api/embeddings) for the AI worker's OllamaProvider.
+  ollama:
+    image: ollama/ollama:latest
+    pull_policy: missing
+    volumes:
+      - ollama-models:/root/.ollama
+    networks:
+      - raven-internal
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+    # Host-bound so the Tauri shell can reach /api/pull for streaming
+    # model-download progress. Other compose services use the internal
+    # network.
+    ports:
+      - "127.0.0.1:11434:11434"
+
+  # Force single-user mode on the API.
+  go-api:
+    environment:
+      RAVEN_SINGLE_USER: "true"
+      RAVEN_OLLAMA_BASE_URL: "http://ollama:11434"
+
+  # AI worker reads the same env so its OllamaProvider knows where to look.
+  ai-worker:
+    environment:
+      RAVEN_OLLAMA_BASE_URL: "http://ollama:11434"
+      RAVEN_OLLAMA_DEFAULT_EMBEDDING_MODEL: "nomic-embed-text"
+
+volumes:
+  ollama-models:

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -27,9 +27,11 @@ tauri-plugin-shell = "2"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "stream"] }
 sysinfo = { version = "0.32", default-features = false, features = ["disk", "system"] }
 thiserror = "1"
+futures-util = "0.3"
+tokio-util = { version = "0.7", features = ["io"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -5,4 +5,5 @@
 //! the orchestrator implementation here so it's available to both.
 
 pub mod compose;
+pub mod ollama;
 pub mod precheck;

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -89,7 +89,10 @@ fn main() {
             let _ = manager_for_shutdown;
             Ok(())
         })
-        .invoke_handler(tauri::generate_handler![])
+        .invoke_handler(tauri::generate_handler![
+            raven_local_lib::ollama::ollama_pull_model,
+            raven_local_lib::ollama::ollama_list_models
+        ])
         .build(tauri::generate_context!())
         .expect("error while building Raven Local")
         .run(|app, event| {

--- a/desktop/src-tauri/src/ollama.rs
+++ b/desktop/src-tauri/src/ollama.rs
@@ -1,0 +1,194 @@
+//! Tauri commands and helpers for managing local Ollama models.
+//!
+//! Ollama's `/api/pull` endpoint streams JSONL — one event per line. We
+//! parse each line, emit progress events to the frontend (so the wizard's
+//! progress bar can update), and stop when we see the terminal
+//! `{"status":"success"}` (or an `{"error": ...}`).
+
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter};
+use tokio::io::{AsyncBufReadExt, BufReader};
+
+const OLLAMA_HOST: &str = "http://127.0.0.1:11434";
+const PULL_PROGRESS_EVENT: &str = "ollama:pull-progress";
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PullProgress {
+    pub model: String,
+    pub completed: u64,
+    pub total: u64,
+    pub percent: u8,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ModelInfo {
+    pub name: String,
+    pub size: u64,
+    pub digest: String,
+}
+
+#[derive(Deserialize)]
+struct OllamaPullEvent {
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    completed: Option<u64>,
+    #[serde(default)]
+    total: Option<u64>,
+    #[serde(default)]
+    error: Option<String>,
+}
+
+/// Returns Some when the line contains a meaningful per-byte progress
+/// snapshot (both `total` and `completed` are present and `total` is
+/// non-zero). Returns None for status-only lines like
+/// `{"status":"pulling manifest"}`.
+pub(crate) fn parse_progress_line(line: &str) -> Option<PullProgress> {
+    let ev: OllamaPullEvent = serde_json::from_str(line).ok()?;
+    let total = ev.total?;
+    let completed = ev.completed?;
+    if total == 0 {
+        return None;
+    }
+    let percent = ((completed as f64 / total as f64) * 100.0).round() as u8;
+    Some(PullProgress {
+        model: String::new(), // filled in by the caller — it knows which model
+        completed,
+        total,
+        percent: percent.min(100),
+    })
+}
+
+/// True when the line is the terminal `{"status":"success"}` event from
+/// /api/pull, signalling the pull completed.
+pub(crate) fn is_success_line(line: &str) -> bool {
+    matches!(
+        serde_json::from_str::<OllamaPullEvent>(line).ok().and_then(|e| e.status),
+        Some(s) if s == "success"
+    )
+}
+
+/// Returns Some(error_message) when the line is `{"error": "..."}`.
+pub(crate) fn parse_error_line(line: &str) -> Option<String> {
+    serde_json::from_str::<OllamaPullEvent>(line).ok().and_then(|e| e.error)
+}
+
+#[tauri::command]
+pub async fn ollama_pull_model(app: AppHandle, model: String) -> Result<(), String> {
+    let url = format!("{OLLAMA_HOST}/api/pull");
+    let body = serde_json::json!({ "name": model, "stream": true });
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30 * 60)) // 30-min cap for big models
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    let resp = client
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("connect to ollama: {e}"))?;
+
+    if !resp.status().is_success() {
+        return Err(format!("ollama pull rejected: status={}", resp.status()));
+    }
+
+    let stream = resp.bytes_stream();
+    use futures_util::StreamExt;
+    let reader = tokio_util::io::StreamReader::new(
+        stream.map(|r| r.map_err(std::io::Error::other)),
+    );
+    let mut lines = BufReader::new(reader).lines();
+
+    while let Some(line) = lines.next_line().await.map_err(|e| e.to_string())? {
+        if line.trim().is_empty() {
+            continue;
+        }
+        if let Some(err) = parse_error_line(&line) {
+            return Err(err);
+        }
+        if let Some(mut progress) = parse_progress_line(&line) {
+            progress.model = model.clone();
+            let _ = app.emit(PULL_PROGRESS_EVENT, &progress);
+        }
+        if is_success_line(&line) {
+            break;
+        }
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn ollama_list_models() -> Result<Vec<ModelInfo>, String> {
+    let url = format!("{OLLAMA_HOST}/api/tags");
+    let resp = reqwest::get(&url).await.map_err(|e| e.to_string())?;
+    if !resp.status().is_success() {
+        return Err(format!("ollama list rejected: status={}", resp.status()));
+    }
+
+    #[derive(Deserialize)]
+    struct ListResp {
+        models: Vec<RawModel>,
+    }
+    #[derive(Deserialize)]
+    struct RawModel {
+        name: String,
+        size: u64,
+        digest: String,
+    }
+
+    let body: ListResp = resp.json().await.map_err(|e| e.to_string())?;
+    Ok(body
+        .models
+        .into_iter()
+        .map(|m| ModelInfo { name: m.name, size: m.size, digest: m.digest })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pull_progress_parser_emits_percent_for_progress_lines() {
+        let raw = include_str!("../tests/fixtures/ollama-pull-stream.jsonl");
+        let mut percents = Vec::new();
+        for line in raw.lines().filter(|l| !l.is_empty()) {
+            if let Some(p) = parse_progress_line(line) {
+                percents.push(p.percent);
+            }
+        }
+        assert_eq!(percents, vec![25, 75, 100]);
+    }
+
+    #[test]
+    fn pull_progress_parser_skips_status_only_lines() {
+        let line = r#"{"status":"pulling manifest"}"#;
+        assert!(parse_progress_line(line).is_none());
+    }
+
+    #[test]
+    fn pull_progress_parser_marks_success() {
+        let line = r#"{"status":"success"}"#;
+        assert!(parse_progress_line(line).is_none());
+        assert!(is_success_line(line));
+    }
+
+    #[test]
+    fn pull_progress_parser_handles_error_lines() {
+        let line = r#"{"error":"unknown model"}"#;
+        let err = parse_error_line(line);
+        assert_eq!(err.as_deref(), Some("unknown model"));
+    }
+
+    #[test]
+    fn pull_progress_parser_caps_percent_at_100() {
+        // Defensive: if completed somehow exceeds total, clamp to 100.
+        let line = r#"{"status":"pulling x","total":100,"completed":150}"#;
+        let p = parse_progress_line(line).unwrap();
+        assert_eq!(p.percent, 100);
+    }
+}

--- a/desktop/src-tauri/tests/fixtures/ollama-pull-stream.jsonl
+++ b/desktop/src-tauri/tests/fixtures/ollama-pull-stream.jsonl
@@ -1,0 +1,8 @@
+{"status":"pulling manifest"}
+{"status":"pulling abc123","digest":"sha256:abc123","total":1000000,"completed":250000}
+{"status":"pulling abc123","digest":"sha256:abc123","total":1000000,"completed":750000}
+{"status":"pulling abc123","digest":"sha256:abc123","total":1000000,"completed":1000000}
+{"status":"verifying sha256 digest"}
+{"status":"writing manifest"}
+{"status":"removing any unused layers"}
+{"status":"success"}

--- a/migrations/00039_seed_ollama_local_provider.sql
+++ b/migrations/00039_seed_ollama_local_provider.sql
@@ -1,0 +1,49 @@
+-- migrations/00039_seed_ollama_local_provider.sql
+-- +goose Up
+-- +goose NO TRANSACTION
+
+-- ALTER TYPE ... ADD VALUE cannot run inside a transaction; that's why this
+-- whole file is annotated NO TRANSACTION above. Each statement auto-commits.
+
+-- 1. Extend the llm_provider enum to include 'ollama'. IF NOT EXISTS makes
+-- this safe to re-run on databases that already have it.
+ALTER TYPE llm_provider ADD VALUE IF NOT EXISTS 'ollama';
+
+-- 2. Defensive UNIQUE index covering (org_id, provider) so the seed below
+-- (and any future seed migrations) can use ON CONFLICT cleanly. CREATE
+-- INDEX IF NOT EXISTS is idempotent.
+CREATE UNIQUE INDEX IF NOT EXISTS llm_provider_configs_org_provider_uniq
+    ON llm_provider_configs (org_id, provider);
+
+-- 3. Seed an 'ollama' provider row for the local org (created in 00038).
+-- The WHERE EXISTS clause filters this out on multi-user deployments where
+-- the local org doesn't exist, so this migration is safe to apply on the
+-- cloud SaaS too.
+INSERT INTO llm_provider_configs (
+    org_id, provider, display_name, api_key_encrypted, api_key_iv,
+    api_key_hint, base_url, config, is_default, status, created_by
+)
+SELECT
+    '00000000-0000-0000-0000-000000000001'::uuid,  -- the local org from 00038
+    'ollama'::llm_provider,
+    'Local Ollama',
+    NULL,                                          -- no API key needed
+    NULL,
+    'local',
+    'http://ollama:11434/v1',
+    '{"is_local": true}'::jsonb,
+    true,
+    'active',
+    '00000000-0000-0000-0000-000000000002'::uuid   -- the local user from 00038
+WHERE EXISTS (
+    SELECT 1 FROM organizations
+    WHERE id = '00000000-0000-0000-0000-000000000001'::uuid
+)
+ON CONFLICT (org_id, provider) DO NOTHING;
+
+-- +goose Down
+
+-- Intentionally empty. Removing 'ollama' from the enum would require
+-- rewriting the column type and migrating any existing 'ollama' rows;
+-- removing the seed row alone would orphan any chat history that
+-- referenced it as the default provider.


### PR DESCRIPTION
## Summary

Bundles Ollama as a sidecar in Raven Local's compose stack and wires it as a first-class provider for both chat (via existing BYOK pipeline using `base_url=http://ollama:11434/v1`) and embeddings (new Python `OllamaEmbeddingProvider`).

### Two commits
1. **Backend pieces** — Python provider + registry update + idempotent goose migration (NO TRANSACTION; ALTER TYPE ADD VALUE 'ollama' + UNIQUE index + seed for local org from #419, filtered out on cloud DBs) + desktop/docker-compose.local.yml rewrite.
2. **Tauri commands** — `ollama_pull_model` (streaming progress events) and `ollama_list_models`. 5 parser unit tests using a recorded JSONL fixture.

### Key implementation notes

- `OllamaEmbeddingProvider` matches the existing async `EmbeddingProvider` Protocol contract (async `embed`, `dimensions` property, `model_name` property). Default `nomic-embed-text` (768 dims).
- Registry uses a new `_KEYLESS_PROVIDERS` set to skip `decrypt_api_key` when the encrypted blob is empty — Ollama doesn't have an auth surface.
- Migration uses goose `-- +goose NO TRANSACTION` because `ALTER TYPE ADD VALUE` can't run inside a transaction in PostgreSQL.
- Tauri `generate_handler!` references the commands by full path because the macro's internal `__cmd__` helpers live in the function's defining module and don't follow a `use` import.

Closes #421 — refs M11.

## Test plan

- [x] `cargo check --manifest-path desktop/src-tauri/Cargo.toml` — clean
- [x] `cargo test --lib ollama` — 5/5 pass
- [x] YAML/JSON validation: docker-compose.local.yml + migration directives
- [ ] Python `pytest tests/test_ollama_provider.py` (local sandbox venv was broken; CI will run)
- [ ] Migration applies cleanly to a fresh and a pre-seeded DB
- [ ] CI: full Go + Python + Rust suites