### PR TITLE
feat(desktop): cross-platform installer + release pipeline (M11/07, closes #423)

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -29,6 +29,10 @@ jobs:
       - name: Install Tauri CLI
         run: cargo install tauri-cli --version '^2.0' --locked
 
+      - name: Clippy
+        working-directory: desktop/src-tauri
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
       - name: Build desktop bundle (debug)
         working-directory: desktop
         run: cargo tauri build --debug

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,0 +1,92 @@
+name: Desktop release
+
+on:
+  push:
+    tags:
+      - 'raven-local-v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to label the build (testing only — no release upload)'
+        required: false
+        default: 'raven-local-v0.0.0-test'
+
+permissions: {}
+
+jobs:
+  build:
+    name: Build (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            target: universal-apple-darwin
+            artifact_glob: 'desktop/src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg'
+            extra_targets: 'aarch64-apple-darwin x86_64-apple-darwin'
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            artifact_glob: 'desktop/src-tauri/target/release/bundle/msi/*.msi'
+            extra_targets: ''
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            artifact_glob: |
+              desktop/src-tauri/target/release/bundle/appimage/*.AppImage
+              desktop/src-tauri/target/release/bundle/deb/*.deb
+            extra_targets: ''
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install macOS extra Rust targets
+        if: matrix.os == 'macos-latest'
+        run: rustup target add ${{ matrix.extra_targets }}
+
+      - name: Install Linux deps
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev libgtk-3-dev \
+            libayatana-appindicator3-dev librsvg2-dev
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: desktop -> desktop/src-tauri/target
+
+      - name: Install Tauri CLI
+        run: cargo install tauri-cli --version '^2.0' --locked
+
+      - name: Build (universal macOS)
+        if: matrix.os == 'macos-latest'
+        working-directory: desktop
+        run: cargo tauri build --target universal-apple-darwin
+
+      - name: Build (Windows / Linux)
+        if: matrix.os != 'macos-latest'
+        working-directory: desktop
+        run: cargo tauri build
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@173725a1209d09b31f9d30a3890cf2757ebbff0d # v1.4.4
+        with:
+          subject-path: ${{ matrix.artifact_glob }}
+
+      - name: Upload to draft release
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/raven-local-v')
+        uses: softprops/action-gh-release@e7a8f85e1c67a31e6ed99a94b41bd0b71bbee6b8 # v2.0.9
+        with:
+          draft: true
+          files: ${{ matrix.artifact_glob }}
+          tag_name: ${{ github.ref_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -1,7 +1,7 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use raven_local_lib::compose::{ComposeManager, StatusEvent};
 use raven_local_lib::precheck::{run_precheck, skip_requested, RealSystemInfo};
@@ -111,10 +111,10 @@ fn main() {
 /// In dev mode (`cargo tauri dev`), it's at `<repo>/desktop/`. We pick the
 /// first parent containing the compose file, falling back to the resource
 /// dir itself.
-fn resolve_project_dir(resource_dir: &PathBuf) -> PathBuf {
+fn resolve_project_dir(resource_dir: &Path) -> PathBuf {
     let candidate = resource_dir.join(COMPOSE_FILE);
     if candidate.exists() {
-        return resource_dir.clone();
+        return resource_dir.to_path_buf();
     }
     let dev_candidate = std::env::current_dir()
         .ok()
@@ -124,5 +124,5 @@ fn resolve_project_dir(resource_dir: &PathBuf) -> PathBuf {
             return p.parent().unwrap().to_path_buf();
         }
     }
-    resource_dir.clone()
+    resource_dir.to_path_buf()
 }

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -26,6 +26,12 @@
   "bundle": {
     "active": true,
     "targets": ["dmg", "msi", "appimage", "deb"],
+    "category": "Productivity",
+    "shortDescription": "Self-contained Raven for local use",
+    "longDescription": "Privacy-first desktop edition of Raven that runs the entire stack locally with Ollama as a bundled LLM provider. No cloud, no telemetry by default.",
+    "copyright": "© 2026 Raven Contributors",
+    "homepage": "https://github.com/ravencloak-org/Raven",
+    "publisher": "Raven Contributors",
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
## Summary

Tag-triggered cross-platform installer pipeline for Raven Local + clippy CI gate + bundle-metadata polish.

- `.github/workflows/desktop-release.yml` — new workflow on `raven-local-v*` tags. Matrix builds on macos-latest (universal arm64+x86_64), windows-latest, ubuntu-latest. SLSA v3 provenance per artefact via `actions/attest-build-provenance`. Tag pushes upload to a draft GitHub Release; `workflow_dispatch` runs the build without uploading.
- `desktop/src-tauri/tauri.conf.json` — bundle metadata polish (category, descriptions, copyright, homepage, publisher).
- `.github/workflows/desktop-build.yml` — adds `cargo clippy --all-targets --all-features -- -D warnings` as a PR-time gate.
- `desktop/src-tauri/src/main.rs` — fixes the one pre-existing clippy::ptr_arg finding (`&PathBuf` → `&Path`) so the new gate lands cleanly.

Signing/notarization (Apple Developer ID, Windows code signing) are deferred to #426 along with the auto-update channel.

Closes #423 — refs M11.

## Test plan

- [x] `cargo clippy --manifest-path desktop/src-tauri/Cargo.toml --all-targets --all-features -- -D warnings` — clean
- [x] tauri.conf.json validates as JSON; new metadata fields present
- [x] desktop-release.yml validates as YAML
- [ ] CI: `Desktop build (macOS)` job (now with clippy step) green on this PR
- [ ] Manual `gh workflow run desktop-release.yml` produces all four artefacts on macOS, Windows, Linux runners