### PR TITLE
fix: 4 quick wins from the docs audit (Bucket A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Raven is built for teams that need a production-grade RAG platform without vendo
 - **Voice agent** -- real-time voice interface via LiveKit Agents with STT/TTS pipeline
 - **WebRTC and WhatsApp** -- browser-based and WhatsApp Business Calling API integration
 - **BYOK LLM** -- bring your own API keys for Anthropic Claude, OpenAI, Cohere, or self-hosted models
-- **Hybrid search** -- pgvector cosine similarity + BM25 full-text search with Reciprocal Rank Fusion
+- **Hybrid search** -- pgvector cosine similarity + BM25-style lexical ranking (PostgreSQL `tsvector` + `ts_rank_cd`) with Reciprocal Rank Fusion
 - **Self-hostable** -- single Docker Compose deployment with no external SaaS dependencies required
 - **Edge-deployable** -- Go API compiles to a ~25 MB ARM64 binary; run the API on a Raspberry Pi with a remote AI worker
 
@@ -56,7 +56,7 @@ PostgreSQL serves as the single source of truth -- storing relational data, vect
 |-------|-----------|---------|
 | **API Server** | Go + Gin | REST API, JWT validation, tenant routing, SSE streaming |
 | **AI Worker** | Python + gRPC | RAG queries, embeddings, document parsing, web scraping |
-| **Database** | PostgreSQL 18 + pgvector | Relational data, vector search, BM25 full-text |
+| **Database** | PostgreSQL 18 + pgvector | Relational data, vector search, full-text keyword ranking |
 | **Frontend** | Vue.js 3 + Tailwind CSS | Admin dashboard (SPA, mobile-first, PWA-capable) |
 | **Chatbot Widget** | Web Component | Embeddable `<raven-chat>` element |
 | **Auth** | SuperTokens | Email/password + OAuth (Google), session management, MFA |

--- a/ai-worker/raven_worker/providers/anthropic_provider.py
+++ b/ai-worker/raven_worker/providers/anthropic_provider.py
@@ -44,7 +44,11 @@ class AnthropicEmbeddingProvider:
         Raises:
             NotImplementedError: Always.
         """
-        raise NotImplementedError("Anthropic embedding not yet available")
+        raise NotImplementedError(
+            "Anthropic does not publish a public embeddings API. "
+            "Configure OpenAI, Cohere, or Ollama as the embedding provider "
+            "for this org/workspace (chat can still route to Anthropic)."
+        )
 
     async def embed_batch(self, texts: list[str]) -> list[list[float]]:  # noqa: ARG002
         """Not implemented — Anthropic has no embedding API yet.
@@ -52,7 +56,11 @@ class AnthropicEmbeddingProvider:
         Raises:
             NotImplementedError: Always.
         """
-        raise NotImplementedError("Anthropic embedding not yet available")
+        raise NotImplementedError(
+            "Anthropic does not publish a public embeddings API. "
+            "Configure OpenAI, Cohere, or Ollama as the embedding provider "
+            "for this org/workspace (chat can still route to Anthropic)."
+        )
 
     @property
     def dimensions(self) -> int:

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   reporter: 'html',
   use: {
-    baseURL: process.env.CI ? 'http://localhost:4173' : 'http://localhost:5173',
+    baseURL: process.env.CI ? 'http://localhost:4173' : 'http://localhost:3000',
     trace: 'on-first-retry',
   },
   projects: [
@@ -24,7 +24,7 @@ export default defineConfig({
   ],
   webServer: {
     command: process.env.CI ? 'npx vite preview' : 'npm run dev',
-    url: process.env.CI ? 'http://localhost:4173' : 'http://localhost:5173',
+    url: process.env.CI ? 'http://localhost:4173' : 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
     timeout: 120000,
   },

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,7 +8,9 @@ export default defineConfig({
     port: 3000,
     proxy: {
       '/api': {
-        target: 'http://localhost:8080',
+        // Go API defaults to RAVEN_SERVER_PORT=8081 (`internal/config/config.go`);
+        // earlier 8080 was a leftover from pre-Phase-1 wiring.
+        target: 'http://localhost:8081',
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Summary

Four small, single-file fixes for issues surfaced while writing the docs site (#488 / #493 / #500). All low-risk, all backed by code citations on their respective docs pages.

| # | File | Fix |
|---|---|---|
| 1 | `frontend/vite.config.ts` | API proxy target 8080 → **8081** (matches `RAVEN_SERVER_PORT` default in `internal/config/config.go`) |
| 2 | `frontend/playwright.config.ts` | baseURL + webServer.url 5173 → **3000** (matches `vite.config.ts` `server.port: 3000`) |
| 3 | `README.md` | "BM25 full-text search" → **"BM25-style lexical ranking (PostgreSQL `tsvector` + `ts_rank_cd`)"** — matches actual implementation as documented in /concepts/hybrid-retrieval/ |
| 4 | `ai-worker/raven_worker/providers/anthropic_provider.py` | `NotImplementedError` message now tells the caller what to configure instead (OpenAI / Cohere / Ollama) — Anthropic has no public embeddings API by design |

## Out of scope (tracked separately)

Bucket B (medium fixes): retrieval-tuning env vars, container hardening, widget `allowed_domains` CORS enforcement.

Bucket C (real feature work): MFA recipe, hybrid-search endpoint, STT/TTS plugin attachment, invitation endpoint, webhook dispatch wiring, subscription lifecycle states, auto-migrate option.

## Test plan
- [ ] Local `cd frontend && npm run dev` proxies to a Go API on 8081 without override
- [ ] Local `cd frontend && npm run test:e2e` runs against the actual dev server, no port mismatch
- [ ] CI still uses `vite preview` on 4173 (unchanged)
- [ ] README renders with the corrected hybrid-search description
- [ ] Calling `AnthropicProvider.embed()` returns the new, helpful error message