### PR TITLE
fix(test): derive expected migration version from migrations/ at runtime

### DIFF
--- a/internal/repository/rls_test.go
+++ b/internal/repository/rls_test.go
@@ -3,6 +3,10 @@ package repository_test
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -169,15 +173,16 @@ func TestRLS_MigrationVersion_AllApplied(t *testing.T) {
 	pool := testutil.NewTestDB(t)
 	ctx := context.Background()
 
-	// The highest migration version_id should match whichever migration
-	// file sits at the tip of `migrations/`. Bump this when adding a new
-	// migration.
+	// The highest applied version_id must match the highest version prefix
+	// of any *.sql file in migrations/. Discovered at test time so adding a
+	// new migration doesn't require touching this assertion.
+	wantVersion := highestMigrationVersion(t)
 	var maxVersion int64
 	err := pool.QueryRow(ctx,
 		"SELECT MAX(version_id) FROM goose_db_version WHERE is_applied = true",
 	).Scan(&maxVersion)
 	require.NoError(t, err)
-	assert.EqualValues(t, 37, maxVersion, "latest migration version must be applied")
+	assert.EqualValues(t, wantVersion, maxVersion, "latest migration version must be applied")
 
 	// Spot-check critical tables exist.
 	for _, table := range []string{
@@ -192,4 +197,35 @@ func TestRLS_MigrationVersion_AllApplied(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 1, count, "table %s must exist after migrations", table)
 	}
+}
+
+// highestMigrationVersion returns the largest numeric prefix among
+// migrations/*.sql files. Walks up from the test's working directory
+// (internal/repository/) to find the migrations dir at the repo root.
+func highestMigrationVersion(t *testing.T) int64 {
+	t.Helper()
+
+	migrationsDir := filepath.Join("..", "..", "migrations")
+	entries, err := os.ReadDir(migrationsDir)
+	require.NoError(t, err, "read migrations directory")
+
+	var max int64
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".sql") {
+			continue
+		}
+		prefix, _, ok := strings.Cut(e.Name(), "_")
+		if !ok {
+			continue
+		}
+		v, err := strconv.ParseInt(prefix, 10, 64)
+		if err != nil {
+			continue
+		}
+		if v > max {
+			max = v
+		}
+	}
+	require.Greater(t, max, int64(0), "no numbered migrations found in %s", migrationsDir)
+	return max
 }


### PR DESCRIPTION
## Summary

`TestRLS_MigrationVersion_AllApplied` in `internal/repository/rls_test.go` was hardcoding the expected `MAX(version_id)` as `37`. PR #480 (Ollama bundled provider) added migrations `00038_*.sql` and `00039_*.sql`, so the assertion fails on `main` and on every subsequent PR.

This pattern broke once before too — see commit [`03474d22`](https://github.com/ravencloak-org/Raven/commit/03474d22) which previously bumped it from a smaller number. Hardcoding the count makes every migration PR pay an unrelated test-fix tax.

Replace the literal with `highestMigrationVersion(t)`, a small helper that walks `../../migrations/` from the test's CWD, parses the numeric prefix from each `*.sql` file, and returns the max. Assertion semantics preserved (we still verify "all migration files were applied"); the value is now self-maintaining.

## Test plan

- [x] `go build ./...` clean
- [x] `golangci-lint run --timeout 2m ./internal/repository/...` exit 0
- [ ] CI green (this is the test that's currently RED on `main`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced database migration verification testing to automatically detect and validate the latest migration version instead of relying on hardcoded values, improving test reliability and maintainability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ravencloak-org/Raven/pull/491)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->