### PR TITLE
docs: real content for 8 more pages (T3 Concepts + T6 link-outs)

### DIFF
--- a/docs-site/stubs/community/support.md
+++ b/docs-site/stubs/community/support.md
@@ -1,16 +1,102 @@
 ---
-title: "Coming Soon"
+title: "Support"
 ---
 
 # Support
 
-::: warning Stub page
-This page is a placeholder. The full content is being written. If you would
-like to contribute, the source for this page lives at the path shown below
-and you can [edit it on GitHub](https://github.com/ravencloak-org/Raven/edit/main/docs-site/stubs/community/support.md).
-:::
+Raven is open source software, maintained as a public good by a single
+maintainer ([Jobin Lawrance](/community/maintainers)). There is no support
+desk and no paid tier — but there are clear, public channels for every kind
+of question, bug, or vulnerability. This page is the router.
 
-## What goes here
+## Quick router
 
-A short bullet list of the topics this page will cover, drawn from the
-[design spec](https://github.com/ravencloak-org/Raven/blob/main/docs/superpowers/specs/2026-05-09-docs-site-design.md).
+Pick the row that matches what you need.
+
+| I need to&hellip; | Go to |
+|---|---|
+| Report a bug | [GitHub Issues](https://github.com/ravencloak-org/Raven/issues) |
+| Ask a question or share an idea | [GitHub Issues](https://github.com/ravencloak-org/Raven/issues) with the `question` label (GitHub Discussions is not enabled on the repo) |
+| Report a security vulnerability | [Private security advisory](https://github.com/ravencloak-org/Raven/security/advisories/new) — **do not** open a public issue. See the [security policy](/reference/security-policy). |
+| Suggest a feature | [Open an issue](https://github.com/ravencloak-org/Raven/issues/new) describing the use case and proposed behaviour |
+| Read the docs | You're here. Start at the [Quickstart](/get-started/installation). |
+| Contribute code | [Contributing overview](/contributing/overview) |
+| Find a maintainer | [Maintainers](/community/maintainers) |
+
+## Issue templates
+
+The repository does not currently use structured issue templates — issues
+use GitHub's default form. When opening one, include:
+
+- **What you expected to happen** and **what actually happened**.
+- The **release tag or commit SHA** you're running.
+- The **deployment shape** (Docker Compose, edge / Raspberry Pi, etc.) and
+  any relevant environment notes.
+- For bugs: a **minimal reproducer** and any logs scrubbed of secrets.
+- For features: the **problem you're trying to solve**, not just the
+  solution you have in mind.
+
+Structured templates may be added later; the checklist above will keep
+working in the meantime.
+
+## Response expectations
+
+Raven is currently maintained by one person, in the open, alongside other
+work. Please calibrate expectations accordingly:
+
+- **Non-security issues and questions:** best-effort, no guaranteed SLA.
+  Triage and replies happen in batches. Well-formed reports with
+  reproducers get answered faster — that's not a policy, it's just how
+  attention works.
+- **Pull requests:** see the [contributing guide](/contributing/overview)
+  for the review and merge workflow. Small, focused PRs are merged quickly;
+  large changes need a discussion in an issue first.
+- **Security reports:** governed by the [security policy](/reference/security-policy).
+  The committed SLA is:
+
+  | Stage | Target |
+  |---|---|
+  | Initial acknowledgement | within **72 hours** |
+  | Triage and severity assessment | within **7 days** |
+  | Fix, disclosure, and release | within **90 days** (coordinated disclosure) |
+
+  If you don't hear back inside the acknowledgement window, escalate by
+  emailing `security@ravencloak.org` or `jobinlawrance@gmail.com` and
+  referencing your original report.
+
+## Commercial support
+
+There is **no paid support tier** for Raven today. The project is run as
+open source for the public good; everything that exists is in the open and
+free to use under the [licence](https://github.com/ravencloak-org/Raven/blob/main/LICENSE).
+
+If managed hosting, paid support, or commercial agreements become
+available in the future, they will be announced here and on the project's
+GitHub releases page. There is nothing to buy in the meantime, and no
+private back-channel that gets you a faster response.
+
+## Stay in touch
+
+The honest answer is that Raven does not yet have a chat community, a
+mailing list, or a social media presence. The public channels that exist
+today are:
+
+- [GitHub Releases](https://github.com/ravencloak-org/Raven/releases) —
+  watch the repository (Releases only) to get notified when a new version
+  ships.
+- [GitHub Issues](https://github.com/ravencloak-org/Raven/issues) — the
+  current home of all public conversation about the project.
+
+Anything that looks like an official Raven Slack, Discord, or Telegram
+right now is not us. If that changes, this page will be updated first.
+
+## Related
+
+- [Security policy](/reference/security-policy) — how to report
+  vulnerabilities, supported versions, and disclosure timelines.
+- [Code of conduct](/community/code-of-conduct) — the behavioural ground
+  rules for every channel above.
+- [Contributing overview](/contributing/overview) — how to land a change
+  in the codebase.
+- [Maintainers](/community/maintainers) — who is currently empowered to
+  merge and release.

--- a/docs-site/stubs/concepts/ai-worker-design.md
+++ b/docs-site/stubs/concepts/ai-worker-design.md
@@ -1,16 +1,317 @@
 ---
-title: "Coming Soon"
+title: "AI Worker Design"
 ---
 
 # AI Worker Design
 
-::: warning Stub page
-This page is a placeholder. The full content is being written. If you would
-like to contribute, the source for this page lives at the path shown below
-and you can [edit it on GitHub](https://github.com/ravencloak-org/Raven/edit/main/docs-site/stubs/concepts/ai-worker-design.md).
-:::
+Raven runs two long-lived backend processes: a Go API server and a Python
+service called the **AI worker**. The split lets each language do what it's
+best at — Go handles HTTP, auth, multi-tenant request routing, Postgres,
+Asynq queues; Python handles document parsing, embedding clients, LLM SDKs,
+re-ranking, and the LiveKit voice agent. The seam between them is gRPC.
 
-## What goes here
+The worker is published as the Python package `raven-worker` (see
+[`ai-worker/pyproject.toml`](https://github.com/ravencloak-org/Raven/blob/main/ai-worker/pyproject.toml))
+and is started by `python -m raven_worker` — see
+[`raven_worker/__main__.py`](https://github.com/ravencloak-org/Raven/blob/main/ai-worker/raven_worker/__main__.py),
+which just calls `asyncio.run(serve())`.
 
-A short bullet list of the topics this page will cover, drawn from the
-[design spec](https://github.com/ravencloak-org/Raven/blob/main/docs/superpowers/specs/2026-05-09-docs-site-design.md).
+## Service boundaries
+
+The worker exposes two network surfaces:
+
+| Surface | Protocol | Default port | Setting | Consumer |
+|---------|----------|--------------|---------|----------|
+| Public RPC | gRPC (HTTP/2) | `50051` | `RAVEN_GRPC_PORT` | Go API server |
+| Internal HTTP | FastAPI on HTTP/1.1 | `8090` | `RAVEN_HTTP_PORT` | Go Asynq workers (same host/pod) |
+
+The gRPC service is the canonical surface; its contract lives in
+[`proto/ai_worker.proto`](https://github.com/ravencloak-org/Raven/blob/main/proto/ai_worker.proto)
+under the `raven.ai.v1` package. The Go side imports the generated stubs
+from `github.com/ravencloak-org/Raven/internal/grpc/pb` (set via the proto's
+`go_package` option) and the Python side from `raven_worker.generated`.
+
+The internal HTTP listener binds to `127.0.0.1` by default — see
+`http_bind_host` in
+[`raven_worker/config.py`](https://github.com/ravencloak-org/Raven/blob/main/ai-worker/raven_worker/config.py).
+It exists for one endpoint that doesn't fit the streaming gRPC contract:
+the M9 post-session email summariser (`POST /internal/summarize`), called
+by the Go-side Asynq worker after a conversation_sessions row is ready.
+
+## RPC surface
+
+The `AIWorker` service in `proto/ai_worker.proto` exposes **three** RPCs:
+
+- **`ParseAndEmbed(ParseRequest) → ParseResponse`** — accepts a document
+  blob (bytes + MIME type) and pushes parsed-and-embedded chunks into
+  Postgres. The proto defines the contract; the Python servicer currently
+  returns `UNIMPLEMENTED` and is being wired into LiteParse.
+- **`QueryRAG(RAGRequest) → stream RAGChunk`** — server-streaming RPC.
+  Each `RAGChunk` carries either a token of the assistant's reply or, on
+  the final message (`is_final = true`), the list of source citations. The
+  request carries `org_id`, `kb_ids`, optional `session_id`, free-form
+  `filters`, and the model/provider selection.
+- **`GetEmbedding(EmbeddingRequest) → EmbeddingResponse`** — one-shot
+  embedding for a single text. Used by the Go API for query-time vector
+  search and for re-embedding tasks scheduled via Asynq.
+
+The Python entry point is
+[`raven_worker/server.py`](https://github.com/ravencloak-org/Raven/blob/main/ai-worker/raven_worker/server.py).
+It composes a single `AIWorkerServicer` from `EmbeddingServicer`
+(in `raven_worker/services/embedding.py`) and `RAGServicer` (in
+`raven_worker/services/rag.py`), registers gRPC reflection plus the
+standard health-checking service, wires the OTel interceptor, and blocks
+on a signal handler for graceful shutdown.
+
+## Module layout
+
+| Directory / file | Responsibility | Key files |
+|------------------|----------------|-----------|
+| `raven_worker/server.py` | gRPC bootstrap, health, reflection, signals | `AIWorkerServicer`, `serve()` |
+| `raven_worker/__main__.py` | `python -m raven_worker` entry point | `main()` |
+| `raven_worker/config.py` | Pydantic settings, `RAVEN_*` env vars | `Settings`, `settings` |
+| `raven_worker/services/` | gRPC servicer implementations | `embedding.py`, `rag.py`, `semantic_cache.py` |
+| `raven_worker/providers/` | LLM / embedding SDK adapters | `base.py`, `registry.py`, `openai_provider.py`, `anthropic_provider.py`, `cohere_provider.py`, `ollama_provider.py` |
+| `raven_worker/processors/` | Document ingestion pipeline | `scraper.py`, `parser.py`, `chunker.py` |
+| `raven_worker/retrieval/` | RAG helpers used by `services/rag.py` | `vector_search.py`, `bm25_search.py`, `rrf.py`, `reranker.py`, `cache_repo.py` |
+| `raven_worker/memory/` | M9 per-session memory tool | `store.py` (`MemoryStore`, `MEMORY_TOOL`) |
+| `raven_worker/http_internal/` | FastAPI app for internal HTTP endpoints | `app.py`, `summarize.py` |
+| `raven_worker/agent.py` | Standalone LiveKit voice worker | `_create_worker_options()` |
+| `raven_worker/telemetry.py` | OpenTelemetry tracing bootstrap | `init_telemetry()`, `get_grpc_server_interceptor()` |
+| `raven_worker/crypto.py` | AES decryption of BYOK keys | `decrypt_api_key()` |
+| `raven_worker/generated/` | `grpcio-tools` output from the proto | `ai_worker_pb2.py`, `ai_worker_pb2_grpc.py` |
+| `raven_worker/ee/` | Enterprise-only modules — non-OSS licence | `analytics/`, `connectors/` |
+
+## Provider pattern
+
+All embedding providers conform to a `typing.Protocol` defined in
+[`raven_worker/providers/base.py`](https://github.com/ravencloak-org/Raven/blob/main/ai-worker/raven_worker/providers/base.py):
+
+```python
+class EmbeddingProvider(Protocol):
+    async def embed(self, text: str) -> list[float]: ...
+    @property
+    def dimensions(self) -> int: ...
+    @property
+    def model_name(self) -> str: ...
+```
+
+Concrete adapters live next to it — `openai_provider.py`,
+`anthropic_provider.py`, `cohere_provider.py`, and `ollama_provider.py` for
+local models. The set of accepted slugs is pinned in
+[`raven_worker/providers/registry.py`](https://github.com/ravencloak-org/Raven/blob/main/ai-worker/raven_worker/providers/registry.py):
+
+```python
+_SUPPORTED_PROVIDERS = {"openai", "cohere", "anthropic", "ollama"}
+```
+
+Selection is **per-request**, not per-deployment. Each `EmbeddingRequest`
+and `RAGRequest` carries `provider` and `model` fields, so a single worker
+serves multiple tenants with different provider mixes simultaneously. The
+registry resolves the request via `get_provider_for_request(org_id,
+provider_name, model)`, looks up the row in the `llm_provider_configs`
+table, decrypts the BYOK key with `decrypt_api_key()`, and caches the live
+client keyed by `(org_id, provider_name, model)`.
+
+The one env var that ties the whole flow together is
+`RAVEN_ENCRYPTION_KEY` (a base64-encoded 32-byte AES key — see
+`config.py`). Without it, BYOK decryption fails and the worker rejects
+provider requests. Local-only providers in `_NO_API_KEY_PROVIDERS`
+(currently `ollama`) skip decryption so Raven Local can run without
+configuring tenants.
+
+## Document processing pipeline
+
+`raven_worker/processors/` is the ingestion side of the worker, designed
+to run inside the future `ParseAndEmbed` implementation:
+
+1. **`scraper.py` — `WebScraper`** uses `httpx` plus `beautifulsoup4`
+   to fetch a URL, follow redirects, parse the robots.txt rules, and
+   extract title + clean text. It raises `RobotsTxtDisallowedError` when
+   crawling is forbidden.
+2. **`parser.py` — `DocumentParser`** shells out to the `liteparse` CLI
+   (path configurable via `RAVEN_LITEPARSE_PATH`) for PDFs, DOCX, PPTX
+   and images, and handles plain text / Markdown / HTML inline. Errors
+   surface as `LiteParseError`.
+3. **`chunker.py` — `TextChunker`** wraps LangChain's
+   `RecursiveCharacterTextSplitter`. Defaults are 512 tokens per chunk
+   with 50 token overlap (the `~4 chars per token` heuristic is encoded
+   in the file), and the separator list is ordered coarsest-to-finest.
+4. **Embedding** — each `Chunk` is passed through the provider returned
+   by the registry; the resulting vector is written to the
+   `document_chunks` table with the chunk text and metadata.
+
+The Go side decides when to invoke this pipeline (on upload, on URL
+ingest, on re-index) and queues the work through Asynq; the worker just
+serves the RPC.
+
+## RAG retrieval
+
+`services/rag.py` is the streaming `QueryRAG` implementation. Its module
+docstring spells out the eight-step pipeline:
+
+1. Exact-match response cache in Valkey.
+2. Embed the user query via the BYOK provider.
+3. Run pgvector cosine search (`retrieval/vector_search.py`) and BM25
+   full-text search (`retrieval/bm25_search.py`) **in parallel**.
+4. Merge the two ranked lists with Reciprocal Rank Fusion
+   (`retrieval/rrf.py`).
+5. Optionally re-rank the top chunks with the Cohere Rerank API —
+   `retrieval/reranker.py` calls `cohere.AsyncClientV2` and returns
+   `None` on any failure so the pipeline can degrade gracefully.
+6. Build a context string from the surviving chunks.
+7. Stream tokens from the configured LLM (Anthropic or OpenAI) back as
+   `RAGChunk` proto messages.
+8. Write the completed response to the semantic + exact-match cache so
+   future identical queries skip steps 2–7.
+
+The semantic cache layer
+([`services/semantic_cache.py`](https://github.com/ravencloak-org/Raven/blob/main/ai-worker/raven_worker/services/semantic_cache.py))
+sits behind the Valkey exact-match cache and uses pgvector to find
+near-identical earlier queries. It's gated by
+`RAVEN_SEMANTIC_CACHE_ENABLED` so operators can disable the second layer
+without losing the first.
+
+For the dual-index design behind steps 3 and 4, see
+[/concepts/hybrid-retrieval](/concepts/hybrid-retrieval).
+
+## Voice agent
+
+`raven_worker/agent.py` is a **separate** long-lived process (not a gRPC
+servicer). It uses the `livekit` and `livekit-agents` packages — both
+pinned to `>=1.0.0` in `pyproject.toml` — to join LiveKit rooms,
+subscribe to audio tracks, and route the transcript through the same RAG
+pipeline. STT/TTS plugin selection is tracked in issues #59 and #60
+respectively. Configuration comes from `RAVEN_LIVEKIT_URL`,
+`RAVEN_LIVEKIT_API_KEY`, and `RAVEN_LIVEKIT_API_SECRET`.
+
+Detailed setup will land at [/guides/voice](/guides/voice) once the STT
+and TTS plugins are wired.
+
+## Memory
+
+The M9 cross-channel memory subsystem lives in `raven_worker/memory/`.
+It exposes two pieces of public surface:
+
+- **`MemoryStore`** — a per-`(org_id, session_id)` file-backed sandbox
+  rooted at `RAVEN_MEMORY_DIR`. Every path operation is sandboxed to
+  prevent directory traversal between tenants or sessions.
+- **`MEMORY_TOOL`** — the JSON tool definition passed to the Anthropic
+  client. Claude calls into it via four commands — `view`, `create`,
+  `str_replace`, `delete` — to persist user preferences and topic
+  context across sessions, regardless of which channel the user is on.
+
+The store is opt-in: set `RAVEN_MEMORY_DIR` to an empty string (the
+default) to disable it entirely. More on the user-facing behaviour at
+[/guides/retrieval](/guides/retrieval).
+
+## Post-session summariser
+
+`raven_worker/http_internal/` is a small FastAPI app, separate from the
+gRPC server. The router is built in
+[`http_internal/app.py`](https://github.com/ravencloak-org/Raven/blob/main/ai-worker/raven_worker/http_internal/app.py)
+with `docs_url`, `redoc_url`, and `openapi_url` all set to `None` —
+there is no externally consumable schema, only the one endpoint:
+
+- **`POST /internal/summarize`** — accepts a session transcript and
+  returns a JSON `{ subject, bullets, body_html, body_text }` recap.
+  Implementation in `summarize.py` calls Claude Haiku (default model
+  `claude-haiku-4-5`, override via `RAVEN_SUMMARY_MODEL`); the
+  transcript is wrapped in `<transcript>…</transcript>` tags as a
+  prompt-injection guard and capped at 32 KB. Returns `503` when
+  `ANTHROPIC_API_KEY` is not configured rather than silently producing
+  a stub summary.
+
+The Go-side Asynq worker fires this RPC once a `conversation_sessions`
+row is finalised and turns the response into the outbound email body.
+
+## EE carve-out
+
+`raven_worker/ee/` is **not** covered by the repo's Apache 2.0 OSS
+licence. The directory contains `analytics/` and `connectors/`
+sub-packages used by the commercial Raven distribution and is governed by
+the [Raven Enterprise License](https://github.com/ravencloak-org/Raven/blob/main/ee-LICENSE).
+Production use of anything inside `raven_worker/ee/` requires a valid
+licence key — see
+[`ai-worker/raven_worker/ee/README.md`](https://github.com/ravencloak-org/Raven/blob/main/ai-worker/raven_worker/ee/README.md)
+for the short version. OSS contributors should treat the directory as
+read-only: changes to it ship through a different review path.
+
+## Telemetry
+
+`raven_worker/telemetry.py` provides two functions:
+
+- `init_telemetry(service_name, endpoint)` — installs a
+  `TracerProvider` with a `BatchSpanProcessor` exporting OTLP/gRPC to
+  the configured endpoint (`RAVEN_OTEL_ENDPOINT`, e.g. `localhost:4317`).
+  When `RAVEN_OTEL_ENABLED` is false or the endpoint is unset, this is
+  a no-op — the rest of the worker continues with the OTel no-op
+  provider and zero overhead.
+- `get_grpc_server_interceptor()` — returns the
+  `opentelemetry.instrumentation.grpc.aio_server_interceptor`, or
+  `None` if the instrumentation package isn't installed, so the server
+  setup in `server.py` can skip it without conditional imports.
+
+Only **traces** are wired today. Structured logs are emitted via
+`structlog` (console renderer in dev), and metrics emission is on the
+roadmap. The Observability page in /guides covers what the Go API and
+the AI worker emit end-to-end.
+
+## Testing
+
+Tests live in `ai-worker/tests/`, run with `pytest`, and use
+`pytest-asyncio` in `asyncio_mode = "auto"` (see `pyproject.toml`).
+A sample of the coverage surface:
+
+- `test_grpc_server.py`, `test_server.py` — server bootstrap and
+  reflection
+- `test_embedding_servicer.py`, `test_embedding_providers.py`,
+  `test_registry.py`, `test_ollama_provider.py` — embedding path
+- `test_rag_service.py`, `test_cache.py` — RAG pipeline + cache layers
+- `test_chunker.py`, `test_parser.py`, `test_scraper.py` — ingestion
+- `test_http_internal_summarize.py` — FastAPI summariser route
+- `test_voice_agent.py` — LiveKit agent options
+- `test_telemetry.py` — OTel init no-op behaviour
+- `tests/ee/`, `tests/processors/`, `tests/retrieval/`, `tests/smoke/` —
+  scoped sub-suites including end-to-end smoke checks
+
+Coverage is enforced at `fail_under = 70` via the `[tool.coverage.report]`
+section of `pyproject.toml`. Mock HTTP traffic is recorded with `respx`,
+declared in the `dev` extras.
+
+## Packaging and deployment
+
+The worker targets Python `>=3.12` and is pinned to a hash-locked
+`requirements.txt` regenerated by `uv pip compile`. The multi-stage
+[`ai-worker/Dockerfile`](https://github.com/ravencloak-org/Raven/blob/main/ai-worker/Dockerfile)
+installs from `requirements.txt` with `--require-hashes` so any
+mismatched archive is rejected, then copies the in-tree
+`raven_worker/` package without re-resolving dependencies. The runtime
+image runs as the non-root `raven` user, exposes `50051`, and entry-points
+through `dotenvx` so the same image works in both bare-env and
+encrypted-env deployments.
+
+## Versioning
+
+The worker's `version = "0.3.0"` in `pyproject.toml` is kept in lockstep
+with the main repository's `CHANGELOG.md` — a single tag rolls both Go
+and Python binaries forward together. Bumps happen at milestone close;
+see [/reference/changelog](/reference/changelog).
+
+## Related reading
+
+- [/concepts/architecture](/concepts/architecture) — where the AI
+  worker sits in the wider system diagram
+- [/concepts/hybrid-retrieval](/concepts/hybrid-retrieval) — the
+  vector + BM25 + RRF flow the worker orchestrates
+- [/concepts/deployment-models](/concepts/deployment-models) — when to
+  co-locate the worker vs. running it on a dedicated node
+- [/concepts/multi-tenancy](/concepts/multi-tenancy) — how `org_id`
+  threads through every RPC and the provider cache key
+- [/reference/configuration](/reference/configuration) — full
+  enumeration of `RAVEN_*` environment variables
+- [/guides/voice](/guides/voice) — voice-agent setup with LiveKit
+- [/guides/retrieval](/guides/retrieval) — RAG tuning and the memory
+  tool
+- [/guides/llm-providers](/guides/llm-providers) — provider-specific
+  setup notes

--- a/docs-site/stubs/concepts/deployment-models.md
+++ b/docs-site/stubs/concepts/deployment-models.md
@@ -1,16 +1,214 @@
 ---
-title: "Coming Soon"
+title: "Deployment Models"
 ---
 
 # Deployment Models
 
-::: warning Stub page
-This page is a placeholder. The full content is being written. If you would
-like to contribute, the source for this page lives at the path shown below
-and you can [edit it on GitHub](https://github.com/ravencloak-org/Raven/edit/main/docs-site/stubs/concepts/deployment-models.md).
-:::
+Raven is designed to run anywhere from a single Raspberry Pi to a multi-host
+AWS deployment. The repository ships three canonical topologies, each driven by
+a different Compose file, plus two optional overlays for specialised
+development tasks.
 
-## What goes here
+The frontend is intentionally **not** part of any compose stack — it is
+always shipped to Cloudflare Pages independently of the API. See
+[Frontend deployment](#frontend-deployment) below.
 
-A short bullet list of the topics this page will cover, drawn from the
-[design spec](https://github.com/ravencloak-org/Raven/blob/main/docs/superpowers/specs/2026-05-09-docs-site-design.md).
+## Cloud-hosted full stack
+
+**File:** [`docker-compose.yml`](https://github.com/ravencloak-org/Raven/blob/main/docker-compose.yml)
+**Services:** 14
+**Best for:** production deployments serving more than ~100 GB of knowledge
+base content, multi-tenant SaaS use, anything that needs voice (LiveKit) or
+the enterprise vector store (ClickHouse).
+
+This is the reference topology — a single host (or a single Compose project
+spread across a small swarm) runs the entire platform. The Go API talks to
+every dependency over the private `raven-internal` Docker network; only
+Traefik exposes ports 80/443 publicly.
+
+| Service | Image | Role |
+|---|---|---|
+| `go-api` | built from `Dockerfile` | REST API, SSE streaming, gRPC client |
+| `python-worker` | built from `ai-worker/Dockerfile` | RAG, embeddings, parsing (gRPC :50051) |
+| `python-agent` | built from `ai-worker/Dockerfile` | LiveKit voice agent (STT/LLM/TTS) |
+| `livekit-server` | `livekit/livekit-server:latest` | WebRTC SFU for voice |
+| `postgres` | `pgvector/pgvector:pg18` | Relational, pgvector, BM25, RLS |
+| `clickhouse` | ClickHouse | Enterprise vector tier (optional path) |
+| `valkey` | Valkey (Redis fork) | Asynq jobs, cache, rate-limit counters |
+| `supertokens` | SuperTokens core | Auth (`:3567`) |
+| `seaweedfs-master` | SeaweedFS master | S3-compatible blob store |
+| `seaweedfs-volume` | SeaweedFS volume | Object data plane |
+| `seaweedfs-filer` | SeaweedFS filer + S3 gateway | S3 API on `:8888` |
+| `traefik` | `traefik:v3.3` | Auto-TLS via ACME DNS-01, routing |
+| `openobserve` | OpenObserve | Traces, metrics, logs |
+| `pgbackrest` | `pgbackrest/pgbackrest:latest` | WAL archiving + on-demand backup |
+
+The Go API requires `RAVEN_ENCRYPTION_AES_KEY` and connects to SuperTokens at
+`http://supertokens:3567` and OpenTelemetry at `openobserve:5081`. The
+production deployment on AWS is automated by an Ansible playbook in
+[`deploy/ansible/`](https://github.com/ravencloak-org/Raven/tree/main/deploy/ansible)
+(roles: `base`, `docker`, `nodejs`, `cloudflared`, `admin-tools`,
+`raven-stack`); a one-shot EC2 bootstrap script lives in
+[`deploy/ec2/setup.sh`](https://github.com/ravencloak-org/Raven/blob/main/deploy/ec2/setup.sh)
+and uses Cloudflare Tunnel (`cloudflared`) instead of opening ports 80/443.
+
+**Minimum host:** 4 vCPU / 8 GB RAM / 50 GB SSD. **Typical host:** AWS
+`t4g.xlarge` or `c7g.xlarge` (ARM64) — Raven is built and tested on ARM64.
+
+## Edge / Single-node
+
+**File:** [`docker-compose.edge.yml`](https://github.com/ravencloak-org/Raven/blob/main/docker-compose.edge.yml)
+**Services:** 3 (`go-api`, `postgres`, `traefik`)
+**Best for:** branch offices, in-store kiosks, on-prem appliances, dev boxes,
+anywhere a full Compose stack is overkill or impossible.
+
+The edge variant is intentionally minimal. The Go API binary is statically
+linked (`CGO_ENABLED=0`, `-ldflags="-s -w"` — see
+[`Makefile.edge`](https://github.com/ravencloak-org/Raven/blob/main/Makefile.edge))
+and compiles to roughly **25 MB** for `linux/arm64`. There is no Python
+ai-worker, no LiveKit, no SeaweedFS, no SuperTokens, no OpenObserve — the API
+talks to a remote ai-worker over gRPC and writes RLS-isolated data to a local
+Postgres.
+
+Per-service memory caps declared in the compose file:
+
+| Service | Image | `deploy.resources.limits.memory` |
+|---|---|---|
+| `go-api` | `ghcr.io/ravencloak-org/raven-api:latest` (ARM64) | 256 MB |
+| `postgres` | `pgvector/pgvector:pg18` (ARM64) | 512 MB |
+| `traefik` | `traefik:v3.3` (ARM64) | 128 MB |
+
+Total reserved memory ≈ 900 MB — the stack fits comfortably on a Raspberry
+Pi 4 (4 GB RAM) or an AWS `t4g.small` (2 GB). The build targets are emitted
+by `make -f Makefile.edge build-arm64` (or `build-amd64`); cross-compilation
+uses `aarch64-linux-musl-gcc` only when eBPF is enabled.
+
+Bring-up:
+
+```bash
+cp deploy/edge/.env.example .env.edge
+# edit .env.edge — set DATABASE_URL, GRPC_AI_WORKER_ADDR, POSTGRES_PASSWORD
+docker compose -f docker-compose.edge.yml --env-file .env.edge up -d
+```
+
+The edge build sets `RAVEN_EDGE_MODE: "true"` and listens on port 8080 (the
+full-stack build uses 8081 to coexist with other dev servers).
+
+## Hybrid
+
+The hybrid model is the edge stack pointed at a cloud ai-worker. It is the
+recommended topology for users who want sub-100 ms first-token latency on
+reads but do not want to host the Python ML runtime themselves.
+
+```
+┌─── EDGE (e.g. Raspberry Pi, in-VPC EC2) ───┐    ┌── CLOUD (managed host) ──┐
+│  go-api  ──┐                               │    │   python-worker (gRPC)   │
+│  postgres ─┤ pgvector + BM25 (local)       │    │   livekit-server         │
+│  traefik   │                               │◀──▶│   clickhouse (optional)  │
+└────────────┴───────────────────────────────┘    │   openobserve            │
+                ▲                                 └──────────────────────────┘
+                │ gRPC, mTLS recommended
+                └── RAVEN_GRPC_WORKER_ADDR=worker.example.com:50051
+```
+
+The edge node points at the cloud ai-worker by setting one environment
+variable, sourced from `GRPC_AI_WORKER_ADDR` in the edge env file and exported
+to the Go process as **`RAVEN_GRPC_WORKER_ADDR`**:
+
+```yaml
+# docker-compose.edge.yml — go-api environment
+RAVEN_GRPC_WORKER_ADDR: ${GRPC_AI_WORKER_ADDR:?GRPC_AI_WORKER_ADDR is required}
+```
+
+The Go API uses the worker for embeddings, document parsing, and chat
+completions only — every other read path (search, KB lookups, auth session
+validation) stays on the local Postgres, so a transient cloud outage does not
+take the edge offline for already-ingested documents.
+
+Voice is currently cloud-only: the LiveKit SFU and the Python voice agent both
+need to be reachable from the user's browser, and Raven does not ship an edge
+LiveKit topology.
+
+## When to pick which
+
+| Concern | Cloud | Edge | Hybrid |
+|---|---|---|---|
+| Latency-sensitive (single-region users) | Good | **Best** | **Best** |
+| Cost-sensitive (small org, < 10 GB KB) | Overkill | **Best** | Good |
+| Privacy-sensitive (data must stay on-prem) | Bad | **Best** | Partial — embeddings leave the box |
+| Compliance (SOC 2, EU data residency) | Good — single region | **Best** — full physical control | Good — pick the worker region |
+| Multi-region / globally distributed users | **Best** | Bad — one node | Good — many edges, one worker |
+| Voice / WhatsApp (LiveKit, public webhooks) | **Best** | Not supported | Good — voice in cloud, chat at edge |
+
+## Frontend deployment
+
+The Vue 3 SPA is **never** packaged inside the Compose stack — not in
+`docker-compose.yml`, not in `docker-compose.edge.yml`. It is built with Vite
+and uploaded to Cloudflare Pages by `wrangler pages deploy`. The deployment
+config lives at
+[`deploy/cloudflare-pages.json`](https://github.com/ravencloak-org/Raven/blob/main/deploy/cloudflare-pages.json):
+
+```json
+{
+  "project_name": "raven-frontend",
+  "build": { "command": "npm run build", "output_directory": "dist", "root_directory": "frontend" },
+  "deployment": { "production_branch": "main" }
+}
+```
+
+The frontend is configured with `VITE_API_URL`, `VITE_API_BASE_URL`,
+`VITE_API_DOMAIN`, and `VITE_LIVEKIT_URL` so it can be pointed at any
+backend — the same SPA build can serve a cloud install and an edge install
+simultaneously.
+
+The marketing site and this documentation site (VitePress, in
+[`docs-site/`](https://github.com/ravencloak-org/Raven/tree/main/docs-site))
+are also Cloudflare Pages projects on their own build pipelines.
+
+## Specialised variants
+
+These two files are overlays, not standalone topologies — combine them with
+either `docker-compose.yml` or `docker-compose.edge.yml`.
+
+### `docker-compose.ebpf.yml`
+
+Adds `CAP_BPF` and `CAP_NET_ADMIN` to the `go-api` container and sets
+`RAVEN_EBPF_ENABLED=true`. Required for the eBPF tenancy-observation probe
+(kernel ≥ 5.8). Use case: developing or debugging the eBPF data path.
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.ebpf.yml up
+# or, with the edge stack:
+docker compose -f docker-compose.edge.yml -f docker-compose.ebpf.yml up
+```
+
+eBPF builds require `CGO_ENABLED=1` and a musl cross-compiler
+(`aarch64-linux-musl-gcc` / `x86_64-linux-musl-gcc`); see the `*-ebpf` targets
+in `Makefile.edge`.
+
+### `docker-compose.chartdb.yml`
+
+Adds a single `chartdb` container (image `ghcr.io/chartdb/chartdb:latest`)
+bound to `127.0.0.1:3000`. Used to visualise the Postgres schema. Not for
+production.
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.chartdb.yml up -d chartdb
+# open http://localhost:3000 and paste the output of scripts/chartdb-query.sh
+```
+
+## Resource footprint summary
+
+| Variant | Services | Minimum host | Typical host |
+|---|---|---|---|
+| Cloud full stack | 14 | 4 vCPU / 8 GB / 50 GB SSD | AWS `t4g.xlarge` / `c7g.xlarge` (ARM64) |
+| Edge / single-node | 3 | 2 vCPU / 2 GB / 16 GB | Raspberry Pi 4 (4 GB) or AWS `t4g.small` |
+| Hybrid (edge half) | 3 at edge + remote worker | 2 vCPU / 2 GB at edge | Pi 4 at edge + `t4g.medium` worker |
+| eBPF overlay | +0 (modifies `go-api`) | Linux kernel ≥ 5.8 | Same as base variant |
+| ChartDB overlay | +1 | Negligible | Dev laptop |
+
+## See also
+
+- [`/guides/self-hosting/docker-compose`](/guides/self-hosting/docker-compose) — full-stack bring-up walkthrough
+- [`/guides/self-hosting/edge-and-raspberry-pi`](/guides/self-hosting/edge-and-raspberry-pi) — Raspberry Pi specifics, ARM64 image pulls, eBPF caveats
+- [`/reference/configuration`](/reference/configuration) — every `RAVEN_*` environment variable

--- a/docs-site/stubs/concepts/hybrid-retrieval.md
+++ b/docs-site/stubs/concepts/hybrid-retrieval.md
@@ -1,16 +1,407 @@
 ---
-title: "Coming Soon"
+title: "Hybrid Retrieval"
 ---
 
 # Hybrid Retrieval
 
-::: warning Stub page
-This page is a placeholder. The full content is being written. If you would
-like to contribute, the source for this page lives at the path shown below
-and you can [edit it on GitHub](https://github.com/ravencloak-org/Raven/edit/main/docs-site/stubs/concepts/hybrid-retrieval.md).
-:::
+Raven combines two complementary retrievers behind a single query: dense
+vector similarity (pgvector / HNSW) and sparse lexical scoring (PostgreSQL
+`tsvector` + `ts_rank_cd`). Vectors are good at semantic recall — they find
+chunks that mean the same thing as the query even when the wording differs.
+Lexical ranking is good at precision on rare tokens — proper nouns, error
+codes, API symbols, identifiers — that an embedding model often smears
+together. Running both and merging the rankings with Reciprocal Rank Fusion
+(RRF) reliably beats either retriever alone on heterogeneous knowledge
+bases.
 
-## What goes here
+## Pipeline
 
-A short bullet list of the topics this page will cover, drawn from the
-[design spec](https://github.com/ravencloak-org/Raven/blob/main/docs/superpowers/specs/2026-05-09-docs-site-design.md).
+A retrieval request follows a fixed pipeline. The two main entry points are
+the Go HTTP service for synchronous hybrid search and the Python
+`ai-worker` for the RAG streaming RPC.
+
+1. **Embed the query.** The Python worker calls the tenant's embedding
+   provider (`await embedding_provider.embed(query_text)`). For the
+   synchronous `HybridSearch` Go endpoint, the embedding is precomputed by
+   the caller and passed in. Embeddings are always 1536 dimensions (see
+   [Data Model](/concepts/data-model)).
+
+2. **Run vector and BM25 searches.** Both retrievers are launched in
+   parallel and constrained to the requesting org's RLS scope. In the Go
+   service the two queries run inside one RLS-scoped transaction:
+
+   ```go
+   err := db.WithOrgID(ctx, s.pool, orgID, func(tx pgx.Tx) error {
+       if len(embedding) > 0 {
+           vectorResults, vErr = s.repo.VectorSearch(ctx, tx, kbID, embedding, candidateK)
+       }
+       if q != "" {
+           bm25Results, bErr = s.repo.BM25Search(ctx, tx, kbID, q, candidateK)
+       }
+       return nil
+   })
+   ```
+
+   In the Python worker the two queries are awaited concurrently with
+   `asyncio.gather` on a single connection:
+
+   ```python
+   vector_results, bm25_results = await asyncio.gather(
+       vector_search(conn, query_embedding, org_id, kb_ids),
+       bm25_search(conn, query_text, org_id, kb_ids),
+   )
+   ```
+
+3. **Fuse the rankings with RRF.** The two ranked lists are merged into one
+   ordered list by Reciprocal Rank Fusion. The Go path computes the fused
+   score inline in `fuseRRF`; the Python path uses the shared helper in
+   `raven_worker.retrieval.rrf`.
+
+4. **(Optional) Rerank.** On the RAG path the top-K fused chunks may be
+   passed to Cohere Rerank when the caller opts in via the
+   `filters["rerank"] == "cohere"` flag and the org has a Cohere BYOK key.
+
+5. **Return top-K.** The Go service returns the fused list directly. The
+   RAG service uses the fused (or reranked) chunks to build a context
+   string, then streams the LLM completion back as `RAGChunk` proto
+   messages over `rpc QueryRAG (RAGRequest) returns (stream RAGChunk);`
+   (defined in `proto/ai_worker.proto`). The Go API talks to the ai-worker
+   via gRPC on `localhost:50051` (see `grpc.worker_addr` in
+   `internal/config/config.go`).
+
+The Go orchestrator for the synchronous hybrid endpoint lives in
+`internal/service/search.go` as `SearchService.HybridSearch`. The streaming
+RAG orchestrator lives in `ai-worker/raven_worker/services/rag.py`.
+
+## Vector search (pgvector + HNSW)
+
+Embeddings are stored in the `embeddings` table, with one row per
+`(chunk_id, model_name)` pair. Migration `00010_chunks_and_embeddings.sql`
+creates the table and an HNSW index over the cosine operator class:
+
+```sql
+CREATE TABLE embeddings (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    org_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    chunk_id UUID NOT NULL REFERENCES chunks(id) ON DELETE CASCADE,
+    embedding vector(1536) NOT NULL,
+    model_name VARCHAR(100) NOT NULL,
+    model_version VARCHAR(50),
+    dimensions INTEGER NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(chunk_id, model_name)
+);
+
+CREATE INDEX idx_embeddings_hnsw
+    ON embeddings
+    USING hnsw (embedding vector_cosine_ops)
+    WITH (m = 16, ef_construction = 64);
+```
+
+The `vector_cosine_ops` operator class fixes the distance function: pgvector
+exposes it as the `<=>` operator, which returns cosine *distance* in the
+range `[0, 2]`. Raven converts that to cosine *similarity* by computing
+`1 - (<=>)` so higher scores mean more similar. The HNSW build parameters
+are the pgvector defaults: `m = 16` (max neighbours per layer) and
+`ef_construction = 64` (candidate-list size during index build).
+
+The vector leg, defined in `internal/repository/search.go` as
+`SearchRepository.VectorSearch`, projects cosine distance back to
+similarity:
+
+```sql
+SELECT c.id, …, 1 - (e.embedding <=> $2) AS score
+FROM embeddings e
+JOIN chunks c ON c.id = e.chunk_id
+WHERE c.knowledge_base_id = $1
+ORDER BY e.embedding <=> $2
+LIMIT $3
+```
+
+The Python equivalent in `ai-worker/raven_worker/retrieval/vector_search.py`
+binds the query embedding as a pgvector literal string:
+
+```python
+_VECTOR_SEARCH_SQL = """
+SELECT c.id::text, 1 - (e.embedding <=> $1::vector) AS score
+FROM chunks c
+JOIN embeddings e ON e.chunk_id = c.id
+WHERE c.org_id = $2::uuid
+  AND c.knowledge_base_id = ANY($3::uuid[])
+ORDER BY e.embedding <=> $1::vector
+LIMIT $4
+"""
+```
+
+Both queries rely on Row-Level Security to enforce org isolation: the Go
+service sets `app.current_org_id` via `db.WithOrgID`, and the Python worker
+does the same with `SELECT set_config('app.current_org_id', $1, false)`
+before the query runs.
+
+## Keyword search (PostgreSQL `tsvector` + `ts_rank_cd`)
+
+Raven's "BM25" leg is implemented with vanilla PostgreSQL full-text search:
+`to_tsvector('english', …)` for indexing, `plainto_tsquery('english', …)`
+for query parsing, and `ts_rank_cd` for relevance scoring. There is no
+external BM25 extension (`pg_search`, `paradedb`, etc.) in the stack — the
+name "BM25" in the README refers to BM25-*style* lexical ranking via
+`ts_rank_cd`, which uses cover-density ranking that approximates BM25's
+behaviour for short documents.
+
+The indexes are created across two migrations.
+`00010_chunks_and_embeddings.sql` creates the baseline GIN index on
+`chunks.content`:
+
+```sql
+CREATE INDEX idx_chunks_content_fts
+    ON chunks USING gin(to_tsvector('english', content));
+```
+
+`00017_bm25_heading_index.sql` adds the heading-only and combined indexes
+that the BM25 query actually targets:
+
+```sql
+CREATE INDEX idx_chunks_heading_fts
+    ON chunks USING gin(to_tsvector('english', heading))
+    WHERE heading IS NOT NULL;
+
+CREATE INDEX idx_chunks_content_heading_fts
+    ON chunks USING gin(to_tsvector('english',
+        coalesce(heading, '') || ' ' || content));
+```
+
+The lexical leg, defined in `internal/repository/search.go` as
+`SearchRepository.BM25Search`:
+
+```sql
+SELECT c.id, …,
+       ts_rank_cd(to_tsvector('english', coalesce(c.heading, '') || ' ' || c.content), q) AS rank
+FROM chunks c, plainto_tsquery('english', $1) q
+WHERE c.knowledge_base_id = $2
+  AND to_tsvector('english', coalesce(c.heading, '') || ' ' || c.content) @@ q
+ORDER BY rank DESC
+LIMIT $3
+```
+
+The Python sibling in `ai-worker/raven_worker/retrieval/bm25_search.py` uses
+the same `ts_rank_cd` formulation, scoped to a list of knowledge bases via
+`c.knowledge_base_id = ANY($3::uuid[])`.
+
+The `@@` operator filters chunks whose composite `tsvector` matches the
+parsed query; rows are then scored by `ts_rank_cd`, which weights both term
+proximity and term frequency over the document.
+
+## Reciprocal Rank Fusion
+
+Once both retrievers return their candidate lists, Raven merges them with
+Reciprocal Rank Fusion. The formula is the canonical one from Cormack et
+al. (2009):
+
+```
+score(d) = Σ 1 / (k + rank_i(d))
+```
+
+where `rank_i(d)` is the 1-based position of document `d` in retriever
+`i`'s ranked list, and `k` is a smoothing constant. **Raven uses `k = 60`**
+in both implementations — the value recommended in the original paper.
+
+The Go implementation lives in `internal/service/search.go` as the
+`fuseRRF` function, with the constant declared at package scope:
+
+```go
+// rrfK is the constant used in the Reciprocal Rank Fusion formula.
+// k=60 is the standard value from the original RRF paper (Cormack et al., 2009).
+const rrfK = 60
+
+// fuseRRF merges vector and BM25 result lists using Reciprocal Rank Fusion.
+// For each document appearing in either list:
+//   score = sum(1 / (k + rank_i))
+// where rank_i is the 1-based position in each retriever.
+```
+
+The Python implementation in `ai-worker/raven_worker/retrieval/rrf.py` is
+the canonical one — both paths produce identical fusion ordering:
+
+```python
+def reciprocal_rank_fusion(
+    ranked_lists: list[list[tuple[str, float]]],
+    k: int = 60,
+    top_n: int = 10,
+) -> list[tuple[str, float]]:
+    rrf_scores: dict[str, float] = {}
+    for ranked in ranked_lists:
+        for rank_idx, (item_id, _) in enumerate(ranked):
+            rank = rank_idx + 1  # 1-based
+            rrf_scores[item_id] = rrf_scores.get(item_id, 0.0) + 1.0 / (k + rank)
+    return sorted(rrf_scores.items(), key=lambda x: x[1], reverse=True)[:top_n]
+```
+
+A few properties to note:
+
+- **Documents appearing in both lists win.** Each list contributes an
+  independent `1 / (k + rank)` term, so a chunk that ranks reasonably
+  well in *both* retrievers will outrank a chunk that ranks slightly
+  higher in only one. The integration test in
+  `internal/integration/search_test.go` asserts exactly this:
+  > Chunk A should rank highest because it appears in BOTH BM25 and
+  > vector results.
+- **The original scores are discarded.** RRF uses only the rank position,
+  which means it is robust to the very different score distributions of
+  pgvector cosine similarity and `ts_rank_cd`.
+- **Candidate-set expansion.** Each leg is queried with
+  `candidateK = topK * 3` (capped at `maxSearchLimit = 100`) so RRF has
+  enough overlap signal to work with; only the top-K survive after
+  fusion.
+
+The fused `HybridSearchResult` carries all the intermediate signals back to
+the caller — `VectorScore`, `BM25Score`, `VectorRank`, `BM25Rank`, and the
+final `RRFScore` — which is what makes the endpoint debuggable.
+
+## Reranking (optional)
+
+The RAG path in `ai-worker/raven_worker/services/rag.py` may apply a
+cross-encoder rerank on top of the RRF-fused list. The provider call lives
+in `ai-worker/raven_worker/retrieval/reranker.py`:
+
+```python
+_DEFAULT_RERANK_MODEL = "rerank-english-v3.0"
+
+async def cohere_rerank(
+    query: str,
+    chunks: list[dict],
+    api_key: str,
+    model: str = _DEFAULT_RERANK_MODEL,
+    top_n: int = 5,
+) -> list[dict] | None:
+    client = cohere.AsyncClientV2(api_key=api_key)
+    resp = await client.rerank(
+        model=model,
+        query=query,
+        documents=[c["content"] for c in chunks],
+        top_n=top_n,
+    )
+```
+
+The default model is **Cohere `rerank-english-v3.0`**, called via the
+`cohere.AsyncClientV2` SDK. The function is BYOK — it pulls the org's
+Cohere API key from `llm_provider_configs` — and degrades gracefully:
+
+- If the `cohere` package is not installed it logs
+  `cohere_rerank_unavailable` and returns `None`.
+- If the API call raises, it logs `cohere_rerank_failed` and returns
+  `None`.
+
+In both fallback cases the caller in `rag.py` keeps the RRF-fused list
+unchanged:
+
+```python
+use_cohere_rerank = filters.get("rerank") == "cohere"
+if use_cohere_rerank and chunk_records:
+    cohere_api_key = await self._get_llm_api_key(org_id, "cohere")
+    if cohere_api_key:
+        reranked = await cohere_rerank(
+            query=query_text,
+            chunks=chunk_records,
+            api_key=cohere_api_key,
+            top_n=5,
+        )
+        if reranked is not None:
+            chunk_records = reranked
+```
+
+Reranking is therefore **off by default**. It runs only when the gRPC
+caller sets `RAGRequest.filters["rerank"] = "cohere"` and the org has a
+Cohere BYOK key configured. The synchronous `SearchService.HybridSearch` Go
+endpoint never reranks — there is a `TODO` placeholder noting that a future
+cross-encoder rerank could be added on top of RRF.
+
+## Configuration
+
+Retrieval-related defaults live in two places.
+
+Go API service constants (`internal/service/search.go`):
+
+| Constant             | Value | Purpose                                              |
+| -------------------- | ----- | ---------------------------------------------------- |
+| `defaultSearchLimit` | `10`  | `topK` returned when the caller omits `top_k`        |
+| `maxSearchLimit`     | `100` | Hard ceiling on `topK` and `candidateK`              |
+| `rrfK`               | `60`  | RRF smoothing constant                               |
+
+The Go service computes `candidateK = topK * 3` and clamps it to
+`maxSearchLimit`. `clampLimit()` and `sanitizeQuery()` apply to every
+hybrid call.
+
+Python ai-worker (`ai-worker/raven_worker/config.py`), via `RAVEN_*` env
+vars:
+
+| Setting                 | Default                | Notes                                                          |
+| ----------------------- | ---------------------- | -------------------------------------------------------------- |
+| `grpc_port`             | `50051`                | RAG and embedding RPCs                                         |
+| `database_url`          | local PG dev URL       | pgvector + tsvector queries run against this                   |
+| `semantic_cache_enabled`| `true`                 | Enables the `response_cache` lookup (separate from hybrid)     |
+
+There is **no `top_k`, RRF `k`, or hybrid-weighting env var** — those are
+hard-coded constants. Rerank toggling is per-request (`filters["rerank"]`),
+not configuration.
+
+## Benchmarks
+
+The integration suite includes p95 latency thresholds for the BM25, hybrid,
+and HNSW paths. The benchmark code lives in
+`internal/integration/benchmark_test.go`:
+
+| Benchmark                       | Target               | Test function                  |
+| ------------------------------- | -------------------- | ------------------------------ |
+| BM25 search, 1K chunks          | p95 < 100 ms         | `TestBenchmarkBM25Threshold`   |
+| Hybrid search, 1K chunks        | p95 < 200 ms         | `TestBenchmarkHybridThreshold` |
+| HNSW vector lookup (cache repo) | p95 < 50 ms          | covered by `cache_test.go`     |
+
+Run the search benchmarks against a real Postgres:
+
+```bash
+go test -tags=integration -run='TestBenchmark(BM25|Hybrid)Threshold' \
+    ./internal/integration/...
+
+# Or, the raw Go benchmarks:
+go test -tags=integration -bench='BenchmarkHybridSearch1K|BenchmarkBM25Search10K' \
+    ./internal/integration/...
+```
+
+The README's numbers — *"BM25 p95 <100ms, hybrid p95 <200ms, HNSW p95
+<50ms"* — come directly from these tests.
+
+## Tradeoffs
+
+A few practical notes for tuning hybrid retrieval on your own data.
+
+- **Vector recall vs. lexical precision.** Embeddings can miss
+  rarely-seen tokens (UUIDs, error codes, library names) because the
+  encoder squashes them. `ts_rank_cd` handles those gracefully. Inversely,
+  lexical search misses paraphrases entirely. RRF resolves the conflict
+  by rewarding agreement, but you should expect single-leg fallbacks to
+  hurt on either side: if `query == ""` only the vector leg runs; if
+  `embedding == nil` only the BM25 leg runs.
+- **Latency cost of reranking.** A Cohere rerank call adds one external
+  HTTP round-trip per query (~100–300 ms typical) and a per-request token
+  charge. The fused list is already strong on its own — keep
+  `filters["rerank"]` off unless a UX evaluation shows it helps.
+- **HNSW parameter conservatism.** `m = 16, ef_construction = 64` are
+  pgvector's defaults and keep index build time low, which matters for
+  small edge deployments (see [Deployment Models](/concepts/deployment-models)).
+  Raising `ef_construction` improves recall at the cost of build time;
+  query-time `hnsw.ef_search` (set per-session) trades latency for recall
+  on the read side and is not currently overridden by Raven.
+- **English-only analyzer.** Both the `to_tsvector` and
+  `plainto_tsquery` calls hard-code the `'english'` configuration.
+  Non-English content will still index and search, but stop-word removal
+  and stemming will not apply correctly. CJK and RTL content is covered
+  by integration tests as a smoke test only.
+
+## See also
+
+- [Data Model](/concepts/data-model) — `chunks` and `embeddings` tables,
+  the substrate the retrievers run against.
+- [AI Worker Design](/concepts/ai-worker-design) — gRPC surface,
+  embedding providers, and the RAG streaming pipeline.
+- [API Overview](/api/overview) — the public HTTP shape of
+  `POST /v1/search/hybrid` and the gRPC `QueryRAG` RPC.

--- a/docs-site/stubs/concepts/multi-tenancy.md
+++ b/docs-site/stubs/concepts/multi-tenancy.md
@@ -1,16 +1,326 @@
 ---
-title: "Coming Soon"
+title: "Multi-Tenancy"
 ---
 
 # Multi-Tenancy
 
-::: warning Stub page
-This page is a placeholder. The full content is being written. If you would
-like to contribute, the source for this page lives at the path shown below
-and you can [edit it on GitHub](https://github.com/ravencloak-org/Raven/edit/main/docs-site/stubs/concepts/multi-tenancy.md).
-:::
+Raven is a multi-tenant platform: a single deployment serves many independent
+**organisations**, each of which owns one or more **workspaces** containing
+one or more **knowledge bases**. Tenant isolation is enforced at the
+**database** layer using PostgreSQL Row Level Security (RLS), not in
+application code. Every tenant-scoped table carries an `org_id` column, every
+request runs inside a transaction with `app.current_org_id` set to the
+caller's organisation, and a `tenant_isolation` policy on each table
+restricts every `SELECT`, `INSERT`, `UPDATE`, and `DELETE` to rows whose
+`org_id` matches. A forgotten `WHERE org_id = ?` clause in repository code
+therefore cannot leak data — the database itself refuses to return it.
 
-## What goes here
+## Hierarchy
 
-A short bullet list of the topics this page will cover, drawn from the
-[design spec](https://github.com/ravencloak-org/Raven/blob/main/docs/superpowers/specs/2026-05-09-docs-site-design.md).
+The tenant tree has four levels. Every level below `Organization` carries a
+denormalised `org_id` foreign key so RLS can be enforced uniformly without
+relying on joins.
+
+| Level | Go type | Key fields | Migration |
+|-------|---------|------------|-----------|
+| Organisation | `model.Organization` | `ID`, `Name`, `Slug`, `Status` | `migrations/00003_organizations.sql` |
+| Workspace | `model.Workspace` | `ID`, `OrgID`, `Name`, `Slug` | `migrations/00005_workspaces.sql` |
+| Knowledge base | `model.KnowledgeBase` | `ID`, `OrgID`, `WorkspaceID`, `Name`, `Slug`, `Status` | `migrations/00007_knowledge_bases.sql` |
+| Document | `model.Document` | `ID`, `OrgID`, `KnowledgeBaseID`, `FileName`, `ProcessingStatus` | `migrations/00008_documents.sql` |
+| Conversation session | `model.ConversationSession` | `ID`, `OrgID`, `KBID`, `UserID`, `Channel` | `migrations/00037_conversation_sessions.sql` |
+
+The `organizations` table is the tenant root and is intentionally **not**
+RLS-protected — it *is* the tenant boundary. See the comment block at the
+top of `migrations/00015_rls_policies.sql`.
+
+## Row Level Security
+
+Postgres [Row Level Security](https://www.postgresql.org/docs/current/ddl-rowsecurity.html)
+attaches a per-row predicate to every query against a table. Once a table
+has `ENABLE ROW LEVEL SECURITY` set and at least one `CREATE POLICY` defined,
+non-superuser connections only see rows that satisfy the policy's `USING`
+expression and may only insert / update rows that satisfy `WITH CHECK`.
+
+Raven enables RLS on every tenant-scoped table at the moment that table is
+created. `migrations/00015_rls_policies.sql` is a no-op marker that records
+which tables are covered. As of writing the list is:
+
+| Table | Created in |
+|-------|------------|
+| `users` | `00004_users.sql` |
+| `workspaces` | `00005_workspaces.sql` |
+| `workspace_members` | `00006_workspace_members.sql` |
+| `knowledge_bases` | `00007_knowledge_bases.sql` |
+| `documents` | `00008_documents.sql` |
+| `sources` | `00009_sources.sql` |
+| `chunks` | `00010_chunks_and_embeddings.sql` |
+| `embeddings` | `00010_chunks_and_embeddings.sql` |
+| `llm_provider_configs` | `00011_llm_provider_configs.sql` |
+| `api_keys` | `00012_api_keys.sql` |
+| `chat_sessions` | `00013_chat.sql` |
+| `chat_messages` | `00013_chat.sql` |
+| `processing_events` | `00014_processing_events.sql` |
+| `routing_rules` | `00020_routing_rules.sql` |
+| `catalog_metadata` | `00020_routing_rules.sql` |
+| `airbyte_connectors` | `00021_airbyte_connectors.sql` |
+| `airbyte_sync_history` | `00021_airbyte_connectors.sql` |
+| `security_rules` | `00022_security_rules.sql` |
+| `security_events` | `00022_security_rules.sql` |
+| `lead_profiles` | `00023_lead_profiles.sql` |
+| `webhook_configs` | `00024_webhook_configs.sql` |
+| `webhook_deliveries` | `00024_webhook_configs.sql` |
+| `stranger_users` | `00025_stranger_users.sql` |
+| `notification_configs` | `00026_email_notifications.sql` |
+| `notification_log` | `00026_email_notifications.sql` |
+| `response_cache` | `00027_response_cache.sql` |
+| `user_identities` | `00028_user_identity.sql` |
+| `voice_sessions` | `00029_voice_sessions.sql` |
+| `voice_turns` | `00029_voice_sessions.sql` |
+| `voice_usage_summaries` | `00030_voice_usage.sql` |
+| `whatsapp_phone_numbers` | `00031_whatsapp_calling.sql` |
+| `whatsapp_calls` | `00031_whatsapp_calling.sql` |
+| `subscriptions` | `00032_billing_rls_and_payment_events.sql` |
+| `payment_events` | `00032_billing_rls_and_payment_events.sql` |
+| `payment_intents` | `00033_payment_intents.sql` |
+| `conversation_sessions` | `00037_conversation_sessions.sql` |
+
+The shape of every policy is identical. Here is the canonical example from
+`migrations/00005_workspaces.sql` verbatim:
+
+```sql
+ALTER TABLE workspaces ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY tenant_isolation ON workspaces
+    FOR ALL
+    USING (org_id = current_setting('app.current_org_id')::uuid)
+    WITH CHECK (org_id = current_setting('app.current_org_id')::uuid);
+
+CREATE POLICY admin_bypass ON workspaces
+    FOR ALL TO raven_admin
+    USING (true);
+```
+
+Two policies are stacked on every protected table:
+
+- `tenant_isolation` — applies to all roles. Reads the per-transaction GUC
+  `app.current_org_id`, casts it to `uuid`, and matches against the row's
+  `org_id`. `WITH CHECK` mirrors `USING` so writes can never plant a row
+  under another tenant.
+- `admin_bypass` — applies only to the `raven_admin` role and returns
+  `true` unconditionally. This is how migrations and operator scripts read
+  across tenants without disabling RLS.
+
+## Per-request GUC
+
+Application code never executes SQL against the pool directly. It calls
+`db.WithOrgID`, which opens a transaction, sets the GUC, runs the caller's
+function, and commits.
+
+`internal/db/db.go`:
+
+```go
+// WithOrgID executes fn inside a transaction with app.current_org_id set for RLS.
+// The transaction is automatically rolled back on error and committed on success.
+// orgID is passed as a parameter to set_config to prevent SQL injection.
+func WithOrgID(ctx context.Context, pool *pgxpool.Pool, orgID string, fn func(tx pgx.Tx) error) error {
+    tx, err := pool.Begin(ctx)
+    if err != nil {
+        return fmt.Errorf("begin tx: %w", err)
+    }
+    defer tx.Rollback(ctx) //nolint:errcheck
+
+    if _, err := tx.Exec(ctx, "SELECT set_config('app.current_org_id', $1, true)", orgID); err != nil {
+        return fmt.Errorf("set org_id: %w", err)
+    }
+    if err := fn(tx); err != nil {
+        return err
+    }
+    return tx.Commit(ctx)
+}
+```
+
+Three details are load-bearing:
+
+1. **`set_config(..., true)` — local scope.** The third argument is
+   `is_local`; the binding is dropped when the transaction commits or rolls
+   back. There is no risk of one request's `org_id` leaking into another
+   request that re-uses the same pooled connection.
+2. **Parameterised, not interpolated.** `orgID` is bound via `$1` rather
+   than concatenated into the SQL string. Even if a caller passed an
+   attacker-controlled string, no SQL injection is possible at this layer.
+3. **`fn` receives a `pgx.Tx`, never the pool.** Every repository method
+   takes the `pgx.Tx` as a parameter, so it is structurally impossible to
+   reach the database with the GUC unset.
+
+The canonical caller pattern comes from `internal/service/seed.go`, where a
+document is created during demo seeding:
+
+```go
+var created *model.Document
+err = db.WithOrgID(ctx, s.pool, orgID, func(tx pgx.Tx) error {
+    var createErr error
+    created, createErr = s.docRepo.Create(ctx, tx, doc)
+    return createErr
+})
+if err != nil {
+    return fmt.Errorf("create document record: %w", err)
+}
+```
+
+Repositories follow the matching shape. From `internal/repository/`
+(Airbyte repository shown — the same shape applies to every repo):
+
+```go
+func (r *AirbyteRepository) Create(ctx context.Context, tx pgx.Tx, orgID string, req model.CreateConnectorRequest, createdBy string) (*model.AirbyteConnector, error) {
+    row := tx.QueryRow(ctx, /* … INSERT … */, orgID, /* … */)
+    /* … */
+}
+```
+
+Note the signature: `(ctx, tx, orgID, …)`. The transaction is always passed
+in from above; the repo never opens its own. Today's call sites for
+`db.WithOrgID` include `internal/repository/notification.go`,
+`internal/repository/conversation.go`, `internal/service/seed.go`, and
+others — `grep -rn db.WithOrgID` in the repo enumerates every one.
+
+## Auth middleware → context → DB flow
+
+A single request travels through this sequence:
+
+1. **SuperTokens session verification.** `middleware.SessionMiddleware` in
+   `internal/middleware/auth.go` calls `provider.VerifySession(c.Request)`
+   on the registered `auth.Provider`. On success it stores the user's
+   `ExternalID`, `Email`, and display name in the Gin context.
+2. **User → org resolution.** A subsequent `UserLookup` middleware
+   resolves the external ID against `users` and writes
+   `ContextKeyUserID`, `ContextKeyOrgID`, `ContextKeyOrgRole`, and
+   `ContextKeyWorkspaceRole` into the Gin context. Context keys are declared
+   in the same file:
+   ```go
+   const (
+       ContextKeyUserID        contextKey = "user_id"
+       ContextKeyOrgID         contextKey = "org_id"
+       ContextKeyOrgRole       contextKey = "org_role"
+       ContextKeyWorkspaceRole contextKey = "workspace_role"
+       // …
+   )
+   ```
+3. **Handler reads `org_id` from context.** The HTTP handler pulls
+   `ContextKeyOrgID` and passes it down to the service layer.
+4. **Service calls `db.WithOrgID`.** The service opens a transaction
+   scoped to that org and invokes the repository inside the callback.
+5. **Postgres evaluates the policy.** Every statement the repository runs
+   is rewritten to append `org_id = current_setting('app.current_org_id')::uuid`.
+   Rows belonging to other tenants are invisible.
+
+`RAVEN_SINGLE_USER=true` swaps `SessionMiddleware` for
+`SingleUserMiddleware`, which injects fixed UUIDs
+(`00000000-0000-0000-0000-000000000001` as the org, `…002` as the user) so
+single-user deployments take the same code path without contacting
+SuperTokens.
+
+## Why RLS instead of application-side filtering
+
+Application-side filtering — every query carrying its own
+`WHERE org_id = $1` clause — is a single point of failure. One forgotten
+clause in one repository method is a tenant data leak. Code review catches
+most of them; an audit log catches the rest *after* the leak has occurred.
+
+RLS makes the leak impossible at the layer below the application. If a
+query against a tenant-scoped table is dispatched without
+`app.current_org_id` set, the GUC defaults to the empty string, the cast
+`''::uuid` raises `invalid input syntax for type uuid`, and Postgres
+returns an error rather than rows. If the GUC is set to a different
+tenant's UUID, the policy evaluates to `false` for every row and the query
+returns the empty set without leaking a count. This is the defence in
+depth the platform's security posture requires.
+
+## Admin bypass
+
+Postgres has a built-in `BYPASSRLS` role attribute, but Raven does **not**
+use it. The `raven_app` and `raven_admin` roles created in
+`migrations/00002_roles.sql` are plain roles with no special attributes:
+
+```sql
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'raven_app') THEN
+    CREATE ROLE raven_app;
+  END IF;
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'raven_admin') THEN
+    CREATE ROLE raven_admin;
+  END IF;
+END $$;
+```
+
+Bypass is implemented as a **second policy** on every protected table,
+restricted to the `raven_admin` role:
+
+```sql
+CREATE POLICY admin_bypass ON workspaces
+    FOR ALL TO raven_admin
+    USING (true);
+```
+
+When goose runs migrations as `raven_admin` (or the postgres superuser,
+which short-circuits RLS in any case) the policy short-circuits to `true`
+and the migration sees every row. Production application traffic connects
+as the unprivileged `raven_app` role, for which `admin_bypass` does not
+match, leaving only `tenant_isolation` in effect.
+
+Newer migrations (`migrations/00032_billing_rls_and_payment_events.sql`)
+have started accepting an alternative bypass signal — a GUC named
+`app.bypass_rls` set to the string `'true'`. This is used by trusted
+internal jobs (e.g. payment webhook reconciliation) that must aggregate
+across tenants without holding the `raven_admin` role.
+
+## Testing
+
+RLS is exercised by live-database integration tests under
+`internal/integration/`. Mocked unit tests cannot exercise RLS by
+construction — there is no Postgres to enforce the policy — which is one
+of the reasons the project's testing convention does not use SQL mocks.
+
+The dedicated coverage lives in `internal/integration/rls_test.go`. The
+top-level `TestRLS(t)` function fans out into the following sub-tests:
+
+| Sub-test | Asserts |
+|----------|---------|
+| `document_isolation` | Org-A cannot read Org-B's documents |
+| `chunk_isolation_bm25` | BM25 search filtered by RLS, no cross-org chunks returned |
+| `embedding_isolation_vector` | Vector similarity does not surface foreign-tenant embeddings |
+| `cache_isolation` | Org-A's `Stats(orgA, orgB.KBID)` returns zero entries |
+| `cache_invalidation_scoping` | Cache invalidation is bounded to the calling org |
+| `source_isolation` | `sources` rows are isolated |
+| `cross_org_kb_access` | `GetKnowledgeBase` with another org's ID returns nothing |
+| `admin_bypass` | The `raven_admin` role can read across tenants |
+
+Supporting fixtures live in `internal/integration/seed_test.go` (two-org
+fixture builder), `internal/integration/helpers_test.go`, and
+`internal/integration/setup_test.go` (live Postgres harness via the
+project's `setup_test` bootstrap). The migration runner itself is exercised
+by `internal/integration/migration_test.go`, which confirms RLS is enabled
+on every table named in `00015_rls_policies.sql`.
+
+## Limitations
+
+RLS only protects rows in Postgres. Each non-relational store has its own
+isolation strategy.
+
+| Surface | Isolation strategy |
+|---------|--------------------|
+| SeaweedFS object storage | Object keys are prefixed with `<org_id>/<kb_id>/`. Buckets are not per-tenant; the application layer never composes a SeaweedFS path without an `org_id` prefix. |
+| Valkey (cache, queues) | Asynq queue names and cache keys include the `org_id` segment. Keyspace separation is convention, not enforced — corrupting it requires either bypassing the queue/cache wrappers or holding direct Valkey credentials. |
+| LiveKit voice rooms | Room names are `<org_id>:<conversation_session_id>`. Tokens minted by the API embed the room name as a claim, and LiveKit rejects a join attempt against a different room. |
+| ClickHouse (enterprise QBit) | A separate connection initialised in `cmd/api/main.go` via `db.NewClickHouse` (`internal/db/clickhouse.go`). ClickHouse does not have RLS; every query is parameterised with the caller's `org_id` and reviewed by hand. |
+| OpenObserve / Beszel telemetry | Run as separate deployments; access control is at the OpenObserve organisation / Beszel user level, not row-level. |
+
+These surfaces are why "Raven uses RLS for tenant isolation" is true but
+incomplete. The full answer is: **RLS for the relational data, key-prefix
+discipline for object and cache stores, and signed room/queue names for
+real-time channels.**
+
+## See also
+
+- [Self-Hosting: Hardening](/guides/self-hosting/hardening)
+- [Data model](/concepts/data-model)
+- [API: Authentication](/api/authentication)

--- a/docs-site/stubs/reference/changelog.md
+++ b/docs-site/stubs/reference/changelog.md
@@ -4,5 +4,10 @@ title: "Changelog"
 
 # Changelog
 
-The full changelog lives in [CHANGELOG.md](https://github.com/ravencloak-org/Raven/blob/main/CHANGELOG.md)
-and on the [GitHub releases page](https://github.com/ravencloak-org/Raven/releases).
+The full changelog is generated from git commits via git-cliff. The latest entries are below; the canonical source is [CHANGELOG.md](https://github.com/ravencloak-org/Raven/blob/main/CHANGELOG.md) on GitHub.
+
+See also: [Release process](/contributing/release-process) for how releases are cut, and [SLSA Build Level 3](/trust/slsa-level-3) for the provenance attached to each release.
+
+<!-- The CHANGELOG.md at the repo root is included verbatim below at build time via VitePress's markdown @include directive. Path resolves from .tmp/reference/changelog.md to docs-site/../CHANGELOG.md. -->
+
+<!--@include: ../../../CHANGELOG.md-->

--- a/docs-site/stubs/reference/cli.md
+++ b/docs-site/stubs/reference/cli.md
@@ -1,16 +1,111 @@
 ---
-title: "Coming Soon"
+title: "CLI Reference"
 ---
 
-# CLI
+# CLI Reference
 
-::: warning Stub page
-This page is a placeholder. The full content is being written. If you would
-like to contribute, the source for this page lives at the path shown below
-and you can [edit it on GitHub](https://github.com/ravencloak-org/Raven/edit/main/docs-site/stubs/reference/cli.md).
-:::
+Raven does not ship a standalone end-user CLI today. The binaries under
+[`cmd/`](https://github.com/ravencloak-org/Raven/tree/main/cmd) are long-running
+**server processes**, not user-facing tools. There is no `raven` or `ravenctl`
+command for operators to drive the platform from a terminal.
 
-## What goes here
+Operators interact with Raven through four surfaces, in roughly this order:
 
-A short bullet list of the topics this page will cover, drawn from the
-[design spec](https://github.com/ravencloak-org/Raven/blob/main/docs/superpowers/specs/2026-05-09-docs-site-design.md).
+- The REST API at `https://api.<your-host>/api/v1/...` — see
+  [API overview](/api/overview).
+- The Vue dashboard at `https://app.<your-host>` — see the
+  [first-knowledge-base guide](/get-started/first-knowledge-base).
+- `docker compose` (or `docker compose -f docker-compose.edge.yml`) against
+  the running stack — see
+  [Self-hosting with Docker Compose](/guides/self-hosting/docker-compose).
+- `wrangler` for Cloudflare Pages deploys of the frontend, landing, and docs
+  sites — managed in the respective `package.json` scripts, not by Raven core.
+
+This page enumerates what actually exists in the repo today.
+
+## Binaries shipped
+
+| Binary | Purpose | How to run |
+|---|---|---|
+| [`cmd/api`](https://github.com/ravencloak-org/Raven/tree/main/cmd/api) | The Go HTTP/REST API server (Gin). Listens on `RAVEN_SERVER_PORT`, default `8081`. | `docker compose up go-api`, or `make build && ./bin/api`. |
+| [`cmd/worker`](https://github.com/ravencloak-org/Raven/tree/main/cmd/worker) | The Asynq background-job worker. Consumes the same Valkey queue the API enqueues onto; runs document processing, URL scraping, KB reindexing, webhook delivery, and the post-session email summary job. | `docker compose up worker` (the worker is a **separate** Compose service from `go-api`), or `go run ./cmd/worker`. |
+
+That is the entire user-runnable Go surface. There is no `cmd/migrate`,
+no `cmd/seed`, and no `cmd/update-check`. The Python AI worker (`ai-worker/`)
+is a separate gRPC service launched by Compose, not a Go binary, and is
+documented under [AI Worker Design](/concepts/ai-worker-design).
+
+## Server flags
+
+**Neither binary uses `flag.*` or positional sub-commands.** Configuration
+is loaded entirely from environment variables (and an optional `.env` file)
+by `internal/config.Load()` using Viper with the `RAVEN_` prefix. The full
+variable list lives in [Configuration](/reference/configuration).
+
+Concretely, running either binary with `--help`, `-h`, `migrate`, or
+`seed-demo` is a no-op — the argument is ignored and the binary boots in
+its single normal mode. To change behaviour you change the environment.
+
+The only argv-like control is the standard process signals:
+
+- `SIGINT` / `SIGTERM` → graceful shutdown. Both binaries register handlers
+  in their `main()` and drain in-flight work before exiting.
+
+## Helper scripts
+
+These live in [`scripts/`](https://github.com/ravencloak-org/Raven/tree/main/scripts)
+and are wrapped by `make` targets where useful.
+
+| Script | Purpose |
+|---|---|
+| `coverage.sh` | Merge unit, integration, and instrumented-binary Go coverage into one report under `coverage/`. Invoked by `make coverage`. |
+| `test-compose.sh` | Validate `docker-compose.yml`, `.env.example` completeness, and Dockerfile healthcheck declarations. |
+| `test-ci-workflows.sh` | Lint and dry-run GitHub Actions workflow files locally before pushing CI changes. |
+| `validate-migrations.sh` | Check `migrations/*.sql` for `+goose Up`/`+goose Down` blocks, sequential numbering, and no duplicates. |
+| `chartdb-query.sh` | Emit `chartdb-query.sql` results as JSON for pasting into the ChartDB schema viewer. |
+| `dev-agent.py` | Local-development helper for the AI worker (not for production). |
+| `test-keycloak-realm.py` | Legacy realm validator from the pre-SuperTokens era; retained for reference. |
+
+The relevant `make` targets that wrap these (and the binaries) are:
+
+| Target | What it does |
+|---|---|
+| `make build` | `go build -o bin/api ./cmd/api`. |
+| `make run` / `make dev` | Run `cmd/api` directly against the local env. |
+| `make migrate-up` / `make migrate-down` | Run goose migrations against `$DATABASE_URL` via `dotenvx`. |
+| `make compose` / `make compose-down` | Bring the full Compose stack up or down with `dotenvx`-decrypted secrets. |
+| `make lint` | `golangci-lint run`. |
+| `make swagger` | Regenerate OpenAPI from `cmd/api/main.go` annotations. |
+| `make -f Makefile.edge build-arm64` | Cross-compile static binaries for Raspberry Pi / ARM64 edge nodes. |
+
+## Common operations
+
+| Task | Command |
+|---|---|
+| Run database migrations | `make migrate-up` (wraps `goose -dir migrations postgres "$DATABASE_URL" up`). |
+| Seed demo data | `curl -X POST -H "X-Seed-Key: $RAVEN_SEED_KEY" https://api.<host>/api/v1/admin/seed-demo` — the seed endpoint is **HTTP**, not a CLI sub-command. |
+| Tail service logs | `docker compose logs -f <service>` (e.g. `go-api`, `worker`, `ai-worker`). |
+| Open a `psql` shell | `docker compose exec postgres psql -U raven` |
+| Inspect the queue | `docker compose exec valkey valkey-cli` |
+| Verify a signed release | `cosign verify ...` — see [Security Policy](/reference/security-policy) for the full verification recipe. |
+| Cross-compile for edge | `make -f Makefile.edge build-arm64` (see [Edge & Raspberry Pi](/guides/self-hosting/edge-and-raspberry-pi)). |
+
+## Where the CLI would go
+
+A dedicated `ravenctl` binary — wrapping the most common operator flows
+(tenant creation, key rotation, queue inspection, demo seeding) into a single
+typed CLI — is a credible candidate for a future milestone, but it is not on
+the current roadmap. Treat this as a tracking item rather than a promise; if
+you have a strong use-case, open an issue and reference the
+[architecture-decisions process](/contributing/architecture-decisions) so the
+shape of the tool gets nailed down before any code lands.
+
+## See also
+
+- [Configuration](/reference/configuration) — every environment variable the
+  binaries read.
+- [Self-hosting with Docker Compose](/guides/self-hosting/docker-compose) —
+  the canonical operator surface today.
+- [API overview](/api/overview) — the REST surface that replaces a CLI.
+- [Security Policy](/reference/security-policy) — release verification with
+  cosign.

--- a/docs-site/stubs/trust/security.md
+++ b/docs-site/stubs/trust/security.md
@@ -1,16 +1,103 @@
 ---
-title: "Coming Soon"
+title: "Security"
 ---
 
 # Security
 
-::: warning Stub page
-This page is a placeholder. The full content is being written. If you would
-like to contribute, the source for this page lives at the path shown below
-and you can [edit it on GitHub](https://github.com/ravencloak-org/Raven/edit/main/docs-site/stubs/trust/security.md).
-:::
+Raven's security posture is defence in depth, not a single control. The build
+pipeline produces signed artifacts with [SLSA Level 3 provenance](/trust/slsa-level-3);
+every pull request and weekly cron run scan source for vulnerabilities
+([CodeQL](https://github.com/ravencloak-org/Raven/blob/main/.github/workflows/codeql.yml)
++ [Semgrep](https://github.com/ravencloak-org/Raven/blob/main/.github/workflows/semgrep.yml))
+and for committed secrets
+([Gitleaks](https://github.com/ravencloak-org/Raven/blob/main/.github/workflows/gitleaks.yml));
+dependencies are tracked by [Dependabot](https://github.com/ravencloak-org/Raven/blob/main/.github/dependabot.yml)
+and [govulncheck](https://github.com/ravencloak-org/Raven/blob/main/.github/workflows/security.yml);
+the project's process compliance is published as a public
+[OSPS-L2 self-assessment](/trust/openssf-baseline); and the disclosure path
+is documented under [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116) at
+`.well-known/security.txt`. Each pillar links to its canonical source below.
 
-## What goes here
+## Pillars
 
-A short bullet list of the topics this page will cover, drawn from the
-[design spec](https://github.com/ravencloak-org/Raven/blob/main/docs/superpowers/specs/2026-05-09-docs-site-design.md).
+| Pillar | What it covers | Canonical link |
+| --- | --- | --- |
+| Build provenance | Container images and release binaries carry SLSA L3 attestations, signed via Sigstore keyless OIDC. | [/trust/slsa-level-3](/trust/slsa-level-3) |
+| Process compliance | OSPS Baseline 2026-02-19, Level 2 — every control mapped to evidence (PR, workflow, file). | [/trust/openssf-baseline](/trust/openssf-baseline) |
+| Self-assessment / questionnaire | OpenSSF Best Practices Badge (project [12590](https://bestpractices.dev/projects/12590)), full answer key reproduced inline. | [/trust/openssf-best-practices](/trust/openssf-best-practices) |
+| Pre-merge SAST | CodeQL with `security-extended` + `security-and-quality` query suites for Go, Python, and JS/TS, plus Semgrep OSS with `p/ci`, `p/security-audit`, `p/owasp-top-ten`, and `p/secrets` rulepacks. | [codeql.yml](https://github.com/ravencloak-org/Raven/blob/main/.github/workflows/codeql.yml) · [semgrep.yml](https://github.com/ravencloak-org/Raven/blob/main/.github/workflows/semgrep.yml) |
+| Pre-merge secrets | Gitleaks blocks merges that introduce credentials; runs on PR, push, and a weekly cron. | [gitleaks.yml](https://github.com/ravencloak-org/Raven/blob/main/.github/workflows/gitleaks.yml) |
+| Dependency security | Dependabot for `gomod`, `pip`, `npm`, `docker`, and `github-actions`; Trivy + govulncheck in CI; OpenSSF Scorecard publishes the `Vulnerabilities` check weekly. | [dependabot.yml](https://github.com/ravencloak-org/Raven/blob/main/.github/dependabot.yml) · [security.yml](https://github.com/ravencloak-org/Raven/blob/main/.github/workflows/security.yml) · [scorecard.yml](https://github.com/ravencloak-org/Raven/blob/main/.github/workflows/scorecard.yml) |
+| Vulnerability disclosure | Coordinated disclosure under a 72h-ack / 7d-triage / 90d-fix SLA. | [/reference/security-policy](/reference/security-policy) |
+| Machine-readable disclosure path | [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116) `security.txt` — also served from the production deploy. | [.well-known/security.txt](https://github.com/ravencloak-org/Raven/blob/main/.well-known/security.txt) |
+
+## Reporting a vulnerability
+
+If you believe you have found a security issue in Raven, please report it
+privately. Two channels are accepted:
+
+- **GitHub Security Advisories** (preferred): open a private advisory at
+  <https://github.com/ravencloak-org/Raven/security/advisories/new>.
+- **Email**: `security@ravencloak.org`. If that alias is unreachable, fall
+  back to `jobinlawrance@gmail.com` and reference the original report.
+
+You will receive an acknowledgement within **72 hours**, a triage and severity
+assessment within **7 days**, and a fix coordinated within **90 days** of the
+initial report. Do not file a public GitHub issue, post on social media, or
+otherwise disclose the issue until the advisory ships.
+
+[Read the full policy →](/reference/security-policy)
+
+## Bug bounty
+
+Raven does not run a paid bug-bounty programme today. The security policy's
+**Safe Harbor** clause applies: good-faith research that complies with the
+policy is treated as authorised, will not be pursued legally, and will be
+acknowledged in the resulting GitHub Security Advisory unless the reporter
+opts out. See the [Safe Harbor section](/reference/security-policy#safe-harbor)
+of the policy for the full terms.
+
+## Cryptographic verification
+
+Release binaries (`checksums.txt`, frontend bundle), Docker images, and their
+attestations are signed with [Sigstore Cosign](https://docs.sigstore.dev/cosign/verifying/verify/)
+using GitHub's OIDC identity — no long-lived signing keys. Step-by-step
+recipes for verifying provenance with `gh attestation verify`, `cosign
+verify-attestation`, and `slsa-verifier`, plus the production guidance on
+**always pinning by digest**, live at:
+
+- [/trust/slsa-level-3](/trust/slsa-level-3) — verification recipes
+- [/trust/openssf-baseline#build--release](/trust/openssf-baseline#build--release) — what we sign and where the certificate identity is anchored
+
+## Audit findings and pentests
+
+Raven has not commissioned a formal third-party security audit or penetration
+test to date. The project is single-maintainer open source pre-1.0 — a paid
+audit is on the post-1.0 milestone list rather than something we can claim
+retroactively. The compensating controls today are: automated SAST and
+dependency scanning on every change, a public OSPS-L2 self-assessment, SLSA L3
+build provenance, and a working coordinated-disclosure channel. When an audit
+or pentest is commissioned, the findings (or a redacted summary) will be
+linked from this page.
+
+## Compliance
+
+The OSS portion of the repository (everything under
+[`LICENSE`](https://github.com/ravencloak-org/Raven/blob/main/LICENSE); the
+Enterprise portion under `ee-LICENSE` is out of scope) targets **OSPS Baseline
+2026-02-19 at Level 2**. The full control-by-control mapping is at
+[/trust/openssf-baseline](/trust/openssf-baseline).
+
+Privacy, GDPR, and India DPDP material lives under `/trust/privacy/`. That
+page is held back behind a DRAFT counsel-review banner and is scheduled for
+publication once counsel review completes; the supporting evidence (DPA
+template, sub-processor list, retention schedule) is being prepared in
+parallel.
+
+## See also
+
+- [Security Policy](/reference/security-policy) — the full disclosure policy mirrored from `SECURITY.md`
+- [OpenSSF Baseline](/trust/openssf-baseline) — OSPS-L2 self-assessment evidence log
+- [OpenSSF Best Practices](/trust/openssf-best-practices) — bestpractices.dev answer key
+- [SLSA Level 3](/trust/slsa-level-3) — provenance verification recipes
+- [Maintainers](/community/maintainers) — security triage owner and escalation path


### PR DESCRIPTION
## Summary

Replaces 8 more stub pages with real, code-grounded content. Continuation of #488.

| Page | Lines | Headline |
|---|---|---|
| **Concepts / Multi-Tenancy** | 326 | **35 tables** with RLS enumerated; documents the real two-step auth middleware flow (SessionMiddleware + UserLookup) and the GUC-based bypass (not the `BYPASSRLS` role) |
| **Concepts / Hybrid Retrieval** | 407 | Honest about sparse search being **vanilla `tsvector` + `ts_rank_cd`**, not a BM25 extension. RRF `k = 60` (hard-coded in both Go and Python). HNSW defaults `m=16, ef_construction=64`, cosine. |
| **Concepts / Deployment Models** | 214 | Cloud (14 services) / Edge (3 services, ~25 MB binary) / Hybrid via the actual env var name `RAVEN_GRPC_WORKER_ADDR` |
| **Concepts / AI Worker Design** | 317 | All 3 RPCs from `proto/ai_worker.proto` enumerated. EE carve-out flagged. Telemetry status: traces only |
| **Reference / CLI** | 111 | Honest: no standalone CLI today. Both `cmd/api` and `cmd/worker` are pure env-var driven (zero `flag.*` calls). Routes to docker-compose / API surfaces. |
| **Reference / Changelog** | 13 | Uses VitePress `<!--@include: ../../../CHANGELOG.md-->` to inline the real changelog at build time. Verified rendering. |
| **Community / Support** | 102 | GitHub Discussions **NOT** enabled; no issue templates. Routes Q&A to Issues with `question` label. |
| **Trust / Security** | 103 | Marketing-quality summary linking out to /trust/openssf-baseline, /trust/openssf-best-practices, /trust/slsa-level-3, /reference/security-policy. |
| **Total** | **~1,593 new lines · 5,049 indexed words (was 4,026)** | |

## Real codebase issues surfaced

1. **README/docs/marketing material says "BM25"** — actual implementation is PostgreSQL `tsvector` + `ts_rank_cd` (BM25-*style* but not actual BM25). Hybrid Retrieval page documents this accurately.
2. **No retrieval tuning env vars** — top-K, RRF `k`, hybrid weights, HNSW params are all hard-coded constants. Documented in Hybrid Retrieval.
3. **No GitHub Discussions** — Support page routes around this until enabled.
4. **No issue templates** — also flagged.
5. **No CLI flags whatsoever** — `grep -n 'flag\.' cmd/` returns zero matches.

## Out of scope

Still stubbed (next pass): T4 User-facing (6 — First KB, Embed Widget, Workspaces, Ingestion, Retrieval, LLM Providers), T5 Niche (8 — Voice ×2, Webhooks, Billing, Edge/Pi, Traefik/TLS, Upgrades + leftover Self-Hosting). Total remaining: 14 stubs.

## Test plan
- [ ] Cloudflare Pages preview renders correctly
- [ ] /reference/changelog shows real changelog content (v0.3.0 entry)
- [ ] /concepts/* pages have zero stub banners
- [ ] PageFind hits for "tsvector", "RRF", "BYPASSRLS" (now correctly NOT claimed), "RAVEN_GRPC_WORKER_ADDR"
- [ ] No dead links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Published complete documentation pages covering support resources and response guidelines, AI worker architecture overview, deployment topology models and sizing guidance, hybrid search pipeline specifications, multi-tenancy isolation design, CLI operational reference, and security posture including vulnerability disclosure and artifact verification processes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ravencloak-org/Raven/pull/493)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->