### PR TITLE
docs: real content for the final 13 stubs (T4 user-facing + T5 niche)

### DIFF
--- a/docs-site/stubs/get-started/embed-the-chat-widget.md
+++ b/docs-site/stubs/get-started/embed-the-chat-widget.md
@@ -1,16 +1,298 @@
 ---
-title: "Coming Soon"
+title: "Embed the Chat Widget"
 ---
 
 # Embed the Chat Widget
 
-::: warning Stub page
-This page is a placeholder. The full content is being written. If you would
-like to contribute, the source for this page lives at the path shown below
-and you can [edit it on GitHub](https://github.com/ravencloak-org/Raven/edit/main/docs-site/stubs/get-started/embed-the-chat-widget.md).
-:::
+Raven ships an embeddable chat widget as a standards-based **Web Component**
+called `<raven-chat>`. Drop the script tag and the element on any HTML page —
+your marketing site, docs portal, customer dashboard, or a static landing page —
+point it at your Raven workspace, and your visitors can chat with your
+knowledge base out of the box.
 
-## What goes here
+This page walks through embedding the widget end-to-end: creating an API key,
+adding the two lines of HTML, customising the look, and locking the widget down
+to the origins you trust.
 
-A short bullet list of the topics this page will cover, drawn from the
-[design spec](https://github.com/ravencloak-org/Raven/blob/main/docs/superpowers/specs/2026-05-09-docs-site-design.md).
+## What you'll need
+
+Before you start, make sure you have:
+
+- A running **Raven workspace** (self-hosted or hosted) reachable over HTTPS.
+- A **knowledge base** with at least one ingested document. See
+  [First Knowledge Base](/get-started/first-knowledge-base) if you haven't
+  ingested anything yet.
+- The hostname of the site that will embed the widget (e.g.
+  `https://www.example.com`).
+- An admin or member role on the knowledge base — you'll need it to mint an
+  API key.
+
+## Create a widget API key
+
+API keys in Raven are **scoped to a single knowledge base**, optionally
+restricted to a list of allowed origins, and optionally rate-limited. The full
+key value is shown **once at creation** and stored hashed thereafter; treat it
+like a secret you can rotate, not a password you can recover.
+
+### From the dashboard
+
+1. Open the Raven dashboard and switch to the organisation and workspace that
+   owns the knowledge base.
+2. Navigate to **Knowledge Bases → _your KB_ → API Keys**.
+3. Click **New API Key**.
+4. Give it a descriptive name (for example `marketing-site-widget`).
+5. Under **Allowed domains**, list every origin that will embed the widget,
+   one per line, with scheme:
+   ```
+   https://www.example.com
+   https://example.com
+   ```
+6. Optionally set a **rate limit** (requests per minute per key). Leave blank
+   for the workspace default.
+7. Click **Create**, then **copy the key value** from the confirmation dialog.
+   You will not be able to view it again — if you lose it, revoke and create a
+   new one.
+
+### Via the API
+
+The dashboard form is a thin wrapper around the REST API. The endpoint lives
+under the knowledge-base path:
+
+```
+POST /api/v1/orgs/{org_id}/workspaces/{ws_id}/knowledge-bases/{kb_id}/api-keys
+```
+
+Authenticate as a workspace member and send a `CreateAPIKeyRequest` body:
+
+```bash
+curl -X POST \
+  "https://app.example.com/api/v1/orgs/$ORG_ID/workspaces/$WS_ID/knowledge-bases/$KB_ID/api-keys" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $SESSION_TOKEN" \
+  -d '{
+    "name": "marketing-site-widget",
+    "allowed_domains": [
+      "https://www.example.com",
+      "https://example.com"
+    ],
+    "rate_limit": 60
+  }'
+```
+
+The response contains the metadata plus a one-time `raw_key`:
+
+```json
+{
+  "id": "ak_01HXYZ…",
+  "knowledge_base_id": "kb_01HABC…",
+  "name": "marketing-site-widget",
+  "key_prefix": "rvn_…",
+  "allowed_domains": ["https://www.example.com", "https://example.com"],
+  "rate_limit": 60,
+  "status": "active",
+  "raw_key": "rvn_live_…",
+  "created_at": "2026-05-12T10:42:00Z"
+}
+```
+
+Capture `raw_key` in your secret store immediately. Only the `key_prefix` is
+ever returned on subsequent `GET` calls.
+
+## Minimal embed
+
+Two tags is the whole story. Paste them anywhere inside `<body>`:
+
+```html
+<raven-chat
+  api-key="rvn_live_your_key_here"
+  api-url="https://app.example.com"
+></raven-chat>
+<script type="module" src="https://app.example.com/chat-widget.js"></script>
+```
+
+That's it. `<raven-chat>` mounts a floating launcher button (bottom-right by
+default). Clicking it expands the chat panel and streams responses from your
+knowledge base over SSE.
+
+- **`api-key`** — the `raw_key` value you copied above.
+- **`api-url`** — the base URL of your Raven API (no trailing slash, no path).
+- **Script source** — the same origin as `api-url`. The widget bundle is built
+  from `frontend/src/components/chat-widget/index.ts` and served as
+  `chat-widget.js`. It registers the `<raven-chat>` custom element on first
+  load and guards against double-registration if the script ends up included
+  twice.
+
+## Attributes
+
+The component reads its configuration from HTML attributes. Every attribute
+listed below is observed — change it at runtime via `setAttribute()` and the
+widget updates without a reload.
+
+| Attribute       | Required | Default     | Purpose                                                                 |
+|-----------------|----------|-------------|-------------------------------------------------------------------------|
+| `api-key`       | yes      | —           | The widget API key minted above.                                        |
+| `api-url`       | yes      | —           | Base URL of the Raven API (e.g. `https://app.example.com`).             |
+| `theme-color`   | no       | `#6366f1`   | Primary brand colour. Drives the launcher, header, and send button.     |
+| `avatar-url`    | no       | (none)      | URL for the assistant avatar shown in the panel header.                 |
+| `welcome-text`  | no       | `Hi! How can I help?` | First-line greeting shown above the message list.            |
+| `position`      | no       | `bottom-right` | Launcher anchor. Accepts `bottom-right` or `bottom-left`.           |
+| `voice-enabled` | no       | `false`     | Set to `"true"` to expose a voice-call button (requires `livekit-url`). |
+| `livekit-url`   | no       | —           | LiveKit server URL used for the voice-call session.                     |
+
+A fully decked-out embed looks like:
+
+```html
+<raven-chat
+  api-key="rvn_live_your_key_here"
+  api-url="https://app.example.com"
+  theme-color="#0ea5e9"
+  avatar-url="https://www.example.com/img/support-avatar.png"
+  welcome-text="Hi there — ask me anything about Example."
+  position="bottom-right"
+  voice-enabled="true"
+  livekit-url="wss://livekit.example.com"
+></raven-chat>
+```
+
+## Styling
+
+The widget renders inside an **open Shadow DOM**, so your site's stylesheet
+cannot accidentally leak into it (and vice-versa). To tweak the appearance,
+either:
+
+1. **Use `theme-color`** for the simplest case — it derives a matching hover
+   shade automatically.
+2. **Override CSS custom properties** on the host element. Because the shadow
+   root is open, inherited custom properties flow through. Add a global rule
+   on the host:
+
+   ```css
+   raven-chat {
+     --rc-primary: #0ea5e9;
+     --rc-bg: #0b1220;
+     --rc-bg-secondary: #111a2d;
+     --rc-text: #e6edf3;
+     --rc-text-muted: #94a3b8;
+     --rc-border: #1f2937;
+     --rc-radius: 16px;
+     --rc-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+   }
+   ```
+
+The variables read by the shadow stylesheet are: `--rc-primary`,
+`--rc-primary-hover`, `--rc-bg`, `--rc-bg-secondary`, `--rc-text`,
+`--rc-text-muted`, `--rc-border`, `--rc-shadow`, `--rc-radius`, and `--rc-font`.
+
+The layout is mobile-first: on viewports narrower than the panel width, the
+launcher anchors to the screen edge and the expanded panel docks full-width.
+You do not need to add any media queries.
+
+## Security
+
+### Public, not secret
+
+The widget API key is a **public credential** — it lives in your page's HTML
+and ships to every visitor. It is safe to commit it to your website's source
+because it is constrained two ways:
+
+- It is **scoped to one knowledge base**. It cannot read other KBs, list
+  documents, manage settings, or touch any admin surface.
+- It is **revocable**. Hit
+  `DELETE /api/v1/orgs/{org_id}/workspaces/{ws_id}/knowledge-bases/{kb_id}/api-keys/{key_id}`
+  (or click **Revoke** in the dashboard) and the key stops working immediately.
+
+If you need to call Raven server-to-server with broader privileges, do not use
+a widget key — use a workspace session token issued by SuperTokens or a
+service account.
+
+### Domain allowlist
+
+The `allowed_domains` array you provided at creation is enforced server-side.
+A request whose `Origin` header is not in the list is rejected before the
+chat handler runs.
+
+> **Note.** As of this release the server enforces the **workspace-level**
+> origin allowlist (`RAVEN_CORS_ALLOWED_ORIGINS`, see below) on every request,
+> and the per-key `allowed_domains` field is stored and returned but not yet
+> joined into the CORS check on every request — that wiring is tracked under
+> milestone M2 (see the `TODO(M2)` in `internal/middleware/cors.go`). Set
+> `allowed_domains` correctly now: it is already stored, listed, and shown in
+> the dashboard, and it will start being enforced automatically once M2 ships.
+
+### Rate limiting
+
+Set `rate_limit` (requests per minute) on the key to cap how chatty a single
+embed can be. This is enforced per key, not per visitor.
+
+## CORS configuration on the server
+
+When the widget runs on `https://www.example.com` and calls
+`https://app.example.com`, the browser issues a cross-origin request. Your
+Raven API must include the embedding origin in its CORS allowlist or the
+browser will block the response.
+
+Set the env var on the API container:
+
+```bash
+RAVEN_CORS_ALLOWED_ORIGINS=https://www.example.com,https://example.com
+```
+
+You can pass multiple origins as a comma-separated list. The middleware
+matches **exactly** — protocol, host, and (non-default) port all have to
+match. `https://example.com` does not cover `https://www.example.com`; list
+both explicitly. There is no wildcard support.
+
+The same value can be set via config file under `cors.allowed_origins` in
+`raven.yaml`.
+
+## Local development
+
+For end-to-end development on your laptop:
+
+1. Start the Raven API on port `8080`.
+2. Start the frontend dev server (`npm --prefix frontend run dev`) on port
+   `3000`. The Vite proxy forwards `/api` to `http://localhost:8080`.
+3. Open a sandbox HTML page — see
+   `frontend/e2e/chat-widget/widget-sandbox.html` for the exact shape:
+
+   ```html
+   <raven-chat
+     api-key="test-api-key-from-env"
+     api-url="http://localhost:8080"
+   ></raven-chat>
+   <script src="http://localhost:5173/chat-widget.js"></script>
+   ```
+
+4. Add the page's origin (`http://localhost:8081`, `file://`, or wherever you
+   are serving it) to `RAVEN_CORS_ALLOWED_ORIGINS` before booting the API.
+
+The Playwright integration tests in `frontend/e2e/chat-widget/widget.spec.ts`
+load the sandbox HTML, type into the shadow-DOM input, and assert that the
+assistant streams a response. Use them as a living reference if your embed
+behaves differently from what you see in the dashboard preview.
+
+## Troubleshooting
+
+| Symptom                                                              | Likely cause                                                                                                       |
+|----------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
+| Launcher never appears; console shows `404` on `chat-widget.js`      | Wrong `src` on the `<script>` tag. The bundle is served from your Raven API origin, not from your marketing site. |
+| Launcher appears but panel shows the **error state** on first send   | Invalid, revoked, or wrong-knowledge-base API key. Check `key_prefix` in the dashboard against your embed.        |
+| Browser console: `CORS policy: No 'Access-Control-Allow-Origin'`     | The embedding origin is not in `RAVEN_CORS_ALLOWED_ORIGINS`. Add it and restart the API.                          |
+| Replies say "no relevant context" no matter what you ask             | The KB has no documents, or ingestion hasn't completed. Check **Knowledge Bases → Documents** for green status.   |
+| Widget renders but styles look unbranded                             | Custom property overrides are scoped too narrowly. Apply them directly to `raven-chat` at the root, not inside `:host {}` from your page CSS — `:host` is a shadow-internal selector.       |
+| Voice call button missing                                            | `voice-enabled="true"` and `livekit-url="wss://…"` are both required, and the workspace must have LiveKit configured. See [Try the Voice Agent](/get-started/try-the-voice-agent). |
+
+If `<raven-chat>` element appears in the DOM but is empty, the script
+registered the element after it was parsed and a re-attach is needed. In
+practice this only happens if the script tag is loaded `async` and parsed
+late; mark it `type="module"` (which is `defer` by default) or place it after
+the element.
+
+## What's next
+
+- [API Overview](/api/overview) — the full REST surface, including the API key
+  management endpoints.
+- [Workspaces & Tenancy](/guides/workspaces-and-tenancy) — how organisations,
+  workspaces, and knowledge bases relate to API keys and CORS scoping.
+- [Try the Voice Agent](/get-started/try-the-voice-agent) — unlock the
+  `voice-enabled` attribute with a LiveKit-backed voice call.

--- a/docs-site/stubs/get-started/first-knowledge-base.md
+++ b/docs-site/stubs/get-started/first-knowledge-base.md
@@ -1,16 +1,415 @@
 ---
-title: "Coming Soon"
+title: "First Knowledge Base"
 ---
 
-# First Knowledge Base
+# Your First Knowledge Base
 
