### PR TITLE
ci(docs): add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,7 @@
 name: Docs
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
## Summary

Two-line add: `on: workflow_dispatch:` on the docs workflow so we can re-trigger deploys from \`gh workflow run docs.yml\` without pushing a no-op commit. The original plan called for it; T8's actual shipped file omitted it.

## Why now

\`CLOUDFLARE_API_TOKEN\` was added as a repo secret moments ago. The workflow file's own path filter means merging this PR triggers a deploy run that exercises the now-unblocked CF deploy step end-to-end and unblocks docs.raven.ravencloak.org.