### PR TITLE
fix(ci/desktop): point target paths at workspace root, not src-tauri/

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          workspaces: desktop -> desktop/src-tauri/target
+          workspaces: desktop -> desktop/target
 
       - name: Install Tauri CLI
         run: cargo install tauri-cli --version '^2.0' --locked

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -32,17 +32,17 @@ jobs:
           - os: macos-latest
             tauri_target: universal-apple-darwin
             rustup_targets: 'aarch64-apple-darwin,x86_64-apple-darwin'
-            artifact_glob: 'desktop/src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg'
+            artifact_glob: 'desktop/target/universal-apple-darwin/release/bundle/dmg/*.dmg'
           - os: windows-latest
             tauri_target: x86_64-pc-windows-msvc
             rustup_targets: 'x86_64-pc-windows-msvc'
-            artifact_glob: 'desktop/src-tauri/target/release/bundle/msi/*.msi'
+            artifact_glob: 'desktop/target/release/bundle/msi/*.msi'
           - os: ubuntu-latest
             tauri_target: x86_64-unknown-linux-gnu
             rustup_targets: 'x86_64-unknown-linux-gnu'
             artifact_glob: |
-              desktop/src-tauri/target/release/bundle/appimage/*.AppImage
-              desktop/src-tauri/target/release/bundle/deb/*.deb
+              desktop/target/release/bundle/appimage/*.AppImage
+              desktop/target/release/bundle/deb/*.deb
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -61,7 +61,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          workspaces: desktop -> desktop/src-tauri/target
+          workspaces: desktop -> desktop/target
 
       - name: Install Tauri CLI
         run: cargo install tauri-cli --version '^2.0' --locked


### PR DESCRIPTION
## Summary

v0.1.1 run finally compiled all three platforms cleanly, then failed at `Attest build provenance`:

```
Error: Could not find subject at path
desktop/src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg
```

Tauri's build log shows the actual artefact at:
```
desktop/target/universal-apple-darwin/release/bundle/dmg/Raven Local_0.1.0_universal.dmg
```

Cargo workspaces put the target dir at the workspace root (`desktop/Cargo.toml`), not in the member crate (`desktop/src-tauri/`). The artefact glob, the `Swatinem/rust-cache` workspaces path, and the PR-time `desktop-build.yml` all had the same wrong path.

This is the **third** issue in the v0.1.0 → v0.1.1 retry chain. None were catchable by `cargo check` — only an end-to-end `cargo tauri build` exposes them, and that runs only on the actual CI runners.

## Test plan

- [x] Both YAMLs validate
- [ ] After merge, tag `raven-local-v0.1.2` to re-trigger the release workflow