-::: warning Stub page
-This page is a placeholder. The full content is being written. If you would
-like to contribute, the source for this page lives at the path shown below
-and you can [edit it on GitHub](https://github.com/ravencloak-org/Raven/edit/main/docs-site/stubs/get-started/first-knowledge-base.md).
-:::
+This tutorial picks up where the [Quickstart](/get-started/installation) leaves
+off. By the end of this page you will have:
 
-## What goes here
+- A workspace under your organisation.
+- A knowledge base with at least one ingested document.
+- A working full-text search call against that knowledge base.
+- A streaming chat reply grounded in your document.
 
-A short bullet list of the topics this page will cover, drawn from the
-[design spec](https://github.com/ravencloak-org/Raven/blob/main/docs/superpowers/specs/2026-05-09-docs-site-design.md).
+## Prerequisites
+
+You should already be at the point where:
+
+- Raven is running locally (`docker compose up -d` from the Quickstart succeeded).
+- You have signed in through Keycloak and Raven created your user.
+- The **Onboarding Wizard** has finished. The wizard auto-creates your first
+  organisation and, by default, a workspace named **Default**. You can use
+  those, or follow along below to create a fresh workspace.
+
+All API examples below assume:
+
+```bash
+export RAVEN_API=http://localhost:8080/api/v1
+export ORG_ID="<your-org-uuid>"     # visible in the URL of the dashboard
+export WS_ID="<your-workspace-uuid>"
+export KB_ID="<filled-in-after-step-3>"
+export TOKEN="<your-keycloak-access-token>"   # see Authentication below
+```
+
+> **Authentication.** Dashboard sessions use cookies — the browser is already
+> signed in. For curl, paste a Keycloak access token (`Authorization: Bearer
+> $TOKEN`) or call the `/api/v1/me` endpoint from the browser's DevTools to
+> grab the session cookie and pass it with `--cookie`. The embeddable chat
+> widget uses long-lived API keys instead; see
+> [Embed the Chat Widget](/get-started/embed-the-chat-widget).
+
+## Concepts in 60 seconds
+
+Raven groups data in a strict hierarchy. Every row in the database carries an
+`org_id`, and Postgres Row-Level Security blocks any query that crosses orgs.
+
+| Concept           | What it is                                                                                  |
+|-------------------|---------------------------------------------------------------------------------------------|
+| **Organisation**  | The top-level tenant boundary. One billing account, one Keycloak realm worth of users.      |
+| **Workspace**     | A team within the organisation. Holds knowledge bases, members, and notification settings.  |
+| **Knowledge Base**| A scoped document store. The unit you point a chatbot, API key, or voice agent at.          |
+| **Source**        | A URL (web page, sitemap, RSS feed) registered with a KB; the crawler fetches and re-fetches it. |
+| **Document**      | A file or crawled page inside a KB. Goes through a processing pipeline before it is queryable. |
+| **Chunk**         | A passage of a document — text plus an optional heading and page number. The retrieval unit. |
+| **Embedding**     | A vector representation of a chunk. Powers semantic similarity in hybrid search.            |
+
+For the deeper picture, read [Data Model](/concepts/data-model) and
+[Multi-Tenancy](/concepts/multi-tenancy).
+
+## Create a workspace
+
+### Dashboard
+
+1. From the dashboard sidebar choose **Workspaces → New Workspace**.
+2. Enter a name (2–255 characters) and submit.
+3. You land on the new workspace's detail page; copy its UUID from the URL.
+
+### API
+
+The dashboard call hits:
+
+```http
+POST /api/v1/orgs/{org_id}/workspaces
+Content-Type: application/json
+```
+
+Body (validated by `model.CreateWorkspaceRequest` — `name` is required,
+2–255 characters):
+
+```json
+{ "name": "My Team" }
+```
+
+Curl:
+
+```bash
+curl -s -X POST "$RAVEN_API/orgs/$ORG_ID/workspaces" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"My Team"}'
+```
+
+A `201 Created` response returns the full `Workspace` object (`id`, `org_id`,
+`name`, `slug`, `settings`, timestamps). Save the `id` as `$WS_ID`.
+
+> **Onboarding shortcut.** The first workspace under a new org does not
+> require any org role — that is why the Onboarding Wizard is allowed to
+> create it. Subsequent workspaces are unrestricted at the API; member
+> management on a workspace requires `admin`.
+
+## Create a knowledge base
+
+### Dashboard
+
+1. Inside your workspace, choose **Knowledge Bases**.
+2. Type a name in the inline form (the `KBListPage` calls
+   `useKnowledgeBasesStore.create` under the hood).
+3. You are redirected to `/orgs/<org-id>/workspaces/<ws-id>/knowledge-bases/<kb-id>` —
+   copy the UUID from the URL.
+
+### API
+
+```http
+POST /api/v1/orgs/{org_id}/workspaces/{ws_id}/knowledge-bases
+Content-Type: application/json
+```
+
+Body (`model.CreateKBRequest` — `name` required, `description` optional):
+
+```json
+{
+  "name": "Product Docs",
+  "description": "Customer-facing product documentation"
+}
+```
+
+Curl:
+
+```bash
+curl -s -X POST "$RAVEN_API/orgs/$ORG_ID/workspaces/$WS_ID/knowledge-bases" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Product Docs","description":"Customer-facing product documentation"}'
+```
+
+A `201 Created` response returns the full `KnowledgeBase`:
+
+```json
+{
+  "id": "5f5a...",
+  "org_id": "1a2b...",
+  "workspace_id": "9c8d...",
+  "name": "Product Docs",
+  "slug": "product-docs",
+  "description": "Customer-facing product documentation",
+  "settings": {},
+  "status": "active",
+  "cache_enabled": false,
+  "cache_similarity_threshold": 0.90,
+  "created_at": "2026-05-08T10:00:00Z",
+  "updated_at": "2026-05-08T10:00:00Z"
+}
+```
+
+Save `id` as `$KB_ID`. (Like workspaces, the first KB under a workspace skips
+the role check — onboarding-friendly.)
+
+## Ingest your first document
+
+You have three ways to put content into a KB. Each one ends in the same place:
+a row in the `documents` table with `processing_status = "queued"` and a job
+on Asynq for the AI worker to pick up.
+
+### Option 1 — Upload a file from the dashboard
+
+1. Open the KB detail page.
+2. Drag and drop a PDF, Markdown, or text file onto the drop zone, or click
+   **Upload**.
+3. The page polls and updates the status badge from `queued` to `ready`
+   (usually a few seconds for a short document).
+
+The frontend calls the same multipart endpoint as the curl example below.
+
+### Option 2 — POST a file to the documents endpoint
+
+```http
+POST /api/v1/orgs/{org_id}/workspaces/{ws_id}/knowledge-bases/{kb_id}/documents/upload
+Content-Type: multipart/form-data
+```
+
+The handler (`internal/handler/upload.go`) accepts a single `file` form field,
+validates the MIME type and size, hashes the bytes for deduplication, writes
+the blob to SeaweedFS, creates a `Document` row, and enqueues a processing
+job. The leaf has a 60-second deadline so large PDFs do not get cut off by
+the global API budget.
+
+Curl:
+
+```bash
+curl -s -X POST \
+  "$RAVEN_API/orgs/$ORG_ID/workspaces/$WS_ID/knowledge-bases/$KB_ID/documents/upload" \
+  -H "Authorization: Bearer $TOKEN" \
+  -F "file=@./getting-started.md"
+```
+
+`201 Created` returns `model.UploadDocumentResponse`:
+
+```json
+{
+  "id": "f3e2...",
+  "org_id": "1a2b...",
+  "knowledge_base_id": "5f5a...",
+  "file_name": "getting-started.md",
+  "file_type": "text/markdown",
+  "file_size_bytes": 4321,
+  "file_hash": "sha256:...",
+  "storage_path": "3,01a47a1234",
+  "processing_status": "queued",
+  "uploaded_by": "user-uuid",
+  "created_at": "2026-05-08T10:01:00Z"
+}
+```
+
+Save the `id` if you want to poll a specific document.
+
+### Option 3 — Add a web source (URL)
+
+For pages you do not want to download locally, register them as a **source**.
+Raven's crawler fetches the URL, parses it, and creates one or more documents.
+
+```http
+POST /api/v1/orgs/{org_id}/workspaces/{ws_id}/knowledge-bases/{kb_id}/sources
+Content-Type: application/json
+```
+
+Body (`model.CreateSourceRequest`):
+
+```json
+{
+  "source_type": "web_page",
+  "url": "https://example.com/docs/intro",
+  "crawl_frequency": "manual"
+}
+```
+
+`source_type` accepts `web_page`, `web_site`, `sitemap`, or `rss_feed`.
+`crawl_frequency` accepts `manual`, `daily`, `weekly`, or `monthly`.
+
+Curl:
+
+```bash
+curl -s -X POST \
+  "$RAVEN_API/orgs/$ORG_ID/workspaces/$WS_ID/knowledge-bases/$KB_ID/sources" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "source_type":"web_page",
+        "url":"https://example.com/docs/intro",
+        "crawl_frequency":"manual"
+      }'
+```
+
+The response includes a `processing_status` field that walks the source from
+`queued` to `ready` the same way a file upload does. Creating a source
+requires the workspace `member` role.
+
+## Watch the pipeline
+
+A document moves through a state machine defined in
+`internal/model/document.go`:
+
+| `processing_status` | Meaning                                                              |
+|---------------------|----------------------------------------------------------------------|
+| `queued`            | Job is on the Asynq queue, waiting for the AI worker.                |
+| `crawling`          | (Source-only) the crawler is fetching the URL.                       |
+| `parsing`           | Extracting text from the file format (PDF, HTML, Markdown, …).       |
+| `chunking`          | Splitting into passages with headings and page anchors.              |
+| `embedding`         | Calling the embedding model for each chunk.                          |
+| `ready`             | Chunks and vectors are written; the document is queryable.           |
+| `failed`            | Pipeline error; see the `processing_error` field for the cause.      |
+| `reprocessing`      | A re-ingestion is in flight (for example after a settings change).   |
+
+Poll the document list endpoint to watch progress:
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$RAVEN_API/orgs/$ORG_ID/workspaces/$WS_ID/knowledge-bases/$KB_ID/documents" \
+  | jq '.documents[] | {file_name, processing_status, processing_error}'
+```
+
+Wait until your document shows `"processing_status": "ready"` before searching.
+
+## Run your first search
+
+Search uses Postgres `tsvector` with BM25-style ranking, scoped to a single
+KB. It is exposed as a `GET` (the search handler reads the query from `?q=`),
+not a `POST` — see `internal/handler/search.go`.
+
+```http
+GET /api/v1/orgs/{org_id}/workspaces/{ws_id}/knowledge-bases/{kb_id}/search?q=...&limit=...
+```
+
+Curl:
+
+```bash
+curl -s -G -H "Authorization: Bearer $TOKEN" \
+  "$RAVEN_API/orgs/$ORG_ID/workspaces/$WS_ID/knowledge-bases/$KB_ID/search" \
+  --data-urlencode "q=how do i get started" \
+  --data-urlencode "limit=5" \
+  | jq
+```
+
+Sample `model.SearchResponse`:
+
+```json
+{
+  "results": [
+    {
+      "id": "c1...",
+      "org_id": "1a2b...",
+      "knowledge_base_id": "5f5a...",
+      "document_id": "f3e2...",
+      "content": "To get started, install Raven with `docker compose up -d`…",
+      "chunk_index": 0,
+      "heading": "Quickstart",
+      "chunk_type": "text",
+      "rank": 0.812,
+      "highlight": "To <mark>get started</mark>, install Raven…",
+      "created_at": "2026-05-08T10:02:00Z"
+    }
+  ],
+  "total": 1
+}
+```
+
+The `rank` is the BM25 score; `highlight` is a snippet wrapped in `<mark>`
+tags. Higher `rank` means more relevant. Use the `doc_ids` query parameter
+(repeatable) to filter to a subset of documents within the KB.
+
+> **Hybrid search.** The dashboard chat path also uses dense vector
+> similarity. The hybrid retriever lives inside the AI worker and is invoked
+> by the chat completion endpoint below. See
+> [Hybrid Retrieval](/concepts/hybrid-retrieval) for the full design.
+
+## Run your first chat
+
+Chat completions stream tokens via Server-Sent Events. The session-authenticated
+endpoint (used by the dashboard) is:
+
+```http
+POST /api/v1/orgs/{org_id}/workspaces/{ws_id}/knowledge-bases/{kb_id}/completions
+Accept: text/event-stream
+Content-Type: application/json
+```
+
+Body (`model.ChatCompletionRequest` — `session_id` is optional; omit it on
+the first turn and Raven creates one, then echoes the `session_id` back so
+you can continue the conversation):
+
+```json
+{
+  "messages": [
+    { "role": "user", "content": "How do I get started?" }
+  ]
+}
+```
+
+Curl (`-N` disables buffering so you see tokens as they stream):
+
+```bash
+curl -N -X POST \
+  "$RAVEN_API/orgs/$ORG_ID/workspaces/$WS_ID/knowledge-bases/$KB_ID/completions" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Accept: text/event-stream" \
+  -H "Content-Type: application/json" \
+  -d '{"messages":[{"role":"user","content":"How do I get started?"}]}'
+```
+
+You will see SSE frames roughly like:
+
+```text
+event: session
+data: {"session_id":"sess_01H...","message_id":"msg_01H..."}
+
+event: token
+data: {"text":"To "}
+
+event: token
+data: {"text":"get started, "}
+
+event: sources
+data: {"sources":[{"document_id":"f3e2...","heading":"Quickstart","rank":0.81}]}
+
+event: done
+data: {"finish_reason":"stop"}
+```
+
+The streaming budget is capped at 30 seconds at the route level. Past
+conversations can be replayed from
+`GET /api/v1/orgs/{org_id}/kbs/{kb_id}/conversations` (cross-channel session
+history — see `internal/handler/conversation.go`).
+
+## What to try next
+
+- **Tune ingestion** — chunk size, parser overrides, deduplication: see
+  [Ingestion](/guides/ingestion).
+- **Tune retrieval** — top-K, similarity thresholds, filtering by document or
+  metadata: see [Retrieval](/guides/retrieval).
+- **Ship it to a website** — issue an API key and drop the widget on any page:
+  [Embed the Chat Widget](/get-started/embed-the-chat-widget).
+- **Compare your KB to the canonical example** — `internal/service/seed.go`
+  builds the `Raven Demo` org → `Movies` workspace → `Movie Database` KB and
+  ingests TMDB movie pages. It is the reference for what a populated KB looks
+  like at every layer (org, workspace, KB, document, chunk, embedding).
+
+## Quick checklist
+
+- [ ] Workspace created.
+- [ ] Knowledge base created.
+- [ ] At least one document uploaded (or one source crawled) and `processing_status = "ready"`.
+- [ ] Search returns at least one result for a query you know is in the document.
+- [ ] Chat returns a streaming reply that cites your document.
+
+When all five boxes are ticked, you have a fully working Raven knowledge base
+end to end. From here, every other guide on this site assumes this baseline.

--- a/docs-site/stubs/get-started/try-the-voice-agent.md
+++ b/docs-site/stubs/get-started/try-the-voice-agent.md
@@ -1,16 +1,329 @@
 ---
-title: "Coming Soon"
+title: "Try the Voice Agent"
 ---
 
 # Try the Voice Agent
 
-::: warning Stub page
-This page is a placeholder. The full content is being written. If you would
-like to contribute, the source for this page lives at the path shown below
-and you can [edit it on GitHub](https://github.com/ravencloak-org/Raven/edit/main/docs-site/stubs/get-started/try-the-voice-agent.md).
+Raven ships a real-time voice agent that joins a [LiveKit](https://livekit.io)
+room and talks to a user from the browser — no special hardware, no native
+client. This page walks through bringing it up against your own
+knowledge base on a full Compose stack.
+
+::: info Prefer the deeper guide?
+This is the get-started path. For sizing, retention tuning, and production
+deployment notes, see the [Voice guide](/guides/voice).
 :::
 
-## What goes here
+## Prerequisites
 
-A short bullet list of the topics this page will cover, drawn from the
-[design spec](https://github.com/ravencloak-org/Raven/blob/main/docs/superpowers/specs/2026-05-09-docs-site-design.md).
+The voice agent depends on two extra services that are **only present in
+the full Compose file**:
+
+| Service          | Image                            | Purpose                                |
+|------------------|----------------------------------|----------------------------------------|
+| `livekit-server` | `livekit/livekit-server:latest`  | WebRTC SFU; brokers audio between participants |
+| `python-agent`   | built from `./ai-worker`         | LiveKit Agents worker that joins rooms and runs the AI loop |
+
+Both are wired up in [`docker-compose.yml`][compose] and **excluded from**
+[`docker-compose.edge.yml`][compose-edge] — the edge variant is too small
+to host real-time media. Run the voice tutorial on the full stack:
+
+```bash
+docker compose up -d livekit-server python-agent go-api postgres valkey
+```
+
+You also need:
+
+- A workspace with at least one knowledge base (see
+  [First Knowledge Base](/get-started/first-knowledge-base)).
+- A microphone-capable browser (any modern Chromium or Firefox build).
+- The following environment variables set in your root `.env` before
+  bringing the stack up:
+
+```env
+LIVEKIT_API_KEY=devkey
+LIVEKIT_API_SECRET=devsecret
+```
+
+The agent container reads them as `RAVEN_LIVEKIT_API_KEY` and
+`RAVEN_LIVEKIT_API_SECRET`; the Go API reads them as the `livekit.api_key`
+and `livekit.api_secret` config keys. Defaults are deliberately the
+LiveKit `devkey`/`devsecret` pair — **rotate before exposing the stack to
+the internet**. See [Configuration](/reference/configuration) for the
+full key list.
+
+## How it works
+
+```
+┌──────────┐   1 join     ┌────────────────┐   2 join    ┌─────────────┐
+│ Browser  │ ───────────► │ livekit-server │ ◄────────── │ python-agent│
+│ (Vue UI) │ ◄ audio ────►│   (SFU :7880)  │◄─ audio ────│ (LiveKit    │
+└─────┬────┘              └────────────────┘             │  Agents)    │
+      │                                                  └──────┬──────┘
+      │ 3 create session + fetch token                          │
+      ▼                                                         │
+┌──────────┐                                                    │
+│ go-api   │                                                    │
+│ (Gin)    │                                                    │
+└─────┬────┘                                                    │
+      │ 4 RAG retrieval (Phase 2, not yet wired in the agent)   │
+      ▼                                                         │
+┌──────────┐                                                    │
+│ ai-worker│ ◄──────────────────────────────────────────────────┘
+│  (gRPC)  │
+└──────────┘
+```
+
+1. The browser asks the Go API for a voice session and gets back a
+   LiveKit access token.
+2. The browser connects to `livekit-server` on `ws://…:7880` using
+   [`livekit-client`][livekit-client] and joins the room named in the
+   session row.
+3. `python-agent` is a long-running [LiveKit Agents](https://docs.livekit.io/agents/)
+   worker that auto-subscribes to new rooms. Its entrypoint is
+   [`ai-worker/raven_worker/agent.py`][agent-py]:
+
+   ```python
+   # ai-worker/raven_worker/agent.py
+   return WorkerOptions(
+       entrypoint_fnc=_entrypoint,
+       ws_url=settings.livekit_url,
+       api_key=settings.livekit_api_key,
+       api_secret=settings.livekit_api_secret,
+       auto_subscribe=AutoSubscribe.AUDIO_ONLY,
+   )
+   ```
+
+4. When a room is created, `_entrypoint` joins, builds an `AgentSession`,
+   and (once wired — see below) hands user audio off to STT → LLM with
+   RAG retrieval → TTS, sending the synthesised reply back into the room.
+
+## Start a voice session from the dashboard
+
+The frontend already ships a complete UI for this. Routes are registered
+in `frontend/src/router/index.ts`:
+
+| Path                              | Page                       |
+|-----------------------------------|----------------------------|
+| `/orgs/:orgId/voice`              | `VoiceSessionListPage.vue` |
+| `/orgs/:orgId/voice/:sessionId`   | `VoiceSessionDetailPage.vue` |
+
+1. Sign in and switch to your org.
+2. Navigate to **Voice Sessions** (or `/orgs/<your-org-id>/voice`
+   directly).
+3. Click **New Session**. The
+   [`CreateSessionModal`][create-modal] lets you supply a room name
+   *or* leave it blank — the service layer auto-generates one of the form
+   `voice-<orgShort>-<uuidShort>` (see `generateRoomName` in
+   `internal/service/voice.go`).
+4. You'll be redirected to the session detail page. Click **Start
+   Session** (transitions state from `created` → `active`) and then
+   **Join LiveKit Room** — the page calls the token endpoint and opens
+   `${url}?token=<jwt>` in a new tab.
+5. Speak. The `python-agent` worker, which is already listening on the
+   LiveKit server, will join the room as a second participant.
+6. Click **End Session** to transition state to `ended`. This also
+   deletes the LiveKit room server-side.
+
+## Start a voice session from the API
+
+Every dashboard action is a thin wrapper over a REST call. The four you
+care about are defined in [`internal/handler/voice.go`][voice-handler]:
+
+```bash
+# 1. Create the session. Returns a row with state="created" and an
+#    auto-generated livekit_room.
+curl -X POST "https://raven.example.com/api/v1/orgs/$ORG_ID/voice-sessions" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+Response (truncated):
+
+```json
+{
+  "id": "f1d3b7c2-…",
+  "org_id": "…",
+  "livekit_room": "voice-ab12-cd34ef56",
+  "state": "created",
+  "created_at": "2026-05-12T10:14:22Z",
+  "updated_at": "2026-05-12T10:14:22Z"
+}
+```
+
+```bash
+# 2. Mint a LiveKit join token. URL is the same WS endpoint the agent
+#    uses; clients connect with livekit-client.
+curl -X POST \
+  "https://raven.example.com/api/v1/orgs/$ORG_ID/voice-sessions/$SESSION_ID/token" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+```json
+{
+  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9…",
+  "url":   "ws://livekit-server:7880"
+}
+```
+
+```bash
+# 3. Transition to active when the participant joins.
+curl -X PATCH \
+  "https://raven.example.com/api/v1/orgs/$ORG_ID/voice-sessions/$SESSION_ID" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"state":"active"}'
+
+# 4. End the session — derives call_duration_seconds and removes the room.
+curl -X PATCH \
+  "https://raven.example.com/api/v1/orgs/$ORG_ID/voice-sessions/$SESSION_ID" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"state":"ended"}'
+```
+
+The token returned at step 2 is a standard LiveKit JWT scoped to a single
+room. Hand it to `livekit-client` in the browser:
+
+```ts
+import { Room } from 'livekit-client'
+
+const { token, url } = await generateVoiceToken(orgId, sessionId)
+const room = new Room()
+await room.connect(url, token)
+```
+
+## Configure the LLM and STT/TTS providers
+
+The python-agent is wired up end-to-end at the **transport layer** today.
+The STT, LLM, and TTS plugins inside `_entrypoint` are tracked as separate
+work items — the source explicitly calls this out:
+
+```python
+# ai-worker/raven_worker/agent.py — inside _entrypoint
+session = AgentSession()
+
+# TODO (#59): Add STT plugin (Deepgram or faster-whisper)
+# TODO (#60): Add TTS plugin (Cartesia or Piper)
+# TODO: Connect to RAG pipeline via gRPC for knowledge retrieval
+```
+
+What this means in practice:
+
+- Audio flows between browser and agent over LiveKit today — you can
+  observe the agent joining the room and the
+  `agent_session_started` structlog event firing.
+- Transcription, LLM responses, and synthesised speech land in a
+  follow-up issue. Until then, the conversation is one-sided.
+
+The provider plumbing is already declared at the **Go side** in
+`internal/config/config.go` for the parallel HTTP-mode endpoints
+(`/v1/tts/*`, plus a future direct STT call). When the agent wires its
+plugins it will read the same settings:
+
+| Concern | Field        | Allowed values             | Default        |
+|---------|--------------|----------------------------|----------------|
+| TTS     | `tts.provider`         | `cartesia`, `piper`        | `cartesia`     |
+| TTS     | `tts.cartesia_model`   | Cartesia Sonic model id    | `sonic-2`      |
+| TTS     | `tts.piper_voice`      | Piper voice file           | `en_US-amy-medium` |
+| STT     | `stt.provider`         | `deepgram`, `whisper`      | `""` (unset)   |
+| STT     | `stt.whisper_model`    | Whisper model name         | (unset)        |
+| LiveKit | `livekit.ws_url`       | LiveKit WSS endpoint       | `ws://localhost:7880` |
+| LiveKit | `livekit.api_url`      | LiveKit HTTPS endpoint     | `http://localhost:7880` |
+
+Set these via Viper env vars (`RAVEN_TTS_PROVIDER`, `RAVEN_STT_PROVIDER`,
+etc.) — see [Configuration](/reference/configuration) for the env-var
+mapping rules.
+
+## Voice limits
+
+The service enforces two limits in `internal/service/voice.go`:
+
+- **Concurrent sessions per org** — resolved from the subscription tier
+  via `QuotaChecker.GetConcurrentVoiceLimit`. Free tier defaults to **1
+  active session**; exceeding it returns `429 Too Many Requests`. The
+  check uses a PostgreSQL advisory lock keyed by org id so concurrent
+  creates can't race past the cap.
+- **Monthly voice-minute quota** — `QuotaChecker.CheckVoiceMinuteQuota`
+  runs before each `CreateSession` and returns `402 Payment Required`
+  when the org is over plan.
+
+Per-turn state lives in `voice_turns` (transcript, `started_at`,
+`ended_at`, `speaker`). Session-level state lives in `voice_sessions`,
+with `call_duration_seconds` derived as a `GENERATED ALWAYS` column from
+`ended_at − started_at`. The schema lives in the migration introduced
+under [Issue #61][issue-61] and rolled up for billing by
+[Issue #69][issue-69]'s `voice_usage_summaries` table.
+
+## Storage and retention
+
+By default, Raven stores transcripts in PostgreSQL (`voice_turns`) and
+short-form audio clips in **SeaweedFS** alongside attachments. Retention
+defaults to **30 days** for voice audio, after which clips are purged and
+only the transcript remains; the privacy posture is documented in
+[`PRIVACY.md`][privacy], which calls out voice audio as a distinct
+processing category requiring consent for any retention beyond the
+default.
+
+If you need longer retention for compliance reasons, configure it
+explicitly per workspace — see the [Voice guide](/guides/voice) once it
+covers the retention knob.
+
+## Demo on the public docs site
+
+A hosted demo against the Raven docs workspace is **coming soon**. Until
+that lands, the closest you can get without standing up the full stack
+is the embedded chat widget on the
+[Installation page](/get-started/installation) — text-only, but it talks
+to the same RAG pipeline the voice agent will use once STT/TTS land.
+
+## Troubleshooting
+
+**The agent doesn't join the room.** Check
+`docker compose logs python-agent`. The most common errors come from
+[`agent.py`][agent-py] itself:
+
+- `livekit_credentials_missing` → set `RAVEN_LIVEKIT_API_KEY` /
+  `RAVEN_LIVEKIT_API_SECRET` and restart `python-agent`.
+- `livekit_agents_not_installed` → the container build is broken; run
+  `docker compose build python-agent`.
+
+**Browser connects but no audio flows.** LiveKit needs UDP ports
+`50000–60000` open. The compose file publishes them, but if you're
+behind a corporate firewall or a NAT that blocks UDP, switch to LiveKit
+Cloud (set `RAVEN_LIVEKIT_URL=wss://<your-project>.livekit.cloud` and
+the cloud project's API key/secret) or front the SFU with a TURN server.
+
+**Token returns 400 "cannot generate token for ended session".** Self-
+explanatory — you patched the session to `ended`. Create a new one.
+
+**Microphone permission silently denied.** Browsers require HTTPS for
+`getUserMedia` outside `localhost`. If you're testing on a LAN IP, either
+expose the frontend through Traefik with a real cert (see
+[Traefik & TLS](/guides/self-hosting/traefik-and-tls)) or run on
+`http://localhost:5173` directly.
+
+**Self-hosted vs LiveKit Cloud.** Self-hosting (the default) keeps audio
+on your network and uses the SFU container in compose. LiveKit Cloud
+trades that for a managed media plane; swap `RAVEN_LIVEKIT_URL` /
+`RAVEN_LIVEKIT_API_KEY` / `RAVEN_LIVEKIT_API_SECRET` to your cloud
+project values and leave everything else unchanged.
+
+## What's next
+
+- Read [Voice](/guides/voice) for production sizing and deployment knobs.
+- Read [AI Worker Design](/concepts/ai-worker-design) for the gRPC
+  service the agent will call into for RAG retrieval.
+- Read [Configuration](/reference/configuration) for the full LiveKit /
+  STT / TTS env-var matrix.
+
+[compose]: https://github.com/ravencloak-org/Raven/blob/main/docker-compose.yml
+[compose-edge]: https://github.com/ravencloak-org/Raven/blob/main/docker-compose.edge.yml
+[agent-py]: https://github.com/ravencloak-org/Raven/blob/main/ai-worker/raven_worker/agent.py
+[voice-handler]: https://github.com/ravencloak-org/Raven/blob/main/internal/handler/voice.go
+[create-modal]: https://github.com/ravencloak-org/Raven/blob/main/frontend/src/components/voice/CreateSessionModal.vue
+[livekit-client]: https://github.com/livekit/client-sdk-js
+[privacy]: https://github.com/ravencloak-org/Raven/blob/main/PRIVACY.md
+[issue-61]: https://github.com/ravencloak-org/Raven/issues/61
+[issue-69]: https://github.com/ravencloak-org/Raven/issues/69

--- a/docs-site/stubs/guides/billing.md
+++ b/docs-site/stubs/guides/billing.md
@@ -1,16 +1,269 @@
 ---
-title: "Coming Soon"
+title: "Billing"
 ---
 
 # Billing
 
-::: warning Stub page
-This page is a placeholder. The full content is being written. If you would
-like to contribute, the source for this page lives at the path shown below
-and you can [edit it on GitHub](https://github.com/ravencloak-org/Raven/edit/main/docs-site/stubs/guides/billing.md).
-:::
+Raven uses [Hyperswitch](https://opensource.hyperswitch.io/) as its payment
+gateway. Hyperswitch is an open-source unified payment-orchestration API that
+routes each charge to a downstream processor — Razorpay for UPI, RuPay, and
+domestic Indian cards; international card networks for everything else.
 
-## What goes here
+We did not pick Stripe. Stripe does not onboard merchants in India for our
+use case, which is the home market for the Raven-hosted offering. Hyperswitch
+gives us a single API surface while letting the routing layer pick the right
+local rails per transaction.
 
-A short bullet list of the topics this page will cover, drawn from the
-[design spec](https://github.com/ravencloak-org/Raven/blob/main/docs/superpowers/specs/2026-05-09-docs-site-design.md).
+This page is about how the Raven-hosted SaaS bills its customers. Customers
+also pay LLM providers directly — that part of the bill is **not** routed
+through Raven. See [LLM Providers](/guides/llm-providers) for the BYOK model.
+
+## What gets billed
+
+Raven only bills you for the platform itself. LLM token costs, embedding
+costs, and any provider-level charges are between you and Anthropic / OpenAI
+/ Cohere / your chosen provider.
+
+| Charge | Frequency | Notes |
+|---|---|---|
+| Subscription plan (Free / Pro / Enterprise) | Monthly | Flat fee per organisation. Defined in `model.DefaultPlans()` (`internal/model/billing.go`). |
+| Seats (users above plan limit) | Monthly | Enforced by quota check — see `MaxUsers` on each plan. Today over-limit users are blocked, not auto-billed. |
+| Knowledge bases above plan limit | Monthly | Same shape as seats. `MaxKBs` is enforced; over-limit creation is blocked. |
+| Storage above plan limit | Monthly | `MaxStorageMB`; enforced, not metered overage. |
+| Voice minutes above plan limit | Monthly | `MaxVoiceMinutesMonthly`; enforced, not metered overage. |
+| LLM tokens | n/a | Not billed by Raven. BYOK, paid to provider. |
+
+The codebase is honest about its current shape: the plan structure exists,
+the **quotas are enforced**, but **metered overage billing is not yet wired**.
+Going over a limit returns `402 Payment Required` from `/billing/usage` and
+related endpoints. Upgrading the plan is the supported path; per-unit
+overage invoices are a future addition.
+
+## Hyperswitch architecture
+
+Raven's API server talks to Hyperswitch over HTTP. Hyperswitch then decides
+which downstream processor handles the actual money movement.
+
+```
+┌──────────────┐   POST /payments   ┌──────────────┐   ┌───────────────┐
+│  Raven API   │ ─────────────────▶ │ Hyperswitch  │ ─▶│  Razorpay     │
+│  (Go, Gin)   │                    │ orchestrator │   │  (UPI/card)   │
+│              │ ◀───── webhook ─── │              │ ─▶│  Card networks│
+└──────────────┘  HMAC-SHA256 sig   └──────────────┘   └───────────────┘
+```
+
+The HTTP client lives at `internal/hyperswitch/client.go`. It is a thin
+wrapper around `POST /payments`, `POST /payments/{id}/cancel`, and
+`GET /payments/{id}`. The package doc-comment is the canonical description:
+
+> Package hyperswitch provides an HTTP client for the Hyperswitch payment
+> orchestration API. Hyperswitch acts as the routing layer and connects to
+> downstream payment processors (e.g. Razorpay for UPI/card in India).
+
+Three environment variables drive the integration. They are bound in
+`internal/config/config.go` and consumed by the billing service:
+
+| Env var | Maps to | Purpose |
+|---|---|---|
+| `RAVEN_HYPERSWITCH_BASE_URL` | `hyperswitch.base_url` | Hyperswitch instance URL. Defaults to `http://localhost:8090`. |
+| `RAVEN_HYPERSWITCH_API_KEY` | `hyperswitch.api_key` | Merchant API key. Empty in dev defaults. |
+| `RAVEN_HYPERSWITCH_WEBHOOK_SECRET` | `hyperswitch.webhook_secret` | HMAC-SHA256 secret for inbound webhook verification. |
+| `RAVEN_HYPERSWITCH_RAZORPAY_KEY_ID` | `hyperswitch.razorpay_key_id` | Razorpay merchant key (used when Razorpay is the routed processor). |
+
+If `RAVEN_HYPERSWITCH_WEBHOOK_SECRET` is empty, the webhook handler **rejects
+every event** with the error `webhook signature verification is not
+configured`. That is by design — silently accepting unsigned events would let
+anyone with the URL activate subscriptions.
+
+See [Configuration](/reference/configuration) for the full env-var reference.
+
+## Plans and tiers
+
+Three plans ship in the codebase today. Prices are in cents and live in
+`model.DefaultPlans()`:
+
+| Plan | ID | Monthly | Users | Workspaces | KBs | Storage | Voice mins/mo |
+|---|---|---|---|---|---|---|---|
+| Free | `plan_free` | $0.00 | 5 | 2 | 3 | 500 MB | 60 |
+| Pro | `plan_pro` | $29.00 | 25 | 10 | 50 | 10 GB | 1 200 |
+| Enterprise | `plan_enterprise` | $99.00 | unlimited | unlimited | unlimited | unlimited | unlimited |
+
+Plans are returned by `GET /api/v1/billing/plans`. Frontend types live in
+`frontend/src/api/billing.ts` (`PlanName = 'free' | 'pro' | 'enterprise'`).
+
+Currency is reported in USD in code but Hyperswitch + Razorpay routing is
+expected to convert / display INR for Indian merchants — the `payment_intents`
+table defaults to `INR` (see `migrations/00033_payment_intents.sql`). The
+canonical currency for a billed transaction is whatever the `PaymentIntent`
+row stores.
+
+## Subscription lifecycle
+
+A subscription is one row in the `subscriptions` table (`migrations/00019_subscriptions.sql`).
+The valid statuses are defined as a `CHECK` constraint in the migration and
+as Go constants in `model.SubscriptionStatus`:
+
+```
+trialing ─┐
+          ├─▶ active ─┬─▶ past_due ──▶ canceled
+          │           │
+          │           └─▶ paused ──▶ active
+          │
+          └─▶ canceled
+                          expired
+```
+
+| Status | Set by | Meaning |
+|---|---|---|
+| `trialing` | Service (future) | Trial period; access granted, no charge. |
+| `active` | Initial insert / webhook `payment_succeeded` | Plan is paid and current. |
+| `past_due` | Webhook `payment_failed` | Renewal payment failed; access policy is per-handler. |
+| `canceled` | `DELETE /billing/subscriptions/:id` or webhook `subscription_cancelled` | Tenant or processor cancelled. |
+| `paused` | Reserved | Defined in schema; not currently emitted by the service. |
+| `expired` | Reserved | Defined in schema; not currently emitted by the service. |
+
+A partial unique index enforces **one active-ish subscription per org**:
+
+```sql
+CREATE UNIQUE INDEX idx_subscriptions_org_active
+    ON subscriptions (org_id)
+    WHERE status IN ('active', 'trialing', 'past_due');
+```
+
+Honest gap: the service today only emits `active` (on create), and transitions
+to `canceled` or `past_due` driven by webhooks. `trialing`, `paused`, and
+`expired` are schema-ready but not yet wired into a service path.
+
+## Payment methods
+
+Whatever Hyperswitch routes to. The two production routes wired today:
+
+- **UPI, RuPay, and domestic Indian cards** via the Razorpay connector.
+  `RAVEN_HYPERSWITCH_RAZORPAY_KEY_ID` is the merchant key.
+- **International cards** via the default Hyperswitch connector chain. The
+  exact routing rules live in the Hyperswitch dashboard, not in Raven.
+
+The frontend opens the Hyperswitch SDK / Razorpay checkout using the
+`client_secret` returned from `POST /api/v1/billing/payment-intents`. The
+secret is a transient field on the `Subscription` and `PaymentIntent` models
+(`json:"client_secret,omitempty"`); it is **never persisted**.
+
+## Webhooks
+
+Hyperswitch posts payment events to `POST /api/v1/billing/webhook`. This
+endpoint **does not** use JWT auth — it verifies an `X-Webhook-Signature`
+header (HMAC-SHA256 of the raw body, hex-encoded, keyed by
+`RAVEN_HYPERSWITCH_WEBHOOK_SECRET`).
+
+Implementation: `internal/handler/billing.go` (`(h *BillingHandler).Webhook`)
+delegates to `internal/service/billing.go` (`HandleWebhook`). The handler
+caps body size at 1 MB.
+
+The payload shape is intentionally generic:
+
+```go
+type HyperswitchWebhookPayload struct {
+    EventType string         `json:"event_type"`
+    Content   map[string]any `json:"content"`
+}
+```
+
+The service handles three event types and ignores the rest with an info log:
+
+| `event_type` | Action |
+|---|---|
+| `payment_succeeded` | Insert into `payment_events` (idempotent by `(payment_id, event_type)`), extend `current_period_end` on the matching subscription. |
+| `payment_failed` | Insert into `payment_events`, leave subscription state alone (move to `past_due` is handled elsewhere by caller policy). |
+| `subscription_cancelled` | Insert into `payment_events`, mark subscription `canceled`. |
+
+`payment_events` exists for **idempotency**: replaying any event is a no-op.
+A unique index on `(payment_id, event_type)` blocks double-application. See
+`migrations/00032_billing_rls_and_payment_events.sql`.
+
+Both `subscriptions` and `payment_events` have row-level security enabled.
+The webhook handler bypasses RLS for one transaction by calling
+`SELECT set_config('app.bypass_rls', 'true', true)`, because the caller has
+no org context. Org attribution comes from `content.metadata.org_id` in the
+event payload, which Raven puts there when it creates the payment.
+
+## Tax and invoicing
+
+Honest about the MVP:
+
+- **GST / VAT computation**: Not done by Raven. Hyperswitch / Razorpay are
+  expected to handle this at the processor level for Indian transactions.
+- **Invoice generation**: Not implemented. There is no `invoices` table and
+  no PDF rendering path. Customers see line-items in the Hyperswitch /
+  Razorpay receipt email.
+- **Dunning** (retry-on-failure for `past_due`): Not implemented in Raven;
+  whatever Hyperswitch does at the connector layer is what you get.
+- **Proration on plan change**: Not implemented. Plan changes apply at the
+  next period boundary; the migration doesn't track mid-period changes.
+
+These are tracked gaps. If you need a tax-compliant invoice today, pull it
+from the Hyperswitch dashboard, not the Raven UI.
+
+## Test mode
+
+Raven ships a local Hyperswitch stack under `deploy/hyperswitch/` for
+development. It is **not** part of the main `docker-compose.yml` — you bring
+it up separately:
+
+```bash
+docker compose -f deploy/hyperswitch/docker-compose.hyperswitch.yml up -d
+```
+
+That brings up:
+
+- The Hyperswitch application server (port `8090` by default — matches the
+  `RAVEN_HYPERSWITCH_BASE_URL` default).
+- Its backing PostgreSQL.
+- Its Redis instance.
+- The Hyperswitch web client (control center) for managing connectors and
+  API keys.
+
+Default admin API key: `test_admin`. Merchant API keys are minted through
+the dashboard or API once the stack is up.
+
+For sandbox card / UPI numbers, use the test credentials documented at
+[opensource.hyperswitch.io](https://opensource.hyperswitch.io/) — the test
+data is upstream, not duplicated in this repo.
+
+To test webhook delivery: configure the webhook destination in the
+Hyperswitch dashboard to point at your Raven API's
+`/api/v1/billing/webhook`. Use the dashboard's "send test event" feature
+once `RAVEN_HYPERSWITCH_WEBHOOK_SECRET` matches on both sides.
+
+## Self-host vs Raven-hosted
+
+This page is about the **Raven-hosted SaaS**. If you are running Raven on
+your own infrastructure — Docker Compose, an edge node, a Raspberry Pi — you
+generally do **not** need Hyperswitch at all:
+
+- There is no SaaS subscription to charge for; the software is yours.
+- The `subscriptions` table will simply not be populated, and your org
+  defaults to the implicit Free-tier subscription returned by
+  `model.DefaultFreeSubscription()`.
+- Plan limits still apply in code, but you can either change the defaults
+  or run on Enterprise quotas (all limits `-1`).
+
+Self-hosters can safely skip the rest of this guide. If you are building
+your own multi-tenant offering on top of Raven and need billing of your own,
+you can either point Raven at your own Hyperswitch tenant or wire a
+different gateway behind the same `BillingService` interface — the
+hyperswitch package is the only place the gateway choice leaks.
+
+See [Self-Hosting → Docker Compose](/guides/self-hosting/docker-compose) for
+the operator path that skips billing entirely.
+
+## Related
+
+- [Configuration reference](/reference/configuration) — full env-var list
+  including the `RAVEN_HYPERSWITCH_*` variables.
+- [Workspaces & Tenancy](/guides/workspaces-and-tenancy) — how plans, quotas,
+  and org isolation tie together.
+- [LLM Providers](/guides/llm-providers) — BYOK model for the
+  Anthropic / OpenAI / Cohere bill that Raven does **not** collect.
+- [Webhooks & Events](/guides/webhooks-and-events) — Raven's own outbound
+  webhook system (separate from the inbound Hyperswitch webhook discussed
+  here).

--- a/docs-site/stubs/guides/ingestion.md
+++ b/docs-site/stubs/guides/ingestion.md
@@ -1,16 +1,395 @@
 ---
-title: "Coming Soon"
+title: "Ingestion"
 ---
 
 # Ingestion
 
-::: warning Stub page
-This page is a placeholder. The full content is being written. If you would
-like to contribute, the source for this page lives at the path shown below
-and you can [edit it on GitHub](https://github.com/ravencloak-org/Raven/edit/main/docs-site/stubs/guides/ingestion.md).
-:::
+Ingestion is the path that turns raw input — uploaded files or scraped web
+pages — into chunks and embeddings that the retrieval pipeline can search.
+It is multi-stage, asynchronous, and tenant-isolated end to end:
 
-## What goes here
+```
+client → POST /documents (or /sources) → documents/sources row (queued)
+       → Asynq enqueue (Valkey)
+       → ai-worker: parse → chunk → embed
+       → chunks + embeddings rows (status=ready)
+```
 
-A short bullet list of the topics this page will cover, drawn from the
-[design spec](https://github.com/ravencloak-org/Raven/blob/main/docs/superpowers/specs/2026-05-09-docs-site-design.md).
+Every stage writes status back to the `documents.processing_status` (or
+`sources.processing_status`) column, so the UI and operators can observe
+progress without polling internal queues.
+
+## Source types
+
+Raven ingests two source families today. The third (connectors) is wired
+through the Asynq `airbyte:sync` task type but is not exposed via a
+first-class REST endpoint yet.
+
+| Type | Where the data comes from | Parser |
+|------|---------------------------|--------|
+| File upload (PDF) | `multipart/form-data` to `/documents/upload` → SeaweedFS | `DocumentParser` shelling out to the LiteParse CLI (`ai-worker/raven_worker/processors/parser.py`) |
+| File upload (DOCX, PPTX) | Same multipart endpoint | LiteParse CLI subprocess |
+| File upload (images: PNG, JPEG, TIFF, WebP) | Same multipart endpoint | LiteParse CLI with OCR |
+| File upload (Markdown, HTML, plain text) | Same multipart endpoint | Handled directly in `DocumentParser` (no subprocess) |
+| Web page | `POST /sources` with a URL | `WebScraper` (httpx + BeautifulSoup) in `ai-worker/raven_worker/processors/scraper.py` |
+| Sitemap / RSS / website crawl | `POST /sources` with `source_type` of `sitemap`, `rss_feed`, or `web_site` (see `internal/model/source.go`) | `WebScraper`, optionally recursive up to `crawl_depth` |
+| Airbyte connector sync | Internal — `queue.TypeAirbyteSync` (`airbyte:sync`) in `internal/queue/tasks.go` | Connector-specific; not yet exposed in the public API |
+
+The allowlist that the upload handler enforces is controlled by
+`RAVEN_UPLOAD_ALLOWED_TYPES` and defaults to PDF, DOCX, PPTX, HTML, MD, TXT,
+and CSV. See [Configuration](/reference/configuration) for the full env-var
+matrix.
+
+## Pipeline overview
+
+The ingestion pipeline is intentionally split between the Go API and the
+Python AI worker. The Go side owns the database transaction; the Python side
+owns the heavy CPU/GPU work.
+
+1. **API receives the source** — the upload handler
+   ([`internal/handler/upload.go`](https://github.com/ravencloak-org/Raven/blob/main/internal/handler/upload.go))
+   validates the MIME type, enforces the 50 MB default upload cap, and
+   streams the file to SeaweedFS via the storage client
+   (`internal/storage/seaweedfs.go`). For URL sources, the source handler
+   ([`internal/handler/source.go`](https://github.com/ravencloak-org/Raven/blob/main/internal/handler/source.go))
+   validates the URL and persists a `sources` row.
+2. **Document record created** — a `documents` row (see
+   `migrations/00008_documents.sql`) is inserted with
+   `processing_status = 'queued'`, the SeaweedFS `storage_path` (fid), the
+   `file_hash`, and the uploader's user ID. Row-level security
+   (`tenant_isolation` policy) confines all reads/writes to the caller's
+   `org_id`.
+3. **Asynq job enqueued** — the API calls
+   `queue.Client.EnqueueDocumentProcess` (or `EnqueueURLScrape`) with the
+   `org_id` / `document_id` / `knowledge_base_id` payload. The task type is
+   `document:process` or `url:scrape` (see
+   [`internal/queue/tasks.go`](https://github.com/ravencloak-org/Raven/blob/main/internal/queue/tasks.go)).
+   Tasks land on the `default` queue in Valkey with `MaxRetry=5`.
+4. **Worker picks up** — the Go worker process
+   (`internal/jobs/document_process.go`) drains the Asynq queue, fetches the
+   document by ID, downloads the bytes from SeaweedFS, and updates the
+   document status to `parsing`.
+5. **Parser extracts text** — the Go worker invokes the AI worker over gRPC
+   to parse the bytes. `DocumentParser` routes PDFs, Office files, and
+   images through the LiteParse CLI subprocess and reads plain text /
+   Markdown / HTML directly.
+6. **Chunker splits** — once text is in hand, the worker advances status to
+   `chunking` and runs the chunker (see below).
+7. **Embedder writes vectors** — for each chunk the worker calls the AI
+   worker's `GetEmbedding` RPC
+   (`ai-worker/raven_worker/services/embedding.py`), then writes one row to
+   `chunks` and one row to `embeddings` per chunk. Status flips to
+   `embedding`, then `ready` on completion.
+8. **On failure** — any error sets `processing_status = 'failed'` and writes
+   the message to `processing_error`. Asynq keeps the task in its retry
+   queue up to `MaxRetry`; after that, the task is archived.
+
+The seed service
+([`internal/service/seed.go`](https://github.com/ravencloak-org/Raven/blob/main/internal/service/seed.go))
+walks exactly this path: it renders a TMDB movie to Markdown, uploads via
+`storage.Client.Upload`, inserts a `documents` row, and calls
+`queue.Client.EnqueueDocumentProcess`. Reading `processMovie` is the
+shortest way to internalise the end-to-end flow.
+
+## Upload a file
+
+The upload endpoint accepts a single file per request as
+`multipart/form-data` with the field name `file`:
+
+```bash
+curl -X POST \
+  "https://api.example.com/api/v1/orgs/${ORG_ID}/workspaces/${WS_ID}/knowledge-bases/${KB_ID}/documents/upload" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -F "file=@./onboarding.pdf"
+```
+
+Successful uploads return `201 Created` with `model.UploadDocumentResponse`:
+
+```json
+{
+  "id": "8e7f...",
+  "org_id": "...",
+  "knowledge_base_id": "...",
+  "file_name": "onboarding.pdf",
+  "file_type": "application/pdf",
+  "file_size_bytes": 1453221,
+  "file_hash": "a1b2c3...",
+  "storage_path": "3,01a7b9...",
+  "processing_status": "queued",
+  "uploaded_by": "...",
+  "created_at": "2026-05-12T09:14:22Z"
+}
+```
+
+A few operator-relevant details:
+
+- The handler runs under a 60-second deadline (`middleware.Deadline(60*time.Second)`
+  in `cmd/api/main.go`).
+- The default size cap is 50 MB (`RAVEN_UPLOAD_MAX_SIZE_BYTES=52428800`).
+- Bytes go to **SeaweedFS**, not the host filesystem. The returned
+  `storage_path` is the SeaweedFS fid; downstream jobs use it to re-download
+  the blob.
+- `file_hash` (SHA-256 of the upload) is stored on the row and indexed —
+  see [Reingest / update](#reingest-update) below for how it's used.
+
+## Add a web source
+
+Use the source endpoint for anything reachable by URL:
+
+```bash
+curl -X POST \
+  "https://api.example.com/api/v1/orgs/${ORG_ID}/workspaces/${WS_ID}/knowledge-bases/${KB_ID}/sources" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "source_type": "web_page",
+        "url": "https://example.com/docs",
+        "crawl_depth": 1,
+        "crawl_frequency": "manual"
+      }'
+```
+
+`source_type` is one of `web_page`, `web_site`, `sitemap`, or `rss_feed`
+(see `internal/model/source.go`). `crawl_frequency` can be `manual`,
+`daily`, `weekly`, or `monthly`; daily/weekly/monthly sources are re-crawled
+by the scheduler.
+
+The scraper enforces robots.txt by default. From
+`ai-worker/raven_worker/processors/scraper.py`:
+
+```python
+class WebScraper:
+    """Scrape web pages using httpx + BeautifulSoup4.
+
+    Features:
+    - Follows redirects (httpx default behaviour)
+    - Respects robots.txt
+    - Extracts clean text from HTML
+    - Captures page title and meta description
+    """
+```
+
+It identifies itself as `RavenBot/1.0 (+https://github.com/AumniPrime/raven)`.
+If `robots.txt` disallows the path, the scraper raises
+`RobotsTxtDisallowedError` and the source moves to `failed` — there is no
+override flag, by design. Self-hosters who want to bypass robots.txt on
+their own intranet can construct a `WebScraper` with `respect_robots=False`,
+but the API never exposes that knob.
+
+## Chunking strategy
+
+Chunking lives in
+[`ai-worker/raven_worker/processors/chunker.py`](https://github.com/ravencloak-org/Raven/blob/main/ai-worker/raven_worker/processors/chunker.py).
+It wraps `langchain_text_splitters.RecursiveCharacterTextSplitter` (declared
+as `langchain-text-splitters>=0.3.0` in `ai-worker/pyproject.toml`).
+
+The defaults are intentionally conservative for RAG workloads:
+
+```python
+_CHARS_PER_TOKEN = 4
+DEFAULT_CHUNK_SIZE_TOKENS = 512
+DEFAULT_CHUNK_OVERLAP_TOKENS = 50
+DEFAULT_CHUNK_SIZE = DEFAULT_CHUNK_SIZE_TOKENS * _CHARS_PER_TOKEN  # 2048
+DEFAULT_CHUNK_OVERLAP = DEFAULT_CHUNK_OVERLAP_TOKENS * _CHARS_PER_TOKEN  # 200
+```
+
+So: **~512 tokens per chunk, ~50 tokens overlap**, measured in characters
+(`length_function` is `len`, not a tokenizer). Headings are not used as
+hard boundaries, but the splitter is given a separator ladder that prefers
+paragraph breaks over arbitrary character splits:
+
+```python
+_DEFAULT_SEPARATORS = [
+    "\n\n",  # paragraph
+    "\n",    # line
+    ". ",    # sentence
+    ", ",    # clause
+    " ",     # word
+    "",      # character
+]
+```
+
+`TextChunker.chunk_with_metadata` additionally attaches a `chunk_index`, the
+source identifier, and a `heading` field when the first line of a chunk
+looks like a heading, all of which land in `chunks.metadata` (JSONB) and on
+`chunks.heading`. The chunk record itself lives in
+`migrations/00010_chunks_and_embeddings.sql`:
+
+```sql
+CREATE TABLE chunks (
+    ...
+    content TEXT NOT NULL,
+    chunk_index INTEGER NOT NULL,
+    token_count INTEGER,
+    page_number INTEGER,
+    heading VARCHAR(500),
+    chunk_type chunk_type NOT NULL DEFAULT 'text',
+    ...
+);
+CREATE INDEX idx_chunks_content_fts ON chunks USING gin(to_tsvector('english', content));
+```
+
+The GIN index over `to_tsvector('english', content)` is what backs the BM25
+arm of [hybrid retrieval](/concepts/hybrid-retrieval). Chunks are emitted
+even before embeddings exist, which means lexical search starts working as
+soon as the chunker finishes — useful when an embedding provider is slow or
+rate-limited.
+
+## Embedding
+
+Embeddings are bring-your-own-key. The Go side never makes the upstream
+provider call; it sends each chunk to the AI worker over gRPC, and the
+worker looks up the org's configured provider before calling out:
+
+```python
+class EmbeddingServicer:
+    async def get_embedding(self, request, context):
+        provider = await get_provider_for_request(
+            request.org_id,
+            request.provider,
+            request.model,
+        )
+        embedding = await provider.embed(request.text)
+        return ai_worker_pb2.EmbeddingResponse(
+            embedding=embedding,
+            dimensions=len(embedding),
+        )
+```
+
+Provider clients live under `ai-worker/raven_worker/providers/` and cover
+OpenAI, Cohere, and Anthropic (see the `openai`, `cohere`, and `anthropic`
+dependencies in `ai-worker/pyproject.toml`). The default deployment uses
+OpenAI `text-embedding-3-small`, which produces **1536-dimensional**
+vectors — the same dimension the `embeddings.embedding` column is declared
+as:
+
+```sql
+CREATE TABLE embeddings (
+    ...
+    embedding vector(1536) NOT NULL,
+    model_name VARCHAR(100) NOT NULL,
+    model_version VARCHAR(50),
+    dimensions INTEGER NOT NULL,
+    UNIQUE(chunk_id, model_name)
+);
+CREATE INDEX idx_embeddings_hnsw ON embeddings USING hnsw (embedding vector_cosine_ops)
+    WITH (m = 16, ef_construction = 64);
+```
+
+A single chunk can carry multiple embeddings, one per `model_name`, but
+each (chunk, model) pair is unique. The HNSW index is built with
+`m = 16, ef_construction = 64` and uses cosine distance. If you swap to a
+provider with a different vector dimension, you need a new migration that
+drops and re-creates the column — Postgres rejects vectors of the wrong
+size at insert time. See [Configuration](/reference/configuration) for how
+to set the per-org provider and model.
+
+## Reingest / update
+
+There is no `reingest` endpoint today. The behaviour depends on how the
+content arrives:
+
+- **Re-uploading the same file** — a fresh row is inserted; the `file_hash`
+  column makes duplicates discoverable, but the upload service does not
+  silently deduplicate. If you want to replace a document, `DELETE` the old
+  row (cascades to chunks and embeddings via the FK) then upload the new
+  copy.
+- **Editing document metadata** — `PUT /documents/{doc_id}` accepts
+  `UpdateDocumentRequest` (title, metadata only). It does **not** trigger
+  re-processing.
+- **Recurring URL crawls** — sources with `crawl_frequency` set to
+  `daily`, `weekly`, or `monthly` are re-scraped by the scheduler; each
+  crawl writes fresh chunks and embeddings under the same `source_id`.
+- **Knowledge-base wide reindex** — for full recomputation of embeddings
+  (e.g. after changing the embedding model), use the
+  `queue.TypeReindex` task (`kb:reindex`). It is enqueued via the
+  `EnqueueReindex` client method on the low-priority queue. There is no
+  public REST endpoint for this yet; trigger it from an admin tool.
+
+The `processing_status` enum has a dedicated `reprocessing` state for the
+in-flight case, distinct from the initial `queued` → `ready` arc.
+
+## Bulk ingest
+
+There is no single bulk-import endpoint. The supported patterns are:
+
+- **Many files, scripted** — loop the upload endpoint client-side, one file
+  per request. Honour the org's general rate limit
+  (`RAVEN_RATELIMIT_DEFAULT_USER_LIMIT`, defaults to 1000 RPM) and the tier
+  limits (`RAVEN_RATELIMIT_FREE_GENERAL_RPM=60`,
+  `RAVEN_RATELIMIT_PRO_GENERAL_RPM=600`,
+  `RAVEN_RATELIMIT_ENTERPRISE_GENERAL_RPM=6000`). The 60 s handler deadline
+  is per-request, not per-batch.
+- **Many URLs** — submit one `POST /sources` per URL. For a whole site,
+  prefer `source_type = "web_site"` or `"sitemap"` with an appropriate
+  `crawl_depth`; the scraper handles the fan-out inside one Asynq job.
+- **Seed-style bootstrap** — the seed service is the reference for
+  programmatic ingest. Self-hosters can adapt the pattern in
+  `internal/service/seed.go` (render → `storage.Upload` → `docRepo.Create`
+  → `qCli.EnqueueDocumentProcess`) to import data already in a tabular
+  form.
+
+Concurrency at the queue layer is governed by the AI worker's
+`grpc_max_workers` (defaults to `10`, configurable via
+`RAVEN_GRPC_MAX_WORKERS`). Scaling ingestion throughput beyond that is a
+matter of running more AI-worker replicas — they share the Valkey-backed
+queue.
+
+## Failures
+
+When something goes wrong, Asynq re-queues the task automatically. Each
+task is enqueued with `asynq.MaxRetry(c.maxRetry)` (default `5`, see
+`internal/queue/client.go`), so transient parser failures, scraper
+timeouts, and embedding-provider 429s usually recover on their own.
+
+To investigate stuck or failed ingests:
+
+1. **Check the document row** — `processing_status` will be `failed` and
+   `processing_error` will hold the last error message.
+2. **Read the worker logs** — both the Go worker
+   (`internal/jobs/document_process.go`) and the AI worker emit structured
+   `structlog` events. Filter on `document_id` and `org_id`. Logs are
+   shipped to OpenObserve in self-hosted deployments (see
+   [Observability](/guides/self-hosting/observability)).
+3. **Inspect Asynq directly** — Raven does not ship Asynqmon in the default
+   Compose. For deep queue debugging, run `asynqmon` against the same
+   Valkey instance:
+
+   ```bash
+   docker run --rm -p 8080:8080 \
+     hibiken/asynqmon --redis-addr=valkey:6379
+   ```
+
+   then browse to `http://localhost:8080`. Use the `default` queue for
+   document processing and URL scraping; `low` for KB reindex tasks.
+
+After `MaxRetry` failures the task lands in Asynq's archived set. From
+there you can replay it via Asynqmon's "Run" button after fixing the
+underlying issue (parser misconfiguration, provider credentials, etc.).
+
+## Storage costs
+
+Raven splits ingested content across three stores. Rough per-document
+sizing for an average 10 MB PDF:
+
+| Where it lives | What it holds | Approximate size |
+|----------------|---------------|------------------|
+| SeaweedFS | The original file bytes | 10 MB (= the upload size; no compression by default) |
+| Postgres `chunks` table | UTF-8 text + small metadata JSONB | ~1.5 × the extracted text; for a 10 MB PDF that's typically 200–500 KB of chunk text |
+| Postgres `embeddings` table (pgvector) | One `vector(1536)` per chunk plus an HNSW entry | ~6 KB per chunk for the vector itself (1536 × 4 bytes), plus index overhead. A 200-chunk document is ~1.2 MB on disk before indexes. |
+
+The HNSW index (`m = 16, ef_construction = 64`) materially inflates the
+embeddings table — budget roughly 2–3× the raw vector size for the index.
+For typical knowledge bases, **embeddings dominate the Postgres footprint
+within a couple of months**; SeaweedFS dominates the overall storage
+budget. Plan capacity accordingly, and run `VACUUM (ANALYZE)` after large
+reingests so the planner picks the right index.
+
+## See also
+
+- [Hybrid retrieval](/concepts/hybrid-retrieval) — how chunks and
+  embeddings are searched together.
+- [Retrieval](/guides/retrieval) — the read side of the pipeline.
+- [Configuration](/reference/configuration) — the env vars referenced
+  throughout this guide (upload limits, rate limits, embedding provider,
+  AI-worker tuning).

--- a/docs-site/stubs/guides/llm-providers.md
+++ b/docs-site/stubs/guides/llm-providers.md
@@ -1,16 +1,327 @@
 ---
-title: "Coming Soon"
+title: "LLM Providers"
 ---
 
 # LLM Providers
 
-::: warning Stub page
-This page is a placeholder. The full content is being written. If you would
-like to contribute, the source for this page lives at the path shown below
-and you can [edit it on GitHub](https://github.com/ravencloak-org/Raven/edit/main/docs-site/stubs/guides/llm-providers.md).
-:::
+Raven is **bring-your-own-key (BYOK)**. You supply credentials for the LLM
+providers you want to use; Raven encrypts them at rest with AES-256-GCM,
+decrypts them in-memory per request, and forwards the call to the upstream
+provider. Token costs are billed by the provider directly to your account —
+Raven never proxies money through itself.
 
-## What goes here
+Supported providers, in the enum that backs `llm_provider_configs.provider`:
 
-A short bullet list of the topics this page will cover, drawn from the
-[design spec](https://github.com/ravencloak-org/Raven/blob/main/docs/superpowers/specs/2026-05-09-docs-site-design.md).
+- `anthropic` — Claude family (chat / RAG generation)
+- `openai` — GPT models (chat) and `text-embedding-3-*` (embeddings)
+- `cohere` — `command-*` (chat), `embed-*` (embeddings), `rerank-*` (reranker)
+- `ollama` — local self-hosted models (chat + embeddings, **no API key**)
+- `google`, `azure_openai`, `custom` — enum values reserved; concrete
+  provider classes not wired yet
+
+The supported set is enforced in two places: the Go enum in
+[`internal/model/llm_provider.go`](https://github.com/ravencloak-org/Raven/blob/main/internal/model/llm_provider.go)
+and the Python registry in
+[`ai-worker/raven_worker/providers/registry.py`](https://github.com/ravencloak-org/Raven/blob/main/ai-worker/raven_worker/providers/registry.py).
+
+## Provider matrix
+
+| Provider    | Default chat / generation model       | Default embedding model               | Reranking            | API key required | Notes                                                            |
+|-------------|---------------------------------------|---------------------------------------|----------------------|------------------|------------------------------------------------------------------|
+| `anthropic` | `claude-*` (passed per request)       | — (stub: `NotImplementedError`)       | —                    | yes              | Supports prompt caching + memory tool in the streaming RAG path. |
+| `openai`    | `gpt-*` (passed per request)          | `text-embedding-3-small` (1536 dims)  | —                    | yes              | 429 rate-limit errors retried with `tenacity` exponential back-off (max 5 attempts). |
+| `cohere`    | `command-*` (passed per request)      | `embed-english-v3.0` (1024 dims)      | `rerank-english-v3.0` | yes             | **Default reranker** for hybrid retrieval. Required only if `filters.rerank == "cohere"`. |
+| `ollama`    | model name passed per request         | `nomic-embed-text` (768 dims)         | —                    | **no**           | Talks to a local Ollama daemon at `OLLAMA_BASE_URL` (default `http://ollama:11434`). |
+
+Provider keys are scoped per **organisation**, not per workspace or KB.
+The active model and provider are selected **per request**.
+
+## Configure a provider (UI)
+
+1. Sign in and open the workspace switcher → **Settings** → **LLM Providers**.
+2. Click **Add provider**, pick a type (`openai` / `anthropic` / `cohere` /
+   `ollama`), and give it a `display_name` (the friendly label the dashboard
+   shows).
+3. Paste the upstream API key. The frontend submits it to
+   `POST /api/v1/orgs/{org_id}/llm-providers`; the server encrypts it with
+   AES-256-GCM before INSERT.
+4. Tick **Set as default** if you want this provider used when a request does
+   not name one explicitly. Only one provider per organisation can be the
+   default (`is_default = true` on `llm_provider_configs`).
+
+The UI lives in `frontend/src/api/llm-providers.ts` and its consuming Vue
+components.
+
+## Configure a provider (API)
+
+`org_admin` is required for every write. The path is nested under the
+organisation:
+
+```http
+POST /api/v1/orgs/{org_id}/llm-providers
+```
+
+```bash
+curl -X POST "https://raven.example.com/api/v1/orgs/$ORG_ID/llm-providers" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "provider": "anthropic",
+    "display_name": "Production Anthropic",
+    "api_key": "sk-ant-api03-...",
+    "is_default": true
+  }'
+```
+
+The full request schema (`CreateLLMProviderRequest`) accepts:
+
+| Field          | Required | Notes                                                     |
+|----------------|----------|-----------------------------------------------------------|
+| `provider`     | yes      | One of the enum values above.                             |
+| `display_name` | yes      | 1–255 chars. Surfaced in the UI.                          |
+| `api_key`      | yes      | Plaintext key. Encrypted before write; never returned.    |
+| `base_url`     | no       | Override the upstream base URL (e.g. for Ollama, custom). |
+| `config`       | no       | Free-form JSONB for provider-specific knobs.              |
+| `is_default`   | no       | Marks this row as the org default for its provider type.  |
+
+The response (`LLMProviderResponse`) intentionally omits
+`api_key_encrypted` and `api_key_iv` — they are tagged `json:"-"` in
+[`internal/model/llm_provider.go`](https://github.com/ravencloak-org/Raven/blob/main/internal/model/llm_provider.go).
+Only an `api_key_hint` (last few characters) is ever returned.
+
+The other endpoints on the same group:
+
+| Method | Path                                                            | Role        | Purpose                       |
+|--------|-----------------------------------------------------------------|-------------|-------------------------------|
+| GET    | `/api/v1/orgs/{org_id}/llm-providers`                           | any member  | List configured providers     |
+| GET    | `/api/v1/orgs/{org_id}/llm-providers/{provider_id}`             | any member  | Fetch one provider            |
+| PUT    | `/api/v1/orgs/{org_id}/llm-providers/{provider_id}`             | `org_admin` | Update (re-encrypts new key)  |
+| DELETE | `/api/v1/orgs/{org_id}/llm-providers/{provider_id}`             | `org_admin` | Remove a provider             |
+| PUT    | `/api/v1/orgs/{org_id}/llm-providers/{provider_id}/default`     | `org_admin` | Mark as the org default       |
+
+Routes are registered in
+[`cmd/api/main.go`](https://github.com/ravencloak-org/Raven/blob/main/cmd/api/main.go)
+under the `llm := api.Group("/orgs/:org_id/llm-providers")` block.
+
+## Selecting a provider per workspace / KB
+
+Provider selection happens **per request**, not per workspace. The flow in
+`ai-worker/raven_worker/providers/registry.py` is:
+
+1. The caller (RAG service, embedding service) passes
+   `(org_id, provider_name, model)` to `get_provider_for_request(...)`.
+2. The registry queries `llm_provider_configs` filtering on
+   `org_id`, `provider = $provider_name`, `status = 'active'`, ordered by
+   `is_default DESC LIMIT 1`. The active default for that provider wins.
+3. The encrypted API key is decrypted with `decrypt_api_key`, except for
+   providers in `_KEYLESS_PROVIDERS = {"ollama"}`.
+4. The matching Python provider class (`AnthropicEmbeddingProvider`,
+   `OpenAIEmbeddingProvider`, `CohereEmbeddingProvider`,
+   `OllamaEmbeddingProvider`) is instantiated and cached at module level
+   keyed by `(org_id, provider_name, model)`.
+
+What can override per request:
+
+- **Provider** — chat requests carry a `provider` field. RAG explicitly
+  threads `provider_name` through `_stream_anthropic` / OpenAI / Cohere
+  branches.
+- **Model** — passed alongside `provider` on the request; falls back to
+  the provider's `_DEFAULT_MODEL` constant.
+- **`base_url`** — read from the `llm_provider_configs.base_url` column on
+  decrypt. Lets you point `ollama` at a non-default host or front
+  `openai`/`cohere` traffic through a corporate proxy.
+
+There is currently no `default_provider_id` foreign key on the `workspaces`
+or `knowledge_bases` tables — defaults are at the organisation level. If you
+need per-KB routing, use the **routing rules** subsystem
+(`/api/v1/orgs/{org_id}/routing-rules`).
+
+## Encryption
+
+Keys are encrypted with **AES-256-GCM** by
+[`internal/crypto/aes.go`](https://github.com/ravencloak-org/Raven/blob/main/internal/crypto/aes.go):
+
+```go
+// Encrypt encrypts plaintext using AES-256-GCM with a random nonce.
+// The key must be exactly 32 bytes. Returns (ciphertext, iv/nonce, error).
+func Encrypt(plaintext []byte, key []byte) ([]byte, []byte, error)
+```
+
+- **Algorithm:** AES-256-GCM (authenticated encryption, no padding).
+- **Master key:** 32 bytes. Anything else returns `ErrInvalidKeyLength`.
+- **Nonce:** 12 bytes (GCM default), generated fresh per encryption via
+  `crypto/rand` and stored next to the ciphertext in `api_key_iv`.
+- **Storage layout** (`migrations/00011_llm_provider_configs.sql`):
+  - `api_key_encrypted BYTEA` — ciphertext including GCM tag
+  - `api_key_iv BYTEA` — per-row nonce
+  - `api_key_hint VARCHAR(20)` — last few characters for UI display
+
+The master key is provided as `RAVEN_ENCRYPTION_AES_KEY` — a 32-byte
+key, conventionally a 64-character hex string. Generate one with:
+
+```bash
+openssl rand -hex 32
+```
+
+Set it before booting the API; compose enforces presence via
+`${RAVEN_ENCRYPTION_AES_KEY:?... is required}`. The variable is bound to
+`config.Encryption.AESKey` in
+[`internal/config/config.go`](https://github.com/ravencloak-org/Raven/blob/main/internal/config/config.go):
+
+```go
+_ = v.BindEnv("encryption.aes_key", "RAVEN_ENCRYPTION_AES_KEY")
+```
+
+### Key rotation
+
+Raven does not yet support online re-encryption. To rotate the master key:
+
+1. Generate the new key: `openssl rand -hex 32`.
+2. Export both `RAVEN_ENCRYPTION_AES_KEY_OLD` (current) and
+   `RAVEN_ENCRYPTION_AES_KEY` (new) on a maintenance host.
+3. For each row in `llm_provider_configs`, `Decrypt(api_key_encrypted,
+   api_key_iv, old_key)` then `Encrypt(plaintext, new_key)` and `UPDATE`
+   the row with the new ciphertext and nonce.
+4. Restart the API and AI worker with the new key only.
+5. Have each `org_admin` re-test their providers via the dashboard "Test
+   connection" button to confirm successful decryption.
+
+Re-issuing keys at the upstream provider (Anthropic, OpenAI, Cohere) and
+running `PUT /api/v1/orgs/{org_id}/llm-providers/{provider_id}` with the new
+`api_key` is the simpler alternative if you suspect a master-key compromise.
+
+## Capabilities matrix
+
+| Capability        | `anthropic` | `openai` | `cohere` | `ollama` |
+|-------------------|-------------|----------|----------|----------|
+| Chat / RAG stream | yes         | yes      | yes      | yes      |
+| Embeddings        | **no** (stub raises `NotImplementedError`) | yes (`text-embedding-3-small`, 1536 dims) | yes (`embed-english-v3.0`, 1024 dims) | yes (`nomic-embed-text`, 768 dims) |
+| Reranking         | no          | no       | **yes** (`rerank-english-v3.0`, default) | no |
+| Prompt caching    | yes (`cache_control: ephemeral` on system prompt) | no | no | no |
+| Web search tool   | yes (`web_search_20260209`, opt-in via `RAVEN_ENABLE_WEB_SEARCH=true`) | no | no | no |
+| Memory tool       | yes (opt-in via `RAVEN_MEMORY_DIR`) | no | no | no |
+
+The Anthropic embedding class exists only so the registry returns a
+consistent error instead of "unknown provider" when an Anthropic-only org
+asks for embeddings — pair Anthropic chat with OpenAI / Cohere / Ollama
+for embeddings.
+
+## Ollama (self-hosted models)
+
+Ollama is the recommended provider for **air-gapped deployments** and
+**PII-sensitive workloads** — nothing leaves the host. The defaults in
+`ai-worker/raven_worker/providers/ollama_provider.py`:
+
+```python
+_DEFAULT_MODEL = "nomic-embed-text"
+_DEFAULT_DIMENSIONS = 768
+_DEFAULT_BASE_URL = "http://ollama:11434"
+```
+
+To wire it up:
+
+```bash
+curl -X POST "https://raven.example.com/api/v1/orgs/$ORG_ID/llm-providers" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "provider": "ollama",
+    "display_name": "On-prem Ollama",
+    "api_key": "unused",
+    "base_url": "http://ollama:11434",
+    "config": {"is_local": true}
+  }'
+```
+
+Notes:
+
+- The `api_key` field is required by the request schema but the registry
+  treats `ollama` as a member of `_KEYLESS_PROVIDERS` and skips the
+  decryption step. Pass any non-empty placeholder.
+- For Raven Local (single-user desktop mode) a row is auto-seeded by
+  [`migrations/00039_seed_ollama_local_provider.sql`](https://github.com/ravencloak-org/Raven/blob/main/migrations/00039_seed_ollama_local_provider.sql)
+  with `base_url = 'http://ollama:11434/v1'` and `is_default = true`.
+- Pull the model on the Ollama host before first use:
+  `ollama pull nomic-embed-text`. The provider raises `ModelNotPulledError`
+  (mapped to a friendly UI affordance) on 404.
+
+## Default provider
+
+The Go API does **not** ship a fallback BYOK key — defaults are per-org
+rows with `is_default = true`. The `.env.example` file exposes the
+upstream keys (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `COHERE_API_KEY`)
+only for the **dev-agent and worker bootstrap scripts**; production
+traffic goes through the encrypted `llm_provider_configs` rows.
+
+The org-level default is set by:
+
+```bash
+curl -X PUT "https://raven.example.com/api/v1/orgs/$ORG_ID/llm-providers/$PROVIDER_ID/default" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Per-workspace overrides are not modelled at the schema level today; prefer
+explicit `provider` + `model` on each request, or use
+[routing rules](/reference/configuration) to map traffic patterns to a
+specific provider.
+
+## Rate limits and retries
+
+Two layers of retry:
+
+- **In-provider** — `OpenAIEmbeddingProvider.embed()` uses `tenacity` with
+  `wait_exponential(multiplier=1, min=1, max=60)` and
+  `stop_after_attempt(5)`, retrying only on
+  `openai.RateLimitError` (HTTP 429). Anthropic and Cohere rely on the
+  worker's task retry.
+- **Async job queue** — `internal/queue` enqueues all worker tasks with
+  `asynq.MaxRetry(c.maxRetry)`. The default is `5`
+  (`v.SetDefault("queue.max_retry", 5)` in `internal/config/config.go`);
+  override with `RAVEN_QUEUE_MAX_RETRY`. Webhook delivery is a deliberate
+  exception (`asynq.MaxRetry(0)` — the handler manages its own retry
+  schedule).
+
+Synchronous RAG streaming is not retried — a transient upstream failure
+surfaces as an error event on the SSE stream and the client decides
+whether to retry.
+
+## Costs
+
+Raven does not bill customers for LLM tokens. Anthropic, OpenAI, and
+Cohere bill your account directly for the keys you upload. The only
+Raven-side costs are:
+
+- The platform subscription (handled by Hyperswitch — see
+  [/guides/billing](/guides/billing)).
+- Voice usage (Deepgram / LiveKit), tracked separately in `voice_usage`.
+
+Ollama is free in absolute terms — the cost is the hardware running the
+daemon.
+
+Cache aggressively to cut your provider bill: the Anthropic provider
+adds `cache_control: ephemeral` on the system prompt, and the semantic
+response cache (KB-level, see [/guides/retrieval](/guides/retrieval))
+deduplicates near-identical questions before any token is spent.
+
+## Troubleshooting
+
+| Symptom                                              | Likely cause                                              | Fix                                                                                                          |
+|------------------------------------------------------|-----------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|
+| Upstream returns **401 Unauthorized**                | Provider key was revoked or pasted incorrectly             | `PUT /llm-providers/{id}` with a fresh `api_key`. Confirm via the upstream provider dashboard.               |
+| Upstream returns **429 Too Many Requests**           | Per-minute / per-day quota exhausted                       | OpenAI auto-retries up to 5 times. For sustained pressure, raise the quota upstream or split across orgs.    |
+| **`model not found`** from OpenAI / Anthropic        | Model name typo or model deprecated                        | Check the upstream provider's current model list — Raven passes the string through unchanged.               |
+| **`ModelNotPulledError`** from Ollama                | The named model has not been pulled on the Ollama host     | `ollama pull <model>` on the host. Verify with `curl http://ollama:11434/api/tags`.                          |
+| Worker logs **`decrypt: cipher: message authentication failed`** | Master key changed without re-encrypting rows | Restore the previous `RAVEN_ENCRYPTION_AES_KEY` or follow the rotation procedure above to re-encrypt rows.   |
+| `decrypt_api_key` returns `None`                     | No active provider config matching `(org_id, provider)`    | Add one via `POST /llm-providers` or mark an existing row `active`.                                          |
+| Cohere rerank silently disabled                      | `cohere` Python package missing, or API call failed        | Check worker logs for `cohere_rerank_unavailable` / `cohere_rerank_failed`. RRF results are returned anyway. |
+
+---
+
+**Related**
+
+- [/guides/retrieval](/guides/retrieval) — how the chosen provider plugs
+  into hybrid search and Cohere reranking
+- [/guides/ingestion](/guides/ingestion) — where the embedding provider
+  is called from
+- [/reference/configuration](/reference/configuration) — full env-var
+  reference, including `RAVEN_ENCRYPTION_AES_KEY` and queue knobs

--- a/docs-site/stubs/guides/retrieval.md
+++ b/docs-site/stubs/guides/retrieval.md
@@ -1,16 +1,351 @@
 ---
-title: "Coming Soon"
+title: "Retrieval"
 ---
 
 # Retrieval
 
-::: warning Stub page
-This page is a placeholder. The full content is being written. If you would
-like to contribute, the source for this page lives at the path shown below
-and you can [edit it on GitHub](https://github.com/ravencloak-org/Raven/edit/main/docs-site/stubs/guides/retrieval.md).
-:::
+This page is the operator's how-to for querying a Raven knowledge base. It
+covers the public HTTP surface, the request and response shapes, the knobs
+you can turn, and how to debug a result list that does not look right.
 
-## What goes here
+For the *why* and *how* of the retrieval pipeline itself — pgvector +
+PostgreSQL `tsvector` running in parallel, fused with Reciprocal Rank
+Fusion, optionally reranked — read
+[Concepts → Hybrid Retrieval](/concepts/hybrid-retrieval) first. This
+page assumes you already know what those words mean.
 
-A short bullet list of the topics this page will cover, drawn from the
-[design spec](https://github.com/ravencloak-org/Raven/blob/main/docs/superpowers/specs/2026-05-09-docs-site-design.md).
+Raven exposes retrieval through two endpoints:
+
+| Use case | Endpoint | Pipeline |
+|---|---|---|
+| Get raw chunks ranked by relevance | `GET …/knowledge-bases/{kb_id}/search` | BM25 only (`ts_rank_cd`) |
+| Ask a question, get a streamed LLM answer with citations | `POST /api/v1/chat/{kb_id}/completions` | Embed → vector + BM25 → RRF → (optional rerank) → LLM |
+
+The standalone hybrid search service (`SearchService.HybridSearch` in
+`internal/service/search.go`) exists in the Go service but is not yet
+wired into a public HTTP route — see `main.go`:
+`// TODO: wire into chat handler for enterprise hybrid search`. For now,
+hybrid search is reached *through* the chat completions endpoint, which
+runs the full RAG pipeline in `ai-worker`.
+
+## Search endpoint
+
+Source: `internal/handler/search.go`, mounted in `cmd/api/main.go`:
+
+```
+GET /api/v1/orgs/{org_id}/workspaces/{ws_id}/knowledge-bases/{kb_id}/search
+```
+
+This is a **GET** with query parameters — not a POST with a JSON body.
+It runs PostgreSQL full-text search (`to_tsvector('english', …)` over the
+heading and content columns, ranked with `ts_rank_cd`) inside the
+requesting org's RLS scope.
+
+```bash
+curl -s \
+  -H "Authorization: Bearer $RAVEN_TOKEN" \
+  --get "https://api.example.com/api/v1/orgs/$ORG/workspaces/$WS/knowledge-bases/$KB/search" \
+  --data-urlencode "q=refund window for enterprise customers" \
+  --data-urlencode "limit=20"
+```
+
+To narrow the search to specific documents, repeat the `doc_ids` parameter:
+
+```bash
+curl -s \
+  -H "Authorization: Bearer $RAVEN_TOKEN" \
+  --get "https://api.example.com/api/v1/orgs/$ORG/workspaces/$WS/knowledge-bases/$KB/search" \
+  --data-urlencode "q=refund window" \
+  --data-urlencode "doc_ids=01H..." \
+  --data-urlencode "doc_ids=01J..."
+```
+
+## Request
+
+The search endpoint takes three query parameters
+(see `SearchHandler.Search`):
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `q` | string | required | The user query. Trimmed and whitespace-collapsed by `sanitizeQuery`. |
+| `limit` | int | `10` | Top-K. Clamped to `[1, 100]` by `clampLimit`. |
+| `doc_ids` | repeated string | — | Restrict to specific document IDs. Maps to `TextSearchWithFilters` in the service. |
+
+The chat-completions endpoint takes a JSON body. From
+`internal/model/chat.go`:
+
+```json
+{
+  "query": "what is the refund window?",
+  "session_id": "01J3...",
+  "model": "claude-3-7-sonnet-20250219",
+  "provider": "anthropic",
+  "filters": { "rerank": "cohere" },
+  "stream": true
+}
+```
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `query` | string | yes | The user message. |
+| `session_id` | string | no | Resume an existing chat session; omit to start a new one. |
+| `model` | string | no | Provider-specific model id; falls back to the org's default. |
+| `provider` | string | no | `anthropic`, `openai`, etc. Falls back to the org's default. |
+| `filters` | map\<string,string\> | no | Free-form bag. Today only `rerank=cohere` is honoured (see [Reranking](#reranking)). |
+| `stream` | bool | no | Whether to stream; the handler always returns SSE today. |
+
+Two server-controlled fields are *never* read from the body and are
+populated from the request context: `UserID` (from the SuperTokens JWT
+`sub` claim) and `ConversationSessionID` (cross-channel memory id).
+Sending them in the client body has no effect.
+
+## Response
+
+`/search` returns a JSON `SearchResponse` (`internal/model/search.go`):
+
+```json
+{
+  "total": 3,
+  "results": [
+    {
+      "id": "01J...",
+      "org_id": "01H...",
+      "knowledge_base_id": "01H...",
+      "document_id": "01J...",
+      "source_id": "01J...",
+      "content": "Refunds are processed within 14 days...",
+      "chunk_index": 7,
+      "token_count": 184,
+      "page_number": 3,
+      "heading": "Refunds & cancellations",
+      "chunk_type": "text",
+      "created_at": "2026-04-19T11:22:01Z",
+      "rank": 0.4187
+    }
+  ]
+}
+```
+
+The `rank` is the raw `ts_rank_cd` score — it is *not* normalised and is
+only comparable within a single response.
+
+The hybrid pipeline (run from the chat endpoint) builds richer results
+internally as `HybridSearchResult`. Each carries both leg scores plus the
+fused score, which is what makes the pipeline debuggable end to end:
+
+| Field | Source |
+|---|---|
+| `vector_score` | `1 - (embedding <=> query)` — cosine similarity in `[0, 1]` |
+| `bm25_score` | `ts_rank_cd(...)` |
+| `rrf_score` | Σ `1 / (k + rank_i)` across both lists, `k = 60` |
+| `vector_rank` | 1-based position in the vector candidate list (or 0 if absent) |
+| `bm25_rank` | 1-based position in the BM25 candidate list (or 0 if absent) |
+
+For the chat endpoint, only a flattened subset surfaces in the SSE
+`source` events — `document_id`, `document_name`, `chunk_text` (first 500
+chars), and `score`. To see the full hybrid result shape, consume the
+internal `HybridSearchResponse` directly from the Go service (no public
+route — yet).
+
+## Filters
+
+What the codebase supports **today**:
+
+- **By document ID** — `doc_ids` on `/search`. Implemented via
+  `SearchRepository.TextSearchWithFilters`.
+- **By knowledge base** — path parameter (`{kb_id}`). The hybrid pipeline
+  in `ai-worker` accepts multiple KBs via `kb_ids` in the gRPC
+  `RAGRequest`, but the public REST endpoint binds a single KB from the
+  URL.
+- **By rerank model** — `filters.rerank = "cohere"` on chat completions.
+
+What is **planned but not wired**:
+
+- Filter by tag, source type, or `created_at` window. The `chunks` table
+  carries `chunk_type`, `source_id`, and `created_at`, but the SQL in
+  `internal/repository/search.go` does not yet expose them as filter
+  predicates. If you need this today, post-filter the response by
+  `source_id` / `chunk_type` client-side.
+- Free-form metadata key/value filters. The data model supports it (each
+  chunk has a `metadata jsonb` column), but neither retriever pushes a
+  predicate through.
+
+## Reranking
+
+The chat endpoint optionally runs a cross-encoder rerank on top of the
+RRF-fused candidates. Opt in via the `filters` map:
+
+```json
+{ "query": "...", "filters": { "rerank": "cohere" } }
+```
+
+The implementation lives in
+`ai-worker/raven_worker/retrieval/reranker.py`. Defaults:
+
+- Model: `rerank-english-v3.0`.
+- SDK: `cohere.AsyncClientV2`.
+- Output size: top 5 chunks (`top_n=5`).
+
+Reranking is **BYOK**. The worker pulls the org's Cohere API key from
+`llm_provider_configs`. If no key is configured, or the `cohere` package
+is missing, or the API call fails, the worker logs the failure and falls
+back to the RRF-fused list — the request never errors because of a
+rerank failure.
+
+Reranking is skipped entirely when:
+
+- `filters.rerank` is unset or not `"cohere"`.
+- No Cohere key is registered for the org.
+- The candidate list is empty.
+
+The synchronous Go `HybridSearch` service never reranks — see the
+`TODO: Rerank placeholder` comment at the bottom of
+`internal/service/search.go`.
+
+## Chat (RAG over search)
+
+The chat endpoint is the public face of the full RAG pipeline. Source:
+`internal/handler/chat.go`, mounted twice in `cmd/api/main.go`:
+
+| Auth | Route | Audience |
+|---|---|---|
+| Session (SuperTokens) | `POST /api/v1/orgs/{org_id}/workspaces/{ws_id}/knowledge-bases/{kb_id}/completions` | Dashboard users |
+| API key | `POST /api/v1/chat/{kb_id}/completions` | Embeddable widgets / 3rd-party apps |
+
+Both call the same handler and return `text/event-stream`. The pipeline
+itself runs in the Python worker
+(`ai-worker/raven_worker/services/rag.py`) and is the canonical 8-step
+flow:
+
+1. Exact-match response cache lookup in Valkey (per-KB).
+2. Embed the query with the org's BYOK embedding provider.
+3. Vector cosine search + BM25 full-text search in parallel
+   (`asyncio.gather`).
+4. Merge with Reciprocal Rank Fusion (k = 60).
+5. Optional Cohere rerank (see above).
+6. Build a numbered context block from the top chunks.
+7. Stream LLM tokens back as `RAGChunk` proto messages.
+8. Store the completed answer in the response cache.
+
+Example call against the public API-key route, consuming SSE with `curl`:
+
+```bash
+curl -N \
+  -H "Authorization: Bearer $RAVEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -H "Accept: text/event-stream" \
+  -d '{
+    "query": "What is our refund window for enterprise customers?",
+    "session_id": "01J3PZS...",
+    "filters": { "rerank": "cohere" }
+  }' \
+  "https://api.example.com/api/v1/chat/$KB/completions"
+```
+
+The stream emits SSE frames in the form:
+
+```
+event: token
+data: {"text":"Refunds "}
+
+event: token
+data: {"text":"are processed "}
+
+event: sources
+data: {"sources":[{"document_id":"01J...","document_name":"Billing Policy","chunk_text":"Refunds are processed within 14 days…","score":0.0312}]}
+
+event: done
+data: {}
+```
+
+To pull message history for a previous chat session:
+
+```bash
+curl -s -H "Authorization: Bearer $RAVEN_API_KEY" \
+  "https://api.example.com/api/v1/chat/$KB/sessions/$SESSION_ID/history?limit=50"
+```
+
+For cross-channel conversation memory (chat + voice + WebRTC fused into
+one history), the dashboard route is
+`GET /api/v1/orgs/{org_id}/kbs/{kb_id}/conversations` — see
+`internal/handler/conversation.go`.
+
+## Debugging a bad search
+
+There is no `debug: true` flag on the HTTP endpoints today — the
+retrievers themselves emit the trace, and the chat handler forwards it
+to your structured-logs sink (OpenObserve in the default deployment).
+
+Work down this checklist:
+
+1. **Is BM25 finding the right chunks?** Hit `/search` with the same
+   query — that handler is the pure BM25 leg, same SQL as
+   `SearchRepository.BM25Search`. If the raw `rank` ranks the wrong
+   chunk first, the problem is in ingestion (tokenisation, missing
+   heading, wrong source attribution), not retrieval.
+2. **Read the structured logs.** The worker emits one line per stage:
+   `vector_search_start`/`done`, `bm25_search_start`/`done`,
+   `chunks_fetched`, `rerank_applied`, `cache_hit`/`miss`. Each is
+   tagged with `org_id`, `kb_ids`, `session_id`, `query_length`.
+3. **Compare ranks across legs.** `HybridSearchResult` carries both
+   `vector_rank` and `bm25_rank`. A chunk with `vector_rank = 1` and
+   `bm25_rank = 0` is matching purely on semantics; the opposite is
+   keyword-only. A chunk in neither leg cannot be fused into existence.
+4. **Inspect the fused score.** RRF is bounded above by
+   `2 / (k + 1) ≈ 0.0328` for a chunk ranked #1 in both legs (with
+   `k = 60`). Above ~`0.025` is a strong dual-leg hit; below ~`0.008`
+   is mostly single-leg. The test `internal/integration/search_test.go`
+   asserts that dual-leg chunks outrank single-leg ones.
+5. **Sanity-check the embedding.** If `vector_rank` is consistently 0
+   for chunks you expect to match semantically, check `embedding_dims`
+   in the `vector_search_start` log — it should be 1536.
+
+## Hard limits
+
+These are baked into the Go service and you cannot override them per
+request without a code change. From `internal/service/search.go`:
+
+| Constant | Value | Effect |
+|---|---|---|
+| `defaultSearchLimit` | `10` | Top-K applied when the caller omits `limit`. |
+| `maxSearchLimit` | `100` | Hard cap on `limit`. Larger values are clamped. |
+| `rrfK` | `60` | Smoothing constant in the RRF formula — value from the original Cormack et al. (2009) paper. |
+| `candidateK` | `topK * 3` | Each leg fetches `topK * 3` candidates, capped at `maxSearchLimit`, so RRF sees enough overlap. |
+
+The rerank `top_n` (in `services/rag.py`) is hardcoded to `5`. The
+response cache TTL (`_CACHE_TTL_SECONDS`) is `3600` (1 hour, exact-match
+per-KB).
+
+## Tuning
+
+The constants above are deliberately *not* runtime knobs. RRF is
+parameterless by design, and `candidateK` was picked to give RRF enough
+overlap signal without paying query latency no one benefits from.
+
+In practice, "tuning retrieval" on Raven means tuning what *is* exposed:
+
+- **Chunk size and overlap.** Bad chunks dominate every other knob.
+  Look at chunk boundaries first — see
+  [Guides → Ingestion](/guides/ingestion).
+- **Source quality.** A keyword in 80% of your chunks contributes
+  almost no BM25 signal. Tighten the source set or split generic
+  documents into smaller, topic-scoped sources.
+- **Headings.** BM25 searches
+  `coalesce(heading, '') || ' ' || content`. Descriptive headings rank
+  dramatically better — make sure ingestion preserves them.
+- **Embedding provider.** Switching to a domain-specific model moves
+  the needle more than any RRF parameter could. See
+  [Guides → LLM providers](/guides/llm-providers).
+- **Reranking.** For end-user chat, set `filters.rerank = "cohere"`.
+  The latency cost (~100–400 ms) is usually worth the top-5 precision.
+
+If you find yourself wanting to tune `rrfK` or `candidateK`, open an
+issue first — the real fix is usually upstream.
+
+## See also
+
+- [Concepts → Hybrid Retrieval](/concepts/hybrid-retrieval) — the
+  algorithm, the SQL, the benchmarks.
+- [Guides → Ingestion](/guides/ingestion) — chunking, sources, what
+  makes retrieval work or not work.
+- [API Overview](/api/overview) — the canonical OpenAPI surface.

--- a/docs-site/stubs/guides/self-hosting/edge-and-raspberry-pi.md
+++ b/docs-site/stubs/guides/self-hosting/edge-and-raspberry-pi.md
@@ -1,16 +1,352 @@
 ---
-title: "Coming Soon"
+title: "Edge & Raspberry Pi"
 ---
 
 # Edge & Raspberry Pi
 
-::: warning Stub page
-This page is a placeholder. The full content is being written. If you would
-like to contribute, the source for this page lives at the path shown below
-and you can [edit it on GitHub](https://github.com/ravencloak-org/Raven/edit/main/docs-site/stubs/guides/self-hosting/edge-and-raspberry-pi.md).
-:::
+This guide is the operator's how-to for running Raven on a Raspberry Pi 4 / 5,
+an AWS `t4g.small`, or any small ARM64 or amd64 single-node host. The edge
+deployment is intentionally minimal — three containers, no Python ai-worker
+in-process, no LiveKit, no object store. If you are wondering *whether* this
+topology suits your use case, read
+[Deployment Models](/concepts/deployment-models) first; this page assumes
+you have already chosen the edge variant and want to bring it up.
 
-## What goes here
+The stack that lands on the Pi is just the Go API, a PostgreSQL with
+pgvector, and a Traefik reverse proxy. The Python ai-worker is offloaded to
+a remote endpoint over gRPC — typically a separate worker host, or a BYOK
+LLM provider fronted by a small worker shim. That offload is what keeps the
+edge footprint under a gigabyte of RAM.
 
-A short bullet list of the topics this page will cover, drawn from the
-[design spec](https://github.com/ravencloak-org/Raven/blob/main/docs/superpowers/specs/2026-05-09-docs-site-design.md).
+## Prereqs
+
+- Raspberry Pi 4 or 5 with **at least 4 GB RAM** (the bootstrap script
+  warns below 1 GB, recommends 2 GB minimum, and the Compose limits add up
+  to ~900 MB before the OS).
+- 32 GB SD card minimum, **SSD strongly preferred** for Postgres durability
+  and SD-wear reasons (see [Backups on a Pi](#backups-on-a-pi)).
+- 64-bit Linux (Raspberry Pi OS 64-bit, Ubuntu Server 24.04 LTS, or
+  Debian 12). The compose file pins `platform: linux/arm64` for every
+  service.
+- **Docker Engine with Compose v2** (`docker compose`, not `docker-compose`).
+  The bootstrap script accepts the v1 standalone binary as a fallback but
+  v2 is preferred.
+- A reachable remote ai-worker — either your own deployment of
+  `ai-worker/` on a beefier host, or a BYOK LLM you proxy from one. The
+  Go API will refuse to start without `GRPC_AI_WORKER_ADDR`.
+- Roughly **one hour** end-to-end, including image pulls.
+
+## Hardware notes
+
+| Concern | Pi 4 (4 GB) | Pi 5 (8 GB) | `t4g.small` |
+|---|---|---|---|
+| Sustained ingest of medium PDFs | Tight — close to the 256 MB API cap. | Comfortable. | Comfortable. |
+| pgvector HNSW build | Slow on SD card; minutes per 10k vectors. | Faster, especially on NVMe HAT. | Fastest. |
+| Idle thermal | OK with passive heatsink. | Needs active cooling under load. | N/A. |
+| Power | PoE+ HAT works; USB-C PD 5 V/3 A also fine. | Use the official 27 W USB-C PD. | N/A. |
+| Storage failure mode | SD wear within ~12 months at heavy write rates. | Same SD risk; NVMe HAT eliminates it. | EBS gp3, durable. |
+
+If you have any choice, run from an SSD or NVMe HAT, not the SD card.
+Postgres on an SD card is a known-bad pattern — the WAL beats the flash
+endurance into the ground. The Pi 5 with an M.2 HAT is materially better
+than a Pi 4 here.
+
+## Bootstrap
+
+Clone the repo, copy the edge env file, and bring the stack up. The
+project ships a bootstrap helper at
+[`deploy/edge/install.sh`](https://github.com/ravencloak-org/Raven/blob/main/deploy/edge/install.sh)
+which does prerequisite checks (Docker present, Compose v2, ARM64
+architecture detected, ≥ 1 GB RAM warning) and creates `data/postgres`
+before you start.
+
+```bash
+git clone https://github.com/ravencloak-org/Raven.git
+cd Raven
+
+# Prereq checks + create data dirs + copy env example
+chmod +x deploy/edge/install.sh
+./deploy/edge/install.sh
+
+# Edit .env.edge — set DATABASE_URL, GRPC_AI_WORKER_ADDR, POSTGRES_PASSWORD
+$EDITOR .env.edge
+
+# Bring it up
+docker compose -f docker-compose.edge.yml --env-file .env.edge up -d
+docker compose -f docker-compose.edge.yml --env-file .env.edge ps
+```
+
+Verify the API is healthy:
+
+```bash
+curl http://localhost/api/healthz
+docker compose -f docker-compose.edge.yml --env-file .env.edge logs -f go-api
+```
+
+The Go API runs database migrations automatically at start — there is no
+separate migrate step on the edge variant.
+
+## The 3-service stack
+
+The full file is at
+[`docker-compose.edge.yml`](https://github.com/ravencloak-org/Raven/blob/main/docker-compose.edge.yml).
+It declares exactly three services. Memory limits below are the values
+declared in the compose file:
+
+| Service | Image | Memory limit | Role |
+|---|---|---|---|
+| `go-api` | `ghcr.io/ravencloak-org/raven-api:latest` (linux/arm64) | **256 MB** | HTTP/JSON API, auth, orchestration; talks to remote ai-worker over gRPC. Sets `RAVEN_EDGE_MODE: "true"`. |
+| `postgres` | `pgvector/pgvector:pg18` (linux/arm64) | **512 MB** | Primary store. pgvector for embeddings; tenant isolation via RLS. |
+| `traefik` | `traefik:v3.3` (linux/arm64) | **128 MB** | Reverse proxy on ports 80/443. Routes `/api` to `go-api`. |
+
+Total reserved ≈ **896 MB**. Typical resident usage in steady state is
+~200–350 MB across the three services (the API floats around 50–80 MB,
+Postgres 100–200 MB, Traefik 20–30 MB).
+
+The Postgres health check uses `pg_isready` and the API waits on
+`postgres: service_healthy` before starting — a clean cold-boot
+sequence is part of the design.
+
+## Remote ai-worker
+
+The defining feature of the edge variant is that the heavy Python service
+runs *somewhere else*. The Go API connects to it as a gRPC client:
+
+```env
+# in .env.edge
+GRPC_AI_WORKER_ADDR=ai-worker.example.com:50051
+```
+
+This is wired into the `go-api` service as `RAVEN_GRPC_WORKER_ADDR` (the
+Compose file re-maps `GRPC_AI_WORKER_ADDR` → `RAVEN_GRPC_WORKER_ADDR`).
+Format is `host:port` with **no scheme prefix** — the Go API speaks plain
+gRPC, TLS is a separate config bit on the worker side.
+
+Typical hybrid topology:
+
+```
+┌──────────────────────┐    gRPC :50051     ┌────────────────────────┐
+│  Edge node (Pi 4)    │ ─────────────────▶ │  Remote ai-worker      │
+│  ┌────────────────┐  │                    │  (cloud VM or GPU box) │
+│  │ traefik :443   │  │                    │  ┌──────────────────┐  │
+│  │ go-api  :8080  │  │                    │  │ python ai-worker │  │
+│  │ postgres :5432 │  │                    │  └──────────────────┘  │
+│  └────────────────┘  │                    │  + BYOK LLM provider   │
+└──────────────────────┘                    └────────────────────────┘
+```
+
+Three rules:
+
+1. The worker endpoint must be reachable from the Pi over the network.
+2. The worker holds the BYOK LLM credentials, not the edge node.
+3. If the worker is on the public internet, terminate TLS for gRPC on
+   the worker side (or front it with an ingress that does). The Pi has no
+   business holding LLM API keys.
+
+## ARM64 binaries
+
+Pre-built ARM64 images are pulled from GHCR by default
+(`ghcr.io/ravencloak-org/raven-api:latest`). If you want to build the
+binary yourself — e.g. for an air-gapped Pi or a custom version string —
+use [`Makefile.edge`](https://github.com/ravencloak-org/Raven/blob/main/Makefile.edge):
+
+```bash
+make -f Makefile.edge build-arm64
+# Output: build/raven-api-linux-arm64
+```
+
+That target runs:
+
+```bash
+CGO_ENABLED=0 GOOS=linux GOARCH=arm64 \
+    go build -ldflags="-s -w -X main.version=$(VERSION) -X main.buildTime=$(BUILD_TIME)" \
+    -o build/raven-api-linux-arm64 ./cmd/api
+```
+
+`CGO_ENABLED=0` makes the binary statically linked (no glibc surprises on
+Alpine or musl-based hosts). The `-s -w` flags strip the symbol table and
+DWARF debug info — the resulting ARM64 binary is roughly **25 MB**, the
+number the README quotes. eBPF builds (`build-arm64-ebpf`) require an
+`aarch64-linux-musl-gcc` cross-compiler and are not relevant for the
+default edge stack.
+
+`make -f Makefile.edge build-all` produces both architectures;
+`docker-arm64` / `docker-amd64` / `docker-all` build the OCI images and
+push a multi-arch manifest.
+
+## Cloudflare Tunnel
+
+Most Pis live behind a home NAT, a corporate firewall, or a carrier-grade
+NAT that you can't reasonably punch through. The standard answer is
+Cloudflare Tunnel — `cloudflared` runs as a daemon on the Pi, dials out
+to Cloudflare's edge, and Cloudflare proxies inbound traffic in.
+
+The Ansible role at
+[`deploy/ansible/roles/cloudflared/`](https://github.com/ravencloak-org/Raven/tree/main/deploy/ansible/roles/cloudflared)
+is the canonical pattern. The role:
+
+- Detects `x86_64` vs `aarch64` and downloads the matching `cloudflared`
+  release binary.
+- Renders `/etc/cloudflared/config.yml` from
+  [`templates/config.yml.j2`](https://github.com/ravencloak-org/Raven/blob/main/deploy/ansible/roles/cloudflared/templates/config.yml.j2)
+  with your `cloudflare_tunnel_id` and ingress rules.
+- Installs a hardened systemd unit (`NoNewPrivileges`, `ProtectSystem`,
+  `ProtectHome`) that runs `cloudflared tunnel run`.
+
+For an edge node you typically only need one ingress rule:
+
+```yaml
+ingress:
+  - hostname: pi.your-domain.example
+    service: http://localhost:80   # Traefik
+  - service: http_status:404
+```
+
+The tunnel credentials JSON (`/etc/cloudflared/<tunnel-id>.json`) must be
+copied to the Pi manually — the role warns if it's missing and won't
+start the service.
+
+## TLS at the edge
+
+You have two choices:
+
+1. **Pi is internet-routable** (you have a static IP or a working
+   dynamic DNS, ports 80/443 forwarded). Add the standard Traefik
+   Let's Encrypt resolver and let it provision certs over HTTP-01. The
+   edge compose file leaves the resolver unconfigured — wire it through
+   the `traefik` service `command:` block. See
+   [Traefik & TLS](/guides/self-hosting/traefik-and-tls).
+
+2. **Pi is behind NAT (most likely)**. Use a Cloudflare Tunnel and a
+   Cloudflare Origin Certificate. The Pi never holds a public cert — the
+   public TLS terminates at Cloudflare's edge, and the tunnel between the
+   Pi and Cloudflare is encrypted by the `cloudflared` daemon. Set
+   `DOMAIN=pi.your-domain.example` and `ACME_EMAIL=...` in `.env.edge` for
+   reference but you don't strictly need a Traefik resolver in this mode.
+
+Option 2 is what we recommend for almost every Pi deployment. It removes
+the need for any inbound port at all.
+
+## Backups on a Pi
+
+Two hard rules:
+
+- **The volume *is* the SD card** unless you've moved the Docker data root
+  to an SSD. `pg-data:` is a named volume that lives under
+  `/var/lib/docker/volumes/` by default — i.e., on the SD card. A card
+  failure loses the database.
+- **Always back up off the device.** pgBackRest (the same tool the
+  full-stack deployment uses for Postgres) works fine on a Pi, but the
+  repo must live somewhere that isn't the Pi.
+
+Practical recipe:
+
+1. Move Docker's data root to your SSD or NVMe (`/etc/docker/daemon.json`
+   → `"data-root": "/mnt/ssd/docker"`, restart Docker, then bring the
+   stack back up). The compose file's `pg-data` named volume will land
+   on the SSD.
+2. Configure pgBackRest to push diffs to S3 (or R2, B2, MinIO — anything
+   S3-compatible). See [Backups](/guides/self-hosting/backups) for the
+   stanza layout the full stack uses.
+3. Add a nightly cron to `pg_dump` as a belt-and-braces safety net while
+   you settle into pgBackRest.
+
+Off-site is not optional. A house fire, theft, or a kid pulling the
+power during a write all end the same way.
+
+## Voice agent on edge
+
+**Probably not.** LiveKit needs UDP, decent uplink bandwidth, and enough
+CPU to terminate WebRTC for every concurrent caller. A Pi 4 will do one,
+maybe two simultaneous voice sessions before audio quality degrades.
+
+If you genuinely want voice on the edge, you have two paths:
+
+1. **Self-host alongside.** Deploy `python-agent/` and `livekit-server`
+   on the same Pi or, more sensibly, on a second host on the same LAN.
+   This is not part of `docker-compose.edge.yml`; it's a manual
+   composition.
+2. **Offload to LiveKit Cloud.** Point your `python-agent/` config at
+   LiveKit Cloud and let them handle the SFU. You still need a `python-agent`
+   process somewhere, but that's the cheap part.
+
+Either way, the edge variant *itself* does not ship voice. If voice is a
+day-one requirement, the [Cloud-hosted full stack](/concepts/deployment-models)
+is the right topology, not edge.
+
+## Update workflow
+
+```bash
+cd Raven
+git pull
+docker compose -f docker-compose.edge.yml --env-file .env.edge pull
+docker compose -f docker-compose.edge.yml --env-file .env.edge up -d
+```
+
+Migrations run automatically on `go-api` start — there is no separate
+migrate step on the edge variant. If you've pinned `RAVEN_API_IMAGE` to a
+specific tag (recommended for production), bump the tag in `.env.edge`
+before `pull`. See [Upgrades](/guides/self-hosting/upgrades) for the
+broader upgrade story.
+
+## Performance
+
+Honest answer: it varies. Some rough numbers from a Pi 4 (4 GB, USB SSD)
+and a Pi 5 (8 GB, NVMe HAT), both with a remote ai-worker on a beefier
+amd64 host:
+
+| Operation | Pi 4 + SSD | Pi 5 + NVMe |
+|---|---|---|
+| Cold start (compose up to `healthz`) | ~20 s | ~10 s |
+| Ingest a 10-page PDF (parse + embed remotely) | 3–5 s | 2–3 s |
+| Hybrid retrieval query, 50k-chunk KB | 80–200 ms | 40–120 ms |
+| pgvector HNSW build, 10k vectors | ~30 s | ~12 s |
+
+Most of the latency budget is in the network hop to the remote
+ai-worker and in pgvector. The Go API itself is rarely the bottleneck on
+either platform. **Benchmark on your own hardware** before you make
+capacity promises.
+
+## Troubleshooting
+
+**OOM kills.** The Go API has a 256 MB cap. If you see `OOMKilled` under
+load, the usual cause is large embedding payloads buffered in memory.
+Raise the limit, or move the ai-worker closer to the Pi. Check with
+`docker compose -f docker-compose.edge.yml ps` and `docker stats`.
+
+**Slow pgvector queries.** HNSW indexes are memory-resident. On a Pi 4
+the 512 MB Postgres cap is tight for any KB above ~100k chunks. Either
+raise the cap (and accept the OS pressure), or use a flat index for
+small KBs.
+
+**SD card wear / Postgres corruption.** `PANIC: could not write to file
+"pg_wal/..."` after months of uptime is the classic SD-failure mode.
+Move to SSD, restore from backup, never look back.
+
+**`GRPC_AI_WORKER_ADDR is required` on `up`.** The compose file enforces
+this with `${GRPC_AI_WORKER_ADDR:?...}` syntax — you have to set it in
+`.env.edge` or the stack refuses to start. There is no "local fallback".
+
+**Architecture mismatch.** All three services pin `platform: linux/arm64`.
+If you run the file on an amd64 host without removing the `platform:`
+lines, Docker will pull the ARM64 image and fail to run it. The bootstrap
+script flags this with an architecture check.
+
+**Cloudflare Tunnel won't start.** Check
+`/etc/cloudflared/<tunnel-id>.json` exists — the Ansible role warns when
+it doesn't, and the systemd unit will sit in a restart loop until it's
+present.
+
+## See also
+
+- [Deployment Models](/concepts/deployment-models) — the full
+  three-topology overview, including when the edge variant is the right
+  call.
+- [Docker Compose](/guides/self-hosting/docker-compose) — full-stack
+  bring-up; useful for the worker host side of a hybrid edge deployment.
+- [Traefik & TLS](/guides/self-hosting/traefik-and-tls) — ACME and
+  DNS-01 details if you do choose Let's Encrypt over Cloudflare Tunnel.
+- [Backups](/guides/self-hosting/backups) — pgBackRest stanza layout.
+- [Upgrades](/guides/self-hosting/upgrades) — the broader update story.
+- [Configuration reference](/reference/configuration) — every `RAVEN_*`
+  environment variable.

--- a/docs-site/stubs/guides/self-hosting/traefik-and-tls.md
+++ b/docs-site/stubs/guides/self-hosting/traefik-and-tls.md
@@ -1,16 +1,437 @@
 ---
-title: "Coming Soon"
+title: "Traefik & TLS"
 ---
 
 # Traefik & TLS
 
-::: warning Stub page
-This page is a placeholder. The full content is being written. If you would
-like to contribute, the source for this page lives at the path shown below
-and you can [edit it on GitHub](https://github.com/ravencloak-org/Raven/edit/main/docs-site/stubs/guides/self-hosting/traefik-and-tls.md).
-:::
+Traefik is the single internet-facing service in a Raven deployment. It
+terminates TLS, routes by hostname and path, and is the only container that
+should publish ports `80` and `443` to the host. Every other Raven service —
+the Go API, LiveKit, OpenObserve, SuperTokens — listens only on the internal
+Docker network and is reached **through** Traefik.
 
-## What goes here
+This guide is a code-grounded operator reference for the Traefik layer as it
+ships in this repository. For the broader hardening posture (HSTS preload,
+rate limits, container-level controls) cross-link to
+[/guides/self-hosting/hardening](/guides/self-hosting/hardening); for compose
+topology see [/guides/self-hosting/docker-compose](/guides/self-hosting/docker-compose).
 
-A short bullet list of the topics this page will cover, drawn from the
-[design spec](https://github.com/ravencloak-org/Raven/blob/main/docs/superpowers/specs/2026-05-09-docs-site-design.md).
+## Service overview
+
+The `traefik` service is defined in
+[`docker-compose.yml`](https://github.com/ravencloak-org/Raven/blob/main/docker-compose.yml)
+and uses the pinned v3 image:
+
+```yaml
+traefik:
+  image: traefik:v3.3
+  ports:
+    - "80:80"     # ACME HTTP-01 fallback + HTTP→HTTPS redirect
+    - "443:443"   # TLS-terminated web traffic
+    - "8082:8080" # dashboard (dev only — disable in prod)
+  volumes:
+    - /var/run/docker.sock:/var/run/docker.sock:ro
+    - ./deploy/traefik/traefik.yml:/etc/traefik/traefik.yml:ro
+    - ./deploy/traefik/dynamic:/etc/traefik/dynamic:ro
+    - acme-data:/acme
+  networks:
+    - raven-internal
+```
+
+Key points:
+
+- **Image**: `traefik:v3.3` (Traefik v3, static config schema).
+- **Network**: `raven-internal` — every backend Traefik routes to must
+  join the same network so the Docker provider can resolve container IPs.
+- **ACME storage**: the named volume `acme-data` is mounted at `/acme` and
+  holds `acme.json` (account key, issued certs, renewal state). Back this up.
+- **Docker socket**: mounted read-only so Traefik can watch container start
+  / stop events and rebuild its router table.
+
+The edge variant (`docker-compose.edge.yml`) uses the same image
+(`traefik:v3.3`, `platform: linux/arm64`) but passes static config via the
+CLI flags `--providers.docker=true --providers.docker.network=raven-edge`
+and skips the dashboard with `--api=false`.
+
+## Static config — `deploy/traefik/traefik.yml`
+
+The full static config lives at [`deploy/traefik/traefik.yml`](https://github.com/ravencloak-org/Raven/blob/main/deploy/traefik/traefik.yml).
+It is mounted read-only at `/etc/traefik/traefik.yml`.
+
+### Entrypoints
+
+```yaml
+entryPoints:
+  web:
+    address: ":80"
+    http:
+      redirections:
+        entryPoint:
+          to: websecure
+          scheme: https
+          permanent: true
+  websecure:
+    address: ":443"
+    http:
+      tls:
+        certResolver: letsencrypt
+      middlewares:
+        - security-headers@file
+```
+
+- `web` (port 80) does nothing useful for application traffic — every
+  request is 301'd to `websecure`. Port 80 stays open only for the ACME
+  HTTP-01 fallback and for the redirect itself.
+- `websecure` (port 443) is the real entry. **Every** request through it
+  is run through the `security-headers@file` middleware (defined in the
+  dynamic config below) before reaching a router.
+
+### Providers
+
+```yaml
+providers:
+  docker:
+    endpoint: "unix:///var/run/docker.sock"
+    exposedByDefault: false
+    network: raven-internal
+  file:
+    directory: /etc/traefik/dynamic
+    watch: true
+```
+
+- `exposedByDefault: false` — a container is invisible to Traefik until
+  it sets `traefik.enable=true` in its labels. This is deliberate: backends
+  that should never face the internet (PostgreSQL, Valkey, the AI worker)
+  simply omit the label.
+- `network: raven-internal` is the network Traefik will connect to when
+  proxying — if a service is on a different network, Traefik can see the
+  labels but cannot reach the container.
+- `file.watch: true` means dynamic config changes (TLS options, headers,
+  middlewares) reload without restarting Traefik.
+
+### Dashboard / API
+
+```yaml
+api:
+  dashboard: true
+  insecure: true
+```
+
+This is the **dev default**. `insecure: true` exposes the dashboard on
+the entrypoint without auth. See
+[Disabling the dashboard in production](#disabling-the-dashboard-in-production)
+below — this MUST be flipped before going to prod.
+
+## Dynamic config — `deploy/traefik/dynamic/tls.yml`
+
+Dynamic configuration is loaded from the file provider at
+[`deploy/traefik/dynamic/`](https://github.com/ravencloak-org/Raven/tree/main/deploy/traefik/dynamic).
+The single file (`tls.yml`) defines TLS options and shared middlewares.
+
+### TLS options
+
+```yaml
+tls:
+  options:
+    default:
+      minVersion: VersionTLS12
+      cipherSuites:
+        - TLS_AES_256_GCM_SHA384
+        - TLS_AES_128_GCM_SHA256
+        - TLS_CHACHA20_POLY1305_SHA256
+        - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+        - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+        - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+      sniStrict: true
+```
+
+- `minVersion: VersionTLS12` — TLS 1.0/1.1 are refused.
+- Cipher list is GCM and ChaCha20-Poly1305 only; no CBC, no RSA key
+  exchange, no static keys.
+- `sniStrict: true` — a TLS handshake without a matching SNI is
+  terminated with `unrecognized_name`, not served the default cert. This
+  blocks scanner traffic that hits the IP directly.
+
+### Middlewares
+
+```yaml
+http:
+  middlewares:
+    security-headers:
+      headers:
+        stsSeconds: 63072000
+        stsIncludeSubdomains: true
+        stsPreload: true
+        forceSTSHeader: true
+        contentTypeNosniff: true
+        browserXssFilter: true
+        frameDeny: true
+        customFrameOptionsValue: "SAMEORIGIN"
+        referrerPolicy: "strict-origin-when-cross-origin"
+        customResponseHeaders:
+          X-Powered-By: ""
+          Server: ""
+
+    rate-limit:
+      rateLimit:
+        average: 100
+        burst: 200
+        period: 1s
+```
+
+Two named middlewares are exported:
+
+- `security-headers@file` — attached globally on the `websecure` entrypoint
+  (HSTS preload, anti-clickjacking, `X-Content-Type-Options`, redacted
+  `Server` header). See
+  [/guides/self-hosting/hardening#security-headers](/guides/self-hosting/hardening)
+  for the rationale and OSPS-L2 evidence trail.
+- `rate-limit@file` — 100 req/s average, 200 burst, per source. Not
+  attached by default; opt-in on noisy routers via
+  `traefik.http.routers.<name>.middlewares=rate-limit@file`.
+
+## ACME / Let's Encrypt
+
+```yaml
+certificatesResolvers:
+  letsencrypt:
+    acme:
+      email: "${ACME_EMAIL}"
+      storage: /acme/acme.json
+      caServer: "${ACME_CA_SERVER:-https://acme-v02.api.letsencrypt.org/directory}"
+      dnsChallenge:
+        provider: "${ACME_DNS_PROVIDER:-cloudflare}"
+        delayBeforeCheck: 10
+        resolvers:
+          - "1.1.1.1:53"
+          - "8.8.8.8:53"
+```
+
+- **CA**: defaults to Let's Encrypt production
+  (`https://acme-v02.api.letsencrypt.org/directory`). Override
+  `ACME_CA_SERVER` to point at the staging directory
+  (`https://acme-staging-v02.api.letsencrypt.org/directory`) when
+  iterating — staging has much higher rate limits and untrusted certs.
+- **Storage**: `/acme/acme.json` inside the `acme-data` named volume.
+  This file contains the account key and every issued cert — back it up,
+  protect it (Traefik creates it as `0600`), and never commit it.
+- **Challenge type**: **DNS-01** via the Cloudflare provider by default.
+  Required environment variables in `.env`:
+  - `ACME_EMAIL` — registration address for renewal notices.
+  - `CF_API_EMAIL` — Cloudflare account email.
+  - `CF_DNS_API_TOKEN` — scoped API token with `Zone:DNS:Edit` on the
+    relevant zone.
+
+  To switch providers, override `ACME_DNS_PROVIDER` and supply the env
+  vars Traefik expects for that provider (see the
+  [Traefik ACME providers reference](https://doc.traefik.io/traefik/https/acme/#providers)).
+- **HTTP-01 fallback**: not configured. Switching from DNS-01 to HTTP-01
+  requires editing `traefik.yml` to replace `dnsChallenge:` with
+  `httpChallenge: { entryPoint: web }` and ensuring port 80 is reachable
+  from the public internet.
+
+DNS-01 is preferred because it works behind NAT, behind Cloudflare proxy,
+and can issue wildcards (`*.raven.example.com`) — which matters for the
+upcoming subdomain layout (see [Hostname routing](#hostname-routing)).
+
+## Service discovery via Docker labels
+
+Traefik discovers backends by reading container labels at startup and on
+every Docker event. Here is the `go-api` service from `docker-compose.yml`
+verbatim:
+
+```yaml
+go-api:
+  labels:
+    - "traefik.enable=true"
+    - "traefik.http.routers.api.rule=Host(`${RAVEN_DOMAIN:-localhost}`) && PathPrefix(`/api`)"
+    - "traefik.http.routers.api.entrypoints=websecure"
+    - "traefik.http.routers.api.tls=true"
+    - "traefik.http.routers.api.tls.certresolver=${TRAEFIK_CERT_RESOLVER:-letsencrypt}"
+    - "traefik.http.routers.api.middlewares=security-headers@file"
+    - "traefik.http.services.api.loadbalancer.server.port=8081"
+```
+
+Label by label:
+
+| Label | Meaning |
+|---|---|
+| `traefik.enable=true` | Opt this container into discovery (the provider is `exposedByDefault: false`). |
+| `traefik.http.routers.api.rule` | Match HTTPS requests to host `${RAVEN_DOMAIN}` with path prefix `/api`. |
+| `traefik.http.routers.api.entrypoints=websecure` | Only attach to the `:443` entrypoint — bare HTTP is handled by the global redirect. |
+| `traefik.http.routers.api.tls=true` | Negotiate TLS using the entrypoint's resolver. |
+| `traefik.http.routers.api.tls.certresolver=letsencrypt` | Use the `letsencrypt` resolver defined in static config. |
+| `traefik.http.routers.api.middlewares=security-headers@file` | Apply the HSTS / nosniff middleware before hitting the backend. |
+| `traefik.http.services.api.loadbalancer.server.port=8081` | Backend listens on `:8081` inside the container. |
+
+The router name (`api`) is local to the container — keep it unique per
+service.
+
+## Hostname routing
+
+Today only two services own a public router in `docker-compose.yml`:
+
+| Service | Router | Rule | Backend port |
+|---|---|---|---|
+| `go-api` | `api` | `Host(${RAVEN_DOMAIN}) && PathPrefix(/api)` | `:8081` |
+| `livekit-server` | `livekit` | `Host(${RAVEN_DOMAIN}) && PathPrefix(/livekit)` | `:7880` |
+
+LiveKit additionally has an inline path-strip middleware so the
+backend sees `/` rather than `/livekit/...`:
+
+```yaml
+- "traefik.http.routers.livekit.middlewares=livekit-strip@docker"
+- "traefik.http.middlewares.livekit-strip.stripprefix.prefixes=/livekit"
+```
+
+Other services (`postgres`, `valkey`, `supertokens`, `python-worker`,
+`python-agent`, `openobserve`, `seaweedfs-*`, `clickhouse`) intentionally
+omit Traefik labels — they are reachable only within `raven-internal`.
+
+A `*.raven.ravencloak.org` subdomain split (e.g. `app.`, `auth.`, `logs.`,
+`monitor.`) is tracked separately and will replace the path-prefix layout
+once the wildcard ACME cert and DNS records are in place.
+
+## Production gotchas
+
+- **Port 80 must be reachable.** Even on a DNS-01-only setup, port 80
+  serves the HTTP→HTTPS redirect users will hit first. Some ISPs and
+  residential CGNAT routes block inbound 80; verify with
+  `curl -v http://your-host/` from outside.
+- **A and AAAA records first, ACME second.** Let's Encrypt validates
+  DNS-01 by querying `_acme-challenge.<host>` from public resolvers; if
+  your zone's NS records lag, validation fails with `propagation timeout`.
+  The static config already sets `delayBeforeCheck: 10` and uses
+  `1.1.1.1` / `8.8.8.8` as resolvers.
+- **Test against staging first.** Production Let's Encrypt enforces
+  [strict rate limits](https://letsencrypt.org/docs/rate-limits/) — 5
+  failures per account per hour, 50 certs per registered domain per
+  week. Export `ACME_CA_SERVER=https://acme-staging-v02.api.letsencrypt.org/directory`
+  during a first deploy, delete the resulting `acme.json`, then re-issue
+  against prod.
+- **Back up `acme.json`.** Losing the named volume `acme-data` means
+  re-issuing every certificate from scratch — which can trip the per-week
+  rate limit if you have several hosts.
+
+## Security headers
+
+The dynamic config exports two middleware names:
+
+- `security-headers@file` — HSTS preload, `X-Content-Type-Options`,
+  `X-Frame-Options: SAMEORIGIN`, `Referrer-Policy`, and `Server` /
+  `X-Powered-By` suppression.
+- `rate-limit@file` — opt-in token bucket (100 rps average, 200 burst).
+
+The full rationale, the OSPS-L2 evidence mapping, and per-service header
+overrides live in [/guides/self-hosting/hardening](/guides/self-hosting/hardening) —
+this guide intentionally does not duplicate them.
+
+## mTLS between services
+
+Traefik does **not** mTLS to backends today. The trust boundary is the
+Docker network `raven-internal`: anything attached to it is trusted by
+the other services on it. There is no client-cert auth between Traefik
+and the Go API, between the Go API and the Python worker, or between the
+Go API and PostgreSQL.
+
+If you need cryptographic identity between containers (zero-trust /
+SPIFFE-style), that is a workload-mesh concern (Linkerd, Istio, Consul
+Connect) layered on top of Compose — Raven does not bake that in.
+
+## Disabling the dashboard in production
+
+The shipped `traefik.yml` is dev-friendly:
+
+```yaml
+api:
+  dashboard: true
+  insecure: true
+```
+
+`insecure: true` exposes the dashboard on the public entrypoint without
+auth. **Flip both to `false` in production** — either edit
+`traefik.yml` and redeploy, or override via CLI (the edge compose already
+does this with `--api=false`):
+
+```yaml
+api:
+  dashboard: false
+  insecure: false
+```
+
+If you want the dashboard available to operators, attach it to a router
+behind `Host(...)` and a `basicAuth` middleware, never on the
+unauthenticated `:8080` port. Also stop publishing `8082:8080` to the
+host in the compose file.
+
+## Cloudflare in front
+
+If Cloudflare proxies your hostname (orange-cloud), client IPs reaching
+Traefik are Cloudflare edge IPs, and the real client IP is in the
+`CF-Connecting-IP` / `X-Forwarded-For` headers. Traefik discards
+forwarded headers by default unless the source is an explicitly trusted
+proxy. To trust Cloudflare:
+
+1. Extend the `websecure` entrypoint with a `forwardedHeaders.trustedIPs`
+   list containing
+   [Cloudflare's published IP ranges](https://www.cloudflare.com/ips/).
+2. Mirror the same list under `proxyProtocol.trustedIPs` if you also
+   enable Cloudflare's PROXY protocol (Spectrum).
+
+Without this, every request appears to come from a Cloudflare node and
+`rate-limit@file` becomes useless. Note that the shipped
+`deploy/traefik/traefik.yml` does **not** ship a default trusted-IP list —
+add it per deployment, because the trust set depends on whether you
+front Traefik with Cloudflare at all.
+
+## Troubleshooting
+
+**ACME challenge fails.**
+
+```
+unable to generate a certificate for the domains [...] propagation: time limit exceeded
+```
+
+- Check that `CF_DNS_API_TOKEN` has `Zone:DNS:Edit` on the right zone.
+- Verify the zone NS records actually point at Cloudflare.
+- Confirm port 80 is reachable from outside the host
+  (`curl -v http://<host>/`) — even DNS-01 keeps the redirect.
+- Watch `docker logs traefik | grep -i acme` for the specific failure;
+  retry against staging first.
+
+**Routing returns 404.**
+
+- `docker exec traefik traefik healthcheck` returns OK but a URL 404s →
+  Traefik is up but no router matched. Common causes:
+  - Typo in a `traefik.http.routers.<name>.rule` label.
+  - Backend not on `raven-internal` — Traefik sees the label but can't
+    reach the container.
+  - `traefik.enable=true` missing.
+- Open the dashboard (or run `traefik` with `--log.level=DEBUG`) and
+  confirm the router shows in the **HTTP Routers** tab.
+
+**TLS handshake errors.**
+
+- `unrecognized_name` — `sniStrict: true` rejected the request because
+  the client did not send SNI matching any router rule. Hit the actual
+  hostname, not the IP.
+- `no certificate found` on a sub-domain — the cert covers a different
+  name. DNS-01 + wildcards solve this; HTTP-01 cannot issue wildcards.
+
+**Dashboard not reachable.**
+
+- Confirm `8082:8080` is published and `api.insecure: true` in
+  `traefik.yml` — both required for the dev dashboard. If you disabled
+  it for prod, that is intentional.
+
+## See also
+
+- [/guides/self-hosting/hardening](/guides/self-hosting/hardening) —
+  full hardening posture, security-header rationale, OSPS-L2 evidence.
+- [/guides/self-hosting/docker-compose](/guides/self-hosting/docker-compose) —
+  compose variants, service map, common workflows.
+- [/reference/configuration](/reference/configuration) — every
+  `RAVEN_*` and `ACME_*` environment variable and default value.

--- a/docs-site/stubs/guides/self-hosting/upgrades.md
+++ b/docs-site/stubs/guides/self-hosting/upgrades.md
@@ -1,16 +1,377 @@
 ---
-title: "Coming Soon"
+title: "Upgrades"
 ---
 
 # Upgrades
 
-::: warning Stub page
-This page is a placeholder. The full content is being written. If you would
-like to contribute, the source for this page lives at the path shown below
-and you can [edit it on GitHub](https://github.com/ravencloak-org/Raven/edit/main/docs-site/stubs/guides/self-hosting/upgrades.md).
+Upgrading a Raven instance is a four-step ritual: read the CHANGELOG, take
+a backup, pull new images, run migrations. The order matters. Skipping the
+backup or skipping the migration step has lost data for operators of
+similar stacks; do not improvise.
+
+::: danger Pre-1.0 means breaking changes can land in any minor release
+Raven is currently pre-1.0. The [release process](/contributing/release-process)
+page is explicit about this:
+
+> While the project is pre-1.0, **minor version bumps may include
+> breaking changes**; patch releases (`vX.Y.Z` → `vX.Y.Z+1`) are reserved
+> for bug-fix and security backports.
+
+Always read every CHANGELOG entry between your current version and the
+target before you upgrade. Schema, config-file shape, and API surfaces
+can all change without a deprecation cycle until `v1.0.0` ships.
 :::
 
-## What goes here
+## Versioning
 
-A short bullet list of the topics this page will cover, drawn from the
-[design spec](https://github.com/ravencloak-org/Raven/blob/main/docs/superpowers/specs/2026-05-09-docs-site-design.md).
+Raven follows [Semantic Versioning](https://semver.org/). The pre-1.0
+contract differs from the post-1.0 contract on **minor** releases:
+
+| Bump    | Pre-1.0 (`v0.x.y`)                                    | Post-1.0 (`v1.x.y` and later)                  |
+|---------|-------------------------------------------------------|------------------------------------------------|
+| `major` | Reserved — `v1.0.0` itself is the first major bump.   | Breaking changes allowed; documented.          |
+| `minor` | **May include breaking changes.** Read CHANGELOG.     | Backwards-compatible features only.            |
+| `patch` | Always safe: bug fixes and security backports only.   | Always safe: bug fixes and security backports. |
+
+The release tag format is `vX.Y.Z`. Release candidates use `-rc` suffixes
+(`v0.4.0-rc1`); these do not get the `latest` Docker tag and should not
+be pulled in production.
+
+See [Release process](/contributing/release-process) for the full
+mechanics of how releases are cut, signed, and attested.
+
+## Read the changelog
+
+Every release entry is generated from conventional commits via `git-cliff`
+(`cliff.toml` at the repo root) and grouped into these sections:
+
+- **Features** (`feat:`) — new behaviour; check for opt-in flags.
+- **Bug Fixes** (`fix:`) — usually safe; read in case the fix changes
+  observable behaviour you relied on.
+- **Performance** (`perf:`), **Refactors** (`refactor:`) — typically
+  internal, but read anyway.
+- **Documentation** (`docs:`), **Tests** (`test:`), **CI / Build**
+  (`ci:`), **Chores** (`chore:`), **Dependencies** (`deps:`) — rarely
+  operator-affecting.
+- **Security** (`security:` / `sec:`) — treat as mandatory upgrades.
+- **Reverts** (`revert:`) — note carefully; a feature you depended on
+  may be gone.
+
+The full changelog is rendered inline on the docs site at
+[/reference/changelog](/reference/changelog); it is the same
+`CHANGELOG.md` shipped at the root of the repository, included verbatim
+via VitePress's `@include` directive. Read it from the version you are
+on through the version you are targeting — not just the latest entry.
+
+## Backup before upgrading
+
+**Do not skip this.** Migrations are forward-only (see below) and image
+rollback while the database is on a newer schema is not guaranteed to
+work.
+
+1. **PostgreSQL full backup via pgBackRest.** The `pgbackrest` sidecar
+   in `docker-compose.yml` is the wired path:
+
+   ```bash
+   docker compose exec pgbackrest pgbackrest --stanza=raven backup --type=full
+   ```
+
+2. **SeaweedFS volume snapshot.** No application-level backup is wired;
+   either `docker compose stop seaweedfs-volume` and `tar -czf
+   seaweedfs-$(date +%F).tar.gz` the `seaweedfs-data` volume contents,
+   or use `weed volume.copy` to a remote target. Full procedure in
+   [Backups](/guides/self-hosting/backups).
+
+3. **Capture your `.env`** (or the `dotenvx`-encrypted `.env.keys`)
+   somewhere outside the host. Config drift across upgrades is a common
+   regression source.
+
+4. **Note your current commit / image tag.** `git rev-parse HEAD` if
+   running from source, or `docker compose images go-api` for the
+   currently-running image digest. You will need this if you have to
+   roll back.
+
+If you do not have a verified restore path, see the
+[Backup verification](/guides/self-hosting/backups#backup-verification)
+section before touching production.
+
+## Upgrade procedure (cloud / full compose)
+
+This is the path for the full `docker-compose.yml` stack — Go API,
+Python AI worker, Python agent, frontend, Postgres, Valkey, SuperTokens,
+OpenObserve, LiveKit, SeaweedFS, Traefik, and pgBackRest.
+
+```bash
+# 1. Update the source tree (if running from source).
+git fetch --tags
+git checkout v0.4.0          # the target tag
+
+# 2. Pull the new container images.
+docker compose pull
+
+# 3. Apply pending database migrations BEFORE starting the new API.
+#    Migrations are NOT auto-run on go-api boot (see "Database
+#    migrations" below).
+make migrate-up
+
+# 4. Clean stop the running stack. Named volumes are preserved.
+docker compose down
+
+# 5. Start the new stack.
+docker compose up -d
+
+# 6. Tail logs until everything reports healthy.
+docker compose logs -f go-api python-worker python-agent
+```
+
+Then smoke-test:
+
+```bash
+curl -fsS http://localhost:8080/healthz       # expect: HTTP 200
+# Run a search query through the UI.
+# Run a chat turn through the UI.
+# If voice is in use, start a LiveKit session and speak.
+```
+
+If `/healthz` is green and a search round-trips, the upgrade landed.
+
+::: tip Order matters
+Apply migrations *before* `docker compose up -d` of the new API image.
+A new API talking to an old schema fails at startup; an old API talking
+to a new schema may silently corrupt data. The order above puts you in
+the safe state at every step.
+:::
+
+## Upgrade procedure (edge)
+
+For `docker-compose.edge.yml` deployments (Raspberry Pi and similar —
+only Go API, Postgres, and Traefik run on the node; the Python AI worker
+lives off-host and is reached over gRPC at `GRPC_AI_WORKER_ADDR`):
+
+```bash
+git fetch --tags && git checkout v0.4.0
+docker compose -f docker-compose.edge.yml --env-file .env.edge pull
+make migrate-up
+docker compose -f docker-compose.edge.yml --env-file .env.edge down
+docker compose -f docker-compose.edge.yml --env-file .env.edge up -d
+```
+
+The edge image is `linux/arm64` only. If you build locally instead of
+pulling, use `make -f Makefile.edge docker-arm64` to produce the
+matching image before `docker compose up`.
+
+Edge nodes typically do not run pgBackRest in-stack. Take a Postgres
+dump (`pg_dump`) to a remote host before upgrading, or skip the
+in-stack backup step and rely on your separate off-host backup job.
+
+## Database migrations
+
+Migrations are managed by [pressly/goose](https://github.com/pressly/goose)
+v3, files in `migrations/` numbered `00001_*.sql` through `00039_*.sql`
+(at time of writing — count grows with each release). The in-DB state
+table is `goose_db_version`.
+
+**Migrations are NOT applied automatically on `go-api` startup.** The
+production binary (`/app/api` in the container) does not import goose at
+all — `github.com/pressly/goose/v3` only appears under
+`internal/testutil/db.go` and other test-only paths. The wired operator
+path is the `Makefile` target:
+
+```bash
+# Apply all pending migrations.
+make migrate-up
+
+# Roll back the most recent migration (rarely safe — see "Rollback").
+make migrate-down
+```
+
+Both targets delegate to:
+
+```bash
+dotenvx run -- goose -dir migrations postgres "$DATABASE_URL" up
+```
+
+Inspect migration state at any time:
+
+```bash
+# Via goose itself (needs DATABASE_URL).
+goose -dir migrations postgres "$DATABASE_URL" status
+
+# Or directly in the DB.
+psql "$DATABASE_URL" -c \
+  "SELECT MAX(version_id) FROM goose_db_version WHERE is_applied = true;"
+```
+
+Migration files are forward-only. A `-- +goose Down` block may exist
+for development convenience, but **production should not rely on goose
+`down` for rollback** — destructive schema changes are not always
+reversible from the down-script alone. Use the
+[pgBackRest restore path](/guides/self-hosting/backups#restore-procedure)
+instead.
+
+## Image tag strategy
+
+The release workflow (`.github/workflows/release.yml`) produces three
+image-tag flavours via `docker/metadata-action`:
+
+| Tag pattern         | Example                | When to use                                                      |
+|---------------------|------------------------|------------------------------------------------------------------|
+| `vX.Y.Z`            | `v0.4.0`               | **Recommended for production.** Pinned, immutable, signed.       |
+| `X.Y` (major.minor) | `0.4`                  | Auto-tracks patch releases inside a minor line. Use for staging. |
+| `latest`            | `latest`               | **Do not use in production.** Tracks the newest non-RC tag.      |
+| `sha-<short>`       | `sha-c3091421`         | Pinned to a specific commit. Useful for bisecting regressions.   |
+
+Set the tag explicitly in `.env`:
+
+```bash
+RAVEN_API_IMAGE=ghcr.io/ravencloak-org/go-api:v0.4.0
+```
+
+Release-candidate tags (`v0.4.0-rc1`) deliberately do **not** receive
+`latest`; the workflow has
+`enable=${{ !contains(needs.preflight.outputs.tag, '-rc') }}` on that
+tag rule. Pulling `latest` will never silently give you an RC.
+
+All multi-arch manifests (`linux/amd64` + `linux/arm64`) are cosign-signed
+with SLSA build provenance and SPDX SBOM attestations. Verify before
+deploying — see [SLSA Build Level 3](/trust/slsa-level-3).
+
+## Rollback
+
+Container rollback is one command away; **database rollback is not.**
+
+### Container images
+
+```bash
+# Edit .env to pin the previous tag, then:
+docker compose pull go-api
+docker compose up -d go-api
+```
+
+This works **only if the database schema is still compatible**. If the
+failed upgrade applied new migrations, the old API may refuse to start
+or — worse — start and write data the new schema expected.
+
+### Database
+
+Goose `down` migrations are not a supported production rollback path.
+The correct procedure is a pgBackRest point-in-time restore to a moment
+just before you ran `make migrate-up`:
+
+```bash
+docker compose stop go-api
+docker compose exec pgbackrest pgbackrest --stanza=raven \
+  --type=time --target="2026-05-12 14:00:00+00" restore
+docker compose start postgres
+docker compose start go-api
+```
+
+Full restore procedure in
+[Backups → Restore procedure](/guides/self-hosting/backups#restore-procedure).
+You will lose any writes made after the target time; coordinate with
+users before doing this in production.
+
+## Breaking changes
+
+The CHANGELOG follows the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+convention. Breaking changes are surfaced in two places:
+
+- A **`Notes`** section at the bottom of an affected release (visible
+  in the rendered changelog) calls out config-shape changes, removed
+  endpoints, and required manual steps.
+- The commit subject for a breaking change uses the conventional-commits
+  `!` marker (`feat!: …`, `refactor!: …`). `cliff.toml` has
+  `protect_breaking_commits = false`, so these are not auto-promoted to
+  a separate section yet — read the **Notes** block carefully.
+
+Typical breaking changes to look for in `Notes`:
+
+- **Config-shape changes** — renamed or removed `RAVEN_*` environment
+  variables. Re-read `.env.example` after each minor bump.
+- **Removed endpoints** — the API surface has not stabilised; older
+  routes may be removed without a deprecation window pre-1.0.
+- **Schema changes that require data migration** — occasionally a
+  migration runs a non-trivial backfill. The release notes will say so;
+  budget extra downtime.
+
+## Frontend, docs, and landing
+
+These three sites deploy via **Cloudflare Pages** on every push to
+`main` (`pages.yml`, `landing.yml`, `docs.yml`). They are **not** part
+of the tagged release artefact set. Upgrading them is implicit — merge
+to `main` and Cloudflare ships in minutes.
+
+Rollback is via the **Cloudflare Pages dashboard** → project →
+Deployments → previous deployment → "Rollback to this deployment". A
+revert PR on `main` will also re-deploy; whichever is faster.
+
+This is the same flow documented in
+[Release process → Rollback → Cloudflare Pages sites](/contributing/release-process#cloudflare-pages-sites-frontend-landing-docs).
+
+## Voice / LiveKit upgrades
+
+The reference compose pins `livekit/livekit-server:latest` in
+`docker-compose.yml`. A LiveKit-server image bump can change the
+WebRTC negotiation surface, which means:
+
+- **Browser clients may need a hard refresh** to pick up the matching
+  client SDK shipped in the new frontend bundle. After an upgrade that
+  touches LiveKit, advise users to reload the tab if voice fails to
+  connect once.
+- **Old desktop clients** (Tauri) bundled with a prior SDK may need to
+  be re-installed. Check the release notes for the desktop bundle.
+- **TURN / SFU port range** (`50000-60000/udp`) and `7882/tcp` are
+  unchanged across LiveKit minor versions to date — no firewall changes
+  expected — but verify in the release notes if voice connection drops
+  after upgrade.
+
+For production, pin `livekit/livekit-server` to a tag rather than
+`latest` so voice upgrades are deliberate rather than incidental.
+
+## Pre-1.0 caveats
+
+Until `v1.0.0` ships, treat the following as possible in any minor
+release:
+
+- **Schema changes without a deprecation cycle.** A column can be
+  renamed or dropped; a table can be merged or split. Read every
+  migration file added between your version and the target.
+- **API shape changes.** Request and response bodies under `/api/v1`
+  can change between minor releases. If you have built integrations,
+  pin to a `vX.Y.Z` Docker tag and upgrade deliberately.
+- **Config-file format changes.** `.env` variables are renamed or
+  removed; the YAML overlays in `docker-compose.*.yml` are restructured.
+  Diff `.env.example` against your `.env` after every minor bump.
+- **Default-value changes.** A feature flag that defaulted to `false`
+  may become `true` (or vice versa). The release notes will say so;
+  read them.
+
+Once `v1.0.0` ships, standard SemVer applies and minor releases become
+strictly additive.
+
+## Post-upgrade checklist
+
+After every upgrade, confirm:
+
+- [ ] `docker compose ps` shows every service in the `healthy` state.
+- [ ] `curl -fsS http://localhost:8080/healthz` returns HTTP 200.
+- [ ] `psql "$DATABASE_URL" -c "SELECT MAX(version_id) FROM goose_db_version WHERE is_applied = true;"` matches the highest filename in `migrations/`.
+- [ ] A search query through the UI returns results.
+- [ ] A chat turn through the UI completes (RAG + LLM round-trip).
+- [ ] If voice is in use, a LiveKit session connects and audio flows.
+- [ ] `docker compose exec pgbackrest pgbackrest --stanza=raven check` succeeds (backups still running).
+- [ ] Telemetry — OpenObserve shows traces and logs from the new build
+  tag; Beszel shows host metrics steady-state.
+
+If any item fails, do not declare the upgrade complete. Open an issue
+with the failing check and the previous + current image tags.
+
+## Cross-references
+
+- [Release process](/contributing/release-process) — how Raven cuts and
+  signs releases.
+- [Changelog](/reference/changelog) — every release entry, rendered
+  inline.
+- [Backups](/guides/self-hosting/backups) — pgBackRest, restore, PITR.
+- [SLSA Build Level 3](/trust/slsa-level-3) — provenance attached to
+  each release.

--- a/docs-site/stubs/guides/voice.md
+++ b/docs-site/stubs/guides/voice.md
@@ -1,16 +1,350 @@
 ---
-title: "Coming Soon"
+title: "Voice"
 ---
 
 # Voice
 
-::: warning Stub page
-This page is a placeholder. The full content is being written. If you would
-like to contribute, the source for this page lives at the path shown below
-and you can [edit it on GitHub](https://github.com/ravencloak-org/Raven/edit/main/docs-site/stubs/guides/voice.md).
-:::
+This guide is the operator-and-developer surface for Raven's voice agent: how
+to deploy LiveKit, how to wire speech-to-text (STT) and text-to-speech (TTS)
+providers, how voice sessions are persisted, what gets billed, and how to keep
+recordings inside the retention promise.
 
-## What goes here
+If you just want a five-minute "is my mic plugged in" demo, start at
+[/get-started/try-the-voice-agent](/get-started/try-the-voice-agent) and
+come back here once a turn round-trips end-to-end.
 
-A short bullet list of the topics this page will cover, drawn from the
-[design spec](https://github.com/ravencloak-org/Raven/blob/main/docs/superpowers/specs/2026-05-09-docs-site-design.md).
+## Architecture recap
+
+The voice path crosses three processes. A browser (or mobile client) joins a
+**LiveKit room** over WebRTC; a separate Python process called **`python-agent`**
+joins the same room as a server-side participant, ferries audio between
+LiveKit and the configured STT/TTS plugins, and calls into the gRPC `RAGServicer`
+to answer using the workspace's knowledge bases. The Go API tracks the session
+lifecycle, mints LiveKit access tokens, and persists turns and usage rows in
+Postgres.
+
+`python-agent` is **not** the same binary as `python-worker` — the gRPC AI worker
+runs `python -m raven_worker` (entrypoint `raven_worker/__main__.py`), while
+the voice agent runs `python -m raven_worker.agent`
+([`ai-worker/raven_worker/agent.py`](https://github.com/ravencloak-org/Raven/blob/main/ai-worker/raven_worker/agent.py))
+as a standalone long-lived worker that calls `livekit.agents.cli.run_app`. They
+ship in the same Python package and the same Docker image, but they are
+deployed and scaled as distinct services in `docker-compose.yml`.
+
+For the full module map see
+[/concepts/ai-worker-design](/concepts/ai-worker-design#voice-agent).
+
+## LiveKit deployment options
+
+### Self-hosted (default in Compose)
+
+The bundled `docker-compose.yml` ships a `livekit-server` service running the
+official `livekit/livekit-server:latest` image, with its config at
+[`deploy/livekit/livekit.yaml`](https://github.com/ravencloak-org/Raven/blob/main/deploy/livekit/livekit.yaml).
+Key ports:
+
+| Port           | Protocol | Purpose                                         |
+|----------------|----------|-------------------------------------------------|
+| `7880`         | HTTP/WS  | Signalling + RoomService HTTP API               |
+| `7882`         | TCP      | WebRTC TCP fallback for restricted networks     |
+| `50000–60000`  | UDP      | WebRTC media (`rtc.port_range_start/end`)       |
+
+`use_external_ip: true` is set so LiveKit advertises the host's public IP in
+its ICE candidates. The two Google STUN servers in `livekit.yaml` are enough
+for the open internet — add a TURN server only when you have clients behind
+symmetric NATs that block UDP entirely.
+
+Behind Traefik, the included labels publish LiveKit's HTTP/WS API on
+`/livekit/*` with TLS via the configured cert resolver. UDP media ports must
+be exposed on the host (not routed through Traefik).
+
+### LiveKit Cloud
+
+To use the managed service instead, stop the `livekit-server` container,
+remove the `depends_on: livekit-server` entry from `python-agent`, and point
+both the agent and the Go API at your cloud URL:
+
+```bash
+RAVEN_LIVEKIT_API_URL=https://<project>.livekit.cloud
+RAVEN_LIVEKIT_WS_URL=wss://<project>.livekit.cloud
+RAVEN_LIVEKIT_API_KEY=<from console>
+RAVEN_LIVEKIT_API_SECRET=<from console>
+```
+
+The same env vars are read by `internal/config/config.go` (`LiveKitConfig`)
+and by the agent's `Settings` in `ai-worker/raven_worker/config.py`. No code
+changes are required for the switch — only credentials.
+
+## STT and TTS provider selection
+
+Provider choice is configured Go-side and consumed by the agent process at
+startup. The supported set, as wired today, is:
+
+| Surface | Provider key | Where it lives                              | Env prefix              |
+|---------|--------------|---------------------------------------------|-------------------------|
+| STT     | `deepgram`   | Deepgram Nova cloud API                     | `RAVEN_STT_DEEPGRAM_*`  |
+| STT     | `whisper`    | Self-hosted faster-whisper / Whisper.cpp    | `RAVEN_STT_WHISPER_*`   |
+| TTS     | `cartesia`   | Cartesia Sonic cloud API                    | `RAVEN_TTS_CARTESIA_*`  |
+| TTS     | `piper`      | Self-hosted Piper voices                    | `RAVEN_TTS_PIPER_*`     |
+
+`STTConfig.Provider` selects the active backend; when left empty,
+`internal/config/config.go` falls back to Deepgram if `RAVEN_STT_DEEPGRAM_API_KEY`
+is set and to Whisper otherwise. `TTSConfig.Provider` accepts `cartesia` or
+`piper`. The full bind list:
+
+```text
+RAVEN_STT_PROVIDER            deepgram | whisper (or empty for auto)
+RAVEN_STT_DEEPGRAM_API_KEY    Deepgram key
+RAVEN_STT_DEEPGRAM_MODEL      e.g. nova-2
+RAVEN_STT_DEEPGRAM_BASE_URL   override for self-hosted Deepgram on-prem
+RAVEN_STT_WHISPER_ENDPOINT    http://whisper:9000 (your faster-whisper server)
+RAVEN_STT_WHISPER_MODEL       e.g. base | small | medium
+
+RAVEN_TTS_PROVIDER            cartesia | piper
+RAVEN_TTS_CARTESIA_API_KEY    Cartesia key
+RAVEN_TTS_CARTESIA_VOICE_ID   Cartesia voice slug
+RAVEN_TTS_CARTESIA_MODEL      e.g. sonic-english
+RAVEN_TTS_CARTESIA_BASE_URL   override for staging endpoints
+RAVEN_TTS_PIPER_ENDPOINT      http://piper:5000
+RAVEN_TTS_PIPER_VOICE         default en_US-amy-medium
+```
+
+### Plugin attachment status
+
+The agent process is currently a thin shell: `agent.py` constructs a
+`livekit.agents.voice.AgentSession()` with `auto_subscribe=AUDIO_ONLY` and
+attaches it to incoming rooms, but it does **not yet** instantiate STT or
+TTS plugins. The provider configuration above is fully read and validated
+Go-side and is ready for the agent to consume; wiring the actual
+`livekit-agents` STT and TTS plugin classes is tracked as issues **#59**
+(STT) and **#60** (TTS). Operators should treat this guide as the **target
+contract** — the env vars listed here will not change once the plugins
+land, but the agent will only start answering with audio after #59 and #60
+are merged.
+
+## Voice session lifecycle
+
+Every voice call is anchored on a row in `voice_sessions` (see migration
+[`00029_voice_sessions.sql`](https://github.com/ravencloak-org/Raven/blob/main/migrations/00029_voice_sessions.sql)).
+The columns:
+
+| Column                  | Type                  | Notes                                       |
+|-------------------------|-----------------------|---------------------------------------------|
+| `id`                    | `UUID`                | primary key                                 |
+| `org_id`                | `UUID`                | tenant scope; enforced by RLS               |
+| `user_id`               | `UUID?`               | mutually exclusive with `stranger_id`       |
+| `stranger_id`           | `UUID?`               | for anonymous public widget callers         |
+| `livekit_room`          | `VARCHAR(255)`        | LiveKit room name; auto-generated on create |
+| `state`                 | `voice_session_state` | `created` → `active` → `ended`              |
+| `started_at`            | `TIMESTAMPTZ?`        | set on first audio                          |
+| `ended_at`              | `TIMESTAMPTZ?`        | set on hangup / timeout                     |
+| `call_duration_seconds` | `INTEGER` (generated) | `ended_at - started_at`, materialised       |
+| `created_at`            | `TIMESTAMPTZ`         |                                             |
+| `updated_at`            | `TIMESTAMPTZ`         | maintained by trigger                       |
+
+State machine (defined as the `voice_session_state` Postgres enum and mirrored
+in `internal/model/voice.go`):
+
+```text
+created ──► active ──► ended
+   │                      ▲
+   └──────────────────────┘   (hangup before audio)
+```
+
+The Go service auto-generates `livekit_room` if the create request omits it.
+A `chk_voice_session_actor` constraint enforces that a session is bound to
+either a known user, an anonymous stranger, or neither — never both.
+
+Endpoints (from `internal/handler/voice.go`, all under
+`/v1/orgs/:org_id/voice-sessions`):
+
+| Method | Path                                | Action                              |
+|--------|-------------------------------------|-------------------------------------|
+| `POST` | `/`                                 | Create session (`created`)          |
+| `GET`  | `/`                                 | List sessions (paginated)           |
+| `GET`  | `/:session_id`                      | Fetch a session                     |
+| `PATCH`| `/:session_id`                      | Transition state (`active`/`ended`) |
+| `POST` | `/:session_id/token`                | Mint a LiveKit JWT for a participant|
+| `POST` | `/:session_id/turns`                | Append a transcribed turn           |
+| `GET`  | `/:session_id/turns`                | List turns ordered by `started_at`  |
+
+## Voice turns and transcripts
+
+Per-turn transcripts live in `voice_turns` (same migration):
+
+| Column       | Type            | Notes                                |
+|--------------|-----------------|--------------------------------------|
+| `id`         | `UUID`          |                                      |
+| `session_id` | `UUID`          | FK → `voice_sessions(id)` `ON DELETE CASCADE` |
+| `org_id`     | `UUID`          | denormalised for RLS efficiency      |
+| `speaker`    | `voice_speaker` | `agent` or `user`                    |
+| `transcript` | `TEXT`          | STT output for user; final assistant text for agent |
+| `started_at` | `TIMESTAMPTZ`   | from the audio frame timeline        |
+| `ended_at`   | `TIMESTAMPTZ?`  | end of utterance                     |
+
+Turns are indexed by `(session_id, started_at)`. They share the
+`tenant_isolation` row-level-security policy on `org_id`, so transcripts from
+one workspace are never visible to another even with shared connection
+pooling.
+
+Transcripts inherit retention from the parent conversation (see
+[Privacy and recording](#privacy-and-recording) below); deleting a session
+cascades to its turns.
+
+## Usage summaries
+
+`voice_usage_summaries` (migration
+[`00030_voice_usage.sql`](https://github.com/ravencloak-org/Raven/blob/main/migrations/00030_voice_usage.sql))
+aggregates ended sessions into one row per `(org_id, period_start)` hour
+window for billing dashboards and tenant-facing usage reports:
+
+| Column                   | Type           | Notes                                  |
+|--------------------------|----------------|----------------------------------------|
+| `id`                     | `UUID`         |                                        |
+| `org_id`                 | `UUID`         |                                        |
+| `period_start`           | `TIMESTAMPTZ`  | hourly bucket, unique per org          |
+| `total_sessions`         | `INTEGER`      | sessions ended in the window           |
+| `total_duration_seconds` | `INTEGER`      | summed `call_duration_seconds`         |
+
+Cost columns (STT minutes, LLM tokens, TTS characters) are **not** stored
+today — operators back into them from provider invoices using
+`total_duration_seconds` as the denominator. The unique constraint
+`uq_voice_usage_org_period` makes the upsert from the aggregator idempotent.
+
+## Audio storage
+
+LiveKit forwards raw RTP to the agent in real time and does not persist
+audio by itself. When you enable session recording (a LiveKit Egress job),
+the resulting WebM/MP4 blob lands in **SeaweedFS**, the same object store
+used for document attachments — see `SeaweedFSConfig` in
+`internal/config/config.go`. There is no separate audio bucket; recordings
+are scoped by the same per-org prefix scheme as uploads.
+
+Default retention for voice audio is **30 days**, as documented in
+[`PRIVACY.md` §9](https://github.com/ravencloak-org/Raven/blob/main/PRIVACY.md#9-retention).
+Callers may opt in to extended retention (Art. 6(1)(a) consent under GDPR;
+the matching DPDP basis applies for Indian deployments). To extend the
+default for a whole workspace you currently need to schedule your own
+SeaweedFS lifecycle job — there is no Raven-level setting for this yet.
+
+## Costs
+
+Voice billing is provider-driven and add-on to your regular LLM bill.
+Rough per-minute order of magnitude (always check the provider's current
+pricing page):
+
+- **STT minutes** — Deepgram Nova is billed per audio minute streamed.
+  Self-hosted faster-whisper has zero per-minute cost but pins one CPU core
+  (or one GPU slot) per concurrent stream.
+- **LLM tokens** — every user turn pulls retrieved chunks into the prompt
+  via the standard RAG pipeline (`raven_worker/services/rag.py`), so cost
+  scales with conversation length and `top_k`. The same model and BYOK key
+  resolved for text chat applies — voice does not bypass `llm_provider_configs`.
+- **TTS characters** — Cartesia Sonic is billed per character of synthesised
+  speech. Piper is free at the cost of one CPU core per stream.
+
+Because `voice_usage_summaries` does not yet aggregate token or character
+counts, link your provider account to the same workspace and reconcile via
+their dashboards.
+
+## Limits
+
+The current build has **no built-in concurrency cap** on voice sessions —
+the limit is whichever runs out first: LiveKit room slots, agent CPU, or
+your STT provider's concurrent-connection quota. Plan for one CPU core per
+self-hosted STT/TTS stream and at least 1 vCPU per agent process.
+
+The Go API rejects `POST /voice-sessions/:id/turns` once a session has
+transitioned to `ended`, which gives you a natural per-session turn ceiling
+via your client logic — there is no hard server-side `max_turns` enforced
+today.
+
+Maximum session length is governed by LiveKit's `room_empty_timeout`
+(currently the LiveKit default; no override in
+[`deploy/livekit/livekit.yaml`](https://github.com/ravencloak-org/Raven/blob/main/deploy/livekit/livekit.yaml)
+right now). Add `room_empty_timeout: 300` to that file to hang up rooms
+five minutes after the last participant leaves.
+
+## Tuning
+
+The voice agent re-uses the gRPC `QueryRAG` pipeline, so retrieval knobs are
+the same ones documented in [/guides/retrieval](/guides/retrieval) —
+`top_k`, the hybrid-search RRF blend, and the Cohere re-ranker toggle all
+apply unchanged. Voice-specific guidance:
+
+- **System prompt** — the voice agent does not maintain its own prompt
+  file; whatever system prompt your tenant has configured for chat is
+  applied. Once the STT/TTS plugins land, expect the agent to layer a short
+  "speak in short sentences, never read URLs aloud" preamble on top of the
+  tenant prompt inside `agent.py`. Treat that as the single place to edit
+  voice-only persona.
+- **Retrieval top-K** — voice answers should be short, so a `top_k` of
+  **3–4** typically reads more natural than the chat default of 6–8.
+- **`max_tokens` for spoken output** — `services/rag.py` caps streaming
+  responses at `max_tokens=1024` (OpenAI) and `max_tokens=2048` (Anthropic);
+  for voice you generally want shorter, so override the per-tenant model
+  config rather than the worker default.
+
+## Privacy and recording
+
+Voice audio, transcripts, and embeddings are **personal data** under GDPR
+Art. 4(1) and may incidentally capture special-category data under Art. 9
+if the caller volunteers it — see `PRIVACY.md` §6. Operator responsibilities:
+
+- **Notice on connect.** Inform the caller that the call is being processed
+  by an AI agent and (where applicable) recorded — the widget should
+  surface this before joining the LiveKit room.
+- **Consent for extended retention.** The 30-day audio default is the only
+  one we rely on Art. 6(1)(f) legitimate-interests for; anything longer is
+  Art. 6(1)(a) **consent**.
+- **Right to erasure.** `voice_sessions` and `voice_turns` cascade-delete
+  cleanly on `org_id` / `user_id`. SeaweedFS objects must be deleted via the
+  same DSAR pipeline as document attachments.
+
+The public-facing privacy notice is still in `/trust/privacy` (held back).
+Defer to the in-repo `PRIVACY.md` until it ships.
+
+## Troubleshooting
+
+**`401 Unauthorized` when creating a LiveKit room.**
+The Go API and the agent must share the same `RAVEN_LIVEKIT_API_KEY` /
+`RAVEN_LIVEKIT_API_SECRET` pair. Compose defaults to `devkey` / `devsecret`
+— check both services are reading the same `.env` and that you didn't
+override only one side.
+
+**Browser connects, no audio in either direction.**
+Almost always blocked UDP. Confirm `50000–60000/udp` is reachable from the
+client to your host, then fall back to TCP via port `7882` and verify with
+a different network (mobile hotspot). If you sit behind symmetric NAT,
+deploy a TURN server (e.g. Coturn) and add it to `rtc.turn_servers` in
+`livekit.yaml`.
+
+**Browser asks for mic permission and gets denied.**
+Browsers only prompt on **secure origins**. Local dev over `http://localhost`
+works; anything else needs HTTPS via the bundled Traefik resolver.
+
+**Agent doesn't respond at all.**
+Check `docker compose logs python-agent`. Common failures:
+`livekit_credentials_missing` (env not threaded), `livekit_agents_not_installed`
+(the `livekit-agents>=1.0.0` dep didn't make it into the image), or the
+agent attaching to the room but not subscribing because `auto_subscribe`
+got changed away from `AUDIO_ONLY`.
+
+**First turn takes 10+ seconds.**
+If you're on self-hosted Whisper, model load happens on first request —
+pre-warm by issuing a one-byte test transcription at container start, or
+size your Whisper model down from `medium` to `small`/`base` on edge
+hardware.
+
+**`voice_session_state` check constraint violated.**
+The state column is a Postgres enum with only three legal values
+(`created`, `active`, `ended`). Callers updating state directly via SQL must
+respect that — the service layer is the only sanctioned writer.
+
+## Related reading
+
+- [/get-started/try-the-voice-agent](/get-started/try-the-voice-agent) — five-minute hands-on demo
+- [/concepts/ai-worker-design](/concepts/ai-worker-design) — where `agent.py` fits in the worker
+- [/guides/retrieval](/guides/retrieval) — RAG knobs that apply to voice too
+- [/guides/llm-providers](/guides/llm-providers) — BYOK setup for the per-turn LLM call
+- [/reference/configuration](/reference/configuration) — exhaustive `RAVEN_*` env-var list

--- a/docs-site/stubs/guides/webhooks-and-events.md
+++ b/docs-site/stubs/guides/webhooks-and-events.md
@@ -1,16 +1,273 @@
 ---
-title: "Coming Soon"
+title: "Webhooks & Events"
 ---
 
 # Webhooks & Events
 
-::: warning Stub page
-This page is a placeholder. The full content is being written. If you would
-like to contribute, the source for this page lives at the path shown below
-and you can [edit it on GitHub](https://github.com/ravencloak-org/Raven/edit/main/docs-site/stubs/guides/webhooks-and-events.md).
+Raven can notify external systems when interesting things happen in your
+workspace by sending a signed JSON `POST` to a URL you register. This page
+documents the data model, the HTTP contract, the signing scheme, the
+delivery semantics, and the current state of the implementation.
+
+::: warning Current state — schema + plumbing, no live emission
+The webhook **data model**, **management API**, **delivery worker**, and
+**HMAC signing** are implemented in the Go backend (`internal/handler/webhook.go`,
+`internal/service/webhook.go`, `internal/jobs/webhook_delivery.go`,
+`migrations/00024_webhook_configs.sql`).
+
+What is **not** wired today: the application code that calls
+`WebhookService.Dispatch` when an event actually occurs. The function is
+defined and unit-tested, but it has no production call sites — grep
+`internal/` and `cmd/` and you will only see the constructor wiring.
+The enterprise emitter package (`internal/ee/webhooks`) is a doc-comment
+placeholder.
+
+Treat this page as the **reference for the data model and the contract a
+receiver must implement**. Event types listed below are the ones the
+backend will *accept* during webhook registration; whether they fire in
+your build depends on whether the corresponding code path has been wired
+to call `Dispatch`. As of this writing, none of them do.
 :::
 
-## What goes here
+## What's wired
 
-A short bullet list of the topics this page will cover, drawn from the
-[design spec](https://github.com/ravencloak-org/Raven/blob/main/docs/superpowers/specs/2026-05-09-docs-site-design.md).
+| Component | File | Status |
+|-----------|------|--------|
+| `webhook_configs` + `webhook_deliveries` tables, RLS, indexes | `migrations/00024_webhook_configs.sql` | Real |
+| CRUD API (`/orgs/:org_id/webhooks`) | `internal/handler/webhook.go`, `cmd/api/main.go` | Real, admin-only |
+| List deliveries (`/orgs/:org_id/webhooks/:id/deliveries`) | `internal/handler/webhook.go` | Real, last 50 |
+| Async delivery worker with HMAC-SHA256 signing, SSRF guard, retries | `internal/jobs/webhook_delivery.go` | Real |
+| Dispatch fan-out (look up active subscribers and enqueue) | `internal/service/webhook.go` `WebhookService.Dispatch` | Defined, **no callers** |
+| Event emission from feature code (leads, conversations, etc.) | — | **Not wired** |
+| Replay / resend endpoint | — | Not implemented |
+
+## Event types
+
+Defined in `internal/model/webhook.go` and enforced by
+`supportedWebhookEvents` in `internal/handler/webhook.go`. Subscribing to
+any other name is rejected with HTTP 400.
+
+| Event | Will fire when (planned) |
+|-------|--------------------------|
+| `lead.generated` | A lead intelligence pipeline run produces a new lead row. |
+| `conversation.escalated` | A conversation is escalated to a human operator. |
+| `document.processed` | A document ingestion job finishes successfully. |
+| `sync.completed` | A data source sync (connector) finishes. |
+
+No other event names are accepted. Billing webhooks (`payment_succeeded`,
+etc.) and the Meta / WhatsApp webhook endpoints (`/webhooks/meta`,
+`/webhooks/whatsapp`) are **inbound** — they are a separate concern and
+do not flow through this system.
+
+## Configure a webhook
+
+`POST /api/v1/orgs/{org_id}/webhooks` — requires the `org_admin` role.
+
+Request body (`model.CreateWebhookRequest`):
+
+```json
+{
+  "name": "ops-pager",
+  "url": "https://ops.example.com/raven-hooks",
+  "secret": "a-long-random-string-min-8-chars",
+  "events": ["lead.generated", "document.processed"],
+  "headers": {
+    "X-Internal-Routing": "leads-team"
+  },
+  "max_retries": 5
+}
+```
+
+Validation rules (from the model tags and `validate*` helpers):
+
+- `name` — required, 2–255 chars, unique per org.
+- `url` — required, must parse as a URL, must use `http://` or `https://`.
+  Non-HTTP schemes and private/loopback IPs are blocked at delivery time
+  by the SSRF guard in `internal/jobs/webhook_delivery.go`.
+- `secret` — required, minimum 8 chars. Stored as plain text in the
+  `secret` column. Marked `json:"-"` so it is never returned in API
+  responses after creation.
+- `events` — at least one entry; every entry must be one of the supported
+  event types above.
+- `headers` — optional custom headers. Cannot override `Content-Type`,
+  `X-Raven-Signature`, or `X-Raven-Event` (silently dropped by the
+  delivery worker).
+- `max_retries` — optional, 0–20 (default 5).
+
+Full set of endpoints:
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/orgs/{org_id}/webhooks` | Create |
+| `GET` | `/orgs/{org_id}/webhooks` | List |
+| `GET` | `/orgs/{org_id}/webhooks/{id}` | Fetch one |
+| `PUT` | `/orgs/{org_id}/webhooks/{id}` | Update (partial) |
+| `DELETE` | `/orgs/{org_id}/webhooks/{id}` | Delete |
+| `GET` | `/orgs/{org_id}/webhooks/{id}/deliveries` | List recent attempts (limit 50) |
+
+## Payload shape
+
+Every outbound delivery is a JSON `POST` with this body (constructed in
+`WebhookDeliveryHandler.Process`):
+
+```json
+{
+  "event_type": "lead.generated",
+  "org_id": "0c9d4f1a-...-...",
+  "timestamp": "2026-05-12T08:14:33Z",
+  "data": {
+    "lead_id": "...",
+    "...": "event-specific fields"
+  }
+}
+```
+
+Fixed headers set by Raven:
+
+```
+Content-Type: application/json
+X-Raven-Event: lead.generated
+X-Raven-Signature: sha256=<hex-encoded HMAC>
+```
+
+The `data` field is a free-form `map[string]any` chosen by the caller of
+`Dispatch`. Concrete shapes for each event type will be specified when
+the corresponding emitter is wired.
+
+## Signing + verification
+
+Signing scheme (`internal/jobs/webhook_delivery.go`):
+
+```go
+mac := hmac.New(sha256.New, []byte(hook.Secret))
+mac.Write(bodyBytes)
+signature := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+req.Header.Set("X-Raven-Signature", signature)
+```
+
+The HMAC is over the **raw request body**, not over headers or the URL.
+
+A Node receiver verifies it like this:
+
+```js
+import crypto from "node:crypto";
+
+function verify(rawBody, signatureHeader, secret) {
+  const expected =
+    "sha256=" +
+    crypto.createHmac("sha256", secret).update(rawBody).digest("hex");
+  const a = Buffer.from(expected);
+  const b = Buffer.from(signatureHeader || "");
+  return a.length === b.length && crypto.timingSafeEqual(a, b);
+}
+```
+
+Always compare with a constant-time comparison
+(`crypto.timingSafeEqual` in Node, `hmac.compare_digest` in Python).
+Read the body as bytes before parsing it as JSON — re-serialising will
+change whitespace and break the HMAC.
+
+## Delivery semantics
+
+Implemented in `internal/jobs/webhook_delivery.go` and
+`internal/queue/client.go`:
+
+- **Transport** — Asynq task `webhook:deliver` on the `default` queue.
+- **Retries** — Asynq itself is enqueued with `MaxRetry(0)`; the job
+  handler manages retry counting against the webhook's `max_retries`
+  column. Each attempt increments `failure_count` on the config; a
+  successful delivery resets it to 0.
+- **Termination** — once `failure_count >= max_retries`, the webhook's
+  status is flipped to `failed` and no further deliveries are
+  attempted. A human re-enables it by `PUT`-ing
+  `{"status": "active"}` and clearing the failure count via update.
+- **Backoff** — the schema includes a `next_retry_at` column on
+  `webhook_deliveries` for scheduled re-attempts, but the current job
+  handler does not populate it. Today, retries happen only if a caller
+  enqueues a fresh task; there is no automatic scheduled re-attempt.
+- **Delivery guarantee** — **at-least-once when emitted**. A
+  `webhook_deliveries` row is created *before* the Asynq task is
+  enqueued (`WebhookService.Dispatch`), so receivers may see retries
+  with the same `id` and must be idempotent on it.
+- **Success** — HTTP `2xx` from the receiver.
+- **Failure** — any non-`2xx`, timeout, DNS failure, or SSRF rejection
+  (private IPs, non-HTTP schemes).
+- **HTTP client** — wraps a dialer that resolves DNS and rejects
+  private/loopback IPs to prevent SSRF against internal services. The
+  response body is read with `io.LimitReader` at 4096 bytes and stored
+  in `webhook_deliveries.response_body` for inspection.
+
+## Inspecting deliveries
+
+```
+GET /api/v1/orgs/{org_id}/webhooks/{id}/deliveries
+```
+
+Returns up to 50 most recent `WebhookDelivery` rows for the given
+webhook. Fields (`internal/model/webhook.go`):
+
+```json
+{
+  "id": "uuid",
+  "webhook_id": "uuid",
+  "org_id": "uuid",
+  "event_type": "lead.generated",
+  "payload": { "...": "the data sent" },
+  "response_status": 200,
+  "response_body": "ok",
+  "attempt_count": 1,
+  "success": true,
+  "delivered_at": "2026-05-12T08:14:34Z",
+  "created_at": "2026-05-12T08:14:33Z"
+}
+```
+
+The underlying `webhook_deliveries` table is RLS-scoped to the org via
+`app.current_org_id` (see migration). Admins have a `raven_admin`
+bypass policy.
+
+## Replaying a failed delivery
+
+**Not yet implemented.** There is no replay or resend endpoint. To
+re-fire an event today you would have to enqueue a new
+`WebhookDeliveryPayload` directly against the Asynq queue (see
+`internal/queue/client.go` `EnqueueWebhookDelivery`), or call
+`WebhookService.Dispatch` from a controlled script. The
+`webhook_deliveries.next_retry_at` column exists in anticipation of
+this but is not populated by current code.
+
+## Rate limits
+
+There are **no per-webhook or per-org rate limits** on outbound
+deliveries today. The only relevant caps are:
+
+- `max_retries` per webhook config (default 5, max 20).
+- A 4096-byte cap on the captured response body per delivery row.
+- The global Asynq worker concurrency configured for the `default`
+  queue in the worker process.
+
+Build a receiver that can absorb bursts. If you need throttling, the
+right place to add it is in `WebhookDeliveryHandler.Process` or as a
+queue-level rate limiter; neither is in place today.
+
+## Best practices
+
+- **Be idempotent on `id`.** A retry will arrive with the same
+  `webhook_deliveries.id`; treat it as the dedup key.
+- **Respond fast.** The job handler uses a single HTTP client; long
+  receivers block worker capacity. Acknowledge with `200` and process
+  asynchronously on your side.
+- **Verify the signature before parsing JSON.** Use the raw bytes.
+- **Rotate `secret` regularly** by `PUT`-ing a new `secret` on the
+  webhook config. There is no overlap window today, so plan a short
+  cutover on the receiver.
+- **Use HTTPS.** `http://` is accepted but unsigned over the wire is a
+  bad idea outside a trusted network.
+- **Pin which events you subscribe to.** Don't subscribe to all four
+  and filter on the receiver — extra deliveries are extra failure
+  surface.
+
+## See also
+
+- [API overview](../reference/api-overview.md)
+- [Configuration reference](../reference/configuration.md)

--- a/docs-site/stubs/guides/workspaces-and-tenancy.md
+++ b/docs-site/stubs/guides/workspaces-and-tenancy.md
@@ -1,16 +1,334 @@
 ---
-title: "Coming Soon"
+title: "Workspaces & Tenancy"
 ---
 
 # Workspaces & Tenancy
 
-::: warning Stub page
-This page is a placeholder. The full content is being written. If you would
-like to contribute, the source for this page lives at the path shown below
-and you can [edit it on GitHub](https://github.com/ravencloak-org/Raven/edit/main/docs-site/stubs/guides/workspaces-and-tenancy.md).
-:::
+A practical, task-oriented guide for operators managing **organisations**,
+**workspaces**, **knowledge bases**, and **members** in Raven. Every example
+below is an HTTP call against the public API (`/api/v1`) — the dashboard at
+`/app` is a thin client over the same endpoints.
 
-## What goes here
+For the *why* behind the model — Postgres Row Level Security, the
+`app.current_org_id` GUC, and the `tenant_isolation` policy — see
+[Multi-Tenancy](/concepts/multi-tenancy). This page is the *how*.
 
-A short bullet list of the topics this page will cover, drawn from the
-[design spec](https://github.com/ravencloak-org/Raven/blob/main/docs/superpowers/specs/2026-05-09-docs-site-design.md).
+## Quick reference
+
+All endpoints are prefixed with `/api/v1` and require a bearer token unless
+noted. `org_admin` always bypasses workspace role checks
+(`internal/middleware/rbac.go`).
+
+| Resource | Method & path | Required role | What it does |
+|----------|---------------|---------------|--------------|
+| Organisation | `POST /orgs` | _(none — onboarding)_ | Create a new org; the caller becomes its `org_admin`. |
+| Organisation | `GET /orgs/:org_id` | any org member | Fetch an organisation. |
+| Organisation | `PUT /orgs/:org_id` | `org_admin` | Update name / settings. |
+| Organisation | `DELETE /orgs/:org_id` | `org_admin` | Hard-delete; cascades to all workspaces, KBs, documents. |
+| Workspace | `POST /orgs/:org_id/workspaces` | _(none — onboarding)_ | Create a workspace inside an org. |
+| Workspace | `GET /orgs/:org_id/workspaces` | any org member | List workspaces. |
+| Workspace | `GET /orgs/:org_id/workspaces/:ws_id` | workspace `viewer`+ | Fetch one workspace. |
+| Workspace | `PUT /orgs/:org_id/workspaces/:ws_id` | workspace `admin` | Update name / settings. |
+| Workspace | `DELETE /orgs/:org_id/workspaces/:ws_id` | `org_admin` | Hard-delete; cascades to KBs and members. |
+| Member | `POST /orgs/:org_id/workspaces/:ws_id/members` | workspace `admin` | Add a user to the workspace at a chosen role. |
+| Member | `PUT /orgs/:org_id/workspaces/:ws_id/members/:user_id` | workspace `admin` | Change a member's role. |
+| Member | `DELETE /orgs/:org_id/workspaces/:ws_id/members/:user_id` | workspace `admin` | Remove a member (callers cannot remove themselves). |
+| Knowledge base | `POST .../workspaces/:ws_id/knowledge-bases` | _(none — onboarding)_ | Create a KB inside a workspace. |
+| Knowledge base | `GET .../workspaces/:ws_id/knowledge-bases` | workspace `viewer`+ | List KBs in a workspace. |
+| Knowledge base | `PUT .../knowledge-bases/:kb_id` | workspace `member` | Update KB name, description, settings, cache knobs. |
+| Knowledge base | `DELETE .../knowledge-bases/:kb_id` | workspace `admin` | **Soft-delete** — sets `status = 'archived'`. |
+| API key | `POST .../knowledge-bases/:kb_id/api-keys` | workspace `member` | Mint a scoped API key for the embedded widget. |
+| API key | `DELETE .../knowledge-bases/:kb_id/api-keys/:key_id` | workspace `admin` | Revoke a key. |
+
+Source: `cmd/api/main.go` (route table) and the `@Router` doc comments in
+`internal/handler/`. The same paths appear in `contracts/openapi.yaml`.
+
+## Create an organisation
+
+The first user signing up creates the org; they receive `org_admin`
+automatically (see the default-role assignment in
+`internal/middleware/auth.go`). Subsequent users are created **inside** an
+existing org and join through workspace membership — Raven does not allow a
+user to "switch orgs".
+
+**Dashboard.** Sign up via `/app/signup` → "Create organisation" — the
+onboarding flow calls `POST /orgs`, then `POST /orgs/:org_id/workspaces`,
+then `POST .../knowledge-bases` in sequence.
+
+**API.**
+
+```http
+POST /api/v1/orgs
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{ "name": "Acme Inc." }
+```
+
+Response `201 Created` returns the `Organization` (`internal/model/org.go`):
+`id`, `name`, `slug`, `status`, `settings`, `created_at`, `updated_at`.
+
+The `slug` is derived server-side and is globally unique across the
+deployment (the `organizations` table has `UNIQUE(slug)` —
+`migrations/00003_organizations.sql`). `status` is one of `active`,
+`suspended`, `deactivated` (the `org_status` ENUM in
+`migrations/00001_extensions_and_types.sql`); set non-`active` values to
+take an org offline without deleting it.
+
+## Invite (add) members
+
+Raven has **no email-invitation flow** today — membership is added directly
+by user ID. The new user first signs in via Keycloak (which creates a row
+in the `users` table — `migrations/00004_users.sql`); a workspace `admin`
+then calls `POST /orgs/:org_id/workspaces/:ws_id/members` with the user's
+UUID and the desired role.
+
+```http
+POST /api/v1/orgs/{org_id}/workspaces/{ws_id}/members
+Authorization: Bearer <admin-token>
+Content-Type: application/json
+
+{
+  "user_id": "0193ffee-...",
+  "role": "member"
+}
+```
+
+`role` must be one of `owner`, `admin`, `member`, `viewer` — validated by
+the `binding:"oneof=..."` tag on `AddWorkspaceMemberRequest`
+(`internal/model/workspace.go`).
+
+> **Email invitations are on the roadmap.** AWS SES is already wired up for
+> transactional mail (notifications, password reset). A future
+> `POST /invitations` endpoint will email a one-time accept link — track the
+> milestone in the issue tracker rather than relying on this page.
+
+## Manage roles
+
+Two role systems coexist:
+
+### Organisation roles
+
+Stored in the JWT claim and resolved by `JWTMiddleware`. Today only
+`org_admin` exists in code (the org creator gets it by default —
+`internal/middleware/auth.go`). An `org_admin` can update/delete the org,
+create/delete workspaces, and manage org-scoped resources (LLM providers,
+routing rules, connectors, security rules). They **bypass every workspace
+role check** (`RequireWorkspaceRole` short-circuits when
+`org_role == "org_admin"`). Additional org-level roles will be added when
+multi-admin orgs are needed.
+
+### Workspace roles
+
+Stored per-user-per-workspace in the `workspace_members` table
+(`migrations/00006_workspace_members.sql`). The `role` column is the
+`workspace_role` ENUM defined in
+`migrations/00001_extensions_and_types.sql`:
+
+```sql
+CREATE TYPE workspace_role AS ENUM ('owner', 'admin', 'member', 'viewer');
+```
+
+Permissions are ranked — `RequireWorkspaceRole` admits any role at or above
+the minimum (`internal/middleware/rbac.go`):
+
+| Role | Rank | Can do (concrete) |
+|------|------|-------------------|
+| `viewer` | 0 | Read the workspace, list KBs, read KBs, run search and chat completions against KBs. |
+| `member` | 1 | Everything `viewer` can, plus update KB settings (rename, description, settings, semantic-cache knobs) and mint API keys. |
+| `admin` | 2 | Everything `member` can, plus update workspace settings, add/remove/change members, revoke API keys, archive (soft-delete) KBs. |
+| `owner` | 3 | Reserved — currently identical to `admin` in middleware checks. Designed for future "single responsible owner" workflows (billing handover, ownership transfer). |
+
+`org_admin` is **not** in the workspace ENUM — it lives at the org level
+and silently outranks every workspace role.
+
+### Change a role
+
+```http
+PUT /api/v1/orgs/{org_id}/workspaces/{ws_id}/members/{user_id}
+Authorization: Bearer <admin-token>
+Content-Type: application/json
+
+{ "role": "admin" }
+```
+
+## Workspaces
+
+Every workspace lives inside exactly one organisation (`workspaces.org_id`
+is `NOT NULL REFERENCES organizations(id) ON DELETE CASCADE` —
+`migrations/00005_workspaces.sql`). Slugs are unique **per org**, not
+globally: `UNIQUE(org_id, slug)`.
+
+```http
+POST   /api/v1/orgs/{org_id}/workspaces           # { "name": "Marketing" }
+GET    /api/v1/orgs/{org_id}/workspaces?offset=0&limit=20
+PUT    /api/v1/orgs/{org_id}/workspaces/{ws_id}   # partial: name, settings
+DELETE /api/v1/orgs/{org_id}/workspaces/{ws_id}   # hard delete — see below
+```
+
+The first workspace is created during onboarding without a role check; all
+subsequent operations are gated by the table above. `settings` is a
+free-form JSONB blob; reserve a stable dotted-key namespace per feature
+(e.g. `notification.daily_digest`).
+
+### Archive a workspace
+
+Workspaces have **no soft-delete**: `DELETE` is a hard delete that cascades
+through every nested resource. To "freeze" a workspace without losing data,
+revoke its API keys, remove non-admin members, and leave it untouched. A
+status column may be added later; track the schema rather than building
+around today's behaviour.
+
+## Knowledge bases
+
+A KB is a scoped document store inside a workspace. It owns documents,
+sources, chunks, embeddings, conversations, and any API keys that
+authenticate the embedded widget.
+
+### Create
+
+```http
+POST /api/v1/orgs/{org_id}/workspaces/{ws_id}/knowledge-bases
+{ "name": "Public docs", "description": "Customer-facing help centre" }
+```
+
+### List
+
+```http
+GET /api/v1/orgs/{org_id}/workspaces/{ws_id}/knowledge-bases
+```
+
+Each entry includes a `doc_count` and a `status` of `active` or `archived`
+(the `kb_status` ENUM, `migrations/00001_extensions_and_types.sql`).
+
+### Update KB-level settings
+
+`PUT .../knowledge-bases/:kb_id` accepts a partial payload (only non-nil
+fields apply — `internal/model/kb.go::UpdateKBRequest`):
+
+```json
+{
+  "name": "Public docs (EN)",
+  "description": "...",
+  "settings": {
+    "default_llm_provider_id": "0193...",
+    "embedding_model": "text-embedding-3-small",
+    "retention_days": 365
+  },
+  "cache_enabled": true,
+  "cache_similarity_threshold": 0.92
+}
+```
+
+| Field | Where it lives | Notes |
+|-------|----------------|-------|
+| `name`, `description` | columns | Trimmed to 255 / TEXT. |
+| `settings.default_llm_provider_id` | JSONB | UUID of an LLM provider created under `/orgs/:org_id/llm-providers`. See [LLM Providers](/guides/llm-providers). |
+| `settings.embedding_model` | JSONB | Free-form string; the AI worker validates it against the configured provider catalogue. |
+| `settings.retention_days` | JSONB | Soft retention hint for conversation logs. |
+| `cache_enabled` | column | Toggles the semantic response cache (issue #256). |
+| `cache_similarity_threshold` | column | Cosine floor for a cache HIT (0.80–0.99). |
+
+### Soft-delete (archive) a KB
+
+```http
+DELETE /api/v1/orgs/{org_id}/workspaces/{ws_id}/knowledge-bases/{kb_id}
+```
+
+This calls `KBHandler.Archive` (`internal/handler/kb.go`) which flips
+`status` from `active` to `archived`. The row stays in the table, documents
+remain on SeaweedFS, and chunk embeddings stay in `pgvector` — search and
+chat against an archived KB return 404 but the data can be revived by an
+operator with direct DB access. There is no API endpoint today to
+un-archive a KB; do this via a SQL `UPDATE knowledge_bases SET status =
+'active' WHERE id = ?` against a connection that holds the `raven_admin`
+role (so the `admin_bypass` RLS policy applies).
+
+## Cross-tenant operations
+
+**There are none.** RLS guarantees that a request authenticated as a member
+of org A cannot read or write rows belonging to org B, even if the
+application code forgets a `WHERE` clause. The only legitimate cross-tenant
+queries are:
+
+- Migrations and operator scripts, which connect as the `raven_admin`
+  Postgres role and short-circuit `tenant_isolation` via the `admin_bypass`
+  policy.
+- Trusted internal jobs (e.g. payment-webhook reconciliation) which set the
+  `app.bypass_rls` GUC to `'true'` —
+  `migrations/00032_billing_rls_and_payment_events.sql`.
+
+Application traffic (the API binary) connects exclusively as `raven_app`
+and has no path to the bypass. See [Multi-Tenancy
+&rarr; Admin bypass](/concepts/multi-tenancy#admin-bypass).
+
+## Soft delete vs hard delete
+
+| Resource | `DELETE` semantics | Where the row goes |
+|----------|-------------------|--------------------|
+| Organisation | **Hard delete**. `ON DELETE CASCADE` removes every workspace, member, KB, document, conversation, API key, security rule, etc. Irreversible from the API. |
+| Workspace | **Hard delete**. Cascades to KBs, members, KB-scoped API keys, KB-scoped conversations. |
+| Workspace member | **Hard delete**. Row removed from `workspace_members`; the user account itself is untouched. |
+| Knowledge base | **Soft delete (archive)**. Row stays, `status` → `archived`. Reads return 404. No tombstone TTL — archived KBs persist until an operator runs a cleanup migration. |
+| API key | **Hard delete (revoke)**. Row stays but `status` → `revoked` (`api_key_status` ENUM); the secret hash is no longer accepted. |
+
+There is no two-phase "tombstone then purge" pipeline today. If you need
+recoverable deletion of an org or workspace, do it at the database level
+before invoking the API.
+
+## API keys per workspace
+
+The embedded chat widget authenticates with a **knowledge-base-scoped** API
+key — it cannot read or write across KB boundaries. Operators mint keys
+through the dashboard or the API:
+
+```http
+POST /api/v1/orgs/{org_id}/workspaces/{ws_id}/knowledge-bases/{kb_id}/api-keys
+{ "name": "marketing-site-prod" }
+```
+
+Response includes the plaintext secret **once** — store it somewhere safe;
+Raven only keeps a hash (`api_keys.status` ENUM is `active` or `revoked` —
+`migrations/00012_api_keys.sql`). For the full embed flow, see
+[Embed the chat widget](/get-started/embed-the-chat-widget).
+
+Revoke a key with `DELETE .../api-keys/:key_id`; the revoked row stays in
+the table so audit queries can still attribute past traffic.
+
+## Audit
+
+Raven records two kinds of audit data:
+
+1. **HTTP access logs** — every request, with `org_id`, `user_id`, route,
+   status, and latency. These ship to OpenObserve (see [Observability
+   stack](/guides/self-hosting/observability)).
+2. **Security events** — `migrations/00022_security_rules.sql` creates
+   `security_events`, an `org_id`-scoped table populated by the security
+   middleware whenever a `security_rules` row fires (`event_type` is
+   `blocked`, `throttled`, `alert`, or `suspicious`). This is **not** a
+   generic CRUD audit log — it captures rule hits (IP/geo blocks, pattern
+   matches, rate overrides), not every API call.
+
+Query security events directly (RLS scopes results to your org):
+
+```sql
+SELECT created_at, event_type, ip_address, request_path, details
+FROM security_events
+WHERE created_at > NOW() - INTERVAL '24 hours'
+ORDER BY created_at DESC;
+```
+
+A dedicated CRUD-audit table (write trail for org / workspace / member /
+KB mutations) is not yet in the schema. Until it lands, reconstruct
+mutation history from OpenObserve access logs filtered to write methods
+(`POST`, `PUT`, `DELETE`).
+
+## See also
+
+- [Multi-Tenancy](/concepts/multi-tenancy) — the RLS model, the
+  `app.current_org_id` GUC, and how the auth middleware drives them.
+- [API Overview](/api/overview) — base URL, auth, and the OpenAPI spec.
+- [Billing](/guides/billing) — per-org plans, usage limits, payment
+  intents.
+- [Embed the chat widget](/get-started/embed-the-chat-widget) — using a
+  workspace-scoped API key from a browser.


### PR DESCRIPTION
## Summary

Replaces the last 13 stub pages with real, code-grounded content. The docs site now has **zero stub pages**.

| Page | Lines | Key finding from the codebase |
|---|---|---|
| Get-Started / First Knowledge Base | 415 | Search is **`GET`** not POST; chat endpoint is `.../completions` not `.../conversations`. 9 endpoints verified. |
| Get-Started / Embed the Chat Widget | 298 | Verified 8 attrs from `observedAttributes`. Per-key `allowed_domains` stored but **not yet joined into CORS check** (TODO(M2) flagged inline). |
| Get-Started / Try the Voice Agent | 329 | Honest: STT/TTS plugins in `python-agent` are **TODOs** (issues #59 / #60). Documented the path without overclaiming. |
| Guides / Workspaces & Tenancy | 334 | Real role enum: `owner` / `admin` / `member` / `viewer` (+ `org_admin` JWT bypass). **No invitation endpoint** today — documented the direct-add flow instead. `security_events` records security-rule hits, not generic CRUD. |
| Guides / Ingestion | 395 | Chunker: `RecursiveCharacterTextSplitter`, default **2048 chars / 200 overlap**. Embedding default: `text-embedding-3-small` (1536 dims, BYOK). |
| Guides / Retrieval | 351 | Public `/search` is **BM25-only GET**; hybrid is reached *through* `/completions` because `SearchService.HybridSearch` is wired but not yet exposed as its own route (`TODO` in `cmd/api/main.go`). Documented honestly. |
| Guides / LLM Providers | 327 | 4 providers wired (anthropic/openai/cohere/ollama); Anthropic embed is `NotImplementedError`. AES-256-GCM 32-byte key in `RAVEN_ENCRYPTION_AES_KEY`. |
| Guides / Voice | 350 | Config wires `RAVEN_STT_*` / `RAVEN_TTS_*` (Deepgram/Whisper/Cartesia/Piper); agent.py has empty session + plugin TODOs. Honest about the gap. |
| Guides / Webhooks & Events | 273 | Schema, HMAC signing, SSRF guard, Asynq delivery — all real. But `WebhookService.Dispatch` has **zero production call sites** — documented as MVP. 4 event types. |
| Guides / Billing | 269 | Subscription lifecycle wires `active` / `canceled` / extends on `payment_succeeded`; `trialing` / `paused` / `expired` are schema-ready but unused. Hyperswitch runs as a **separate compose stack**. |
| Self-Hosting / Edge & Raspberry Pi | 352 | 3 services (256 + 512 + 128 MB reserved). `deploy/edge/install.sh` is real. `GRPC_AI_WORKER_ADDR` → `RAVEN_GRPC_WORKER_ADDR`. |
| Self-Hosting / Traefik & TLS | 437 | `traefik:v3.3`, ACME via **DNS-01 / Cloudflare** (`CF_API_EMAIL` + `CF_DNS_API_TOKEN`). `api.insecure: true` shipped default flagged. |
| Self-Hosting / Upgrades | 377 | Migrations **NOT auto-run on boot** — operators run `make migrate-up` (goose via dotenvx). Image tags from `release.yml` documented. |
| **Total** | **~4,507 new lines · 6,750 indexed words (was 5,049)** | |

## Real codebase issues surfaced (each documented honestly on its page)

1. **Search is GET not POST** (Retrieval, First KB).
2. **Hybrid search not exposed as a standalone endpoint** — wired internally, reached through `/completions` only.
3. **Per-widget-key `allowed_domains` not enforced in CORS** — schema exists, middleware TODO(M2).
4. **STT/TTS plugins not attached to the LiveKit agent yet** — issues #59 / #60.
5. **No invitation endpoint** — workspace membership is direct-add only.
6. **`security_events` is NOT a generic CRUD audit log** — it records security-rule hits.
7. **`WebhookService.Dispatch` has zero call sites** — webhooks are MVP-shape.
8. **Subscription states `trialing` / `paused` / `expired` are schema-ready, unused** in service code.
9. **Anthropic embed provider raises `NotImplementedError`** — chat works, embeddings don't.
10. **Migrations don't auto-run** — operators must `make migrate-up` separately during upgrades.

## Stub count

| Before this PR | 13 |
| After this PR | **0** |

Every IA leaf now has real content. The 5 OSPS-L2 / SLSA / openssf-baseline pages remain sourced verbatim from `docs/` (unchanged from earlier PRs).

## Test plan
- [ ] Cloudflare Pages preview renders cleanly
- [ ] All 13 new pages have zero stub banners
- [ ] PageFind hits for "RAVEN_ENCRYPTION_AES_KEY", "RecursiveCharacterTextSplitter", "cartesia", "Hyperswitch", "DNS-01", "make migrate-up"