### PR TITLE
docs: real content for 8 operator/contributor pages + Mermaid rendering

### DIFF
--- a/docs-site/.vitepress/config.ts
+++ b/docs-site/.vitepress/config.ts
@@ -1,11 +1,12 @@
 import { defineConfig } from "vitepress";
+import { withMermaid } from "vitepress-plugin-mermaid";
 import { mainSidebar } from "./sidebars/main";
 
 // `apiSidebar` from ./openapi will be re-enabled in Phase 2 once we ship the
 // vitepress-openapi dynamic-route file that materialises per-operation pages.
 // Until then, /api/ shows only the Overview link to avoid dead-link UX.
 
-export default defineConfig({
+export default withMermaid(defineConfig({
   title: "Raven Docs",
   description:
     "Open-source multi-tenant knowledge base platform with AI chat, voice, and WhatsApp.",
@@ -101,4 +102,8 @@ export default defineConfig({
       provider: "local",
     },
   },
-});
+
+  mermaid: {
+    theme: "default",
+  },
+}));

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -13,10 +13,12 @@
       },
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
+        "mermaid": "^11.14.0",
         "pagefind": "^1.1.0",
         "tsx": "^4.19.0",
         "typescript": "^5.6.0",
         "vitepress": "^1.5.0",
+        "vitepress-plugin-mermaid": "^2.0.17",
         "vue": "^3.5.0"
       }
     },
@@ -260,6 +262,20 @@
         "node": ">= 14.0.0"
       }
     },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
@@ -305,6 +321,55 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/cst-dts-gen": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-12.0.0.tgz",
+      "integrity": "sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/gast": "12.0.0",
+        "@chevrotain/types": "12.0.0"
+      }
+    },
+    "node_modules/@chevrotain/gast": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-12.0.0.tgz",
+      "integrity": "sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/types": "12.0.0"
+      }
+    },
+    "node_modules/@chevrotain/regexp-to-ast": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-12.0.0.tgz",
+      "integrity": "sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-12.0.0.tgz",
+      "integrity": "sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/utils": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-12.0.0.tgz",
+      "integrity": "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@docsearch/css": {
       "version": "3.8.2",
@@ -873,6 +938,18 @@
       "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
       "license": "MIT"
     },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.3.tgz",
+      "integrity": "sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
+      }
+    },
     "node_modules/@internationalized/date": {
       "version": "3.12.1",
       "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.1.tgz",
@@ -896,6 +973,41 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
+    },
+    "node_modules/@mermaid-js/mermaid-mindmap": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/mermaid-mindmap/-/mermaid-mindmap-9.3.0.tgz",
+      "integrity": "sha512-IhtYSVBBRYviH1Ehu8gk69pMDF8DSRqXBRDMWrEfHoaMruHeaP2DXA3PBnuwsMaCdPQhlUUcy/7DBLAEIXvCAw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@braintree/sanitize-url": "^6.0.0",
+        "cytoscape": "^3.23.0",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.1.0",
+        "d3": "^7.0.0",
+        "khroma": "^2.0.0",
+        "non-layered-tidy-tree-layout": "^2.0.2"
+      }
+    },
+    "node_modules/@mermaid-js/mermaid-mindmap/node_modules/@braintree/sanitize-url": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.4.tgz",
+      "integrity": "sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.0.tgz",
+      "integrity": "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "langium": "^4.0.0"
+      }
     },
     "node_modules/@pagefind/darwin-arm64": {
       "version": "1.5.2",
@@ -1473,10 +1585,301 @@
         "vue": "^2.7.0 || ^3.0.0"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/hast": {
@@ -1526,6 +1929,14 @@
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -1543,6 +1954,17 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
       "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
       "license": "ISC"
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
     },
     "node_modules/@vitejs/plugin-vue": {
       "version": "5.2.4",
@@ -1874,6 +2296,36 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chevrotain": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz",
+      "integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/cst-dts-gen": "12.0.0",
+        "@chevrotain/gast": "12.0.0",
+        "@chevrotain/regexp-to-ast": "12.0.0",
+        "@chevrotain/types": "12.0.0",
+        "@chevrotain/utils": "12.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/chevrotain-allstar": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.4.3.tgz",
+      "integrity": "sha512-2X4mkroolSMKqW+H22pyPMUVDqYZzPhephTmg/NODKb1IGYPHfxfhcW0EjS7wcPJNbze2i4vBWT7zT5FKF2lrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "^4.18.1"
+      },
+      "peerDependencies": {
+        "chevrotain": "^12.0.0"
+      }
+    },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
@@ -1905,6 +2357,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/copy-anything": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
@@ -1920,10 +2382,568 @@
         "url": "https://github.com/sponsors/mesqueeb"
       }
     },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/cytoscape": {
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.3.tgz",
+      "integrity": "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/defu": {
@@ -1931,6 +2951,16 @@
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
       "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "license": "MIT"
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -1952,6 +2982,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "dev": true,
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/emoji-regex-xs": {
@@ -2056,6 +3096,13 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/hast-util-to-html": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
@@ -2108,6 +3155,40 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/is-what": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
@@ -2131,6 +3212,72 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/katex": {
+      "version": "0.16.45",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.45.tgz",
+      "integrity": "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==",
+      "dev": true,
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==",
+      "dev": true
+    },
+    "node_modules/langium": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/langium/-/langium-4.2.3.tgz",
+      "integrity": "sha512-sOPIi4hISFnY7twwV97ca1TsxpBtXq0URu/LL1AvxwccPG/RIBBlKS7a/f/EL6w8lTNaS0EFs/F+IdSOaqYpng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/regexp-to-ast": "~12.0.0",
+        "chevrotain": "~12.0.0",
+        "chevrotain-allstar": "~0.4.3",
+        "vscode-languageserver": "~9.0.1",
+        "vscode-languageserver-textdocument": "~1.0.11",
+        "vscode-uri": "~3.1.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lucide-vue-next": {
       "version": "0.577.0",
@@ -2162,6 +3309,19 @@
       "integrity": "sha512-pg5OK0jPLg62H4k7M9mRJLT61gUp9nvG0XveKYHMOOluASo9OEF13WlXrpAp2aj35LbedAy3QOCgQCw0tkLKAQ==",
       "license": "MIT"
     },
+    "node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/mdast-util-to-hast": {
       "version": "13.2.1",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
@@ -2181,6 +3341,36 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mermaid": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.14.0.tgz",
+      "integrity": "sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.1",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.1.0",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.1",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.19",
+        "dompurify": "^3.3.1",
+        "katex": "^0.16.25",
+        "khroma": "^2.1.0",
+        "lodash-es": "^4.17.23",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0"
       }
     },
     "node_modules/micromark-util-character": {
@@ -2302,6 +3492,14 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/non-layered-tidy-tree-layout": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/non-layered-tidy-tree-layout/-/non-layered-tidy-tree-layout-2.0.2.tgz",
+      "integrity": "sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/ohash": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
@@ -2318,6 +3516,13 @@
         "regex": "^6.0.1",
         "regex-recursion": "^6.0.2"
       }
+    },
+    "node_modules/package-manager-detector": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pagefind": {
       "version": "1.5.2",
@@ -2338,6 +3543,13 @@
         "@pagefind/windows-x64": "1.5.2"
       }
     },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
@@ -2349,6 +3561,24 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.14",
@@ -2501,6 +3731,13 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "license": "MIT"
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "dev": true,
+      "license": "Unlicense"
+    },
     "node_modules/rollup": {
       "version": "4.60.3",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
@@ -2544,6 +3781,33 @@
         "@rollup/rollup-win32-x64-msvc": "4.60.3",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/search-insights": {
       "version": "2.17.3",
@@ -2610,6 +3874,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/superjson": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
@@ -2628,6 +3899,16 @@
       "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
       "license": "MIT"
     },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -2636,6 +3917,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
       }
     },
     "node_modules/tslib": {
@@ -2744,6 +4035,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vfile": {
@@ -3338,6 +4643,75 @@
       "peerDependencies": {
         "vue": "^3.5.0"
       }
+    },
+    "node_modules/vitepress-plugin-mermaid": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/vitepress-plugin-mermaid/-/vitepress-plugin-mermaid-2.0.17.tgz",
+      "integrity": "sha512-IUzYpwf61GC6k0XzfmAmNrLvMi9TRrVRMsUyCA8KNXhg/mQ1VqWnO0/tBVPiX5UoKF1mDUwqn5QV4qAJl6JnUg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "@mermaid-js/mermaid-mindmap": "^9.3.0"
+      },
+      "peerDependencies": {
+        "mermaid": "10 || 11",
+        "vitepress": "^1.0.0 || ^1.0.0-alpha"
+      }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vue": {
       "version": "3.5.34",

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -13,10 +13,12 @@
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",
+    "mermaid": "^11.14.0",
     "pagefind": "^1.1.0",
     "tsx": "^4.19.0",
     "typescript": "^5.6.0",
     "vitepress": "^1.5.0",
