### PR TITLE
fix(ci/docs): correct CF account-id var ref + skip-on-missing-token guard

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -78,10 +78,14 @@ jobs:
         id: deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           # Pass user-controlled branch name through env to avoid the
           # script-injection risk of inlining it into the shell script.
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+        # Skip silently on forks / PRs where the secret isn't exposed,
+        # mirroring the pattern in landing.yml so external contributors
+        # don't see a hard CI failure.
+        if: env.CLOUDFLARE_API_TOKEN != ''
         working-directory: docs-site
         run: |
           set -o pipefail
@@ -97,7 +101,7 @@ jobs:
           echo "url=$url" >> "$GITHUB_OUTPUT"
 
       - name: Comment preview URL on PR
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.deploy.outputs.url != ''
         uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31  # v2.9.0
         with:
           header: docs-preview


### PR DESCRIPTION
## Summary

The first Docs workflow run after #482 merged failed with \`Not logged in\` from wrangler. Two fixes:

1. **`CLOUDFLARE_ACCOUNT_ID` is a variable, not a secret.** \`landing.yml\` already uses \`vars.CLOUDFLARE_ACCOUNT_ID\`; \`docs.yml\` was reading from \`secrets.\` which rendered empty. Switch the reference to \`vars.\`.
2. **Guard the deploy step on the token being present.** Mirror \`landing.yml\`'s \`if: env.CLOUDFLARE_API_TOKEN != ''\` pattern so forks and PRs from external contributors don't hard-fail CI when the secret isn't exposed. The preview-comment step gets the corresponding guard \`steps.deploy.outputs.url != ''\` so it doesn't post an empty URL.

## Still required for production deploys

\`CLOUDFLARE_API_TOKEN\` is **not** set as a repo secret today. Adding it with \`Pages:Edit\` scope is what unblocks the actual deploy. With this PR alone, the workflow will *complete green* but the deploy step skips — the merged \`#482\` will not produce a deployment until the secret is added.

## Test plan
- [ ] After this merges and the secret is set, a no-op push to a docs-affecting path triggers a successful deploy
- [ ] Cloudflare Pages \`raven-docs\` project shows a production deployment
- [ ] \`https://docs.raven.ravencloak.org\` resolves with HTTP 200 (currently 522)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined deployment pipeline configuration to improve robustness of documentation preview deployments with enhanced safety checks for deployment conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->