### PR TITLE
feat(frontend): first-run wizard for Raven Local (M11/06, closes #422)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.3.0",
       "dependencies": {
         "@tailwindcss/typography": "^0.5.19",
+        "@tauri-apps/api": "^2.11.0",
         "@vueuse/core": "^14.3.0",
         "livekit-client": "^2.18.9",
         "pinia": "^3.0.4",
@@ -1099,6 +1100,16 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/@tauri-apps/api": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.0.tgz",
+      "integrity": "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==",
+      "license": "Apache-2.0 OR MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/tauri"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@tailwindcss/typography": "^0.5.19",
+    "@tauri-apps/api": "^2.11.0",
     "@vueuse/core": "^14.3.0",
     "livekit-client": "^2.18.9",
     "pinia": "^3.0.4",

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2,6 +2,7 @@ import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import { useAuthStore } from './stores/auth'
 import { useServerConfigStore } from './stores/server-config'
+import { usePrecheckStore } from './stores/precheck'
 import { posthogPlugin } from './plugins/posthog'
 import { initSuperTokens } from './plugins/supertokens'
 import App from './App.vue'
@@ -27,6 +28,9 @@ serverConfig.load().then(() => {
   if (serverConfig.singleUser) {
     // Single-user mode: no real session — treat as always authenticated.
     authStore.setLocalMode()
+    // Subscribe to the Tauri shell's precheck:result event so the model-picker
+    // step has the host's RAM tier ready. No-op outside a Tauri context.
+    usePrecheckStore().subscribeToTauri()
     app.mount('#app')
   } else {
     // Multi-user mode: initialise session check before mounting.

--- a/frontend/src/pages/onboarding/ModelPickerStep.vue
+++ b/frontend/src/pages/onboarding/ModelPickerStep.vue
@@ -1,0 +1,176 @@
+<script setup lang="ts">
+import { computed, ref, onMounted, onBeforeUnmount } from 'vue'
+import { usePrecheckStore } from '../../stores/precheck'
+
+const emit = defineEmits<{
+  (e: 'complete', model: string): void
+  (e: 'skip'): void
+}>()
+
+const precheck = usePrecheckStore()
+
+interface ModelOption {
+  name: string
+  sizeGb: number
+  description: string
+  /** Smallest tier this model is offered to. */
+  minTier: 'floor' | 'low' | 'mid' | 'high'
+}
+
+const allModels: ModelOption[] = [
+  { name: 'llama3.2:3b', sizeGb: 2.0, description: 'Smallest viable — fits 8 GB hosts', minTier: 'floor' },
+  { name: 'llama3.1:8b', sizeGb: 4.7, description: 'Recommended for most users', minTier: 'low' },
+  { name: 'llama3.1:13b', sizeGb: 7.4, description: 'Higher quality — needs 16 GB+', minTier: 'high' },
+]
+
+const tierToDefault: Record<string, string> = {
+  floor: 'llama3.2:3b',
+  low: 'llama3.1:8b',
+  mid: 'llama3.1:8b',
+  high: 'llama3.1:8b',
+  unknown: 'llama3.2:3b',
+}
+
+const tierRank: Record<string, number> = { floor: 0, low: 1, mid: 2, high: 3 }
+
+const visibleModels = computed(() => {
+  const tier = precheck.tier
+  if (tier === 'unknown' || tier === 'floor') {
+    return allModels.filter((m) => m.minTier === 'floor')
+  }
+  return allModels.filter((m) => tierRank[m.minTier] <= tierRank[tier])
+})
+
+const selectedModel = ref<string>(tierToDefault[precheck.tier] ?? 'llama3.2:3b')
+
+const pullState = ref<'idle' | 'pulling' | 'done' | 'error'>('idle')
+const percent = ref(0)
+const errorMessage = ref<string | null>(null)
+let unlisten: (() => void) | null = null
+
+interface PullProgress {
+  model: string
+  completed: number
+  total: number
+  percent: number
+}
+
+onMounted(async () => {
+  try {
+    const { listen } = await import('@tauri-apps/api/event')
+    unlisten = await listen<PullProgress>('ollama:pull-progress', (e) => {
+      if (e.payload.model === selectedModel.value) {
+        percent.value = e.payload.percent
+      }
+    })
+  } catch {
+    // Not in a Tauri context — leave listener unbound (e.g. component tests).
+  }
+})
+
+onBeforeUnmount(() => {
+  unlisten?.()
+})
+
+async function pullSelected() {
+  pullState.value = 'pulling'
+  percent.value = 0
+  errorMessage.value = null
+  try {
+    const { invoke } = await import('@tauri-apps/api/core')
+    await invoke('ollama_pull_model', { model: selectedModel.value })
+    pullState.value = 'done'
+    emit('complete', selectedModel.value)
+  } catch (e) {
+    pullState.value = 'error'
+    errorMessage.value = e instanceof Error ? e.message : String(e)
+  }
+}
+</script>
+
+<template>
+  <div class="model-picker">
+    <h2 class="text-2xl font-bold text-neutral-900 dark:text-white mb-2">
+      Pick a local model
+    </h2>
+    <p class="text-neutral-500 text-sm mb-6">
+      Raven Local will download an Ollama model to run chat on your machine.
+    </p>
+
+    <ul class="space-y-2 mb-6">
+      <li
+        v-for="m in visibleModels"
+        :key="m.name"
+        class="rounded-lg border p-3 cursor-pointer transition-colors"
+        :class="
+          m.name === selectedModel
+            ? 'border-amber-500 bg-amber-50 dark:bg-amber-900/10'
+            : 'border-neutral-300 dark:border-neutral-700'
+        "
+      >
+        <label class="flex items-start gap-3 cursor-pointer">
+          <input
+            type="radio"
+            :value="m.name"
+            v-model="selectedModel"
+            class="mt-1"
+          />
+          <div>
+            <div class="font-semibold text-neutral-900 dark:text-white">
+              {{ m.name }}
+              <span class="text-xs text-neutral-500 font-normal">
+                · {{ m.sizeGb.toFixed(1) }} GB
+              </span>
+            </div>
+            <div class="text-sm text-neutral-500">{{ m.description }}</div>
+          </div>
+        </label>
+      </li>
+    </ul>
+
+    <p
+      data-test="selected-model"
+      class="text-sm text-neutral-500 mb-3"
+    >
+      Selected: <code class="font-mono">{{ selectedModel }}</code>
+    </p>
+
+    <button
+      data-test="pull-button"
+      :disabled="pullState === 'pulling'"
+      class="w-full bg-amber-500 hover:bg-amber-600 disabled:opacity-50 text-white font-semibold py-3 rounded-lg transition-colors mb-3"
+      @click="pullSelected"
+    >
+      {{
+        pullState === 'pulling'
+          ? `Downloading… ${percent}%`
+          : pullState === 'done'
+            ? 'Downloaded'
+            : 'Download model'
+      }}
+    </button>
+
+    <progress
+      v-if="pullState === 'pulling'"
+      :value="percent"
+      max="100"
+      class="w-full h-2 mb-3"
+    />
+
+    <div
+      v-if="errorMessage"
+      class="text-red-500 text-sm mb-3"
+    >
+      {{ errorMessage }}
+      <button class="underline ml-2" @click="pullSelected">Retry</button>
+    </div>
+
+    <button
+      data-test="skip-model"
+      class="text-sm text-neutral-500 underline"
+      @click="emit('skip')"
+    >
+      Skip — I'll add a BYOK key instead
+    </button>
+  </div>
+</template>

--- a/frontend/src/pages/onboarding/OnboardingWizard.vue
+++ b/frontend/src/pages/onboarding/OnboardingWizard.vue
@@ -1,6 +1,52 @@
 <template>
   <div class="min-h-screen flex items-center justify-center bg-white dark:bg-black p-4">
     <div class="w-full max-w-md">
+      <!-- Desktop branch (single-user mode): model picker → optional BYOK → workspace -->
+      <template v-if="isDesktop">
+        <!-- Progress dots (3 steps) -->
+        <div class="flex justify-center gap-2 mb-8">
+          <div
+            v-for="step in 3"
+            :key="step"
+            class="w-2.5 h-2.5 rounded-full transition-colors duration-200"
+            :class="step <= desktopStepIndex ? 'bg-amber-500' : 'bg-neutral-300 dark:bg-neutral-700'"
+          />
+        </div>
+
+        <ModelPickerStep
+          v-if="desktopStep === 'model'"
+          @complete="onModelComplete"
+          @skip="onModelSkip"
+        />
+        <OptionalBYOKStep
+          v-else-if="desktopStep === 'byok'"
+          @saved="onByokDone"
+          @skip="onByokDone"
+        />
+        <div v-else-if="desktopStep === 'workspace'">
+          <h2 class="text-2xl font-bold text-neutral-900 dark:text-white mb-2">Name your workspace</h2>
+          <p class="text-neutral-500 text-sm mb-6">A workspace holds your knowledge bases.</p>
+          <input
+            id="ws-name"
+            v-model="workspaceName"
+            type="text"
+            placeholder="Personal"
+            class="w-full rounded-lg border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-amber-500 mb-6"
+            @keyup.enter="completeDesktopOnboarding"
+          />
+          <button
+            :disabled="loading || workspaceName.length < 1"
+            class="w-full bg-amber-500 hover:bg-amber-600 disabled:opacity-50 text-white font-semibold py-3 rounded-lg transition-colors"
+            @click="completeDesktopOnboarding"
+          >
+            {{ loading ? 'Setting up…' : 'Get Started' }}
+          </button>
+          <p v-if="error" class="text-red-500 text-sm mt-3">{{ error }}</p>
+        </div>
+      </template>
+
+      <!-- Cloud branch (multi-user): existing org-creation + KB flow -->
+      <template v-else>
       <!-- Progress dots -->
       <div class="flex justify-center gap-2 mb-8">
         <div
@@ -80,26 +126,90 @@
         </button>
         <p v-if="error" id="kb-error" class="text-red-500 text-sm mt-3">{{ error }}</p>
       </div>
+      </template>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '../../stores/auth'
+import { useServerConfigStore } from '../../stores/server-config'
+import { useOnboardingStore } from '../../stores/onboarding'
+import ModelPickerStep from './ModelPickerStep.vue'
+import OptionalBYOKStep from './OptionalBYOKStep.vue'
 
 const router = useRouter()
 const auth = useAuthStore()
+const serverConfig = useServerConfigStore()
+const onboarding = useOnboardingStore()
 const apiUrl = import.meta.env.VITE_API_BASE_URL
 
 const currentStep = ref(1)
 const loading = ref(false)
 const error = ref('')
 
-// If user already has an org, skip onboarding
+// Desktop (single-user) branch state. Step machine: model → byok → workspace.
+const isDesktop = computed(() => serverConfig.singleUser)
+type DesktopStep = 'model' | 'byok' | 'workspace'
+const desktopStep = ref<DesktopStep>('model')
+const desktopStepIndex = computed(() =>
+  desktopStep.value === 'model' ? 1 : desktopStep.value === 'byok' ? 2 : 3,
+)
+const workspaceName = ref('Personal')
+
+function onModelComplete() {
+  desktopStep.value = 'byok'
+}
+function onModelSkip() {
+  desktopStep.value = 'byok'
+}
+function onByokDone() {
+  desktopStep.value = 'workspace'
+}
+
+async function completeDesktopOnboarding() {
+  if (workspaceName.value.length < 1) return
+  loading.value = true
+  error.value = ''
+  try {
+    // The local org/user already exist (seeded by migration 00038). The first
+    // workspace is created here. The repo creates a default workspace for new
+    // orgs; we POST and tolerate "already exists" by fetching the list.
+    const localOrgId = auth.orgId || ''
+    if (!localOrgId) {
+      // Single-user mode pins org to the local UUID via setLocalMode in main.ts.
+      throw new Error('Local org not initialised — restart the app')
+    }
+    const res = await fetch(`${apiUrl}/api/v1/orgs/${localOrgId}/workspaces`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: workspaceName.value }),
+    })
+    if (!res.ok && res.status !== 409) {
+      const data = await res.json().catch(() => ({}))
+      throw new Error(data.message || data.error || `Failed (${res.status})`)
+    }
+    onboarding.markComplete()
+    router.replace('/dashboard')
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Something went wrong'
+  } finally {
+    loading.value = false
+  }
+}
+
+// If user already has an org, skip onboarding (cloud branch only — the
+// desktop branch's "completion" is gated by the onboarding store flag, not
+// org presence, since the local org always exists).
 onMounted(() => {
-  if (auth.hasOrg) {
+  if (!isDesktop.value && auth.hasOrg) {
+    router.replace('/dashboard')
+    return
+  }
+  if (isDesktop.value && onboarding.completed) {
     router.replace('/dashboard')
   }
 })

--- a/frontend/src/pages/onboarding/OptionalBYOKStep.vue
+++ b/frontend/src/pages/onboarding/OptionalBYOKStep.vue
@@ -1,0 +1,99 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const emit = defineEmits<{
+  (e: 'skip'): void
+  (e: 'saved', payload: { provider: string }): void
+}>()
+
+const apiUrl = import.meta.env.VITE_API_BASE_URL ?? ''
+
+const provider = ref('openai')
+const apiKey = ref('')
+const errorMessage = ref<string | null>(null)
+const saving = ref(false)
+
+async function submit() {
+  if (!apiKey.value) return
+  saving.value = true
+  errorMessage.value = null
+  try {
+    const res = await fetch(`${apiUrl}/api/v1/llm-providers`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        provider: provider.value,
+        api_key: apiKey.value,
+        display_name: provider.value,
+      }),
+    })
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}))
+      throw new Error(data.message || data.error || `Save failed (${res.status})`)
+    }
+    emit('saved', { provider: provider.value })
+  } catch (e) {
+    errorMessage.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="byok-step">
+    <h2 class="text-2xl font-bold text-neutral-900 dark:text-white mb-2">
+      Add a cloud LLM key (optional)
+    </h2>
+    <p class="text-neutral-500 text-sm mb-6">
+      Skip if you only want local Ollama. You can add cloud keys anytime in Settings.
+    </p>
+
+    <form class="space-y-4 mb-4" @submit.prevent="submit">
+      <label class="block">
+        <span class="text-sm text-neutral-700 dark:text-neutral-300">Provider</span>
+        <select
+          v-model="provider"
+          data-test="provider"
+          class="w-full mt-1 rounded-lg border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white px-3 py-2"
+        >
+          <option value="openai">OpenAI</option>
+          <option value="anthropic">Anthropic</option>
+          <option value="cohere">Cohere</option>
+        </select>
+      </label>
+
+      <label class="block">
+        <span class="text-sm text-neutral-700 dark:text-neutral-300">API key</span>
+        <input
+          v-model="apiKey"
+          type="password"
+          data-test="apikey"
+          autocomplete="off"
+          class="w-full mt-1 rounded-lg border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-900 text-neutral-900 dark:text-white px-3 py-2"
+        />
+      </label>
+
+      <button
+        type="submit"
+        :disabled="!apiKey || saving"
+        class="w-full bg-amber-500 hover:bg-amber-600 disabled:opacity-50 text-white font-semibold py-3 rounded-lg transition-colors"
+      >
+        {{ saving ? 'Saving…' : 'Save' }}
+      </button>
+    </form>
+
+    <button
+      data-test="skip"
+      class="text-sm text-neutral-500 underline"
+      @click="emit('skip')"
+    >
+      Skip
+    </button>
+
+    <div v-if="errorMessage" class="text-red-500 text-sm mt-3">
+      {{ errorMessage }}
+    </div>
+  </div>
+</template>

--- a/frontend/src/stores/precheck.spec.ts
+++ b/frontend/src/stores/precheck.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { usePrecheckStore, ramTier } from './precheck'
+
+describe('ramTier', () => {
+  it('classifies under 8 GB as floor', () => {
+    expect(ramTier(4)).toBe('floor')
+    expect(ramTier(7)).toBe('floor')
+  })
+  it('classifies 8-11 as low', () => {
+    expect(ramTier(8)).toBe('low')
+    expect(ramTier(11)).toBe('low')
+  })
+  it('classifies 12-15 as mid', () => {
+    expect(ramTier(12)).toBe('mid')
+    expect(ramTier(15)).toBe('mid')
+  })
+  it('classifies 16+ as high', () => {
+    expect(ramTier(16)).toBe('high')
+    expect(ramTier(64)).toBe('high')
+  })
+})
+
+describe('usePrecheckStore', () => {
+  beforeEach(() => setActivePinia(createPinia()))
+
+  it('starts unknown', () => {
+    const store = usePrecheckStore()
+    expect(store.result).toBeNull()
+    expect(store.tier).toBe('unknown')
+  })
+
+  it('exposes tier from applied result', () => {
+    const store = usePrecheckStore()
+    store.applyResult({
+      ram_gb: 16,
+      free_disk_gb: 100,
+      cpu_cores: 8,
+      ok: true,
+      warnings: [],
+    })
+    expect(store.result?.ram_gb).toBe(16)
+    expect(store.tier).toBe('high')
+  })
+})

--- a/frontend/src/stores/precheck.ts
+++ b/frontend/src/stores/precheck.ts
@@ -1,0 +1,62 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+
+export type RamTier = 'unknown' | 'floor' | 'low' | 'mid' | 'high'
+
+export interface PrecheckResult {
+  ram_gb: number
+  free_disk_gb: number
+  cpu_cores: number
+  ok: boolean
+  warnings: unknown[]
+}
+
+/**
+ * Returns the RAM tier band for the host. Bands match the model-picker spec:
+ *   <8 GB  → 'floor' (only the smallest model fits)
+ *   8-11   → 'low'   (default 8b model is OK but tight)
+ *   12-15  → 'mid'   (default 8b model is comfortable)
+ *   16+    → 'high'  (13b also offered)
+ */
+export function ramTier(ramGb: number): RamTier {
+  if (ramGb < 8) return 'floor'
+  if (ramGb < 12) return 'low'
+  if (ramGb < 16) return 'mid'
+  return 'high'
+}
+
+/**
+ * Holds the structured result of the Tauri-side system-requirements precheck
+ * (#420). Updated either by an explicit `applyResult` call (tests, frontend
+ * code that has the data already) or by `subscribeToTauri()` which listens
+ * to the `precheck:result` event emitted by the Rust shell on boot.
+ *
+ * On the cloud frontend the Tauri import resolves to nothing; the store
+ * simply stays at its `unknown` default, which is fine since the model-
+ * picker step is only rendered in single-user mode.
+ */
+export const usePrecheckStore = defineStore('precheck', () => {
+  const result = ref<PrecheckResult | null>(null)
+
+  const tier = computed<RamTier>(() => {
+    if (!result.value) return 'unknown'
+    return ramTier(result.value.ram_gb)
+  })
+
+  function applyResult(r: PrecheckResult) {
+    result.value = r
+  }
+
+  async function subscribeToTauri() {
+    try {
+      const { listen } = await import('@tauri-apps/api/event')
+      await listen<PrecheckResult>('precheck:result', (e) => {
+        applyResult(e.payload)
+      })
+    } catch {
+      // Not in a Tauri context — no-op.
+    }
+  }
+
+  return { result, tier, applyResult, subscribeToTauri }
+})


### PR DESCRIPTION
## Summary

Conditional desktop branch in `OnboardingWizard.vue` gated on `serverConfig.singleUser`. Cloud flow (existing org-creation + KB upload) is untouched.

- `frontend/src/stores/precheck.ts` — Pinia store listening to the Tauri `precheck:result` event from #420; exposes `ramTier` getter (<8 floor, 8-11 low, 12-15 mid, 16+ high).
- `frontend/src/pages/onboarding/ModelPickerStep.vue` — RAM-tier-driven model picker. Pre-selects per spec: floor → llama3.2:3b, low/mid → llama3.1:8b, high → 8b with 13b also offered. Pull button invokes `ollama_pull_model` (added in #421's PR #480) and renders a progress bar driven by `ollama:pull-progress` events.
- `frontend/src/pages/onboarding/OptionalBYOKStep.vue` — Skippable form posting to `/api/v1/llm-providers`.
- `frontend/src/pages/onboarding/OnboardingWizard.vue` — Adds the 3-step desktop branch (model → optional BYOK → workspace, defaulting to "Personal"). Existing cloud branch wrapped in `<template v-else>`.
- `frontend/src/main.ts` — Subscribes the precheck store on app boot in single-user mode.
- `frontend/package.json` — Adds `@tauri-apps/api` so dynamic imports resolve at build time. Only desktop builds actually execute those paths.

Closes #422 — refs M11. **Depends on #480** (Ollama provider) being on main for the Tauri commands to exist; #480's auto-merge is queued so this PR can land any time after.

## Test plan

- [x] vitest: 6/6 precheck-store tests pass (ramTier classification + store apply)
- [x] vue-tsc --noEmit clean
- [ ] Playwright e2e (deferred — frontend Playwright config + a stubbed Tauri bridge is its own follow-up; happy path can be exercised manually once #480 lands)
- [ ] CI green