### PR TITLE
fix(ci/desktop): use real rustup targets, keep tauri universal target

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -25,31 +25,31 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # On macOS, `tauri_target=universal-apple-darwin` is a Tauri-CLI
+          # concept — Tauri stitches builds of the two real rustup targets
+          # (aarch64-apple-darwin + x86_64-apple-darwin) into one universal
+          # binary. `rustup_targets` lists the real targets to install.
           - os: macos-latest
-            target: universal-apple-darwin
+            tauri_target: universal-apple-darwin
+            rustup_targets: 'aarch64-apple-darwin,x86_64-apple-darwin'
             artifact_glob: 'desktop/src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg'
-            extra_targets: 'aarch64-apple-darwin x86_64-apple-darwin'
           - os: windows-latest
-            target: x86_64-pc-windows-msvc
+            tauri_target: x86_64-pc-windows-msvc
+            rustup_targets: 'x86_64-pc-windows-msvc'
             artifact_glob: 'desktop/src-tauri/target/release/bundle/msi/*.msi'
-            extra_targets: ''
           - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
+            tauri_target: x86_64-unknown-linux-gnu
+            rustup_targets: 'x86_64-unknown-linux-gnu'
             artifact_glob: |
               desktop/src-tauri/target/release/bundle/appimage/*.AppImage
               desktop/src-tauri/target/release/bundle/deb/*.deb
-            extra_targets: ''
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
-          targets: ${{ matrix.target }}
-
-      - name: Install macOS extra Rust targets
-        if: matrix.os == 'macos-latest'
-        run: rustup target add ${{ matrix.extra_targets }}
+          targets: ${{ matrix.rustup_targets }}
 
       - name: Install Linux deps
         if: matrix.os == 'ubuntu-latest'
@@ -69,7 +69,7 @@ jobs:
       - name: Build (universal macOS)
         if: matrix.os == 'macos-latest'
         working-directory: desktop
-        run: cargo tauri build --target universal-apple-darwin
+        run: cargo tauri build --target ${{ matrix.tauri_target }}
 
       - name: Build (Windows / Linux)
         if: matrix.os != 'macos-latest'


### PR DESCRIPTION
## Summary

First run of `desktop-release.yml` on tag `raven-local-v0.1.0` failed on macos-latest with:

```
error: component 'rust-std' for target 'universal-apple-darwin' is unavailable for download for channel 'stable'
```

`universal-apple-darwin` is a Tauri-CLI concept — Tauri stitches builds of the two real rustup targets (`aarch64-apple-darwin` + `x86_64-apple-darwin`) into one universal binary at packaging time. The previous workflow passed it directly to `dtolnay/rust-toolchain` and `rustup target add`, which don't recognise it.

Splits the matrix into:
- `rustup_targets` — comma-separated list of real targets to install via dtolnay/rust-toolchain.
- `tauri_target` — value used by `cargo tauri build --target`. Only macOS uses it explicitly.

The dedicated `Install macOS extra Rust targets` step is removed because dtolnay/rust-toolchain installs both targets directly.

## Test plan

Once merged, re-tag `raven-local-v0.1.0` (force-delete + recreate) or push a new test tag like `raven-local-v0.1.1` to re-trigger the workflow.