+    "vitepress-plugin-mermaid": "^2.0.17",
     "vue": "^3.5.0"
   },
   "dependencies": {

--- a/docs-site/stubs/contributing/architecture-decisions.md
+++ b/docs-site/stubs/contributing/architecture-decisions.md
@@ -1,16 +1,146 @@
 ---
-title: "Coming Soon"
+title: "Architecture Decisions"
 ---
 
 # Architecture Decisions
 
-::: warning Stub page
-This page is a placeholder. The full content is being written. If you would
-like to contribute, the source for this page lives at the path shown below
-and you can [edit it on GitHub](https://github.com/ravencloak-org/Raven/edit/main/docs-site/stubs/contributing/architecture-decisions.md).
-:::
+Raven does not maintain a parallel `docs/adr/` tree, and it does not use the
+[MADR](https://adr.github.io/madr/) template. Instead, **specification documents
+in [`docs/superpowers/specs/`](https://github.com/ravencloak-org/Raven/tree/main/docs/superpowers/specs)
+are the ADR equivalent**. Each spec captures the rationale for a non-trivial
+decision, lives alongside the code it describes, and is preserved as a
+canonical archive once its implementation lands.
 
-## What goes here
+Specs are produced by the [`superpowers:brainstorming`](https://github.com/ravencloak-org/Raven/tree/main/docs/superpowers)
+skill flow and are paired with an implementation plan in
+[`docs/superpowers/plans/`](https://github.com/ravencloak-org/Raven/tree/main/docs/superpowers/plans).
 
-A short bullet list of the topics this page will cover, drawn from the
-[design spec](https://github.com/ravencloak-org/Raven/blob/main/docs/superpowers/specs/2026-05-09-docs-site-design.md).
+## When to write a spec
+
+| Change type                                          | Write a spec? | Why                                                     |
+| ---------------------------------------------------- | ------------- | ------------------------------------------------------- |
+| One-line bug fix                                     | No            | The PR description is the record.                       |
+| Multi-file refactor with no behaviour change         | No            | The PR description is enough; link prior spec if any.   |
+| New feature with non-obvious tradeoffs               | Yes           | Capture options considered and the chosen path.         |
+| Cross-service contract change (API, gRPC, schema)    | Yes           | Multiple consumers need a shared, durable rationale.    |
+| Replacing a vendor (e.g. Zitadel → SuperTokens)      | Yes           | Plus a paired failure post-mortem (see below).          |
+| Process change (commits, PR flow, branch naming)     | No            | Edit `CLAUDE.md` / `CONTRIBUTING.md` instead.           |
+
+If the spec cannot be finished in one sitting, ship it with `Status: DRAFT`
+and iterate. A draft spec beats a decision with no record.
+
+## Naming and location
+
+```
+docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md
+docs/superpowers/plans/YYYY-MM-DD-<topic>-implementation.md
+```
+
+- `YYYY-MM-DD` is the date the spec was opened, not when it was approved.
+- `<topic>` is kebab-case and matches the plan filename.
+- Specs are immutable archives once their implementation merges. To revise
+  a decision, write a **new** dated spec that links back via a
+  `Supersedes:` header (see the SuperTokens example below).
+
+## Structure
+
+Specs follow a loose template drawn from the existing corpus. Not every
+section is required — pick what fits — but the ordering should hold so
+reviewers know where to look.
+
+| Section                  | Purpose                                                        |
+| ------------------------ | -------------------------------------------------------------- |
+| **Status**               | `DRAFT`, `Approved`, `Superseded`, or `Final`.                 |
+| **Date**                 | ISO date matching the filename.                                |
+| **Author(s)**            | Humans accountable for the decision.                           |
+| **Supersedes / Spec ID** | Link to any prior spec being replaced; optional stable ID.     |
+| **Summary**              | 2–4 sentences. What is being decided and why now.              |
+| **Goals**                | Bulleted, testable success criteria.                           |
+| **Non-goals**            | Explicitly out of scope. Future work goes here.                |
+| **Architecture**         | Diagrams, sequence flows, module layouts, decision tables.     |
+| **IA / API / Data**      | Routes, gRPC methods, schemas, events, sidebar layout, etc.    |
+| **Build & deploy**       | CI/CD, container topology, Cloudflare bindings, env vars.      |
+| **Risks**                | Failure modes and the mitigation for each.                     |
+| **Acceptance criteria**  | Concrete checks the implementation must pass.                  |
+| **Tracking items**       | GitHub issues, milestones, follow-up tickets.                  |
+
+The Status / Date / Author block is typically rendered as a small markdown
+table at the top of the file (see `2026-05-09-docs-site-design.md`).
+
+## Workflow
+
+1. **Brainstorm** — invoke the `superpowers:brainstorming` skill to scope
+   the problem, surface options, and produce the design spec.
+2. **Plan** — invoke `superpowers:writing-plans` to convert the approved
+   spec into a step-by-step implementation plan in
+   `docs/superpowers/plans/`.
+3. **Execute** — invoke `superpowers:subagent-driven-development` (or
+   `superpowers:executing-plans` for solo work) to ship the plan.
+4. **Archive** — once the implementation merges, the spec stays in place
+   as the canonical record. Do not delete or rewrite it; supersede it.
+
+See [Dev Setup](/contributing/dev-setup) for environment prerequisites and
+[Release Process](/contributing/release-process) for how the implementation
+lands in a release.
+
+## Examples
+
+Real specs currently in [`docs/superpowers/specs/`](https://github.com/ravencloak-org/Raven/tree/main/docs/superpowers/specs):
+
+- **`2026-03-27-raven-platform-design-final.md`** — the v1.2 source of
+  truth for the whole platform; every wiki page, milestone, and roadmap
+  derives from it.
+- **`2026-04-07-ebpf-edge-optimization-design.md`** — kernel-level
+  observability and edge networking via shared eBPF programs.
+- **`2026-04-13-integration-tests-design.md`** — Go integration test
+  harness for the Raven core pipeline (test DB lifecycle, gRPC AI worker
+  mock, fixtures).
+- **`2026-04-13-zitadel-migration-design.md`** — original plan to replace
+  Keycloak with Zitadel. Now superseded; see post-mortems below.
+- **`2026-04-14-supertokens-migration-design.md`** — replaces Zitadel with
+  SuperTokens; explicitly cites the production failures of the prior spec
+  and switches to cookie-based sessions on PG18.
+- **`2026-04-19-osps-l2-compliance-design.md`** — OpenSSF OSPS Baseline
+  Level 2 compliance design.
+- **`2026-05-06-raven-marketing-site-design.md`** — Tailwind Plus Salient
+  rebuild of `raven.ravencloak.org`.
+- **`2026-05-08-resilience-design.md`** — circuit breakers, retries, and
+  deadlines across the Go API, gRPC AI worker, and Asynq handlers.
+- **`2026-05-08-m11-phase1-design.md`** — Ollama-backed local AI worker,
+  setup wizard, and installer for the M11 self-hosting path.
+- **`2026-05-09-docs-site-design.md`** — the spec that produced **this
+  documentation site** (VitePress at `docs.raven.ravencloak.org`,
+  spec-fed OpenAPI reference, PageFind search).
+
+Every implementation plan referenced from these specs lives at the matching
+date in `docs/superpowers/plans/`.
+
+## Failure post-mortems
+
+When a decision is reversed, the new spec **must** explain why the previous
+one failed. Do not silently delete or rewrite the original — keep it as
+evidence and link to it from the replacement.
+
+The canonical example: `2026-04-14-supertokens-migration-design.md` opens
+with a `Supersedes:` header pointing at
+`2026-04-13-zitadel-migration-design.md`, then names the four production
+failures (PG18 incompatibility, opaque token behaviour, broken
+`start-from-init` steps, forced MFA on passkey registration) before
+proposing the replacement. That is the pattern to copy.
+
+If a reversal is large enough to warrant a standalone narrative, add a
+sibling document under `docs/superpowers/specs/` (e.g.
+`<date>-<topic>-postmortem.md`) and cross-link both ways.
+
+## Do not
+
+- **Do not** introduce a parallel `docs/adr/` directory. The spec file
+  *is* the ADR.
+- **Do not** copy MADR, Nygard, or Y-statement templates from elsewhere.
+  The structure above is what reviewers expect.
+- **Do not** rewrite a merged spec in place. Supersede it with a new
+  dated file and link both directions.
+- **Do not** put process or workflow rules in a spec. Those belong in
+  `CLAUDE.md` or `CONTRIBUTING.md`.
+- **Do not** open a spec for a one-line bug fix or a pure refactor — the
+  PR description is the audit trail.

--- a/docs-site/stubs/contributing/dev-setup.md
+++ b/docs-site/stubs/contributing/dev-setup.md
@@ -1,16 +1,319 @@
 ---
-title: "Coming Soon"
+title: "Dev Setup"
 ---
 
 # Dev Setup
 
-::: warning Stub page
-This page is a placeholder. The full content is being written. If you would
-like to contribute, the source for this page lives at the path shown below
-and you can [edit it on GitHub](https://github.com/ravencloak-org/Raven/edit/main/docs-site/stubs/contributing/dev-setup.md).
+Zero-to-running on a fresh checkout in 5–10 minutes. This page tracks the
+canonical developer flow — every command is verified against `main`. For
+deeper architectural detail, see
+[Architecture Decisions](/contributing/architecture-decisions). For release
+mechanics, see [Release Process](/contributing/release-process). For the
+exhaustive environment variable list, see
+[Configuration](/reference/configuration).
+
+## Prerequisites
+
+| Tool | Version | Install hint |
+|------|---------|--------------|
+| Go | 1.25+ (toolchain pins `go1.26.2`) | `brew install go` · `apt install golang-go` · [go.dev/dl](https://go.dev/dl/) |
+| Python | 3.12+ | `brew install python@3.12` · `apt install python3.12` · [python.org](https://www.python.org/downloads/) |
+| Node.js | 22 LTS+ | `brew install node@22` · `apt install nodejs npm` · [nodejs.org](https://nodejs.org/) |
+| Docker + Docker Compose | Latest | `brew install --cask docker` · [docs.docker.com](https://docs.docker.com/get-docker/) — required for testcontainers integration tests |
+| `uv` (recommended) | Latest | `curl -LsSf https://astral.sh/uv/install.sh \| sh` · `brew install uv` |
+| `golangci-lint` | v2 | `brew install golangci-lint` · `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest` |
+| `make` | Any | Preinstalled on macOS/Linux; on Windows use WSL2 |
+
+Optional but useful:
+
+| Tool | Use |
+|------|-----|
+| `dotenvx` | Wraps Make targets to load `.env`; `npm i -g @dotenvx/dotenvx` |
+| `air` | Hot reload for the Go API; `go install github.com/air-verse/air@latest` |
+| `goose` | Database migrations; `go install github.com/pressly/goose/v3/cmd/goose@latest` |
+| `ruff` | Python lint/format; bundled in `ai-worker` dev deps, also `pipx install ruff` |
+
+::: tip Windows users
+Develop inside WSL2 (Ubuntu 22.04+). Native Windows is not a supported dev
+target — pre-commit shell hooks and Docker bind mounts both assume POSIX.
 :::
 
-## What goes here
+## Clone and bootstrap
 
-A short bullet list of the topics this page will cover, drawn from the
-[design spec](https://github.com/ravencloak-org/Raven/blob/main/docs/superpowers/specs/2026-05-09-docs-site-design.md).
+```bash
+git clone https://github.com/ravencloak-org/Raven.git
+cd Raven
+
+# Seed local config from the committed template
+cp .env.example .env
+# Required overrides at minimum:
+#   POSTGRES_PASSWORD       — any non-empty string for local dev
+#   RAVEN_ENCRYPTION_AES_KEY — 32-byte hex (e.g. `openssl rand -hex 32`)
+#   ZO_ROOT_USER_PASSWORD   — OpenObserve admin password
+# BYOK secrets (set whichever providers you'll exercise):
+#   ANTHROPIC_API_KEY / OPENAI_API_KEY / COHERE_API_KEY
+
+# Wire up the repo's hooks (pre-commit lint + pre-push DCO)
+git config core.hooksPath .githooks
+```
+
+The two hooks under `.githooks/` mirror CI:
+
+| Hook | Triggers | Checks |
+|------|----------|--------|
+| `pre-commit` | `git commit` | `golangci-lint run ./...` when staged changes touch `.go` files |
+| `pre-push` | `git push` | every commit being pushed has a `Signed-off-by:` trailer (DCO) |
+
+`pre-commit` skips silently if `golangci-lint` is not on `PATH`. Always
+commit with `git commit -s` so the DCO check passes.
+
+## Bring up dependencies
+
+For most workflows you only need the data layer running in containers. Run
+the application services natively for fast iteration.
+
+```bash
+docker compose up -d postgres valkey supertokens
+```
+
+This starts:
+
+| Service | Image | Port |
+|---------|-------|------|
+| `postgres` | `pgvector/pgvector:pg18` | `5432` |
+| `valkey` | `valkey/valkey:8.1-alpine` | `6379` |
+| `supertokens` | `registry.supertokens.io/supertokens/supertokens-postgresql` | internal `3567` |
+
+Add `openobserve` if you want to inspect traces/metrics locally:
+
+```bash
+docker compose up -d postgres valkey supertokens openobserve
+# UI at http://localhost:5080
+```
+
+To run **everything** in containers (the slow path) use `make compose`,
+which wraps `docker compose up --build` with `dotenvx`.
+
+## Run the Go API
+
+The API binary lives under `cmd/api`. The Makefile targets load `.env`
+through `dotenvx` automatically.
+
+```bash
+# Apply migrations (first run only, or after pulling new ones)
+make migrate-up
+
+# Start the server
+make run            # plain `go run ./cmd/api`
+# OR
+make dev            # hot-reload via `air`
+# OR, without dotenvx:
+go run ./cmd/api
+```
+
+Default listen port is **`8081`** (configurable via `RAVEN_SERVER_PORT`).
+Smoke-test:
+
+```bash
+curl http://localhost:8081/healthz
+# → {"status":"ok"}
+```
+
+OpenAPI / Swagger UI is regenerated with `make swagger` and served at
+`/swagger/index.html`.
+
+## Run the AI worker
+
+The Python gRPC service lives in `ai-worker/`. `uv` is the recommended
+dependency manager — it's faster than pip and respects the lockfile.
+
+```bash
+cd ai-worker
+
+# Create the venv and install runtime + dev deps
+uv sync --extra dev
+
+# Generate gRPC stubs from .proto files (one-time, or when proto changes)
+uv run ./scripts/generate_proto.sh
+
+# Start the worker
+uv run python -m raven_worker
+```
+
+The worker exposes:
+
+| Endpoint | Port | Purpose |
+|----------|------|---------|
+| gRPC | `50051` | Embeddings, RAG, ingestion (called by Go API) |
+| HTTP internal | `8090` | `POST /internal/summarize` and other intra-cluster RPCs |
+
+gRPC reflection is enabled in dev — point `grpcurl` at it:
+
+```bash
+grpcurl -plaintext localhost:50051 list
+```
+
+If you don't have `uv`, the legacy flow still works:
+
+```bash
+cd ai-worker
+python -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+python -m raven_worker
+```
+
+## Run the frontend
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Vite dev server listens on **`http://localhost:3000`** (overridden in
+`vite.config.ts`); it proxies `/api/*` to `http://localhost:8080`. If you
+run the Go API on the default `8081`, either update the Vite proxy target
+or set `RAVEN_SERVER_PORT=8080` when starting the API.
+
+The first time you run Playwright e2e tests, install the browser binaries:
+
+```bash
+npx playwright install
+```
+
+## Run tests
+
+### Go
+
+```bash
+# Unit tests
+go test ./...
+
+# With race detector (matches CI)
+go test -race -timeout 30m ./...
+
+# Integration tests — requires Docker (testcontainers)
+go test -tags=integration ./internal/integration/... -v -timeout 5m -count=1
+
+# Or via Make
+make test                 # unit
+make test-integration     # integration
+make coverage             # merged unit + integration coverage report
+```
+
+### Python
+
+```bash
+cd ai-worker
+uv run pytest                        # all
+uv run pytest -k "test_rag"          # filter by name
+uv run pytest -x                     # stop on first failure
+```
+
+### Frontend
+
+```bash
+cd frontend
+npm run test:unit         # Vitest, headless, no live stack needed
+npm run test:e2e          # Playwright; auto-spawns Vite via webServer
+npm run build             # vue-tsc + vite build — catches TS errors Vite skips
+```
+
+Playwright runs against `http://localhost:5173` in CI (`vite preview`) and
+spawns the dev server otherwise. The `webServer` block in
+`playwright.config.ts` handles startup and reuse.
+
+## Linting
+
+| Linter | Scope | Command | Gated by hook? |
+|--------|-------|---------|----------------|
+| `golangci-lint` | All Go code | `golangci-lint run ./...` (or `make lint`) | ✅ pre-commit |
+| `ruff` (lint) | `ai-worker/` | `cd ai-worker && uv run ruff check .` | ❌ run before push |
+| `ruff` (format) | `ai-worker/` | `cd ai-worker && uv run ruff format --check .` | ❌ run before push |
+| `eslint` | `frontend/` | `cd frontend && npm run lint` | ❌ run before push |
+| `vue-tsc` | `frontend/` | `cd frontend && npx vue-tsc --noEmit` | ❌ run before push |
+| DCO sign-off | every commit | enforced by pre-push hook | ✅ pre-push |
+
+The pre-commit hook only runs `golangci-lint`. Python and frontend linters
+are not hooked — run them manually before pushing. The shortest pre-push
+checklist:
+
+```bash
+# From repo root
+make lint && \
+( cd ai-worker && uv run ruff check . && uv run ruff format --check . ) && \
+( cd frontend && npm run lint && npx vue-tsc --noEmit )
+```
+
+CI rejects any push that fails these. Never use `--no-verify`.
+
+## Editor setup
+
+VS Code is the reference editor; the suggestions below also apply to
+JetBrains GoLand / PyCharm with equivalent plugins.
+
+**Extensions**
+
+- `golang.go` — Go language server (`gopls`), test runner, debug
+- `charliermarsh.ruff` — Ruff lint + format on save for Python
+- `vue.volar` — Vue 3 Single File Components, TypeScript-aware
+- `dbaeumer.vscode-eslint` — ESLint for the frontend
+- `ms-azuretools.vscode-docker` — Compose file support
+- `tamasfe.even-better-toml` — `pyproject.toml` editing
+- `redhat.vscode-yaml` — schema-aware YAML
+
+**Recommended `.vscode/settings.json`** (workspace-local, not committed):
+
+```jsonc
+{
+  "go.useLanguageServer": true,
+  "go.lintTool": "golangci-lint",
+  "go.lintFlags": ["--fast-only"],
+  "go.formatTool": "goimports",
+  "[python]": {
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": { "source.organizeImports": "explicit" }
+  },
+  "[vue]": { "editor.defaultFormatter": "Vue.volar" },
+  "eslint.workingDirectories": [{ "directory": "frontend", "changeProcessCWD": true }],
+  "files.eol": "\n"
+}
+```
+
+Make sure `gopls` picks up the toolchain pin — run
+`go env GOTOOLCHAIN` and confirm it returns `go1.26.2` or higher.
+
+## Tip: parallel-worktree workflow
+
+Raven is developed almost entirely inside `git worktree` checkouts. Each
+feature gets its own worktree under `.worktrees/`, which is gitignored.
+
+```bash
+# Spin up a worktree for a new feature
+git worktree add .worktrees/feat-my-feature -b feat/my-feature
+
+# Work inside it
+cd .worktrees/feat-my-feature
+
+# Tear it down once the PR has merged
+git worktree remove .worktrees/feat-my-feature
+```
+
+This isolates each branch's `bin/`, `node_modules/`, and `.venv/` from
+your main checkout — important when running multiple agents in parallel,
+or just hopping between long-lived features. Never commit the
+`.worktrees/` directory, and never let two worktrees run the same dev
+servers on the same ports simultaneously.
+
+---
+
+**Next steps**
+
+- [Configuration reference](/reference/configuration) — every env var
+  the API and worker read
+- [Architecture Decisions](/contributing/architecture-decisions) — why
+  Raven is built the way it is
+- [Release Process](/contributing/release-process) — milestone cadence,
+  squash-merge rules, tagging

--- a/docs-site/stubs/contributing/release-process.md
+++ b/docs-site/stubs/contributing/release-process.md
@@ -1,16 +1,263 @@
 ---
-title: "Coming Soon"
+title: "Release Process"
 ---
 
 # Release Process
 
-::: warning Stub page
-This page is a placeholder. The full content is being written. If you would
-like to contribute, the source for this page lives at the path shown below
-and you can [edit it on GitHub](https://github.com/ravencloak-org/Raven/edit/main/docs-site/stubs/contributing/release-process.md).
-:::
+Raven follows [Semantic Versioning](https://semver.org/). While the project
+is pre-1.0, **minor version bumps may include breaking changes**; patch
+releases (`vX.Y.Z` → `vX.Y.Z+1`) are reserved for bug-fix and security
+backports. Once `v1.0.0` ships, the standard SemVer contract applies.
 
-## What goes here
+A release publishes the following artefacts together under a single Git tag:
 
-A short bullet list of the topics this page will cover, drawn from the
-[design spec](https://github.com/ravencloak-org/Raven/blob/main/docs/superpowers/specs/2026-05-09-docs-site-design.md).
+- **Go binaries** — `raven-api` and `raven-worker`, built per OS/arch by
+  GoReleaser (`linux/amd64`, `linux/arm64`, `darwin/arm64`).
+- **Docker images** — `ghcr.io/ravencloak-org/{go-api,python-worker,frontend}`,
+  multi-arch (`linux/amd64` + `linux/arm64`), cosign-signed with SLSA
+  build provenance and SPDX SBOM attestations.
+- **Frontend bundle** — `frontend-X.Y.Z.tgz` (Vite `dist/`) for self-hosted
+  static deployments, with a SHA256 sum and a cosign blob signature.
+- **Release notes** — generated from conventional commits via `git-cliff`.
+- **GitHub Release** — assembled by `softprops/action-gh-release`.
+
+Cloudflare Pages production deploys for the frontend, landing, and docs
+sites are **not** part of this workflow; they ship continuously on every
+push to `main` via dedicated workflows (`pages.yml`, `landing.yml`,
+`docs.yml`).
+
+## Versioning policy
+
+| Phase | Rule |
+|-------|------|
+| `0.x.y` (current) | Minor bumps (`0.3 → 0.4`) may break APIs, CLI flags, env vars, or config. Patch bumps (`0.3.0 → 0.3.1`) MUST be backwards-compatible. |
+| `1.x.y` (future)  | Standard SemVer: breaking changes only on major bumps; minors add features, patches fix bugs. |
+| Release candidates | `vX.Y.Z-rcN` (matched by the workflow regex). The release is automatically marked **prerelease** on GitHub. |
+
+Tags MUST match `^v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$` — the preflight job
+in `release.yml` rejects anything else.
+
+## Release cadence
+
+There is no fixed cadence. Releases are cut when a milestone closes or
+when a critical fix needs to ship. The most recent published release
+sequence on the signed-pipeline line:
+
+| Tag       | Date         | Trigger |
+|-----------|--------------|---------|
+| `v0.3.0`  | 2026-04-23   | M9 milestone + security hardening (#362, etc.) |
+| `v0.1.0`  | 2026-04-20   | First public release |
+
+`v0.2.0` exists as an older pre-signed-pipeline tag and was deliberately
+skipped in the signed-release sequence to avoid collision (see the
+`Notes` section in `CHANGELOG.md`).
+
+## How to cut a release
+
+### 1. Pre-flight (local)
+
+- Lint clean: `golangci-lint run ./...` and `ruff check ai-worker/`.
+- Unit tests green: `go test ./...`, `pytest ai-worker/`,
+  `cd frontend && npm run test`.
+- Integration tests green: `make integration-test`.
+- All milestone issues closed; all dependent PRs merged.
+- `main` is green on CI.
+
+### 2. Bump versions on `main`
+
+Open a PR titled `chore(release): vX.Y.Z` that bumps:
+
+- `frontend/package.json` → `"version": "X.Y.Z"`
+- `ai-worker/pyproject.toml` → `version = "X.Y.Z"`
+
+Get the PR reviewed and squash-merged. (The Go binaries embed the version
+via `-X main.version={{.Version}}` ldflags injected by GoReleaser at build
+time; no source bump is required there.)
+
+### 3. Regenerate `CHANGELOG.md`
+
+`cliff.toml` reads conventional commits (`feat:`, `fix:`, `perf:`,
+`refactor:`, `docs:`, `test:`, `ci:`, `chore:`, `deps:`, `security:`,
+`revert:`) and groups them into Markdown sections.
+
+```bash
+git cliff --tag vX.Y.Z -o CHANGELOG.md
+```
+
+Commit on `main` as `docs(changelog): vX.Y.Z` and merge.
+
+### 4. Tag the release commit
+
+Tags MUST be **signed** (the repo enforces signed commits + DCO; the same
+key SHOULD sign tags) and MUST be cut from `main` — `release.yml`'s
+preflight job verifies the tag is reachable from `origin/main` with
+`git merge-base --is-ancestor` and aborts otherwise.
+
+```bash
+git checkout main
+git pull --ff-only
+git tag -s vX.Y.Z -m "vX.Y.Z — <one-line summary>"
+git push origin vX.Y.Z
+```
+
+For a release candidate use `vX.Y.Z-rcN` (e.g. `v0.4.0-rc1`).
+
+That is the entire manual step. The rest is the workflow.
+
+## What the release workflow does
+
+`.github/workflows/release.yml` triggers on tag push and runs six jobs in
+DAG order. Each job's permissions are scoped to the minimum it needs.
+
+### `preflight`
+
+- Validates the tag against the SemVer regex (`v[0-9]+.[0-9]+.[0-9]+(-rcN)?`).
+- Verifies the tag is reachable from `origin/main`.
+- Exposes `tag` and `version` outputs to downstream jobs.
+
+### `changelog`
+
+- Runs `orhun/git-cliff-action` with `--latest --strip header` against
+  `cliff.toml`.
+- Writes `RELEASE_NOTES.md` and uploads it as an artefact.
+
+### `go-binaries`
+
+- Sets up Go (`1.26.x`) with module cache.
+- Installs `cosign` via `sigstore/cosign-installer`.
+- Runs `goreleaser release --clean --skip=publish` (GoReleaser v2). The
+  `release.disable: true` setting in `.goreleaser.yaml` lets the workflow,
+  not GoReleaser, create the GitHub Release.
+- GoReleaser produces tar.gz archives per OS/arch + `checksums.txt`, then
+  cosign-keyless-signs `checksums.txt` (Rekor transparency log →
+  `checksums.txt.sig` + `checksums.txt.pem`).
+
+### `docker-build` (matrix) → `docker-merge`
+
+- `docker-build` runs **per (component, arch)** on native runners
+  (`ubuntu-latest` for amd64, `ubuntu-24.04-arm` for arm64). Each leg
+  pushes by digest only — no tags. This avoids QEMU emulation for the
+  arm64 leg (CGO + eBPF build) and keeps the critical path under
+  five minutes per arch.
+- `docker-merge` downloads the per-arch digests, assembles a multi-arch
+  manifest, tags it (`{{version}}`, `{{major}}.{{minor}}`, `latest`),
+  signs it with `cosign sign --yes`, and attaches:
+  - **SLSA build provenance** via `actions/attest-build-provenance@v4`
+    (in-toto statement, OIDC-signed by the GitHub-hosted Sigstore Fulcio CA),
+  - **SPDX SBOM** generated by `anchore/sbom-action`, attested via
+    `actions/attest-sbom@v4` (SPDX JSON only — CycloneDX is not produced).
+  Both attestations are pushed to the registry as referrer manifests.
+
+### `frontend-bundle`
+
+- Builds `frontend/` with `npm ci && npm run build`.
+- Tarballs `dist/` as `frontend-X.Y.Z.tgz`, computes a SHA256 sum, and
+  cosign-blob-signs the tarball.
+
+### `publish-release`
+
+- Downloads all artefacts from the previous jobs.
+- Calls `softprops/action-gh-release` to create the GitHub Release with:
+  - `tag_name` and `name` set to the tag,
+  - `body_path` pointing at `RELEASE_NOTES.md`,
+  - `prerelease: true` when the tag contains `-rc`,
+  - the Go archives, checksums + signatures, and the frontend bundle +
+    its signature attached as release assets.
+
+Docker images are *not* attached as release assets — they live in
+`ghcr.io/ravencloak-org/*` and are referenced by tag and digest.
+
+## Verifying a release
+
+Every signed artefact in the pipeline can be verified offline by anyone.
+Full instructions live at [/trust/slsa-level-3](/trust/slsa-level-3).
+
+Quick reference for the container images:
+
+```bash
+# Provenance
+cosign verify-attestation \
+  --type slsaprovenance1 \
+  --certificate-identity-regexp \
+    'https://github.com/ravencloak-org/Raven/.github/workflows/(docker|release)\.yml@.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/ravencloak-org/go-api:vX.Y.Z
+
+# SBOM
+cosign verify-attestation \
+  --type spdxjson \
+  --certificate-identity-regexp \
+    'https://github.com/ravencloak-org/Raven/.github/workflows/(docker|release)\.yml@.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/ravencloak-org/go-api:vX.Y.Z
+```
+
+For the Go binary checksums:
+
+```bash
+cosign verify-blob \
+  --certificate checksums.txt.pem \
+  --signature   checksums.txt.sig \
+  --certificate-identity-regexp \
+    'https://github.com/ravencloak-org/Raven/.github/workflows/release\.yml@.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  checksums.txt
+```
+
+`gh attestation verify` is the simpler path when the GitHub CLI is
+available — see [/trust/slsa-level-3](/trust/slsa-level-3) for the
+exact commands.
+
+## Hotfix releases
+
+For a critical security or correctness fix that lands on `main` between
+scheduled releases:
+
+1. Cherry-pick or merge the fix into `main` via PR (squash, signed).
+2. Bump the patch version (`vX.Y.Z` → `vX.Y.(Z+1)`) per the steps above.
+3. Regenerate `CHANGELOG.md` and tag.
+4. The release workflow republishes images, binaries, and the frontend
+   bundle exactly as for any other release.
+
+There is no separate hotfix branch — Raven releases are always cut from
+`main`, and the preflight job enforces this.
+
+## Rollback
+
+### Container images
+
+Pinned tags are immutable in practice (signatures and attestations
+reference a specific manifest digest). To roll back a deployment:
+
+```bash
+# In your docker-compose.yml or k8s manifest, replace the tag:
+#   image: ghcr.io/ravencloak-org/go-api:v0.3.0
+# with the previous good version:
+#   image: ghcr.io/ravencloak-org/go-api:v0.1.0
+docker compose pull && docker compose up -d
+```
+
+For paranoia, pin by digest (`@sha256:...`) — the merged manifest digest
+is captured in the `docker-merge` job log.
+
+### Go binaries / frontend bundle
+
+Re-download the previous tag's assets from
+`https://github.com/ravencloak-org/Raven/releases/tag/vX.Y.Z` and
+re-deploy. Verify signatures before swapping in (see above).
+
+### Cloudflare Pages sites (frontend / landing / docs)
+
+These deploy continuously from `main`, not from tags. Rollback is via the
+**Cloudflare Pages dashboard** → project → Deployments → previous
+deployment → "Rollback to this deployment". A revert PR on `main` will
+also redeploy automatically; pick whichever is faster.
+
+## Cross-references
+
+- [Dev setup](/contributing/dev-setup) — how to get a local build green
+  before a release.
+- [SLSA Level 3 verification](/trust/slsa-level-3) — full verification
+  procedure, what the attestations prove, and what they don't.
+- [Security policy](/reference/security-policy) — how to report a
+  vulnerability that may warrant a hotfix.

--- a/docs-site/stubs/guides/self-hosting/backups.md
+++ b/docs-site/stubs/guides/self-hosting/backups.md
@@ -1,16 +1,293 @@
 ---
-title: "Coming Soon"
+title: "Backups"
 ---
 
 # Backups
 
-::: warning Stub page
-This page is a placeholder. The full content is being written. If you would
-like to contribute, the source for this page lives at the path shown below
-and you can [edit it on GitHub](https://github.com/ravencloak-org/Raven/edit/main/docs-site/stubs/guides/self-hosting/backups.md).
-:::
+Raven persists state across four data layers, but only some carry durable,
+irreplaceable data. Backups in the reference deployment are anchored on
+**pgBackRest**, run as a sidecar container against PostgreSQL. Everything
+else is recomputable, externally backed (object volumes), or out of scope.
 
-## What goes here
+## What's backed up
 
-A short bullet list of the topics this page will cover, drawn from the
-[design spec](https://github.com/ravencloak-org/Raven/blob/main/docs/superpowers/specs/2026-05-09-docs-site-design.md).
+| Layer / artefact          | What it stores                                                       | Backup mechanism in repo                                              | RPO target                |
+|---------------------------|----------------------------------------------------------------------|-----------------------------------------------------------------------|---------------------------|
+| PostgreSQL data           | Relational + pgvector + RLS state                                    | `pgbackrest` sidecar in `docker-compose.yml` — full + diff + incr     | < 1 hour (hourly `incr`)  |
+| PostgreSQL WAL            | Continuous write-ahead log                                           | `archive_command=pgbackrest --stanza=raven archive-push %p` (line 142 of `docker-compose.yml`) | Streaming (PITR-capable) |
+| ClickHouse                | Audit logs, analytics                                                | **Not wired.** No `clickhouse-backup` service or `BACKUP TABLE` automation in the repo. | n/a — see below           |
+| SeaweedFS                 | Attachments, voice audio, anything written via `internal/storage`    | **Volume-level only.** No application-level backup; relies on `seaweedfs-data` volume snapshots. | Operator-defined          |
+| Valkey                    | Cache + Asynq queues                                                 | **Not backed up by design.** Pending Asynq tasks live here too — accept loss on restart. | n/a                       |
+| `migrations/*.sql`        | Schema definitions (goose-managed, 30 files at last count)           | Versioned in Git; not data, but the schema state every restore depends on. | n/a                       |
+
+Note on Valkey: `internal/queue/client.go` and `internal/queue/server.go`
+both wire Asynq with `asynq.RedisClientOpt{Addr: redisAddr}`. Asynq stores
+task state in Valkey, not Postgres — so if Valkey is wiped, in-flight and
+scheduled tasks are lost. That is the chosen trade-off; producers must be
+idempotent. Do not add Valkey to your backup plan.
+
+## pgBackRest setup
+
+The `pgbackrest` service in `docker-compose.yml` (lines 289–311) runs the
+official `pgbackrest/pgbackrest:latest` image as a long-lived sidecar
+(`command: ["sleep", "infinity"]`) you `exec` into. Mounts:
+
+| Host path / volume         | Container path                          | Purpose                                |
+|----------------------------|-----------------------------------------|----------------------------------------|
+| `./backup/pgbackrest.conf` | `/etc/pgbackrest/pgbackrest.conf` (ro)  | Config (also mounted into `postgres`). |
+| `./backup/backup.sh`       | `/backup/backup.sh` (ro)                | Wrapper around `pgbackrest backup`.    |
+| `./backup/restore.sh`      | `/backup/restore.sh` (ro)               | Wrapper around `pgbackrest restore`.   |
+| `pg-data` volume           | `/var/lib/postgresql/data` (ro)         | Read-only access to the live cluster.  |
+| `pgbackrest-repo` volume   | `/var/lib/pgbackrest`                   | The backup repository itself.          |
+| `pgbackrest-log` volume    | `/var/log/pgbackrest`                   | pgBackRest log files.                  |
+
+PostgreSQL is configured for archive-mode WAL shipping in the `postgres`
+service `command:`:
+
+```yaml
+command:
+  - "postgres"
+  - "-c"
+  - "archive_mode=on"
+  - "-c"
+  - "archive_command=pgbackrest --stanza=raven archive-push %p || true"
+  - "-c"
+  - "wal_level=replica"
+  - "-c"
+  - "max_wal_senders=3"
+```
+
+The `|| true` is deliberate: if pgBackRest is briefly unreachable,
+Postgres keeps accepting writes rather than blocking. WAL replay on
+restore is then limited to whatever was successfully archived.
+
+### Repository, retention, compression
+
+Defaults from `backup/pgbackrest.conf`:
+
+| Setting                   | Value                            |
+|---------------------------|----------------------------------|
+| `repo1-type`              | `posix` (local volume `pgbackrest-repo`) |
+| `repo1-path`              | `/var/lib/pgbackrest`            |
+| `repo1-retention-full`    | `4` (keep last 4 full backups)   |
+| `repo1-retention-diff`    | `30` (expire diffs older than 30)|
+| `compress-type` / `level` | `zst` / `3`                      |
+| `process-max`             | `2`                              |
+| Stanza                    | `raven`                          |
+| `pg1-host` / `pg1-port`   | `postgres` / `5432`              |
+| `pg1-path`                | `/var/lib/postgresql/data`       |
+
+### Backup cadence
+
+`backup/backup.sh` accepts `full | diff | incr` (default `incr`) and is
+invoked via `docker compose exec`. The script header documents the
+recommended cron pattern (host crontab):
+
+```bash
+# Daily full backup at 02:00 UTC
+0  2 * * * docker compose -f /path/to/docker-compose.yml exec -T pgbackrest /backup/backup.sh full
+
+# Hourly incremental
+0  * * * * docker compose -f /path/to/docker-compose.yml exec -T pgbackrest /backup/backup.sh incr
+```
+
+The script:
+
+1. Validates the backup type.
+2. Calls `pgbackrest --stanza=raven stanza-create` (idempotent).
+3. Runs `pgbackrest --stanza=raven --type=<type> backup`.
+4. Prints `pgbackrest info` so the cron log records the new inventory.
+5. Runs `pgbackrest --stanza=raven expire` to apply the retention policy
+   from `pgbackrest.conf`.
+
+One-shot manual run:
+
+```bash
+docker compose exec -T pgbackrest /backup/backup.sh           # incr
+docker compose exec -T pgbackrest /backup/backup.sh full      # full
+docker compose exec -T pgbackrest pgbackrest --stanza=raven info  # inventory
+```
+
+## Restore procedure
+
+`backup/restore.sh` is the wrapper. PostgreSQL **must be stopped** — the
+script enforces this with a `pg_isready` probe and refuses to run otherwise.
+
+```bash
+# 1. Stop Postgres (workers depending on it will fail their healthchecks
+#    and pause; restart them after the restore).
+docker compose stop postgres
+
+# 2. Restore latest backup
+docker compose exec -T pgbackrest /backup/restore.sh
+
+# 3. Bring Postgres back up — WAL replay happens on startup
+docker compose start postgres
+```
+
+The script runs `pgbackrest --stanza=raven --delta --link-all "$@" restore`
+under the hood, so any extra flags are forwarded.
+
+### Point-in-time recovery (PITR)
+
+```bash
+docker compose stop postgres
+
+docker compose exec -T pgbackrest /backup/restore.sh \
+  --type=time \
+  --target="2026-03-28 12:00:00+00"
+
+docker compose start postgres
+```
+
+The `--type=time` and `--target` flags are passed straight through to
+`pgbackrest restore`. See the [upstream pgBackRest command
+reference](https://pgbackrest.org/command.html#command-restore) for the
+full flag set (`--type=immediate`, `--target-action`, etc.) — Raven does
+not wrap them.
+
+### Restoring on a fresh host
+
+To rebuild on a new host:
+
+1. Provision the host, check out the repo, populate `.env`.
+2. Copy the source `pgbackrest-repo` volume contents onto the new host's
+   `pgbackrest-repo` volume.
+3. `docker compose up -d postgres pgbackrest`, then stop Postgres and run
+   `restore.sh`.
+4. Start Postgres, then bring up the rest of the stack.
+
+## Off-host backup
+
+**Status: not wired in the repo.** `repo1-type` is `posix` — backups live
+on the `pgbackrest-repo` Docker volume on the same host as the database.
+A single host failure (disk, theft, region outage) loses both the live
+data and the backup repository.
+
+Recommended (configure separately):
+
+- **S3 / R2 / B2.** pgBackRest natively supports S3-compatible storage.
+  Add a second repo to `pgbackrest.conf`:
+
+  ```ini
+  [global]
+  repo2-type=s3
+  repo2-path=/raven
+  repo2-s3-bucket=raven-backups
+  repo2-s3-endpoint=s3.amazonaws.com   # or r2 / b2 endpoint
+  repo2-s3-region=us-east-1
+  repo2-s3-key=<access-key>
+  repo2-s3-key-secret=<secret-key>
+  repo2-retention-full=12
+  ```
+
+  pgBackRest will write to both repos on each backup. See [pgBackRest S3
+  configuration](https://pgbackrest.org/user-guide.html#quickstart/configure-s3).
+- **rsync / restic the `pgbackrest-repo` volume.** Lower-rent alternative:
+  on a cron, `rsync` the contents of the volume to remote storage. You
+  lose pgBackRest's verification and atomicity but it is one line of bash.
+
+Pick one. Without an off-host copy, the in-repo setup is local-disaster
+protection only.
+
+## SeaweedFS volume backup
+
+pgBackRest covers Postgres only. SeaweedFS object data lives in the
+`seaweedfs-data` volume (line 316 of `docker-compose.yml`), mounted into
+the `seaweedfs-volume` service at `/data`. There is no application-level
+backup wired in the repo. Two practical options:
+
+### Option A — offline volume snapshot (simplest)
+
+```bash
+# Quiesce writes
+docker compose stop seaweedfs-volume seaweedfs-filer seaweedfs-master
+
+# Snapshot the volume to a tarball
+docker run --rm \
+  -v seaweedfs-data:/data:ro \
+  -v "$(pwd)/snapshots":/out \
+  alpine tar czf /out/seaweedfs-$(date -u +%Y%m%dT%H%M%SZ).tgz -C /data .
+
+# Bring services back
+docker compose start seaweedfs-master seaweedfs-volume seaweedfs-filer
+```
+
+Acceptable for small deployments and edge nodes where a few minutes of
+write downtime per night is fine.
+
+### Option B — `weed volume.copy` (online, between hosts)
+
+SeaweedFS ships `weed shell` with a `volume.copy` command that can clone
+volumes to a second cluster on another host without stopping the source.
+See [SeaweedFS replication and
+backup](https://github.com/seaweedfs/seaweedfs/wiki/Replication) and
+[`volume.copy`](https://github.com/seaweedfs/seaweedfs/wiki/SeaweedFS-Shell-commands).
+This is the path for production but is operator-configured — Raven does
+not run a second SeaweedFS cluster out of the box.
+
+## ClickHouse backup
+
+**Not wired in the repo.** A `grep` for `clickhouse.*backup` returns
+nothing across `docker-compose.yml`, `backup/`, and `deploy/`. The
+ClickHouse instance (line 157, image `clickhouse/clickhouse-server`)
+mounts only `clickhouse-data:/var/lib/clickhouse` and the init SQL.
+
+If you care about ClickHouse history (audit logs, analytics), the
+canonical options are:
+
+- `BACKUP TABLE … TO Disk(...)` / `RESTORE TABLE` — built into
+  ClickHouse 22.8+. See [ClickHouse BACKUP
+  docs](https://clickhouse.com/docs/en/operations/backup).
+- The
+  [clickhouse-backup](https://github.com/Altinity/clickhouse-backup)
+  sidecar — same model as `pgbackrest` here.
+- Volume snapshots of `clickhouse-data` — same idea as the SeaweedFS
+  Option A above; works because ClickHouse on-disk format is
+  copy-friendly when the server is stopped.
+
+If audit logs are not critical to your deployment, treat ClickHouse as
+rebuildable and don't bother.
+
+## Backup verification
+
+A backup you have never restored is a guess. Verify quarterly at minimum:
+
+1. Spin up a sandbox stack with a different project name:
+   `docker compose -p raven-restore-test up -d postgres pgbackrest`.
+2. Copy a recent `pgbackrest-repo` volume contents into the sandbox.
+3. Stop the sandbox Postgres and run `restore.sh`.
+4. Start Postgres and sanity-check known tables (`SELECT count(*) FROM
+   organizations;`, `SELECT max(created_at) FROM documents;`).
+5. Run the integrity probe:
+
+   ```bash
+   docker compose -p raven-restore-test exec -T pgbackrest \
+     pgbackrest --stanza=raven check
+   ```
+
+Run `pgbackrest check` on the production stanza on a cron too. See
+[`pgbackrest check`](https://pgbackrest.org/command.html#command-check)
+upstream.
+
+## What's NOT backed up
+
+Explicit list, so nobody is surprised:
+
+- **Valkey state** — cache and Asynq queues. Pending and scheduled jobs
+  are lost on a Valkey restart. Producers must be idempotent.
+- **ClickHouse data** — audit logs and analytics. No backup mechanism is
+  configured in this repo (see above).
+- **OpenObserve data** (`openobserve-data` volume) — telemetry. Treat as
+  ephemeral; rebuild from re-ingestion.
+- **LiveKit / SuperTokens internal state** — SuperTokens persists into
+  the same Postgres database (see `POSTGRESQL_CONNECTION_URI` on line
+  199), so it rides along inside the pgBackRest backups. LiveKit is
+  stateless beyond the live session.
+- **Traefik ACME data** (`acme-data` volume) — certificates. Lose them
+  and Let's Encrypt will reissue. Not worth backing up unless you are
+  near rate limits; back up only if you operate at scale.
+- **Container filesystems**, `node_modules/`, build caches, `.tmp/`, and
+  anything else not in a named volume — by definition ephemeral.
+- **`.env`** — not a backup target; treat as a secret and store it in
+  your password manager / SOPS / Vault, separately from data backups.

--- a/docs-site/stubs/guides/self-hosting/docker-compose.md
+++ b/docs-site/stubs/guides/self-hosting/docker-compose.md
@@ -1,16 +1,304 @@
 ---
-title: "Coming Soon"
+title: "Docker Compose"
 ---
 
 # Docker Compose
 
-::: warning Stub page
-This page is a placeholder. The full content is being written. If you would
-like to contribute, the source for this page lives at the path shown below
-and you can [edit it on GitHub](https://github.com/ravencloak-org/Raven/edit/main/docs-site/stubs/guides/self-hosting/docker-compose.md).
-:::
+Raven ships four Compose files. The main file (`docker-compose.yml`) brings up
+the full self-hosted stack — Go API, Python AI worker, voice agent, Postgres,
+Valkey, ClickHouse, SeaweedFS, SuperTokens, LiveKit, Traefik, OpenObserve and
+the pgBackRest sidecar. Two overlays opt into eBPF and a schema viewer; a
+separate, smaller file targets ARM64 edge nodes such as a Raspberry Pi.
 
-## What goes here
+The frontend is **not** a Compose service — it deploys to Cloudflare Pages.
+Compose serves the API and the platform; the SPA points at the API over
+Traefik.
 
-A short bullet list of the topics this page will cover, drawn from the
-[design spec](https://github.com/ravencloak-org/Raven/blob/main/docs/superpowers/specs/2026-05-09-docs-site-design.md).
+For the canonical first-run path, see
+[Installation](/get-started/installation). This page is the deeper reference
+once you know what each container is doing.
+
+## Variants
+
+| File | Services | Use case | Footprint |
+|------|----------|----------|-----------|
+| [`docker-compose.yml`](https://github.com/ravencloak-org/Raven/blob/main/docker-compose.yml) | 14 | Cloud / full self-hosted | ~3 GB RAM, ~6 GB disk after seeding |
+| [`docker-compose.edge.yml`](https://github.com/ravencloak-org/Raven/blob/main/docker-compose.edge.yml) | 3 (Go API + Postgres + Traefik) | Raspberry Pi / ARM64 edge | ~1 GB RAM (memory limits enforced via `deploy.resources`) |
+| [`docker-compose.ebpf.yml`](https://github.com/ravencloak-org/Raven/blob/main/docker-compose.ebpf.yml) | overlay (`go-api` only) | Adds `CAP_BPF` + `CAP_NET_ADMIN` for eBPF audit/XDP | negligible |
+| [`docker-compose.chartdb.yml`](https://github.com/ravencloak-org/Raven/blob/main/docker-compose.chartdb.yml) | overlay (1 service: `chartdb`) | Browse the live Postgres schema at `127.0.0.1:3000` | ~150 MB |
+
+Overlays compose in the usual way:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.ebpf.yml up -d
+docker compose -f docker-compose.yml -f docker-compose.chartdb.yml up -d chartdb
+```
+
+## Prerequisites
+
+- **Docker** 24+ with **Compose v2** (the bundled `docker compose` plugin, not
+  the legacy `docker-compose` Python script).
+- **4 GB RAM** minimum for the full stack. ClickHouse, Postgres and the AI
+  worker dominate; Valkey is capped at `--maxmemory 256mb` in the compose file.
+- **An x86_64 host** for the main file. `docker-compose.edge.yml` pins
+  `platform: linux/arm64` for Raspberry Pi 4/5 class devices.
+- A **domain name** if you want real TLS via Traefik's ACME resolver (see
+  [Traefik & TLS](/guides/self-hosting/traefik-and-tls)). For local
+  development, leave `RAVEN_DOMAIN` unset and Traefik routes on `localhost`.
+
+The build layer pins exact base images by digest:
+
+| Component | Base image |
+|-----------|------------|
+| Go API ([`Dockerfile`](https://github.com/ravencloak-org/Raven/blob/main/Dockerfile)) | `golang:1.26.3-alpine` (build) → `alpine` (runtime) |
+| AI worker ([`ai-worker/Dockerfile`](https://github.com/ravencloak-org/Raven/blob/main/ai-worker/Dockerfile)) | `python:3.14-slim` |
+| Frontend ([`frontend/Dockerfile`](https://github.com/ravencloak-org/Raven/blob/main/frontend/Dockerfile)) | `node:22-alpine` (build) → `nginxinc/nginx-unprivileged:1.27-alpine` (serve). Used in CI; production deploys to Cloudflare Pages. |
+
+Secrets are decrypted at container start by `dotenvx` (currently `v1.65.0`,
+hash-pinned across all four install sites). The Go and Python images both run
+as non-root UID 1000.
+
+## Initial setup
+
+```bash
+git clone https://github.com/ravencloak-org/Raven.git
+cd Raven
+cp .env.example .env
+```
+
+Open `.env` and fill in, at minimum:
+
+| Variable | Source / purpose |
+|----------|------------------|
+| `POSTGRES_PASSWORD` | Required — Postgres rejects start without it (`${POSTGRES_PASSWORD:?...}` in compose). |
+| `CLICKHOUSE_PASSWORD` | Required — same enforcement on the ClickHouse service. |
+| `RAVEN_ENCRYPTION_AES_KEY` | 32-byte hex key for at-rest encryption. The Go API refuses to start without it. |
+| `SUPERTOKENS_API_KEY` | Shared secret between Go API and SuperTokens core; defaults to a placeholder you must replace. |
+| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | OAuth credentials for SuperTokens social login. |
+| `ZO_ROOT_USER_PASSWORD` | OpenObserve admin password — required (`${ZO_ROOT_USER_PASSWORD:?...}`). |
+| One of `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `COHERE_API_KEY` | At least one BYOK LLM key for the AI worker. |
+| `RAVEN_HYPERSWITCH_API_KEY`, `RAVEN_HYPERSWITCH_WEBHOOK_SECRET`, `RAVEN_HYPERSWITCH_RAZORPAY_KEY_ID` | Payments orchestrator keys (UPI / cards via Razorpay). Leave blank to disable billing. |
+
+Then start the stack:
+
+```bash
+docker compose up -d
+docker compose ps
+docker compose logs -f go-api
+```
+
+Postgres runs `deploy/postgres/init.sql` on first boot. ClickHouse runs
+`deploy/clickhouse/init.sql`. The Go API waits on Postgres, Valkey,
+SuperTokens and OpenObserve health before serving traffic; you can watch the
+gating with `docker compose ps`.
+
+The full env-var contract is parsed in
+[`internal/config/config.go`](https://github.com/ravencloak-org/Raven/blob/main/internal/config/config.go)
+(Viper, `RAVEN_` prefix, dot-to-underscore key replacement). See the
+[Configuration reference](/reference/configuration) for the resolved list.
+
+## Service map
+
+All services attach to the `raven-internal` bridge network. Only Traefik,
+Postgres-via-pgBackRest, OpenObserve, the SeaweedFS S3 filer and LiveKit
+publish ports on the host.
+
+### API & worker tier
+
+| Service | Image | Host port | Role |
+|---------|-------|-----------|------|
+| `go-api` | built from `./Dockerfile` | `8081` | Gin HTTP API; runs gRPC client to AI worker; serves `/healthz`, `/api/*` (Traefik path-prefix routing). |
+| `python-worker` | built from `./ai-worker/Dockerfile` | (internal) | gRPC service on port `50051`; parsing, embeddings, RAG, summaries. Mounts `raven-memories` volume at `/var/raven/memories`. |
+| `python-agent` | built from `./ai-worker/Dockerfile` | (internal) | LiveKit voice agent; same image, command `python -m raven_worker.agent`. Connects to `livekit-server:7880`. |
+
+### Auth tier
+
+| Service | Image | Host port | Role |
+|---------|-------|-----------|------|
+| `supertokens` | `registry.supertokens.io/supertokens/supertokens-postgresql` | (internal `3567`) | Auth core. Persists to the same Postgres instance. Telemetry disabled. |
+
+### Data tier
+
+| Service | Image | Host port | Role |
+|---------|-------|-----------|------|
+| `postgres` | `pgvector/pgvector:pg18` | (internal `5432`) | Primary OLTP + pgvector + BM25. Started with `archive_mode=on` and `archive_command=pgbackrest --stanza=raven archive-push`. |
+| `clickhouse` | `clickhouse/clickhouse-server:25` | `127.0.0.1:9000`, `127.0.0.1:8123` | Enterprise-tier vector + analytics store. Bound to loopback only. |
+| `valkey` | `valkey/valkey:8.1-alpine` | (internal `6379`) | Redis-compatible cache; `--maxmemory 256mb --maxmemory-policy allkeys-lru`. |
+| `seaweedfs-master` | `chrislusf/seaweedfs` | (internal) | SeaweedFS master. |
+| `seaweedfs-volume` | `chrislusf/seaweedfs` | (internal) | Object storage volumes (`seaweedfs-data` volume). |
+| `seaweedfs-filer` | `chrislusf/seaweedfs` | `8888` | S3-compatible filer for blob uploads. |
+| `pgbackrest` | `pgbackrest/pgbackrest:latest` | (internal) | Sidecar; `command: ["sleep", "infinity"]` so backups run via `docker compose exec`. |
+
+### Voice tier
+
+| Service | Image | Host port | Role |
+|---------|-------|-----------|------|
+| `livekit-server` | `livekit/livekit-server:latest` | `7882/tcp`, `50000-60000/udp` | WebRTC SFU. Config mounted from `deploy/livekit/livekit.yaml`. |
+
+### Edge / infra tier
+
+| Service | Image | Host port | Role |
+|---------|-------|-----------|------|
+| `traefik` | `traefik:v3.3` | `80`, `443`, `8082` (dashboard) | Reverse proxy; ACME via DNS-01 (default provider Cloudflare). Discovers services via `traefik.enable=true` labels. |
+| `openobserve` | `public.ecr.aws/zinclabs/openobserve:latest` | `5080` (UI), `5081` (OTLP gRPC) | Logs / metrics / traces. The Go API ships OTLP to `openobserve:5081`. |
+
+The Vue frontend is served from Cloudflare Pages and points at
+`https://api.<RAVEN_DOMAIN>` over Traefik. There is no `frontend` service in
+`docker-compose.yml`; the Dockerfile under `frontend/` is used by CI and
+self-hosters who want to run the SPA themselves.
+
+## Health checks
+
+Compose-defined health is wired into `depends_on: condition: service_healthy`,
+so `go-api` only starts once its dependencies report healthy.
+
+| Service | Probe | Interval / timeout / retries |
+|---------|-------|------------------------------|
+| `go-api` | `wget --spider http://localhost:8081/healthz` | 10s / 5s / 5 (start_period 10s) |
+| `postgres` | `pg_isready -U $POSTGRES_USER -d $POSTGRES_DB` | 5s / 5s / 5 |
+| `valkey` | `valkey-cli ping` | 5s / 3s / 5 |
+| `clickhouse` | `clickhouse-client --query 'SELECT 1'` | 10s / 5s / 5 (start_period 10s) |
+| `supertokens` | `curl -sf http://localhost:3567/hello` | 10s / 5s / 5 (start_period 10s) |
+| `livekit-server` | `wget --spider http://localhost:7880` | 10s / 5s / 5 (start_period 5s) |
+
+The Go runtime image also declares its own `HEALTHCHECK` in `Dockerfile` so
+orchestrators that don't read the compose file (e.g. plain `docker run`) still
+get a probe.
+
+`go-api`'s `depends_on` block:
+
+```yaml
+depends_on:
+  postgres:
+    condition: service_healthy
+  valkey:
+    condition: service_healthy
+  supertokens:
+    condition: service_healthy
+  openobserve:
+    condition: service_started
+```
+
+OpenObserve uses `service_started` (not `service_healthy`) so a misconfigured
+observability backend can't block the API from booting.
+
+## Common workflows
+
+```bash
+# Tail the API
+docker compose logs -f go-api
+
+# Tail several services at once
+docker compose logs -f go-api python-worker
+
+# Open a psql shell on the live database
+docker compose exec postgres psql -U raven -d raven
+
+# Run an on-demand pgBackRest backup
+docker compose exec pgbackrest pgbackrest --stanza=raven backup
+
+# Rebuild after a code change
+docker compose up -d --build go-api
+
+# Stop the stack but keep volumes
+docker compose down
+
+# DESTRUCTIVE — drops all volumes (Postgres, ClickHouse, SeaweedFS, OpenObserve, ACME certs)
+docker compose down -v
+```
+
+`docker compose down -v` deletes `pg-data`, `clickhouse-data`,
+`seaweedfs-data`, `valkey-data`, `openobserve-data`, `acme-data`,
+`pgbackrest-repo`, `pgbackrest-log` and `raven-memories`. Run a backup first.
+
+## Edge deployment
+
+For Raspberry Pi / ARM64 single-node deployments, use `docker-compose.edge.yml`.
+It strips the stack down to three services — Go API, Postgres, Traefik — and
+expects the AI worker to run remotely (via gRPC at `GRPC_AI_WORKER_ADDR`):
+
+```bash
+cp deploy/edge/.env.example .env.edge
+# edit .env.edge — at minimum set DATABASE_URL, GRPC_AI_WORKER_ADDR,
+#                   POSTGRES_PASSWORD, RAVEN_ENCRYPTION_AES_KEY
+docker compose -f docker-compose.edge.yml --env-file .env.edge up -d
+```
+
+Differences from the main file:
+
+- `platform: linux/arm64` pinned on every service.
+- `deploy.resources.limits.memory` set per service (Go API 256M, Postgres
+  512M, Traefik 128M).
+- Network is `raven-edge` (not `raven-internal`).
+- `RAVEN_EDGE_MODE=true` is exported into the Go API; behaviour switches
+  documented in `internal/config/config.go`.
+- No SuperTokens, ClickHouse, Valkey, SeaweedFS, OpenObserve, LiveKit or
+  pgBackRest — those run elsewhere or are disabled.
+
+To enable eBPF audit on edge, layer the eBPF overlay:
+
+```bash
+docker compose -f docker-compose.edge.yml -f docker-compose.ebpf.yml up -d
+```
+
+The overlay adds `CAP_BPF` and `CAP_NET_ADMIN` to `go-api` and sets
+`RAVEN_EBPF_ENABLED=true`. Requires kernel ≥ 5.8. Drop `CAP_NET_ADMIN` if
+`RAVEN_EBPF_XDP_ENABLED=false`.
+
+See [Edge & Raspberry Pi](/guides/self-hosting/edge-and-raspberry-pi) for the
+hardware sizing and provisioning walkthrough.
+
+## Troubleshooting
+
+**`postgres` won't start: `POSTGRES_PASSWORD is required`** — the value uses
+the strict `${POSTGRES_PASSWORD:?...}` form. Fill `.env` before
+`docker compose up`. Same applies to `CLICKHOUSE_PASSWORD`,
+`RAVEN_ENCRYPTION_AES_KEY` and `ZO_ROOT_USER_PASSWORD`.
+
+**`pgbackrest` exits immediately or write errors** — the sidecar mounts
+`pgbackrest-repo` at `/var/lib/pgbackrest` and `pgbackrest-log` at
+`/var/log/pgbackrest`. Both are named volumes; if you bind-mount over them
+make sure the path is writable by the `pgbackrest` user. The Postgres archive
+command pipes WAL through `pgbackrest --stanza=raven archive-push %p`, so
+broken volumes will start failing WAL archival within minutes — watch
+`docker compose logs postgres`.
+
+**LiveKit voice doesn't connect** — the SFU needs `7882/tcp` and the full
+`50000-60000/udp` range reachable from clients. NAT and firewalls drop UDP
+silently; verify with `docker compose port livekit-server 7882` and a UDP
+probe. The agent also needs a real `LIVEKIT_API_KEY` / `LIVEKIT_API_SECRET`
+pair — the compose default `devkey:devsecret` is for local dev only.
+
+**Traefik returns 404 for `/api`** — the router rule is
+``Host(`${RAVEN_DOMAIN}`) && PathPrefix(`/api`)``. If `RAVEN_DOMAIN` is unset
+it falls back to `localhost`, so `curl https://example.com/api/...` will miss
+the router. Set `RAVEN_DOMAIN` in `.env` and recreate Traefik.
+
+**OpenTelemetry exporter errors at boot** — the Go API ships OTLP to
+`openobserve:5081`. If OpenObserve is slow to start, the API logs warnings
+but continues (because of `condition: service_started`). Persistent failures
+usually mean `ZO_GRPC_PORT` was overridden away from `5081` in `.env`.
+
+**ChartDB "external network not found"** — `docker-compose.chartdb.yml`
+attaches to `raven_raven-internal`, the auto-named network from the main
+file. Bring the main stack up first, then add the overlay:
+
+```bash
+docker compose up -d
+docker compose -f docker-compose.yml -f docker-compose.chartdb.yml up -d chartdb
+```
+
+Then visit `http://127.0.0.1:3000`, choose PostgreSQL, and paste the SQL
+output of `scripts/chartdb-query.sh`.
+
+## See also
+
+- [Installation](/get-started/installation) — first-run path
+- [Configuration reference](/reference/configuration) — every `RAVEN_*` env
+  var
+- [Traefik & TLS](/guides/self-hosting/traefik-and-tls) — ACME, DNS-01,
+  Cloudflare provider
+- [Edge & Raspberry Pi](/guides/self-hosting/edge-and-raspberry-pi) — ARM64
+  hardware notes
+- [Backups](/guides/self-hosting/backups) — pgBackRest stanza, restore drill
+- [Observability](/guides/self-hosting/observability) — OpenObserve + Beszel

--- a/docs-site/stubs/guides/self-hosting/hardening.md
+++ b/docs-site/stubs/guides/self-hosting/hardening.md
@@ -1,16 +1,406 @@
 ---
-title: "Coming Soon"
+title: "Hardening"
 ---
 
 # Hardening
 
-::: warning Stub page
-This page is a placeholder. The full content is being written. If you would
-like to contribute, the source for this page lives at the path shown below
-and you can [edit it on GitHub](https://github.com/ravencloak-org/Raven/edit/main/docs-site/stubs/guides/self-hosting/hardening.md).
-:::
+Raven's default production posture is [OpenSSF Baseline Level 2](/trust/openssf-baseline)
+attested and [SLSA Build Level 3](/trust/slsa-level-3) for every signed
+release. CodeQL, Semgrep, Gitleaks and OpenSSF Scorecard run on every PR;
+`golangci-lint`, `ruff`, and DCO sign-off are gating; container images and
+release blobs are keyless-signed with cosign.
 
-## What goes here
+That gives you a hardened **build** pipeline. This page is the operator's
+checklist for everything that requires deployment-time choices: TLS,
+authentication, tenant isolation, secrets, rate limiting, container and
+network exposure, audit logging, and the supply-chain controls you should
+verify before going live.
 
-A short bullet list of the topics this page will cover, drawn from the
-[design spec](https://github.com/ravencloak-org/Raven/blob/main/docs/superpowers/specs/2026-05-09-docs-site-design.md).
+If a control is not bundled today, this page says **"recommended, not bundled"**
+rather than implying it is enforced. Read the linked source files to verify.
+
+## TLS termination — Traefik + Let's Encrypt
+
+Public traffic terminates TLS at Traefik v3 in front of every other service.
+The shipped configuration lives in two files.
+
+**`deploy/traefik/traefik.yml`** — static configuration:
+
+- `entryPoints.web` (`:80`) issues a permanent 301 redirect to `websecure`,
+  so plain HTTP is never served.
+- `entryPoints.websecure` (`:443`) attaches the `security-headers@file`
+  middleware to every route by default and resolves certificates via the
+  `letsencrypt` resolver.
+- `certificatesResolvers.letsencrypt.acme` performs a DNS-01 challenge
+  (Cloudflare provider by default; override with `ACME_DNS_PROVIDER`) so
+  certificates can be issued for hosts that are not directly reachable on
+  port 80.
+- `providers.docker.exposedByDefault: false` — services must opt in via
+  `traefik.enable=true` labels; no container is exposed accidentally.
+
+**`deploy/traefik/dynamic/tls.yml`** — TLS options and headers:
+
+- `tls.options.default.minVersion: VersionTLS12`, `sniStrict: true`, and an
+  explicit allow-list of TLS 1.3 / strong TLS 1.2 ciphers (`AES_*_GCM`,
+  `CHACHA20_POLY1305`).
+- The `security-headers` middleware sets HSTS (`stsSeconds: 63072000`,
+  `stsPreload: true`, `forceSTSHeader: true`), `X-Content-Type-Options`,
+  `X-Frame-Options: SAMEORIGIN`, `Referrer-Policy: strict-origin-when-cross-origin`,
+  and strips `Server` / `X-Powered-By`.
+
+The Go API also emits an HSTS-preload-eligible header itself
+(`Strict-Transport-Security: max-age=31536000; includeSubDomains; preload`)
+plus a `Content-Security-Policy` and `Permissions-Policy` from
+`internal/middleware/security.go::SecurityHeadersMiddleware` — Traefik and the
+app are belt-and-braces.
+
+**Operator action:** set `ACME_EMAIL`, `RAVEN_DOMAIN`, and the DNS-01 provider
+credentials (`CF_DNS_API_TOKEN` for Cloudflare) in your environment before the
+first start.
+
+## Authentication — SuperTokens session cookies
+
+Authentication is delegated to SuperTokens. The Go API never issues its own
+JWTs; it verifies opaque session cookies on every request via
+`internal/auth/supertokens.go::SuperTokensProvider.VerifySession`, and
+`internal/middleware/auth.go::SessionMiddleware` aborts with a structured 401
+on any failure. Initialisation lives in
+`internal/auth/supertokens_init.go::InitSuperTokens`:
+
+- The `session.Init` recipe is configured with `CookieSameSite: "none"` so that
+  `app.<domain>` and `api.<domain>` can share sessions across subdomains.
+- `cookieDomain` is auto-set to `.ravencloak.org` in production and
+  `localhost` in dev — set `RAVEN_API_DOMAIN` and `RAVEN_WEBSITE_DOMAIN` to
+  match your deployment.
+- Access-token and refresh-token lifetimes are managed by **SuperTokens Core**
+  and not exposed in `internal/config/config.go::SuperTokensConfig`. Configure
+  them in your SuperTokens instance — the Core defaults (1 h access token,
+  100 day refresh token) are reasonable; tighten the access token to 15
+  minutes for high-sensitivity tenants.
+- Multi-factor authentication is supported by SuperTokens via its TOTP /
+  email-OTP recipes. Enrolment is **not** enabled by default in
+  `InitSuperTokens` and is recommended, not bundled — register the recipe
+  client-side and the matching server-side init for production tenants.
+
+For the **single-tenant desktop edition** (`RAVEN_SINGLE_USER=true`), the
+session middleware is replaced with `SingleUserMiddleware` which injects a
+synthetic `user_id=local`, `org_id=local` and skips SuperTokens entirely.
+Never enable `RAVEN_SINGLE_USER` on a publicly reachable deployment.
+
+## Tenant isolation — PostgreSQL row-level security
+
+Every tenant-scoped table has Postgres row-level security enabled at table
+creation time. Grep `migrations/` for `ROW LEVEL SECURITY` to see the full
+list — the per-table policies are applied in:
+
+- `migrations/00004_users.sql`
+- `migrations/00005_workspaces.sql`
+- `migrations/00006_workspace_members.sql`
+- `migrations/00007_knowledge_bases.sql`
+- `migrations/00008_documents.sql`
+- `migrations/00009_sources.sql`
+- `migrations/00010_chunks_and_embeddings.sql`
+- `migrations/00011_llm_provider_configs.sql`
+- `migrations/00012_api_keys.sql`
+- `migrations/00013_chat.sql`
+- `migrations/00014_processing_events.sql`
+- `migrations/00022_security_rules.sql` (also `security_events`)
+- `migrations/00032_billing_rls_and_payment_events.sql`
+
+`migrations/00015_rls_policies.sql` is the audit marker that consolidates this
+coverage and is intentionally a no-op — confirming, not introducing, the
+policies.
+
+Every policy follows the same shape:
+
+```sql
+CREATE POLICY tenant_isolation ON <table> FOR ALL
+    USING       (org_id = current_setting('app.current_org_id')::uuid)
+    WITH CHECK  (org_id = current_setting('app.current_org_id')::uuid);
+CREATE POLICY admin_bypass ON <table> FOR ALL TO raven_admin USING (true);
+```
+
+The Go API enforces this by wrapping every tenant query in a transaction that
+sets the GUC. See `internal/db/db.go::WithOrgID`:
+
+```go
+tx, _ := pool.Begin(ctx)
+tx.Exec(ctx, "SELECT set_config('app.current_org_id', $1, true)", orgID)
+```
+
+The third argument `true` makes the setting **transaction-local** so it
+cannot leak across pooled connections. The org ID is bound as a parameter,
+not interpolated, so this is not a SQL-injection vector.
+
+The DB role used by the API must **not** be a member of `raven_admin`; reserve
+that role for migrations and out-of-band ops only. The `admin_bypass` policy
+is the escape hatch — never use it from request handlers.
+
+## Secrets management
+
+All secrets are env-driven. The repo uses [`dotenvx`](https://dotenvx.com/) at
+runtime — see `Makefile`, `Dockerfile`, `ai-worker/Dockerfile` — and the
+container `CMD` is wrapped in `dotenvx run --` so a Sigstore-signed `.env`
+file can be decrypted from `DOTENV_PRIVATE_KEY` at boot.
+
+**Required, fail-fast secrets** (the API refuses to start without them; see
+the `:?` markers in `docker-compose.yml`):
+
+- `POSTGRES_PASSWORD`
+- `CLICKHOUSE_PASSWORD`
+- `RAVEN_ENCRYPTION_AES_KEY` — 32-byte AES-256 key used by
+  `internal/crypto/aes.go` to seal LLM provider API keys at rest in
+  `llm_provider_configs`.
+- `ZO_ROOT_USER_PASSWORD` (OpenObserve)
+
+**Recommended secrets to rotate per deployment:**
+
+- `SUPERTOKENS_API_KEY` — auth Core admin key.
+- `RAVEN_RATELIMIT_APIKEY_HASH_SECRET` — HMAC key for hashing API-key bucket
+  identifiers in Valkey. If unset,
+  `internal/middleware/ratelimit.go::NewRateLimiter` logs a warning and uses
+  a zero-length HMAC key (acceptable only for dev).
+- `RAVEN_SEED_KEY` — gate for the `/admin/seed-demo` endpoint
+  (`cmd/api/main.go` line 869). Leave **empty** in production to disable the
+  seed route entirely.
+- `LIVEKIT_API_KEY`, `LIVEKIT_API_SECRET`, `CF_DNS_API_TOKEN`, OAuth client
+  secrets, etc.
+
+**Recommended, not bundled:** front the deployment with a real secrets store
+— HashiCorp Vault, AWS Secrets Manager, Doppler, 1Password CLI, or k8s
+sealed-secrets. Treat committed `.env*` files as templates only; the actual
+production values should be injected at deploy time. Encrypted dotenvx files
+are an acceptable middle ground for small edge deployments.
+
+## Rate limiting
+
+Rate limiting is implemented in `internal/middleware/ratelimit.go` against
+Valkey and is multi-scope:
+
+- **Algorithm:** atomic sliding window via a Lua script over a Valkey sorted
+  set (see `slidingWindowLua`). Window is fixed at 60 s.
+- **Failure mode:** **fail-open** — if Valkey is unreachable within the
+  500 ms `callCtx`, the request is admitted with a logged warning. Operators
+  must monitor for sustained Valkey errors; relying on rate-limit + Valkey
+  outage as a denial-of-service prevention layer is not safe.
+- **Scopes:** `ByAPIKey`, `ByUserID`, `ByOrgID`, and tier-aware `ByOrgTier`
+  (route groups: `general`, `completion`, `widget`).
+- **API key bucket keys** are HMAC-SHA-256 of the raw key, keyed with
+  `RAVEN_RATELIMIT_APIKEY_HASH_SECRET` — raw API keys never reach Valkey.
+- **Per-tier defaults** from `DefaultTierConfig()` in
+  `internal/middleware/ratelimit.go`:
+
+  | Tier        | General RPM | Completion RPM | Widget RPM |
+  |-------------|------------:|---------------:|-----------:|
+  | Free        | 60          | 10             | 30         |
+  | Pro         | 600         | 120            | 30         |
+  | Enterprise  | 6000        | unlimited (-1) | 30         |
+
+Override per-tier limits via `RAVEN_RATELIMIT_*` env vars
+(`internal/config/config.go::RateLimitConfig`).
+
+**Recommended, not bundled:** add an edge-tier rate limit at Traefik
+(`traefik.http.middlewares.rate-limit.rateLimit.average` — see
+`deploy/traefik/dynamic/tls.yml`) or a WAF/CDN in front for L7 DDoS.
+
+## Container hardening
+
+All three runtime images run as a non-root UID:
+
+| Image                     | Base                                       | USER         |
+|---------------------------|--------------------------------------------|--------------|
+| Go API (`Dockerfile`)     | `alpine:3.23` (digest-pinned)              | `raven` (1000) — line 42 |
+| AI worker (`ai-worker/Dockerfile`) | `python:3.14-slim` (digest-pinned) | `raven` (1000) — line 53 |
+| Frontend (`frontend/Dockerfile`)   | `nginxinc/nginx-unprivileged:1.27-alpine` (digest-pinned) | already non-root by image |
+
+Every base image reference is **digest-pinned** (e.g.
+`alpine:3.23@sha256:5b10f432...`) so image rebuilds are reproducible.
+
+Build pipelines are multi-stage: the Go binary is statically linked
+(`-extldflags '-static'`) into a minimal Alpine runtime; the Python build
+uses `pip install --require-hashes` against a `uv pip compile`d lockfile
+with full per-archive hashes; the frontend builds Vue with `npm ci` (lockfile
+required) and serves the dist via the unprivileged nginx image.
+
+**Not bundled, recommended for production hardening — add per-service:**
+
+```yaml
+read_only: true
+tmpfs:
+  - /tmp
+security_opt:
+  - no-new-privileges:true
+cap_drop:
+  - ALL
+```
+
+These directives are intentionally **absent** from the shipped
+`docker-compose.yml` so the dev experience remains low-friction. For
+production self-hosting, wrap each service with a `docker-compose.override.yml`
+that applies these — non-root USER alone is necessary but not sufficient.
+
+## Network exposure
+
+The bundled `docker-compose.yml` puts all services on the `raven-internal`
+bridge network and exposes ports through Traefik. **However**, several
+services also publish ports directly on the host for development convenience:
+
+- `go-api`: `8081:8081`
+- `livekit-server`: `7882/tcp` and `50000-60000/udp`
+- `clickhouse`: `127.0.0.1:9000`, `127.0.0.1:8123` (loopback only)
+- `seaweedfs-filer`: `8888:8888` (S3 API)
+- `openobserve`: `5080:5080`, `5081:5081`
+- `traefik`: `80:80`, `443:443`, `8082:8080` (dashboard)
+
+**For production, remove or override every `ports:` block except Traefik's
+`80` and `443`** (LiveKit's UDP range is the necessary exception — WebRTC
+media cannot be reverse-proxied). The OpenObserve UI on `5080` and the
+Traefik dashboard on `8082` are particularly sensitive — never expose them
+publicly. Use SSH tunnelling or a VPN to reach them.
+
+`providers.docker.network: raven-internal` in `traefik.yml` ensures Traefik
+only routes through the internal network even if other networks exist.
+
+## Supply chain
+
+Every signed Raven release ships:
+
+- **SLSA v1 Build Level 3 provenance** for the Go binary checksums and for
+  every container image — verifiable with `cosign verify-blob` /
+  `cosign verify` and the recipe in `docs/security/slsa-verification.md`
+  (rendered at [/trust/slsa-level-3](/trust/slsa-level-3)).
+- **Sigstore keyless signatures** with a workflow-identity certificate that
+  ties the artifact to the exact GitHub Actions run that produced it.
+- **SPDX SBOMs** as image attestations.
+
+**Inputs to those builds are pinned at the same level:**
+
+- Every action in `.github/workflows/*.yml` is pinned to a 40-character
+  commit SHA with the human-readable tag in a comment — e.g.
+  `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2` in
+  `.github/workflows/codeql.yml`.
+- Python builds pass `pip install --require-hashes` against
+  `requirements*.txt` generated by `uv pip compile --generate-hashes`
+  (`.github/workflows/python.yml`, line 41 and 94; AI-worker `Dockerfile`,
+  line 11).
+- `pgBackRest` repository checksums protect WAL and full backups; verify on
+  restore as documented on the [Backups](/guides/self-hosting/backups)
+  documentation page.
+- `dotenvx` itself is installed from a release URL with a verified
+  `sha256sum -c` against the `DOTENVX_INSTALLER_SHA256` ARG in the
+  Dockerfiles — bumps require updating the hash in lockstep.
+
+Verify before deploying:
+
+```bash
+cosign verify ghcr.io/ravencloak-org/go-api:<tag> \
+  --certificate-identity-regexp '^https://github.com/ravencloak-org/Raven/' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
+```
+
+## Audit logging
+
+The OSS distribution records security-relevant events in the Postgres
+`security_events` table (defined in `migrations/00022_security_rules.sql`).
+Each row carries `org_id`, `rule_id`, `event_type` (`blocked`, `throttled`,
+`alert`, `suspicious`), `ip_address`, `country_code`, `request_path`,
+`request_method`, `user_agent`, and a freeform `details` JSONB. RLS is
+enforced on this table the same way as on tenant data — `tenant_isolation`
+plus an `admin_bypass` for `raven_admin`.
+
+OpenTelemetry traces, metrics, and structured logs from every Go and Python
+service are shipped to OpenObserve via OTLP gRPC on `5081` (configured by
+`RAVEN_OTEL_ENABLED`, `RAVEN_OTEL_ENDPOINT`, `RAVEN_OTEL_SERVICE_NAME` in
+`docker-compose.yml`). The Beszel agent runs alongside on the host for
+process and resource metrics. See the
+[Observability](/guides/self-hosting/observability) page for retention and
+forwarding.
+
+**Recommended, not bundled:** ship `security_events` and the application log
+stream off-box to immutable storage (S3 with object lock, or a SIEM) for
+forensic retention beyond the local Postgres / OpenObserve window.
+
+A richer EE audit subsystem lives in `internal/ee/audit/audit.go` for
+GDPR/SOC2 compliance reporting — that is part of the Enterprise edition and
+out of scope for this self-hosting page.
+
+## Demo seed — turn off in production
+
+The Go API ships a `/admin/seed-demo` route that scaffolds a demo TMDB
+knowledge base. It is gated by **two** env vars (see `cmd/api/main.go`
+around line 865 and `internal/service/seed.go::SeedDemo`):
+
+- `TMDB_API_KEY` — the seed service refuses to run without it (returns
+  `"TMDB client not configured"`).
+- `RAVEN_SEED_KEY` — the route is mounted only inside an `admin` group whose
+  middleware checks the `X-Seed-Key` header against `cfg.Seed.Key`. **If
+  `RAVEN_SEED_KEY` is empty, every request to `/admin/seed-demo` returns 401**
+  — the route is effectively disabled.
+
+For production, **leave both env vars unset.** If you must seed a demo
+tenant, set both, run the call once, then unset and restart the API.
+
+## Disable optional services
+
+Not every deployment needs every service. The Compose file is modular —
+remove what you do not run:
+
+- **LiveKit + Python voice agent** — voice/WhatsApp calling. Drop the
+  `livekit-server` and `python-agent` services if you are not exposing the
+  voice features. This also frees the UDP `50000-60000` range.
+- **SeaweedFS** — only needed if you ingest binary documents that need
+  block-storage. Direct S3 (with `RAVEN_S3_*` env) is supported as an
+  alternative.
+- **ClickHouse** — only required for the EE vector path; OSS uses Postgres
+  + pgvector.
+- **Hyperswitch** — payments orchestrator for the billing layer. The OSS
+  build does not enable the Hyperswitch worker by default; only deploy it if
+  you operate metered billing.
+- **eBPF observability** — `docker-compose.ebpf.yml` is an opt-in overlay
+  that adds `CAP_BPF` and `CAP_NET_ADMIN` to `go-api`. Only enable it on
+  hosts where you understand the kernel-level visibility implications.
+
+The recommended pattern is a `docker-compose.override.yml` that comments out
+unused services rather than editing the shipped file — that way the upstream
+file can keep diff-clean.
+
+## Recommended additions
+
+The following are not bundled and not enforced by Raven, but are advisable
+in any self-hosted production deployment:
+
+- **Web Application Firewall** in front of Traefik — Cloudflare, AWS WAF,
+  or self-hosted Coraza/ModSecurity. The shipped Traefik config has hooks
+  (`security-headers@file`) but no WAF middleware.
+- **OS-level CIS benchmark** for the host (Debian/Ubuntu CIS, AWS-EC2-CIS,
+  or your distribution's STIG). At minimum: enable unattended security
+  upgrades, disable password SSH (key-only), and run `lynis audit system`
+  quarterly.
+- **fail2ban** or sshguard for SSH brute-force protection on the host
+  itself (Traefik's rate limiter does not cover SSH).
+- **Host-level firewall** — `ufw` / `nftables` rules that allow only `22`
+  (or your moved SSH port), `80`, `443`, and the LiveKit UDP range.
+- **`cap_drop: ALL` + `read_only: true` + `no-new-privileges`** in a
+  Compose override (see [Container hardening](#container-hardening)).
+- **Out-of-band log shipping** of `security_events` and OpenObserve to an
+  immutable sink — see [Audit logging](#audit-logging).
+- **Quarterly dependency review** — Dependabot is enabled and CodeRabbit
+  reviews PRs, but a human review of the major-version bumps before merging
+  is still warranted.
+
+## See also
+
+- [/trust/openssf-baseline](/trust/openssf-baseline) — full OSPS-L2
+  control evidence map.
+- [/trust/slsa-level-3](/trust/slsa-level-3) — SLSA verification recipe
+  for binaries and container images.
+- [/reference/security-policy](/reference/security-policy) — vulnerability
+  disclosure path and 72 h / 7 d / 90 d response SLAs.
+- [/reference/configuration](/reference/configuration) — exhaustive list
+  of `RAVEN_*` environment variables and their defaults.
+- [/guides/self-hosting/traefik-and-tls](/guides/self-hosting/traefik-and-tls)
+  — deeper Traefik and ACME walk-through.
+- [/guides/self-hosting/observability](/guides/self-hosting/observability)
+  — OpenObserve and Beszel deployment.
+- [/guides/self-hosting/backups](/guides/self-hosting/backups) —
+  pgBackRest configuration and restore drills.

--- a/docs-site/stubs/guides/self-hosting/observability.md
+++ b/docs-site/stubs/guides/self-hosting/observability.md
@@ -1,16 +1,263 @@
 ---
-title: "Coming Soon"
+title: "Observability"
 ---
 
 # Observability
 
-::: warning Stub page
-This page is a placeholder. The full content is being written. If you would
-like to contribute, the source for this page lives at the path shown below
-and you can [edit it on GitHub](https://github.com/ravencloak-org/Raven/edit/main/docs-site/stubs/guides/self-hosting/observability.md).
-:::
+Raven splits telemetry into two layers and uses a different tool for each:
 
-## What goes here
+- **Application telemetry** (traces, logs, metrics emitted by the Go API and the
+  Python AI worker) lands in **OpenObserve**.
+- **Host telemetry** (CPU, memory, disk, network, per-container resource usage
+  for the box itself) lands in **Beszel**.
 
-A short bullet list of the topics this page will cover, drawn from the
-[design spec](https://github.com/ravencloak-org/Raven/blob/main/docs/superpowers/specs/2026-05-09-docs-site-design.md).
+There is no Grafana in the stack. OpenObserve provides its own dashboarding,
+SQL/PromQL query, and alerting; Beszel provides its own UI for host metrics.
+Keeping them separate means a host-level issue (disk full, agent dead) can
+still be diagnosed when the application stack is unhealthy.
+
+## Stack overview
+
+| Tool        | Covers                                          | Where it runs                                                                 | Default access                       |
+| ----------- | ----------------------------------------------- | ----------------------------------------------------------------------------- | ------------------------------------ |
+| OpenObserve | App traces, logs, metrics (OTLP/gRPC)           | `docker-compose.yml` service `openobserve`                                    | `http://localhost:5080`              |
+| Beszel Hub  | Host CPU/RAM/disk/network, container resources  | `deploy/ansible/files/docker-compose.admin.yml` (separate admin compose file) | `http://<host>:8090` / `monitor.<your-domain>` via Cloudflare tunnel |
+| Beszel Agent| Reports host stats to the hub                   | Standalone container, started by Ansible (`deploy/ansible/roles/admin-tools/tasks/main.yml`) | n/a — talks to the hub on `localhost:45876` |
+
+Beszel is **not** bundled in the main Compose file. It lives in a separate
+admin Compose file because it monitors the host running Raven; it must keep
+running even when you tear the application stack down for maintenance.
+
+## OpenObserve — app telemetry
+
+### Default deployment (Compose)
+
+The service block in [`docker-compose.yml`](https://github.com/ravencloak-org/Raven/blob/main/docker-compose.yml):
+
+```yaml
+openobserve:
+  image: public.ecr.aws/zinclabs/openobserve:latest
+  ports:
+    - "5080:5080"   # UI + HTTP API
+    - "5081:5081"   # gRPC OTLP receiver (traces, metrics, logs)
+  environment:
+    ZO_ROOT_USER_EMAIL: ${ZO_ROOT_USER_EMAIL:-admin@raven.local}
+    ZO_ROOT_USER_PASSWORD: ${ZO_ROOT_USER_PASSWORD:?ZO_ROOT_USER_PASSWORD is required}
+    ZO_GRPC_PORT: "5081"
+  volumes:
+    - openobserve-data:/data
+  networks:
+    - raven-internal
+  restart: unless-stopped
+```
+
+| Setting       | Default                                          | Purpose                                            |
+| ------------- | ------------------------------------------------ | -------------------------------------------------- |
+| Image         | `public.ecr.aws/zinclabs/openobserve:latest`     | Pin to a digest in production.                     |
+| HTTP/UI port  | `5080`                                           | Web UI, REST API, query.                           |
+| OTLP gRPC port| `5081`                                           | Where Raven services push traces/logs/metrics.     |
+| Data volume   | `openobserve-data` → `/data`                     | All ingested data, dashboards, users.              |
+| Admin email   | `${ZO_ROOT_USER_EMAIL:-admin@raven.local}`       | Initial root user; first-login credentials.        |
+| Admin password| `${ZO_ROOT_USER_PASSWORD}`                       | Required at boot — Compose fails fast without it.  |
+
+Open the UI at `http://localhost:5080` and log in with the email and password
+above (configured via `.env`; see [`.env.example`](https://github.com/ravencloak-org/Raven/blob/main/.env.example)).
+
+### What gets emitted
+
+#### Go API (`raven-api`)
+
+Telemetry is wired in [`internal/telemetry/telemetry.go`](https://github.com/ravencloak-org/Raven/blob/main/internal/telemetry/telemetry.go)
+and applied via the Gin middleware in [`internal/middleware/otel.go`](https://github.com/ravencloak-org/Raven/blob/main/internal/middleware/otel.go).
+
+- **Traces** — one span per HTTP request (server kind), named `<METHOD> <route>`,
+  with `http.request.method` and `url.path` attributes. The middleware sets an
+  `X-Trace-ID` response header so a trace can be looked up from any user-facing
+  error.
+- **Logs** — `slog` is wrapped with the `otelslog` bridge: every structured log
+  goes to stderr **and** to OpenObserve as an OTLP log record, automatically
+  decorated with `trace_id` / `span_id` from the request context.
+- **Metrics** — pre-registered instruments in
+  [`internal/telemetry/metrics.go`](https://github.com/ravencloak-org/Raven/blob/main/internal/telemetry/metrics.go):
+
+  | Metric                          | Type            | Unit          |
+  | ------------------------------- | --------------- | ------------- |
+  | `raven.http.requests.total`     | counter         | `{request}`   |
+  | `http.server.request.duration`  | histogram       | `s`           |
+  | `raven.chat.completions.total`  | counter         | `{completion}`|
+  | `raven.chat.tokens.total`       | counter         | `{token}`     |
+  | `raven.chat.completion.latency` | histogram       | `ms`          |
+  | `raven.voice.sessions.created`  | counter         | `{session}`   |
+  | `raven.voice.sessions.active`   | up-down counter | `{session}`   |
+  | `raven.voice.turns.total`       | counter         | `{turn}`      |
+  | `raven.whatsapp.calls.total`    | counter         | `{call}`      |
+  | `raven.whatsapp.messages.total` | counter         | `{message}`   |
+
+When OTLP is not configured, all of these become no-ops with zero overhead.
+
+#### Python AI worker (`raven-ai-worker`)
+
+Configured in [`ai-worker/raven_worker/telemetry.py`](https://github.com/ravencloak-org/Raven/blob/main/ai-worker/raven_worker/telemetry.py)
+using `opentelemetry-sdk`, `opentelemetry-exporter-otlp`, and
+`opentelemetry-instrumentation-grpc` (versions pinned in
+[`ai-worker/pyproject.toml`](https://github.com/ravencloak-org/Raven/blob/main/ai-worker/pyproject.toml)).
+
+The worker emits **traces** for gRPC calls — one server-side span per RPC,
+covering ingest, embedding, retrieval, and chat completion. Logs go through
+`structlog` to stdout (collected by Docker); the worker does not currently
+push OTLP logs or custom metrics to OpenObserve.
+
+### OTLP wiring
+
+Two ways to point a Raven service at OpenObserve.
+
+**Go API — Raven-specific vars**
+
+| Variable                  | Default (Compose)         | Notes                                       |
+| ------------------------- | ------------------------- | ------------------------------------------- |
+| `RAVEN_OTEL_ENABLED`      | `true` (in `docker-compose.yml`) | When unset/false, telemetry is a no-op. |
+| `RAVEN_OTEL_ENDPOINT`     | `openobserve:5081`        | gRPC endpoint, host:port (no scheme).       |
+| `RAVEN_OTEL_SERVICE_NAME` | `raven-api`               | Becomes `service.name` resource attribute.  |
+
+**Python worker — standard OTel var**
+
+| Variable                       | Default                       |
+| ------------------------------ | ----------------------------- |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`  | `http://openobserve:5081`     |
+
+When connecting from outside the Compose network, replace `openobserve` with
+the host's address. TLS is **not** enabled by default (the exporter uses
+`WithInsecure()`); put OpenObserve behind your reverse proxy or a Cloudflare
+tunnel for external exposure.
+
+See [`/reference/configuration/`](/reference/configuration) for the full set
+of env vars consumed by the API.
+
+### Retention
+
+Retention is **not** preconfigured in this repo. `deploy/observability/` ships
+dashboards only — no retention or storage policy YAMLs. OpenObserve defaults
+apply (per-stream retention is set in the OpenObserve UI under
+**Streams → \<stream\> → Settings**). Recommended starting points for a
+single-node deployment:
+
+- Traces: 7 days
+- Logs: 14 days
+- Metrics: 30 days
+
+Tighten or loosen based on the disk allocated to the `openobserve-data`
+volume.
+
+### Querying
+
+OpenObserve supports SQL for logs and PromQL for metrics; consult its
+[official docs](https://openobserve.ai/docs/) for full syntax. Two examples
+that work against Raven's emitted telemetry:
+
+```sql
+-- Logs: every error from the API in the last 15 minutes
+SELECT _timestamp, body, trace_id, attributes_org_id
+FROM "default"
+WHERE service_name = 'raven-api'
+  AND severity_text = 'ERROR'
+ORDER BY _timestamp DESC
+LIMIT 200
+```
+
+```promql
+# Metrics: P95 HTTP server latency, per route, over 5-minute windows
+histogram_quantile(
+  0.95,
+  sum by (le, http_route) (rate(http_server_request_duration_bucket[5m]))
+)
+```
+
+## Beszel — host telemetry
+
+### What it covers
+
+CPU usage, memory, disk usage and I/O, network throughput, system load, plus
+per-container CPU/memory for every Docker container running on the host. It
+does **not** see application metrics — that's OpenObserve's job.
+
+### Default deployment
+
+Beszel is split into two pieces and deployed by Ansible, separately from the
+main application stack:
+
+- **Beszel Hub** — `henrygd/beszel:0.18.7`, defined in
+  [`deploy/ansible/files/docker-compose.admin.yml`](https://github.com/ravencloak-org/Raven/blob/main/deploy/ansible/files/docker-compose.admin.yml).
+  Runs with `network_mode: host` because the agent talks to it over SSH on
+  `localhost:45876`.
+- **Beszel Agent** — `henrygd/beszel-agent:0.18.7`, started as a standalone
+  container by [`deploy/ansible/roles/admin-tools/tasks/main.yml`](https://github.com/ravencloak-org/Raven/blob/main/deploy/ansible/roles/admin-tools/tasks/main.yml).
+  Mounts `/var/run/docker.sock` read-only so it can report container stats.
+  Requires a `KEY` obtained from the Hub UI after adding the system; the key
+  is stored in Ansible vault as `beszel_agent_key`.
+
+The agent is intentionally **not** in `docker-compose.yml`: it must survive
+`docker compose down` of the application stack so you can still see what is
+happening to the host while you bring services back up.
+
+### Default URL
+
+In production deployments wired through Cloudflare tunnels (see
+`deploy/ansible/roles/cloudflared/templates/config.yml.j2`) the hub is
+exposed at `monitor.<your-domain>` — for the reference deployment that is
+`https://monitor.ravencloak.org`. On a local host without a tunnel, it is
+served on port `8090` of the host network.
+
+## Application logs vs host logs
+
+| You're investigating…                              | Look at      |
+| -------------------------------------------------- | ------------ |
+| Why a chat completion returned 500                 | OpenObserve (logs + traces, filter by `trace_id`) |
+| Why a request took 8 seconds                       | OpenObserve (`http.server.request.duration` histogram) |
+| Why the box is OOM-killing containers              | Beszel (memory + per-container) |
+| Why a container is restarting on a loop            | Beszel (container state) **then** OpenObserve (logs from before the restart) |
+| Why disk pressure is alerting                      | Beszel (disk usage) — OpenObserve will likely also be unhappy |
+
+## Alerting
+
+OpenObserve has built-in alert rules with webhook actions. Raven ships **alert
+rule definitions but not active alerts** — they live as JSON in
+[`deploy/observability/dashboards/alerts.json`](https://github.com/ravencloak-org/Raven/blob/main/deploy/observability/dashboards/alerts.json)
+and must be imported (or recreated) manually in the OpenObserve UI before
+they fire. The bundled rules cover:
+
+| Rule                       | Condition                                                         | Severity |
+| -------------------------- | ----------------------------------------------------------------- | -------- |
+| `high_error_rate`          | 5xx rate > 5% over 5 min                                          | critical |
+| `high_p95_latency`         | P95 `http.server.request.duration` > 2 s over 5 min               | warning  |
+| `chat_completion_failures` | 5xx rate on `/api/v1/chat/.../completions` > 5% over 5 min        | critical |
+
+Each rule has a `${ALERT_WEBHOOK_URL}` placeholder; point it at Slack,
+PagerDuty, or any other receiver before enabling.
+
+Beszel has its own alerting (CPU/memory/disk thresholds, SSH liveness)
+configured per-system in the Hub UI.
+
+## Sample dashboards
+
+Four dashboards ship in [`deploy/observability/dashboards/`](https://github.com/ravencloak-org/Raven/tree/main/deploy/observability/dashboards):
+
+| File                     | Purpose                                                                  |
+| ------------------------ | ------------------------------------------------------------------------ |
+| `api-overview.json`      | Request rate, error rate, P50/P95/P99 latency, status code distribution  |
+| `chat-completions.json`  | Completion volume, token throughput, latency by org/KB/model             |
+| `voice-sessions.json`    | Sessions created, active gauge, turns processed                          |
+| `whatsapp.json`          | Calls and messages by org, direction, type                               |
+
+These are JSON definitions, **not** OpenObserve native exports — you will
+need to recreate them in the UI (PromQL queries are reusable as-is) or import
+via the OpenObserve API. Treat them as a known-good starting set; build
+deployment-specific dashboards on top.
+
+## See also
+
+- [Configuration reference](/reference/configuration) — full env-var list,
+  including all `RAVEN_OTEL_*` and `OTEL_EXPORTER_OTLP_*` variables.
+- [Docker Compose guide](/guides/self-hosting/docker-compose) — bringing the
+  stack up, including the `openobserve` service.
+- [Hardening guide](/guides/self-hosting/hardening) — putting OpenObserve
+  behind TLS and restricting access.

--- a/docs-site/stubs/reference/configuration.md
+++ b/docs-site/stubs/reference/configuration.md
@@ -1,16 +1,485 @@
 ---
-title: "Coming Soon"
+title: "Configuration"
 ---
 
 # Configuration
 
-::: warning Stub page
-This page is a placeholder. The full content is being written. If you would
-like to contribute, the source for this page lives at the path shown below
-and you can [edit it on GitHub](https://github.com/ravencloak-org/Raven/edit/main/docs-site/stubs/reference/configuration.md).
-:::
+Raven is configured entirely via environment variables. There is no central
+runtime config file — every binary reads its environment at startup, validates
+required values, and fails fast if the set is incomplete.
 
-## What goes here
+Three runtimes consume those variables:
 
-A short bullet list of the topics this page will cover, drawn from the
-[design spec](https://github.com/ravencloak-org/Raven/blob/main/docs/superpowers/specs/2026-05-09-docs-site-design.md).
+- **Go API and Asynq worker** — [Viper](https://github.com/spf13/viper) loads
+  defaults, optional `config.yaml`, then env overrides. Defined in
+  [`internal/config/config.go`](https://github.com/ravencloak-org/Raven/blob/main/internal/config/config.go).
+  All keys are bound under the `RAVEN_` prefix (with a few legacy bindings such
+  as `GOOGLE_CLIENT_ID`, `AWS_SES_*`, `TMDB_API_KEY`).
+- **Python AI worker** — [pydantic-settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/)
+  reads the same `RAVEN_` prefix. Defined in
+  [`ai-worker/raven_worker/config.py`](https://github.com/ravencloak-org/Raven/blob/main/ai-worker/raven_worker/config.py)
+  with `env_prefix="RAVEN_"`.
+- **Frontend (Vue 3 + Vite)** — `import.meta.env.VITE_*` substitutions are
+  baked in at build time. Defined per build in `frontend/.env.example`,
+  `frontend/.env.production`, and the deploy config at
+  `deploy/cloudflare-pages.json`.
+
+## Precedence
+
+For the Go binaries, Viper resolves each key in this order (later wins):
+
+1. Built-in `SetDefault` value in `config.go`.
+2. Optional `config.yaml` under `.` or `./config`. Missing file is not an error.
+3. Process environment (the Compose stack mounts `.env` into containers and
+   relies on Compose's variable substitution + `env_file` loading).
+4. Explicit `BindEnv` mappings — both `RAVEN_*` and the legacy aliases noted
+   above.
+
+Frontend `VITE_*` values are read once at `vite build` and frozen into the
+JS bundle; you cannot change them without a rebuild.
+
+## Secrets handling
+
+- All secrets are environment-only. The repo ships `.env.example` files;
+  there is no committed `.env`.
+- The Compose stack supports `dotenvx`-encrypted `.env` files: each service
+  bind-mounts `./.env:/app/.env:ro` and receives `DOTENV_PRIVATE_KEY`. Never
+  commit `.env.keys`.
+- Required secrets fail loudly via Compose's `${VAR:?...}` syntax — see
+  `RAVEN_ENCRYPTION_AES_KEY` and `DATABASE_URL` in `docker-compose.yml` and
+  `docker-compose.edge.yml`.
+- For production, push `.env` into a secrets manager (Vault, SSM Parameter
+  Store, 1Password Connect) and inject at boot — see the hardening guide.
+
+## Quick start
+
+The minimum env vars to bring up the full Compose stack:
+
+```bash
+# postgres + valkey
+POSTGRES_USER=raven
+POSTGRES_PASSWORD=changeme
+POSTGRES_DB=raven
+DATABASE_URL=postgresql://raven:changeme@postgres:5432/raven?sslmode=disable
+VALKEY_URL=redis://valkey:6379/0
+
+# Raven API
+RAVEN_DATABASE_URL=${DATABASE_URL}
+RAVEN_VALKEY_URL=${VALKEY_URL}
+RAVEN_GRPC_WORKER_ADDR=python-worker:50051
+RAVEN_ENCRYPTION_AES_KEY=<base64 32-byte key>
+
+# auth
+SUPERTOKENS_API_KEY=supertokens-dev-key-replace-me
+
+# at least one LLM provider for the AI worker
+ANTHROPIC_API_KEY=sk-ant-...
+```
+
+Generate `RAVEN_ENCRYPTION_AES_KEY` with `openssl rand -base64 32`. Without it
+the API container refuses to start (Compose enforces this with `:?required`).
+
+## Go API — `cmd/api`
+
+The API binary loads config via `config.Load()` in `internal/config/config.go`.
+
+### Server
+
+| Env var | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `RAVEN_SERVER_PORT` | int | `8081` | no | HTTP listener port (`Server.Port`). |
+| `RAVEN_SERVER_MODE` | string | `debug` | no | Gin mode (`debug` or `release`). `Server.Mode`. |
+| `RAVEN_HTTP_READ_HEADER_TIMEOUT` | duration | `5s` | no | `http.Server.ReadHeaderTimeout`. |
+| `RAVEN_HTTP_READ_TIMEOUT` | duration | `30s` | no | Full request read timeout. |
+| `RAVEN_HTTP_WRITE_TIMEOUT` | duration | `60s` | no | Full response write timeout. |
+| `RAVEN_HTTP_IDLE_TIMEOUT` | duration | `120s` | no | Keep-alive idle timeout. |
+| `RAVEN_AI_WORKER_TIMEOUT` | duration | `5s` | no | Per-call gRPC deadline against the Python worker. |
+| `RAVEN_AI_WORKER_BREAKER_THRESHOLD` | uint | `5` | no | Consecutive AI-worker failures that open the circuit breaker. |
+| `RAVEN_AI_WORKER_BREAKER_COOLDOWN` | duration | `30s` | no | Cooldown before the breaker probes again. |
+| `RAVEN_SINGLE_USER` | bool | `false` | no | Raven Local / desktop mode. Injects a synthetic `user_id=local`, `org_id=local` session and disables `/auth/*`. |
+| `RAVEN_CORS_ALLOWED_ORIGINS` | csv | `http://localhost:5173,https://raven-frontend.pages.dev` | no | Comma-separated origin allowlist. |
+
+Durations accept Go `time.Duration` syntax (`5s`, `500ms`, `2m`).
+
+### Database & cache
+
+| Env var | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `RAVEN_DATABASE_URL` | URL | — | yes | PostgreSQL DSN (with `pgvector`). Validated as non-empty in `Load()`. |
+| `RAVEN_VALKEY_URL` | URL | — | no | Valkey/Redis DSN, used by Asynq + rate-limit buckets + cache. |
+
+`config.Load()` returns an error if `RAVEN_DATABASE_URL` is unset:
+`database.url is required`.
+
+### gRPC client (AI worker)
+
+| Env var | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `RAVEN_GRPC_WORKER_ADDR` | host:port | `localhost:50051` | no (yes in Compose) | Address of the Python AI worker gRPC server. No scheme prefix. |
+
+### Auth — SuperTokens
+
+| Env var | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `RAVEN_SUPERTOKENS_CONNECTION_URI` | URL | `http://supertokens:3567` | no | SuperTokens core URI. |
+| `RAVEN_SUPERTOKENS_API_KEY` | string | _(empty)_ | yes (prod) | SuperTokens core API key. Never commit. |
+| `RAVEN_SUPERTOKENS_API_DOMAIN` | URL | `http://localhost:8081` | no | Public API domain that frontend calls. |
+| `RAVEN_SUPERTOKENS_WEBSITE_DOMAIN` | URL | `http://localhost:5173` | no | Public frontend domain (used for cookie scoping + CORS). |
+| `GOOGLE_CLIENT_ID` | string | _(empty)_ | no | Google OAuth client ID for SuperTokens social login. |
+| `GOOGLE_CLIENT_SECRET` | string | _(empty)_ | no | Google OAuth client secret. Never commit. |
+
+### Encryption
+
+| Env var | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `RAVEN_ENCRYPTION_AES_KEY` | base64(32 bytes) | — | yes | AES-256-GCM key for at-rest encryption of tenant LLM API keys (BYOK). Never commit. |
+
+Compose enforces this with `${RAVEN_ENCRYPTION_AES_KEY:?... is required}`.
+
+### Rate limits
+
+All values are requests-per-minute unless noted. Tier limits override
+`default_*` for orgs on that tier.
+
+| Env var | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `RAVEN_RATELIMIT_DEFAULT_USER_LIMIT` | int | `1000` | no | Per-user fallback (must be > 0). |
+| `RAVEN_RATELIMIT_DEFAULT_ORG_LIMIT` | int | `10000` | no | Per-org fallback (must be > 0). |
+| `RAVEN_RATELIMIT_FREE_GENERAL_RPM` | int | `60` | no | Free-tier general endpoints. |
+| `RAVEN_RATELIMIT_FREE_COMPLETION_RPM` | int | `10` | no | Free-tier LLM completions. |
+| `RAVEN_RATELIMIT_PRO_GENERAL_RPM` | int | `600` | no | Pro tier general. |
+| `RAVEN_RATELIMIT_PRO_COMPLETION_RPM` | int | `120` | no | Pro tier completions. |
+| `RAVEN_RATELIMIT_ENTERPRISE_GENERAL_RPM` | int | `6000` | no | Enterprise general. |
+| `RAVEN_RATELIMIT_ENTERPRISE_COMPLETION_RPM` | int | `-1` | no | Enterprise completions; `-1` means unlimited. |
+| `RAVEN_RATELIMIT_WIDGET_RPM` | int | `30` | no | Public widget endpoints. |
+| `RAVEN_RATELIMIT_APIKEY_HASH_SECRET` | string | _(empty)_ | yes (prod) | HMAC-SHA-256 key for deriving Valkey bucket IDs from raw API keys. Must be stable across nodes; never commit. |
+
+`Load()` returns an error if either `default_user_limit` or
+`default_org_limit` is zero or negative.
+
+### Asynq queue (used by the API to enqueue, by the worker to consume)
+
+| Env var | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `RAVEN_QUEUE_CONCURRENCY` | int | `10` | no | Worker concurrency. |
+| `RAVEN_QUEUE_MAX_RETRY` | int | `5` | no | Max retries per task. |
+
+### Storage — SeaweedFS
+
+| Env var | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `RAVEN_SEAWEEDFS_MASTER_URL` | URL | `http://seaweedfs-master:9333` | no | SeaweedFS master node URL. |
+
+### Uploads
+
+| Env var | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `RAVEN_UPLOAD_MAX_SIZE_BYTES` | int64 | `52428800` (50 MB) | no | Max upload size in bytes. |
+| `RAVEN_UPLOAD_ALLOWED_TYPES` | csv | _PDF, DOCX, PPTX, HTML, MD, TXT, CSV_ | no | MIME allowlist (Viper accepts a comma list). |
+
+### LLM provider keys (BYOK + summary job)
+
+These are not bound by Viper; they are read directly by the AI worker (and by
+the dev-agent script). The Go API receives tenant-scoped keys via the
+`/api/v1/byok` endpoints and stores them encrypted with
+`RAVEN_ENCRYPTION_AES_KEY`.
+
+| Env var | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `ANTHROPIC_API_KEY` | string | — | yes (one provider) | Anthropic key. Never commit. |
+| `OPENAI_API_KEY` | string | — | no | OpenAI key. Never commit. |
+| `COHERE_API_KEY` | string | — | no | Cohere key (rerank + embeddings). Never commit. |
+
+### Voice — LiveKit
+
+| Env var | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `RAVEN_LIVEKIT_API_URL` | URL | `http://localhost:7880` | no | LiveKit server HTTP(S) URL for RoomService API calls. |
+| `RAVEN_LIVEKIT_WS_URL` | URL | `ws://localhost:7880` | no | WebSocket URL returned to clients (use `wss://` in production). |
+| `RAVEN_LIVEKIT_API_KEY` | string | `devkey` | yes (prod) | LiveKit API key. Never commit. |
+| `RAVEN_LIVEKIT_API_SECRET` | string | `devsecret` | yes (prod) | LiveKit API secret. Never commit. |
+
+### Voice — TTS (text-to-speech)
+
+| Env var | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `RAVEN_TTS_PROVIDER` | enum | `cartesia` | no | `cartesia` or `piper`. |
+| `RAVEN_TTS_CARTESIA_API_KEY` | string | _(empty)_ | yes (cartesia) | Cartesia Sonic API key. Never commit. |
+| `RAVEN_TTS_CARTESIA_VOICE_ID` | string | _(empty)_ | no | Cartesia voice UUID. |
+| `RAVEN_TTS_CARTESIA_MODEL` | string | `sonic-2` | no | Cartesia model id. |
+| `RAVEN_TTS_CARTESIA_BASE_URL` | URL | _(empty)_ | no | Override Cartesia API base. |
+| `RAVEN_TTS_PIPER_ENDPOINT` | URL | `http://localhost:5000` | no | Self-hosted Piper HTTP endpoint. |
+| `RAVEN_TTS_PIPER_VOICE` | string | `en_US-amy-medium` | no | Piper voice file id. |
+
+### Voice — STT (speech-to-text)
+
+| Env var | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `RAVEN_STT_PROVIDER` | enum | _(empty)_ | no | `deepgram`, `whisper`, or empty. Empty falls back to Deepgram if a key is set, otherwise Whisper. |
+| `RAVEN_STT_DEEPGRAM_API_KEY` | string | _(empty)_ | yes (deepgram) | Deepgram key. Never commit. |
+| `RAVEN_STT_DEEPGRAM_MODEL` | string | `nova-2` | no | Deepgram model id. |
+| `RAVEN_STT_DEEPGRAM_BASE_URL` | URL | `https://api.deepgram.com` | no | Deepgram API base. |
+| `RAVEN_STT_WHISPER_ENDPOINT` | URL | `http://localhost:8000` | no | Self-hosted Whisper HTTP endpoint. |
+| `RAVEN_STT_WHISPER_MODEL` | string | `large-v3` | no | Whisper model id. |
+
+### ClickHouse (large-tenant vector backend)
+
+ClickHouse is opt-in. The API uses `pgvector` by default and switches per-org
+once the chunk count exceeds `chunk_threshold`.
+
+| Env var | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `RAVEN_CLICKHOUSE_HOST` | host | _(empty)_ | no | Empty disables ClickHouse entirely. |
+| `RAVEN_CLICKHOUSE_PORT` | int | `9000` | no | Native protocol port. |
+| `RAVEN_CLICKHOUSE_DATABASE` | string | `raven` | no | ClickHouse database name. |
+| `RAVEN_CLICKHOUSE_USER` | string | `default` | no | ClickHouse user. |
+| `RAVEN_CLICKHOUSE_PASSWORD` | string | _(empty)_ | yes (if host set) | ClickHouse password. Never commit. |
+| `RAVEN_CLICKHOUSE_VECTOR_BACKEND` | enum | `pgvector` | no | Default vector backend: `pgvector` or `clickhouse`. |
+| `RAVEN_CLICKHOUSE_CHUNK_THRESHOLD` | int64 | `5000000` | no | Per-org chunk count above which ClickHouse is preferred. |
+
+### Telemetry — OpenTelemetry / OpenObserve
+
+| Env var | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `RAVEN_OTEL_ENABLED` | bool | `false` | no | Master switch for OTEL exporters. |
+| `RAVEN_OTEL_ENDPOINT` | host:port | _(empty)_ | yes (if enabled) | OTLP gRPC endpoint, e.g. `openobserve:5081`. |
+| `RAVEN_OTEL_SERVICE_NAME` | string | `raven-api` | no | `service.name` resource attribute. |
+
+### Payments — Hyperswitch + Razorpay
+
+Raven uses Hyperswitch as the payment orchestrator with Razorpay underneath
+for Indian rails (UPI, RuPay, cards).
+
+| Env var | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `RAVEN_HYPERSWITCH_BASE_URL` | URL | `http://localhost:8090` | yes (billing) | Hyperswitch API base. Use `https://sandbox.hyperswitch.io` for testing. |
+| `RAVEN_HYPERSWITCH_API_KEY` | string | _(empty)_ | yes (billing) | Hyperswitch API key. Never commit. |
+| `RAVEN_HYPERSWITCH_WEBHOOK_SECRET` | string | _(empty)_ | yes (billing) | HMAC-SHA-256 secret for webhook verification. Never commit. |
+| `RAVEN_HYPERSWITCH_RAZORPAY_KEY_ID` | string | _(empty)_ | yes (Razorpay) | Razorpay public key id (surfaced to the frontend checkout SDK). |
+
+### Email — AWS SES (SMTP)
+
+Credentials are SES SMTP credentials, **not** IAM access keys. Generate via
+AWS Console → SES → SMTP settings.
+
+| Env var | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `AWS_SES_REGION` | string | `ap-south-1` | no | SES region. |
+| `AWS_SES_FROM_ADDRESS` | email | _(empty)_ | yes (email) | Verified SES identity used as the From address. |
+| `AWS_SES_FROM_NAME` | string | `Raven` | no | Friendly From name. |
+| `AWS_SES_SMTP_USERNAME` | string | _(empty)_ | yes (email) | SES SMTP username. Never commit. |
+| `AWS_SES_SMTP_PASSWORD` | string | _(empty)_ | yes (email) | SES SMTP password. Never commit. |
+
+### Email summary job (M9 #257)
+
+Required when the post-session summary email pipeline is on. Setting
+`RAVEN_UNSUBSCRIBE_BASE_URL` flips the pipeline on; that requires
+`UNSUBSCRIBE_TOKEN_SECRET` to be at least 32 bytes — `Load()` rejects shorter
+secrets at startup.
+
+| Env var | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `RAVEN_FRONTEND_BASE_URL` | URL | _(empty)_ | yes (email) | Public frontend URL used to build deep-links in emails. |
+| `RAVEN_SUPPORT_ADDRESS` | email | `support@ravencloak.io` | no | Reply-To / footer contact. |
+| `RAVEN_UNSUBSCRIBE_BASE_URL` | URL | _(empty)_ | yes (email) | Public URL of the one-click unsubscribe endpoint, proxied by the API. |
+| `UNSUBSCRIBE_TOKEN_SECRET` | string (≥ 32 bytes) | _(empty)_ | yes (email) | HMAC-SHA-256 key for unsubscribe tokens. Generate with `openssl rand -hex 32`. Never commit. |
+| `RAVEN_AI_WORKER_HTTP_URL` | URL | `http://ai-worker:8090` | no | AI-worker FastAPI base for `POST /internal/summarize`. |
+
+### PostHog (server-side, opt-in)
+
+| Env var | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `RAVEN_POSTHOG_API_KEY` | string | _(empty)_ | no | PostHog project API key. Empty disables event capture. |
+| `RAVEN_POSTHOG_HOST` | URL | `https://us.i.posthog.com` | no | PostHog ingestion host (use `https://eu.i.posthog.com` for the EU region). |
+
+### Meta WhatsApp Business API
+
+| Env var | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `RAVEN_META_ACCESS_TOKEN` | string | _(empty)_ | yes (WhatsApp) | Permanent access token. Never commit. |
+| `RAVEN_META_PHONE_NUMBER_ID` | string | _(empty)_ | yes (WhatsApp) | WhatsApp Cloud API phone-number id. |
+| `RAVEN_META_APP_SECRET` | string | _(empty)_ | yes (WhatsApp) | App secret used to verify webhook HMAC signatures. Never commit. |
+| `RAVEN_META_WEBHOOK_TOKEN` | string | _(empty)_ | yes (WhatsApp) | `hub.verify_token` for webhook subscription handshake. |
+
+> Note: the variables above match the field names on `MetaConfig` in
+> `config.go` and Viper's default `RAVEN_<SECTION>_<FIELD>` derivation
+> (`SetEnvPrefix("RAVEN")` + `EnvKeyReplacer(".", "_")`). They are not
+> additionally bound via `BindEnv`.
+
+### TMDB (demo seed)
+
+The demo knowledge base uses TMDB. Both names work because the legacy
+`TMDB_API_KEY` is bound via `BindEnv`.
+
+| Env var | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `TMDB_API_KEY` | string | _(empty)_ | yes (demo seed) | TMDB API key. Never commit. |
+| `RAVEN_TMDB_BASE_URL` | URL | `https://api.themoviedb.org/3` | no | TMDB API base. |
+
+### Seed endpoint
+
+| Env var | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `RAVEN_SEED_KEY` | string | _(empty)_ | yes (admin seed) | Value required in the `X-Seed-Key` header to call the protected seed endpoint. Never commit. |
+
+### eBPF (Linux ≥ 5.8 with `CONFIG_DEBUG_INFO_BTF=y`)
+
+All flags default to `false`. The subsystem is a no-op on non-Linux platforms
+regardless. `Load()` rejects `RAVEN_EBPF_AUDIT_RING_BUFFER_SIZE` values that
+are not a power of two when `RAVEN_EBPF_ENABLED=true`.
+
+| Env var | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `RAVEN_EBPF_ENABLED` | bool | `false` | no | Master switch. When `false`, all sub-flags are ignored. |
+| `RAVEN_EBPF_OBSERVABILITY_ENABLED` | bool | `false` | no | Enable eBPF-based observability hooks. |
+| `RAVEN_EBPF_AUDIT_ENABLED` | bool | `false` | no | Enable eBPF audit. |
+| `RAVEN_EBPF_AUDIT_IP_ALLOWLIST` | csv | _(empty)_ | no | IPs excluded from audit logging. |
+| `RAVEN_EBPF_AUDIT_EXEC_ALLOWLIST` | csv | _(empty)_ | no | Exec paths excluded from audit logging. |
+| `RAVEN_EBPF_AUDIT_RING_BUFFER_SIZE` | int (power of 2) | `1048576` | no | BPF ring buffer size in bytes. |
+| `RAVEN_EBPF_XDP_ENABLED` | bool | `false` | no | Enable XDP rate-limit dataplane. |
+| `RAVEN_EBPF_XDP_INTERFACE` | string | `eth0` | no | Network interface to attach XDP to. |
+
+## Asynq worker — `cmd/worker`
+
+The Asynq worker (`cmd/worker/main.go`) calls `config.Load()` and reuses
+**every** variable above. The environment is identical to the API's. The
+worker additionally consumes:
+
+- `RAVEN_QUEUE_CONCURRENCY`, `RAVEN_QUEUE_MAX_RETRY` — Asynq runtime knobs.
+- `AWS_SES_*` and `RAVEN_*` summary keys — the post-session summary job runs
+  inside this binary (M9 #257).
+- `RAVEN_AI_WORKER_HTTP_URL` — used to call `POST /internal/summarize` on the
+  Python worker.
+
+When SES SMTP credentials are unset and the binary is in `debug` server mode,
+the worker falls back to a stub email sender; in `release` mode it returns
+an init error from `email.Config.Validate()`.
+
+## AI worker — Python (`ai-worker`)
+
+Defined in
+[`ai-worker/raven_worker/config.py`](https://github.com/ravencloak-org/Raven/blob/main/ai-worker/raven_worker/config.py)
+as a `pydantic_settings.BaseSettings` subclass with
+`SettingsConfigDict(env_prefix="RAVEN_")`. Version `0.3.0`
+(`ai-worker/pyproject.toml`).
+
+| Env var | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `RAVEN_GRPC_PORT` | int | `50051` | no | gRPC listen port. |
+| `RAVEN_GRPC_MAX_WORKERS` | int | `10` | no | gRPC server thread-pool size. |
+| `RAVEN_DATABASE_URL` | URL | `postgresql://raven:raven@localhost:5432/raven` | yes | Same DSN the Go API uses. |
+| `RAVEN_VALKEY_URL` | URL | `redis://localhost:6379/0` | yes | Same Valkey/Redis URL. |
+| `RAVEN_OTEL_ENDPOINT` | host:port | _(empty)_ | no | OTLP endpoint (if enabled). |
+| `RAVEN_OTEL_ENABLED` | bool | `false` | no | Toggle OTEL exporters. |
+| `RAVEN_LOG_LEVEL` | string | `INFO` | no | Python logging level. |
+| `RAVEN_LITEPARSE_PATH` | path | `liteparse` | no | Path to the `liteparse` binary used for document parsing. |
+| `RAVEN_ENCRYPTION_KEY` | base64(32 bytes) | _(empty)_ | yes (BYOK) | Same key used by the Go API to decrypt tenant LLM keys. Never commit. |
+| `RAVEN_LIVEKIT_URL` | URL | `ws://localhost:7880` | yes (voice) | LiveKit WebSocket URL. |
+| `RAVEN_LIVEKIT_API_KEY` | string | _(empty)_ | yes (voice) | LiveKit API key. Never commit. |
+| `RAVEN_LIVEKIT_API_SECRET` | string | _(empty)_ | yes (voice) | LiveKit API secret. Never commit. |
+| `RAVEN_MEMORY_DIR` | path | _(empty)_ | no | Per-session memory directory. Empty disables memory. In Compose this is mounted from a named volume. |
+| `RAVEN_ENABLE_WEB_SEARCH` | bool | `false` | no | Allow Anthropic `web_search` tool in RAG responses. |
+| `RAVEN_HTTP_PORT` | int | `8090` | no | FastAPI internal endpoints (`POST /internal/summarize`). |
+| `RAVEN_HTTP_ENABLED` | bool | `true` | no | Toggle the FastAPI side-server. |
+| `RAVEN_HTTP_BIND_HOST` | string | `127.0.0.1` | no | Binds loopback by default; override only when callers live on a separate node and a network policy gates external access. |
+| `RAVEN_SEMANTIC_CACHE_ENABLED` | bool | `true` | no | Toggle the pgvector semantic-response cache (M9 #256). When false the exact-match Valkey cache still applies. |
+
+In addition, the AI worker reads provider keys directly from the environment
+at request time (not via pydantic-settings):
+
+- `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `COHERE_API_KEY` — used as
+  fallbacks when a tenant has not provided a BYOK key.
+
+## Frontend — Vite (`frontend`)
+
+Vite substitutes `import.meta.env.VITE_*` at `vite build`. Defaults defined
+in `frontend/.env.example`, production overrides in `frontend/.env.production`,
+and the canonical Cloudflare Pages build env in `deploy/cloudflare-pages.json`.
+
+| Env var | Type | Default (build) | Required | Where used | Description |
+|---|---|---|---|---|---|
+| `VITE_API_URL` | URL | `http://localhost:8081/api` | no | `frontend/src/api/client.ts` | Legacy/base API URL fallback. |
+| `VITE_API_BASE_URL` | URL | `http://localhost:8081/api/v1` | yes | API store + auth callback wiring | The `/api/v1` prefix used by the bulk of the SPA. |
+| `VITE_API_DOMAIN` | URL | `http://localhost:8081` | yes | SuperTokens `apiDomain` config in the SPA | Public API origin (no path). |
+| `VITE_LIVEKIT_URL` | URL | _(empty)_ | no | Voice room joining | `wss://` LiveKit endpoint. |
+| `VITE_POSTHOG_API_KEY` | string | _(empty)_ | no | Frontend PostHog client | Empty disables client-side analytics. |
+| `VITE_POSTHOG_HOST` | URL | `https://us.i.posthog.com` | no | Frontend PostHog client | EU region: `https://eu.i.posthog.com`. |
+| `VITE_WIDGET_URL` | URL | `https://cdn.raven.example/widget.js` | no | Embed widget loader | Override for self-hosted CDN. |
+| `VITE_KEYCLOAK_URL` | URL | _(empty)_ | no | Legacy auth path (kept in `.env.production`) | Pre-SuperTokens Keycloak base URL. |
+| `VITE_KEYCLOAK_REALM` | string | _(empty)_ | no | Legacy auth path | Keycloak realm. |
+| `VITE_KEYCLOAK_CLIENT_ID` | string | _(empty)_ | no | Legacy auth path | Keycloak client id. |
+
+> Reminder: Vite freezes these values into the bundle. To change them in
+> production you must rebuild the frontend image (or redeploy Cloudflare
+> Pages with new build env). They cannot be overridden at container start.
+
+## Edge variant differences — `docker-compose.edge.yml`
+
+The edge compose file (`docker-compose.edge.yml`) ships only the Go API, a
+local PostgreSQL, and Traefik. The Python AI worker runs remotely. Env
+differences vs the full stack:
+
+| Env var | Edge value / behaviour | Notes |
+|---|---|---|
+| `RAVEN_SERVER_PORT` | `${RAVEN_SERVER_PORT:-8080}` | Edge default is `8080` (vs API default `8081`). |
+| `RAVEN_DATABASE_URL` | `${DATABASE_URL:?required}` | Compose enforces required; uses local Postgres. |
+| `RAVEN_GRPC_WORKER_ADDR` | `${GRPC_AI_WORKER_ADDR:?required}` | Points to a remote AI worker; required and validated by Compose. |
+| `RAVEN_EDGE_MODE` | `"true"` (set in compose) | Signals the API to skip local-worker checks. |
+| `RAVEN_API_IMAGE` | `ghcr.io/ravencloak-org/raven-api:latest` (default) | Override for pinned tags, e.g. `:latest-arm64`. |
+| `DOMAIN`, `ACME_EMAIL` | optional | Used by Traefik for HTTPS. |
+
+What is **not** present in the edge compose: SuperTokens, OpenObserve,
+SeaweedFS, LiveKit, Asynq worker. Voice + WhatsApp + email + storage features
+are not available on the edge profile; configure them only when you bring up
+the full stack.
+
+## Validation — how invalid configs fail
+
+Go API and worker (`config.Load()`):
+
+- `RAVEN_DATABASE_URL` empty ⇒ returns `database.url is required` and the
+  binary exits non-zero on startup (`log.Fatalf` in `cmd/api/main.go` and
+  `cmd/worker/main.go`).
+- `RAVEN_RATELIMIT_DEFAULT_USER_LIMIT` ≤ 0 ⇒ explicit error.
+- `RAVEN_RATELIMIT_DEFAULT_ORG_LIMIT` ≤ 0 ⇒ explicit error.
+- `RAVEN_EBPF_ENABLED=true` and `RAVEN_EBPF_AUDIT_RING_BUFFER_SIZE` not a
+  power of 2 ⇒ explicit error (`bits.OnesCount` check).
+- `RAVEN_UNSUBSCRIBE_BASE_URL` set and `UNSUBSCRIBE_TOKEN_SECRET` shorter
+  than 32 bytes ⇒ explicit error.
+
+Compose (`docker-compose.yml`, `docker-compose.edge.yml`):
+
+- `${VAR:?...}` syntax aborts `docker compose up` with the message before any
+  container starts. Used for `RAVEN_ENCRYPTION_AES_KEY`, `DATABASE_URL`, and
+  `GRPC_AI_WORKER_ADDR` (edge).
+
+Python AI worker (pydantic-settings):
+
+- Type-mismatch (e.g. non-int into `grpc_port`) raises `ValidationError` at
+  import time and the gRPC process exits with a non-zero code.
+
+Frontend (Vite):
+
+- No runtime validation. Missing `VITE_*` values fall back to the `??`
+  defaults in source. Misconfiguration manifests as runtime API errors in
+  the browser console.
+
+## Secrets handling — recommendations
+
+- **Local dev** — copy `.env.example` to `.env`, fill values, never commit.
+  `.gitignore` excludes `.env`, `.env.*` (except `.env.example`).
+- **CI** — use repo secrets and inject only what the job needs.
+- **Production** — use a secrets manager (Vault, AWS Secrets Manager, SSM
+  Parameter Store, 1Password Connect, Doppler). The Compose stack supports
+  encrypted `.env` files via [`dotenvx`](https://dotenvx.com/) — pass the
+  decryption key as `DOTENV_PRIVATE_KEY` and bind-mount the encrypted `.env`
+  read-only. Never mount `.env.keys` into a container.
+- **Rotation** — `RAVEN_ENCRYPTION_AES_KEY`, `RAVEN_RATELIMIT_APIKEY_HASH_SECRET`,
+  and `UNSUBSCRIBE_TOKEN_SECRET` are sticky: rotating them invalidates
+  encrypted BYOK keys, existing rate-limit buckets, and outstanding
+  unsubscribe tokens respectively. Plan rotations explicitly.
+
+## See also
+
+- [Self-hosting with Docker Compose](/guides/self-hosting/docker-compose)
+- [Hardening guide](/guides/self-hosting/hardening)


### PR DESCRIPTION
## Summary

Replaces 8 stub pages with real, code-grounded content and adds Mermaid diagram rendering so existing diagrams (currently in \`docs/architecture.md\`) actually render on the site.

| Page | Source ground-truth |
|---|---|
| **Mermaid plugin** | \`vitepress-plugin-mermaid@^2.0.17\` + \`mermaid@^11.14.0\`; wraps \`defineConfig\` with \`withMermaid()\`. |
| **Self-Hosting / Docker Compose** | All four \`docker-compose*.yml\` variants, three Dockerfiles, \`internal/config\`. 304 lines. |
| **Self-Hosting / Backups** | \`backup/pgbackrest.conf\`, \`backup/backup.sh\`, \`backup/restore.sh\`, \`docker-compose.yml\`. 293 lines. Honest about ClickHouse not having a wired backup; pgBackRest off-host (S3) is recommended-only. |
| **Self-Hosting / Hardening** | \`SECURITY.md\`, every middleware in \`internal/middleware/\`, SuperTokens init, RLS migrations \`00015\`/\`00022\`, all 3 Dockerfiles, \`deploy/traefik\`. 406 lines. |
| **Self-Hosting / Observability** | \`internal/telemetry\`, \`ai-worker/raven_worker/telemetry.py\`, \`deploy/observability/dashboards/\`, \`deploy/ansible/files/docker-compose.admin.yml\` (Beszel). 263 lines. |
| **Reference / Configuration** | \`internal/config/config.go\` end-to-end, \`ai-worker/raven_worker/config.py\`, all \`.env*\` files, Vite envs. ~110 env vars documented. 485 lines. |
| **Contributing / Dev Setup** | \`Makefile\`, \`Makefile.edge\`, \`ai-worker/Makefile\`, \`.githooks/\`, \`frontend/package.json\`, \`go.mod\`. 319 lines. |
| **Contributing / Architecture Decisions** | \`docs/superpowers/specs/\` (18 specs found, 10 cited). 146 lines. |
| **Contributing / Release Process** | \`.github/workflows/release.yml\`, \`docker.yml\`, \`.goreleaser.yaml\`, \`cliff.toml\`, \`CHANGELOG.md\`. 263 lines. |

**Total: ~2,479 new lines, build indexes 4,026 words (up from 2,264).** Stubs remaining: 21 (was 29).

## Real codebase issues surfaced (not fixed in this PR — flagged for follow-ups)

- **API port mismatch.** \`internal/config/config.go\` defaults \`server.port=8081\`; \`frontend/vite.config.ts\` proxy targets \`localhost:8080\`. Dev Setup page calls this out so users know to align them.
- **Frontend dev-port inconsistency.** \`vite.config.ts\` hard-codes 3000; \`playwright.config.ts\` uses Vite's default 5173.
- **Audit-events table.** The brief assumed a ClickHouse \`audit_events\` table — the OSS schema has \`security_events\` in Postgres (migration \`00022_security_rules.sql\`); EE has its own audit package. Hardening page documents the OSS surface only.
- **Container hardening not bundled.** \`docker-compose.yml\` has no \`security_opt\` / \`read_only\` / \`cap_drop\` blocks. Hardening page provides a copy-pasteable override snippet rather than pretending these defaults exist.
- **MFA recipe not registered.** SuperTokens supports MFA but \`InitSuperTokens\` doesn't enable the recipe today. Flagged as a recommendation.
- **CycloneDX SBOM + per-platform SBOM** flagged as known follow-ups in \`docs/security/slsa-verification.md\` notes section.

## Out of scope

The remaining 21 stubs (Tier 3 Concepts, Tier 4 User-facing, Tier 5 Niche, Tier 6 Link-outs) are tracked for the next content pass. They're untouched here.

## Test plan
- [ ] Cloudflare Pages preview renders correctly
- [ ] \`docs/architecture.md\`'s Mermaid diagram now renders at \`/concepts/architecture/\` (client-side via vitepress-plugin-mermaid)
- [ ] Every page in the table above has zero "Coming Soon"/"Stub" content
- [ ] PageFind search returns hits for queries like "pgBackRest", "OpenObserve", "OTLP", "RAVEN_SERVER_PORT", "SLSA"
- [ ] No dead links in build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Mermaid diagram rendering enabled in documentation site

* **Documentation**
  * Complete developer setup and onboarding guide
  * Self-hosting guides: Docker Compose deployment, backups, hardening, and observability
  * Release process and comprehensive configuration reference documentation
  * Architecture decision recording guidance

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ravencloak-org/Raven/pull/488)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->