### PR TITLE
fix(ci/docs): allow Cloudflare project-subdomain suffix in URL regex

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,7 @@
 name: Docs
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -94,7 +94,10 @@ jobs:
             --project-name=raven-docs \
             --branch="$BRANCH_NAME" \
             | tee wrangler.out
-          url=$(grep -oE 'https://[a-z0-9-]+\.raven-docs\.pages\.dev' wrangler.out | head -1)
+          # Cloudflare may auto-suffix the project subdomain (e.g.
+          # `raven-docs-28s.pages.dev`) when the bare name is already
+          # taken globally; allow the optional suffix in the regex.
+          url=$(grep -oE 'https://[a-z0-9-]+\.raven-docs(-[a-z0-9]+)?\.pages\.dev' wrangler.out | head -1)
           if [ -z "$url" ]; then
             echo "::error::Could not parse preview URL from wrangler output"
             exit 1


### PR DESCRIPTION
## Summary

Cloudflare assigned our Pages project the auto-suffixed subdomain
\`raven-docs-28s.pages.dev\` (because \`raven-docs.pages.dev\` was already taken globally). The previous regex \`https://[a-z0-9-]+\.raven-docs\.pages\.dev\` didn't match, so the URL-parse step in the deploy job exited 1 even though wrangler's upload + deployment succeeded. Loosen the regex to allow an optional \`-<suffix>\` after \`raven-docs\`.

## Live confirmation

- \`https://docs.raven.ravencloak.org/\` → **HTTP 200** (BOM edge)
- \`https://raven-docs-28s.pages.dev/\` → HTTP 200
- Deploy was 4e99e3e4 from the post-#484 push run

## Test plan
- [ ] After merge, the next docs.yml run shows the Deploy step concluding **success** end-to-end
- [ ] The job summary captures the parsed pages.dev URL via \`steps.deploy.outputs.url\`