### PR TITLE
fix: 3 medium-effort fixes from the docs audit (Bucket B)

### DIFF
--- a/ai-worker/raven_worker/config.py
+++ b/ai-worker/raven_worker/config.py
@@ -34,6 +34,13 @@ class Settings(BaseSettings):
     # Semantic response cache (issue #256 — M9). Flip to False to bypass the
     # pgvector lookup entirely while keeping the exact-match Valkey cache.
     semantic_cache_enabled: bool = True
+    # Retrieval / hybrid-search tuning. Mirrors the RAVEN_RETRIEVAL_* env
+    # vars consumed by the Go API (see internal/config/config.go and
+    # docs-site/stubs/reference/configuration.md). The Python defaults
+    # match the Go defaults so both code paths produce identical fusion
+    # ordering out of the box.
+    retrieval_rrf_k: int = 60
+    retrieval_default_top_n: int = 10
     model_config = SettingsConfigDict(env_prefix="RAVEN_")
 
 

--- a/ai-worker/raven_worker/services/rag.py
+++ b/ai-worker/raven_worker/services/rag.py
@@ -488,8 +488,14 @@ class RAGServicer:
             bm25_hits=len(bm25_results),
         )
 
-        # 3. RRF fusion
-        fused = reciprocal_rank_fusion([vector_results, bm25_results], top_n=10)
+        # 3. RRF fusion — k and top_n come from the RAVEN_RETRIEVAL_* env
+        # vars (see raven_worker.config.Settings) so the Python and Go
+        # paths stay in lock-step. Defaults: k=60, top_n=10.
+        fused = reciprocal_rank_fusion(
+            [vector_results, bm25_results],
+            k=settings.retrieval_rrf_k,
+            top_n=settings.retrieval_default_top_n,
+        )
         log.debug("rrf_done", fused_count=len(fused))
 
         if not fused:

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -354,7 +354,7 @@ func main() {
 	kbSvc := service.NewKBService(kbRepo, pool, quotaChecker)
 	sourceSvc := service.NewSourceService(sourceRepo, pool)
 	docSvc := service.NewDocumentService(docRepo, pool).WithCacheInvalidator(semCacheRepo)
-	searchSvc := service.NewSearchService(searchRepo, pool)
+	searchSvc := service.NewSearchService(searchRepo, pool, cfg.Retrieval)
 	hybridRetrievalSvc := service.NewHybridRetrievalService(
 		searchRepo, chEmbeddingRepo, pool,
 		model.VectorBackend(cfg.ClickHouse.VectorBackend),

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -508,7 +508,11 @@ func main() {
 	// Global middleware order: OTel → SecurityHeaders → CORS → ErrorHandler
 	router.Use(middleware.OTelMiddleware())
 	router.Use(middleware.SecurityHeadersMiddleware())
-	router.Use(middleware.CORSMiddleware(&cfg.CORS))
+	// Pass the API-key lookup so CORS can honour per-key allowed_domains in
+	// addition to the workspace-wide RAVEN_CORS_ALLOWED_ORIGINS list. A widget
+	// key bound to example.com is unusable from any other origin even if the
+	// server allowlist is broader. See internal/middleware/cors.go for rules.
+	router.Use(middleware.CORSMiddleware(&cfg.CORS, &apiKeyLookupAdapter{repo: apiKeyRepo}))
 	router.Use(apierror.ErrorHandler())
 
 	// Infrastructure endpoint — intentionally outside the versioned group.

--- a/docker-compose.edge.yml
+++ b/docker-compose.edge.yml
@@ -18,6 +18,11 @@ services:
       dockerfile: Dockerfile
       platforms:
         - linux/arm64
+    # Hardening: static Go binary as non-root; no capabilities required.
+    security_opt:
+      - "no-new-privileges:true"
+    cap_drop:
+      - ALL
     ports:
       - "8080:8080"
     environment:
@@ -52,6 +57,17 @@ services:
   postgres:
     image: pgvector/pgvector:pg18
     platform: linux/arm64
+    # Hardening: see main docker-compose.yml — entrypoint drops privs via gosu.
+    security_opt:
+      - "no-new-privileges:true"
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - FOWNER
+      - SETGID
+      - SETUID
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-raven}
       POSTGRES_USER: ${POSTGRES_USER:-raven}
@@ -76,6 +92,13 @@ services:
   traefik:
     image: traefik:v3.3
     platform: linux/arm64
+    # Hardening: NET_BIND_SERVICE needed for ports 80/443.
+    security_opt:
+      - "no-new-privileges:true"
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE
     command:
       - "--api=false"
       - "--providers.docker=true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,13 @@ services:
       dockerfile: Dockerfile
     ports:
       - "8081:8081"
+    # Hardening: static Go binary running as non-root `raven` (uid 1000); no
+    # Linux capabilities required for normal operation. eBPF features (when
+    # enabled via docker-compose.ebpf.yml) re-add CAP_BPF + CAP_NET_ADMIN.
+    security_opt:
+      - "no-new-privileges:true"
+    cap_drop:
+      - ALL
     volumes:
       - ./.env:/app/.env:ro
     environment:
@@ -57,6 +64,12 @@ services:
     build:
       context: ./ai-worker
       dockerfile: Dockerfile
+    # Hardening: Python service runs as non-root `raven` (uid 1000); no
+    # capabilities required.
+    security_opt:
+      - "no-new-privileges:true"
+    cap_drop:
+      - ALL
     volumes:
       - ./.env:/app/.env:ro
       - raven-memories:/var/raven/memories
@@ -77,6 +90,11 @@ services:
     build:
       context: ./ai-worker
       dockerfile: Dockerfile
+    # Hardening: same image as python-worker, non-root, no capabilities needed.
+    security_opt:
+      - "no-new-privileges:true"
+    cap_drop:
+      - ALL
     volumes:
       - ./.env:/app/.env:ro
     environment:
@@ -96,6 +114,12 @@ services:
   # ─── LiveKit SFU (WebRTC media server) ────────────────────────────────────
   livekit-server:
     image: livekit/livekit-server:latest
+    # Hardening: livekit-server binds only high ports (7880/7882/50000-60000)
+    # and ships its own non-root entrypoint; no capabilities required.
+    security_opt:
+      - "no-new-privileges:true"
+    cap_drop:
+      - ALL
     ports:
       - "7882:7882/tcp"
       - "50000-60000:50000-60000/udp"
@@ -126,6 +150,19 @@ services:
   # ─── PostgreSQL + pgvector ─────────────────────────────────────────────────
   postgres:
     image: pgvector/pgvector:pg18
+    # Hardening: docker-entrypoint.sh starts as root, fixes ownership on
+    # PGDATA, then drops to the `postgres` user via gosu. The capabilities
+    # below are the minimum required for that bootstrap.
+    security_opt:
+      - "no-new-privileges:true"
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN          # docker-entrypoint chowns PGDATA on first run
+      - DAC_OVERRIDE   # reading config and socket files across uid boundaries
+      - FOWNER         # chmod on PGDATA contents during init
+      - SETGID         # gosu switches to postgres group
+      - SETUID         # gosu switches to postgres user
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-raven}
       POSTGRES_USER: ${POSTGRES_USER:-raven}
@@ -156,6 +193,21 @@ services:
   # ─── ClickHouse (Enterprise vector storage) ────────────────────────────────
   clickhouse:
     image: clickhouse/clickhouse-server:25
+    # Hardening: entrypoint runs as root, fixes /var/lib/clickhouse perms,
+    # then drops to `clickhouse`. IPC_LOCK is required by mlock() for the
+    # mark/uncompressed caches; SYS_NICE for io_uring/cpu scheduling tweaks.
+    security_opt:
+      - "no-new-privileges:true"
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - FOWNER
+      - SETGID
+      - SETUID
+      - IPC_LOCK       # mlock() of buffer pools
+      - SYS_NICE       # priority of background merges / io_uring
     environment:
       CLICKHOUSE_DB: ${CLICKHOUSE_DB:-raven}
       CLICKHOUSE_USER: ${CLICKHOUSE_USER:-default}
@@ -180,6 +232,17 @@ services:
   # ─── Valkey (Redis-compatible cache) ───────────────────────────────────────
   valkey:
     image: valkey/valkey:8.1-alpine
+    # Hardening: docker-entrypoint.sh starts as root, chowns /data, then
+    # drops to `valkey` via su-exec. Minimum caps for that handoff.
+    security_opt:
+      - "no-new-privileges:true"
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - SETGID
+      - SETUID
     command: ["valkey-server", "--maxmemory", "256mb", "--maxmemory-policy", "allkeys-lru"]
     volumes:
       - valkey-data:/data
@@ -195,6 +258,17 @@ services:
   # ─── SuperTokens Auth Backend ─────────────────────────────────────────────
   supertokens:
     image: registry.supertokens.io/supertokens/supertokens-postgresql
+    # Hardening: SuperTokens Core boots a JVM that listens on a high port and
+    # drops to the `supertokens` user via its entrypoint.
+    security_opt:
+      - "no-new-privileges:true"
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - SETGID
+      - SETUID
     environment:
       POSTGRESQL_CONNECTION_URI: "postgresql://${POSTGRES_USER:-raven}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-raven}"
       API_KEYS: "${SUPERTOKENS_API_KEY:-supertokens-dev-key-replace-me}"
@@ -215,6 +289,17 @@ services:
   # ─── SeaweedFS Master ──────────────────────────────────────────────────────
   seaweedfs-master:
     image: chrislusf/seaweedfs
+    # Hardening: the SeaweedFS image entrypoint uses su-exec to drop privs,
+    # which needs SETUID/SETGID, and SETPCAP to shrink the bounding set on
+    # re-exec.
+    security_opt:
+      - "no-new-privileges:true"
+    cap_drop:
+      - ALL
+    cap_add:
+      - SETGID
+      - SETUID
+      - SETPCAP
     command: "master -ip=seaweedfs-master -ip.bind=0.0.0.0"
     networks:
       - raven-internal
@@ -223,6 +308,14 @@ services:
   # ─── SeaweedFS Volume ──────────────────────────────────────────────────────
   seaweedfs-volume:
     image: chrislusf/seaweedfs
+    security_opt:
+      - "no-new-privileges:true"
+    cap_drop:
+      - ALL
+    cap_add:
+      - SETGID
+      - SETUID
+      - SETPCAP
     command: "volume -mserver=seaweedfs-master:9333 -ip.bind=0.0.0.0 -dir=/data"
     volumes:
       - seaweedfs-data:/data
@@ -235,6 +328,14 @@ services:
   # ─── SeaweedFS Filer (S3 API) ─────────────────────────────────────────────
   seaweedfs-filer:
     image: chrislusf/seaweedfs
+    security_opt:
+      - "no-new-privileges:true"
+    cap_drop:
+      - ALL
+    cap_add:
+      - SETGID
+      - SETUID
+      - SETPCAP
     command: "filer -master=seaweedfs-master:9333 -ip.bind=0.0.0.0 -s3"
     ports:
       - "8888:8888"
@@ -248,6 +349,14 @@ services:
   # ─── Traefik Reverse Proxy ────────────────────────────────────────────────
   traefik:
     image: traefik:v3.3
+    # Hardening: Traefik binds the privileged ports 80 and 443, so it needs
+    # CAP_NET_BIND_SERVICE. Everything else is dropped.
+    security_opt:
+      - "no-new-privileges:true"
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE
     ports:
       - "80:80"
       - "443:443"
@@ -272,6 +381,11 @@ services:
   # ─── OpenObserve (Observability) ───────────────────────────────────────────
   openobserve:
     image: public.ecr.aws/zinclabs/openobserve:latest
+    # Hardening: Rust binary on a high port; no capabilities required.
+    security_opt:
+      - "no-new-privileges:true"
+    cap_drop:
+      - ALL
     ports:
       - "5080:5080"   # UI + HTTP API
       - "5081:5081"   # gRPC OTLP receiver (traces, metrics, logs)
@@ -289,6 +403,19 @@ services:
   # ─── pgBackRest Backup Sidecar ────────────────────────────────────────────
   pgbackrest:
     image: pgbackrest/pgbackrest:latest
+    # Hardening: pgbackrest reads PGDATA owned by uid 999 (postgres) and
+    # writes its repo as uid 1001 (pgbackrest); needs the standard
+    # ownership/uid-switch caps but nothing privileged.
+    security_opt:
+      - "no-new-privileges:true"
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - FOWNER
+      - SETGID
+      - SETUID
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs-site/stubs/concepts/hybrid-retrieval.md
+++ b/docs-site/stubs/concepts/hybrid-retrieval.md
@@ -202,21 +202,26 @@ score(d) = Σ 1 / (k + rank_i(d))
 ```
 
 where `rank_i(d)` is the 1-based position of document `d` in retriever
-`i`'s ranked list, and `k` is a smoothing constant. **Raven uses `k = 60`**
-in both implementations — the value recommended in the original paper.
+`i`'s ranked list, and `k` is a smoothing constant. **Raven defaults `k`
+to 60** in both implementations — the value recommended in the original
+paper — and exposes it as `RAVEN_RETRIEVAL_RRF_K` for tuning. Per-leg
+weights are exposed as `RAVEN_RETRIEVAL_HYBRID_VECTOR_WEIGHT` and
+`RAVEN_RETRIEVAL_HYBRID_BM25_WEIGHT` (both default `1.0`).
 
-The Go implementation lives in `internal/service/search.go` as the
-`fuseRRF` function, with the constant declared at package scope:
+The Go implementation lives in `internal/service/search.go` as
+`fuseRRFWith`, with the default declared as a package constant and the
+runtime-effective value flowing in from `config.RetrievalConfig`:
 
 ```go
-// rrfK is the constant used in the Reciprocal Rank Fusion formula.
-// k=60 is the standard value from the original RRF paper (Cormack et al., 2009).
+// rrfK is the compile-time default; the runtime value comes from
+// cfg.RRFK (RAVEN_RETRIEVAL_RRF_K). k=60 is the standard value from the
+// original RRF paper (Cormack et al., 2009).
 const rrfK = 60
 
-// fuseRRF merges vector and BM25 result lists using Reciprocal Rank Fusion.
+// fuseRRFWith merges vector and BM25 result lists using weighted RRF.
 // For each document appearing in either list:
-//   score = sum(1 / (k + rank_i))
-// where rank_i is the 1-based position in each retriever.
+//   score = vectorWeight * 1/(k + rank_vec) + bm25Weight * 1/(k + rank_bm25)
+// where rank_* is the 1-based position in each retriever.
 ```
 
 The Python implementation in `ai-worker/raven_worker/retrieval/rrf.py` is
@@ -249,9 +254,10 @@ A few properties to note:
   which means it is robust to the very different score distributions of
   pgvector cosine similarity and `ts_rank_cd`.
 - **Candidate-set expansion.** Each leg is queried with
-  `candidateK = topK * 3` (capped at `maxSearchLimit = 100`) so RRF has
-  enough overlap signal to work with; only the top-K survive after
-  fusion.
+  `candidateK = topK * RAVEN_RETRIEVAL_CANDIDATE_MULTIPLIER` (default
+  multiplier `3`, capped at `RAVEN_RETRIEVAL_MAX_LIMIT` which defaults
+  to `100`) so RRF has enough overlap signal to work with; only the
+  top-K survive after fusion.
 
 The fused `HybridSearchResult` carries all the intermediate signals back to
 the caller — `VectorScore`, `BM25Score`, `VectorRank`, `BM25Rank`, and the
@@ -317,32 +323,44 @@ cross-encoder rerank could be added on top of RRF.
 
 ## Configuration
 
-Retrieval-related defaults live in two places.
+The Go API exposes the hybrid-retrieval tunables as
+[`RetrievalConfig`](https://github.com/ravencloak-org/Raven/blob/main/internal/config/config.go)
+fields, all overridable at runtime via `RAVEN_RETRIEVAL_*` env vars. The
+Python ai-worker mirrors the two values that affect fused ordering so both
+code paths can be tuned together.
 
-Go API service constants (`internal/service/search.go`):
+Go API (`internal/config/config.go` → `RetrievalConfig`, consumed by
+`internal/service/search.go`):
 
-| Constant             | Value | Purpose                                              |
-| -------------------- | ----- | ---------------------------------------------------- |
-| `defaultSearchLimit` | `10`  | `topK` returned when the caller omits `top_k`        |
-| `maxSearchLimit`     | `100` | Hard ceiling on `topK` and `candidateK`              |
-| `rrfK`               | `60`  | RRF smoothing constant                               |
+| Env var                                  | Default | Purpose                                                                 |
+| ---------------------------------------- | ------- | ----------------------------------------------------------------------- |
+| `RAVEN_RETRIEVAL_DEFAULT_LIMIT`          | `10`    | `topK` returned when the caller omits `top_k`                           |
+| `RAVEN_RETRIEVAL_MAX_LIMIT`              | `100`   | Hard ceiling on `topK` and `candidateK`                                 |
+| `RAVEN_RETRIEVAL_RRF_K`                  | `60`    | RRF smoothing constant — score = sum(weight / (k + rank))               |
+| `RAVEN_RETRIEVAL_CANDIDATE_MULTIPLIER`   | `3`     | Per-leg candidate set sized as `topK * multiplier` (then clamped)       |
+| `RAVEN_RETRIEVAL_HYBRID_VECTOR_WEIGHT`   | `1.0`   | Multiplier on the vector leg's RRF contribution                         |
+| `RAVEN_RETRIEVAL_HYBRID_BM25_WEIGHT`     | `1.0`   | Multiplier on the BM25 leg's RRF contribution                           |
 
-The Go service computes `candidateK = topK * 3` and clamps it to
-`maxSearchLimit`. `clampLimit()` and `sanitizeQuery()` apply to every
+`config.Load` validates these at startup: every integer must be positive,
+weights must be non-negative, and `MaxLimit >= DefaultLimit`. A
+misconfigured value causes the API binary to exit non-zero before serving
+the first request. `clampLimitWith()` and `sanitizeQuery()` apply to every
 hybrid call.
 
 Python ai-worker (`ai-worker/raven_worker/config.py`), via `RAVEN_*` env
 vars:
 
-| Setting                 | Default                | Notes                                                          |
-| ----------------------- | ---------------------- | -------------------------------------------------------------- |
-| `grpc_port`             | `50051`                | RAG and embedding RPCs                                         |
-| `database_url`          | local PG dev URL       | pgvector + tsvector queries run against this                   |
-| `semantic_cache_enabled`| `true`                 | Enables the `response_cache` lookup (separate from hybrid)     |
+| Setting                              | Default                | Notes                                                                                            |
+| ------------------------------------ | ---------------------- | ------------------------------------------------------------------------------------------------ |
+| `grpc_port`                          | `50051`                | RAG and embedding RPCs                                                                           |
+| `database_url`                       | local PG dev URL       | pgvector + tsvector queries run against this                                                     |
+| `semantic_cache_enabled`             | `true`                 | Enables the `response_cache` lookup (separate from hybrid)                                       |
+| `retrieval_rrf_k`                    | `60`                   | Mirrors `RAVEN_RETRIEVAL_RRF_K`; used by the RAG path's `reciprocal_rank_fusion` call            |
+| `retrieval_default_top_n`            | `10`                   | Mirrors `RAVEN_RETRIEVAL_DEFAULT_LIMIT`; size of the fused list passed to rerank/context build   |
 
-There is **no `top_k`, RRF `k`, or hybrid-weighting env var** — those are
-hard-coded constants. Rerank toggling is per-request (`filters["rerank"]`),
-not configuration.
+Rerank toggling is per-request (`filters["rerank"]`), not configuration.
+The Python worker reuses the same `RAVEN_RETRIEVAL_RRF_K` env var as the Go
+API so a single value tunes both code paths in lock-step.
 
 ## Benchmarks
 

--- a/docs-site/stubs/get-started/embed-the-chat-widget.md
+++ b/docs-site/stubs/get-started/embed-the-chat-widget.md
@@ -211,13 +211,36 @@ The `allowed_domains` array you provided at creation is enforced server-side.
 A request whose `Origin` header is not in the list is rejected before the
 chat handler runs.
 
-> **Note.** As of this release the server enforces the **workspace-level**
-> origin allowlist (`RAVEN_CORS_ALLOWED_ORIGINS`, see below) on every request,
-> and the per-key `allowed_domains` field is stored and returned but not yet
-> joined into the CORS check on every request — that wiring is tracked under
-> milestone M2 (see the `TODO(M2)` in `internal/middleware/cors.go`). Set
-> `allowed_domains` correctly now: it is already stored, listed, and shown in
-> the dashboard, and it will start being enforced automatically once M2 ships.
+The check runs in two complementary places:
+
+1. **CORS middleware** (browser-facing). When a request carries
+   `X-API-Key`, the global CORS layer (`internal/middleware/cors.go`)
+   compares the request's `Origin` against that key's `allowed_domains`
+   in addition to the workspace-level `RAVEN_CORS_ALLOWED_ORIGINS` list.
+   If the key has a non-empty `allowed_domains`, the server-wide allowlist
+   does **not** widen it — a widget key bound to `example.com` is unusable
+   from any other origin even if the workspace allowlist is broader. If the
+   key's `allowed_domains` is empty, the workspace-level list applies as
+   before.
+2. **API-key auth** (`internal/middleware/apikey.go`). After CORS, the
+   API-key middleware re-runs the same check against `Origin` (falling
+   back to `Referer` for non-browser callers) and returns
+   `403 domain_not_allowed` if the host is not in the per-key list.
+
+### Wildcard syntax
+
+Each entry is matched against the **host** part of the `Origin` URL.
+Exact hostnames (`example.com`, `app.example.com`) match literally.
+A single leading-wildcard form is supported:
+
+| Entry           | Matches                                              |
+|-----------------|------------------------------------------------------|
+| `example.com`   | `example.com` only                                   |
+| `*.example.com` | `example.com` (apex), `www.example.com`, `a.b.example.com` (any depth) |
+
+Wildcards in any other position (e.g. `foo.*.example.com`,
+`example.*`) are **not** supported — the entry is treated as a literal
+hostname and will never match.
 
 ### Rate limiting
 

--- a/docs-site/stubs/guides/self-hosting/hardening.md
+++ b/docs-site/stubs/guides/self-hosting/hardening.md
@@ -222,22 +222,53 @@ uses `pip install --require-hashes` against a `uv pip compile`d lockfile
 with full per-archive hashes; the frontend builds Vue with `npm ci` (lockfile
 required) and serves the dist via the unprivileged nginx image.
 
-**Not bundled, recommended for production hardening — add per-service:**
+**Bundled, applied to every service in `docker-compose.yml`:**
+
+```yaml
+security_opt:
+  - "no-new-privileges:true"
+cap_drop:
+  - ALL
+```
+
+`security_opt: no-new-privileges:true` is universal — it prevents any setuid
+binary from elevating privileges and has zero functional impact. `cap_drop:
+[ALL]` removes the full Linux capability set, then each service re-adds only
+the capabilities it actually needs via `cap_add`:
+
+| Service | Re-added capabilities | Reason |
+|---------|-----------------------|--------|
+| `go-api`              | — (none)                                            | Static Go binary, runs as non-root `raven` UID. eBPF overlay adds `CAP_BPF` + `CAP_NET_ADMIN`. |
+| `python-worker`       | — (none)                                            | Python service, non-root. |
+| `python-agent`        | — (none)                                            | Python LiveKit agent, non-root. |
+| `livekit-server`      | — (none)                                            | High-port SFU. |
+| `postgres`            | `CHOWN`, `DAC_OVERRIDE`, `FOWNER`, `SETGID`, `SETUID` | `docker-entrypoint.sh` fixes `PGDATA` ownership then drops to `postgres` via gosu. |
+| `clickhouse`          | `CHOWN`, `DAC_OVERRIDE`, `FOWNER`, `SETGID`, `SETUID`, `IPC_LOCK`, `SYS_NICE` | Same ownership/gosu handoff plus mlock for caches and io_uring scheduling. |
+| `valkey`              | `CHOWN`, `DAC_OVERRIDE`, `SETGID`, `SETUID`         | Entrypoint chowns `/data` then drops to `valkey` via su-exec. |
+| `supertokens`         | `CHOWN`, `DAC_OVERRIDE`, `SETGID`, `SETUID`         | JVM entrypoint drops to `supertokens` user. |
+| `seaweedfs-master`    | `SETGID`, `SETUID`, `SETPCAP`                       | Image uses su-exec; needs `SETPCAP` to shrink the bounding set on re-exec. |
+| `seaweedfs-volume`    | `SETGID`, `SETUID`, `SETPCAP`                       | Same as master. |
+| `seaweedfs-filer`     | `SETGID`, `SETUID`, `SETPCAP`                       | Same as master. |
+| `traefik`             | `NET_BIND_SERVICE`                                  | Binds privileged ports 80 and 443. |
+| `openobserve`         | — (none)                                            | Rust binary on high ports. |
+| `pgbackrest`          | `CHOWN`, `DAC_OVERRIDE`, `FOWNER`, `SETGID`, `SETUID` | Reads `PGDATA` as uid 999 (postgres) and writes the repo as uid 1001 (pgbackrest). |
+
+`docker-compose.edge.yml` applies the same defaults to its three services
+(`go-api`, `postgres`, `traefik`).
+
+**Not bundled (deferred to a follow-up):**
 
 ```yaml
 read_only: true
 tmpfs:
   - /tmp
-security_opt:
-  - no-new-privileges:true
-cap_drop:
-  - ALL
 ```
 
-These directives are intentionally **absent** from the shipped
-`docker-compose.yml` so the dev experience remains low-friction. For
-production self-hosting, wrap each service with a `docker-compose.override.yml`
-that applies these — non-root USER alone is necessary but not sufficient.
+`read_only: true` requires per-service tmpfs additions for `/tmp`,
+`/var/run`, and any other write paths the image expects, and breaks several
+images that write outside the data volume (Postgres lock dirs, OpenObserve
+work dirs). Add this in a `docker-compose.override.yml` once you have
+identified the writable paths each service genuinely needs.
 
 ## Network exposure
 
@@ -380,8 +411,9 @@ in any self-hosted production deployment:
   itself (Traefik's rate limiter does not cover SSH).
 - **Host-level firewall** — `ufw` / `nftables` rules that allow only `22`
   (or your moved SSH port), `80`, `443`, and the LiveKit UDP range.
-- **`cap_drop: ALL` + `read_only: true` + `no-new-privileges`** in a
-  Compose override (see [Container hardening](#container-hardening)).
+- **`read_only: true` filesystems with explicit `tmpfs:`** per service in a
+  Compose override (`cap_drop: ALL` + `no-new-privileges` are already bundled —
+  see [Container hardening](#container-hardening)).
 - **Out-of-band log shipping** of `security_events` and OpenObserve to an
   immutable sink — see [Audit logging](#audit-logging).
 - **Quarterly dependency review** — Dependabot is enabled and CodeRabbit

--- a/docs-site/stubs/reference/configuration.md
+++ b/docs-site/stubs/reference/configuration.md
@@ -222,6 +222,22 @@ the dev-agent script). The Go API receives tenant-scoped keys via the
 | `RAVEN_STT_WHISPER_ENDPOINT` | URL | `http://localhost:8000` | no | Self-hosted Whisper HTTP endpoint. |
 | `RAVEN_STT_WHISPER_MODEL` | string | `large-v3` | no | Whisper model id. |
 
+### Retrieval (hybrid search tuning)
+
+Tunables for `SearchService.HybridSearch` and the RRF fusion step. All
+values are validated at startup (`config.Load` rejects non-positive
+integers, negative weights, and `max_limit < default_limit`). See
+[Hybrid Retrieval](/concepts/hybrid-retrieval) for what each value does.
+
+| Env var | Type | Default | Required | Description |
+|---|---|---|---|---|
+| `RAVEN_RETRIEVAL_DEFAULT_LIMIT` | int | `10` | no | `topK` returned when the caller omits `top_k`. |
+| `RAVEN_RETRIEVAL_MAX_LIMIT` | int | `100` | no | Hard ceiling on both `topK` and the per-leg `candidateK`. Must be `>= RAVEN_RETRIEVAL_DEFAULT_LIMIT`. |
+| `RAVEN_RETRIEVAL_RRF_K` | int | `60` | no | RRF smoothing constant. Lower → top-ranked agreement matters more; higher → smoother distribution. Mirrored by the Python ai-worker. |
+| `RAVEN_RETRIEVAL_CANDIDATE_MULTIPLIER` | int | `3` | no | Per-leg candidate set is sized as `topK * multiplier` (then clamped to `MAX_LIMIT`) so RRF has enough overlap signal. |
+| `RAVEN_RETRIEVAL_HYBRID_VECTOR_WEIGHT` | float | `1.0` | no | Multiplier on the vector leg's RRF contribution. `0` disables the leg's influence on the fused score; both weights at `0` fall back to `1.0/1.0`. |
+| `RAVEN_RETRIEVAL_HYBRID_BM25_WEIGHT` | float | `1.0` | no | Multiplier on the BM25 leg's RRF contribution. |
+
 ### ClickHouse (large-tenant vector backend)
 
 ClickHouse is opt-in. The API uses `pgvector` by default and switches per-org
@@ -383,6 +399,8 @@ as a `pydantic_settings.BaseSettings` subclass with
 | `RAVEN_HTTP_ENABLED` | bool | `true` | no | Toggle the FastAPI side-server. |
 | `RAVEN_HTTP_BIND_HOST` | string | `127.0.0.1` | no | Binds loopback by default; override only when callers live on a separate node and a network policy gates external access. |
 | `RAVEN_SEMANTIC_CACHE_ENABLED` | bool | `true` | no | Toggle the pgvector semantic-response cache (M9 #256). When false the exact-match Valkey cache still applies. |
+| `RAVEN_RETRIEVAL_RRF_K` | int | `60` | no | RRF smoothing constant used by `reciprocal_rank_fusion` on the RAG path. Shares the env var with the Go API so both code paths stay in lock-step. |
+| `RAVEN_RETRIEVAL_DEFAULT_TOP_N` | int | `10` | no | Size of the fused list emitted by RRF before optional reranking / context build. |
 
 In addition, the AI worker reads provider keys directly from the environment
 at request time (not via pydantic-settings):

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,37 @@ type Config struct {
 	Seed         SeedConfig
 	SES          SESConfig
 	EmailSummary EmailSummaryConfig
+	Retrieval    RetrievalConfig
+}
+
+// RetrievalConfig holds tunables for the hybrid search / RRF pipeline used by
+// SearchService.HybridSearch. All values are overridable via the
+// RAVEN_RETRIEVAL_* env vars listed below; see
+// docs-site/stubs/reference/configuration.md for the canonical reference.
+type RetrievalConfig struct {
+	// DefaultLimit is the topK returned when the caller omits top_k.
+	// Env: RAVEN_RETRIEVAL_DEFAULT_LIMIT (default 10).
+	DefaultLimit int `mapstructure:"default_limit"`
+	// MaxLimit is the hard ceiling applied to topK and candidateK.
+	// Env: RAVEN_RETRIEVAL_MAX_LIMIT (default 100).
+	MaxLimit int `mapstructure:"max_limit"`
+	// RRFK is the smoothing constant in score = sum(1 / (k + rank_i)).
+	// Env: RAVEN_RETRIEVAL_RRF_K (default 60 — standard value from the
+	// original RRF paper, Cormack et al., 2009).
+	RRFK int `mapstructure:"rrf_k"`
+	// CandidateMultiplier sizes each retriever's candidate set as
+	// topK * CandidateMultiplier (then clamped to MaxLimit) so RRF has
+	// enough overlap signal. Env: RAVEN_RETRIEVAL_CANDIDATE_MULTIPLIER
+	// (default 3).
+	CandidateMultiplier int `mapstructure:"candidate_multiplier"`
+	// HybridVectorWeight is the multiplier applied to the vector leg's
+	// per-document RRF contribution. Env:
+	// RAVEN_RETRIEVAL_HYBRID_VECTOR_WEIGHT (default 1.0 — both legs equal).
+	HybridVectorWeight float64 `mapstructure:"hybrid_vector_weight"`
+	// HybridBM25Weight is the multiplier applied to the BM25 leg's
+	// per-document RRF contribution. Env:
+	// RAVEN_RETRIEVAL_HYBRID_BM25_WEIGHT (default 1.0).
+	HybridBM25Weight float64 `mapstructure:"hybrid_bm25_weight"`
 }
 
 // SESConfig holds AWS SES outbound email settings.
@@ -395,6 +426,15 @@ func Load() (*Config, error) {
 		"text/csv",
 	})
 
+	// Retrieval / hybrid-search tuning. See RetrievalConfig docstring and
+	// docs-site/stubs/reference/configuration.md for the canonical reference.
+	v.SetDefault("retrieval.default_limit", 10)
+	v.SetDefault("retrieval.max_limit", 100)
+	v.SetDefault("retrieval.rrf_k", 60)
+	v.SetDefault("retrieval.candidate_multiplier", 3)
+	v.SetDefault("retrieval.hybrid_vector_weight", 1.0)
+	v.SetDefault("retrieval.hybrid_bm25_weight", 1.0)
+
 	// Config file (optional)
 	v.SetConfigName("config")
 	v.SetConfigType("yaml")
@@ -490,6 +530,12 @@ func Load() (*Config, error) {
 	_ = v.BindEnv("emailsummary.summarizer_base_url", "RAVEN_AI_WORKER_HTTP_URL")
 	_ = v.BindEnv("posthog.api_key", "RAVEN_POSTHOG_API_KEY")
 	_ = v.BindEnv("posthog.host", "RAVEN_POSTHOG_HOST")
+	_ = v.BindEnv("retrieval.default_limit", "RAVEN_RETRIEVAL_DEFAULT_LIMIT")
+	_ = v.BindEnv("retrieval.max_limit", "RAVEN_RETRIEVAL_MAX_LIMIT")
+	_ = v.BindEnv("retrieval.rrf_k", "RAVEN_RETRIEVAL_RRF_K")
+	_ = v.BindEnv("retrieval.candidate_multiplier", "RAVEN_RETRIEVAL_CANDIDATE_MULTIPLIER")
+	_ = v.BindEnv("retrieval.hybrid_vector_weight", "RAVEN_RETRIEVAL_HYBRID_VECTOR_WEIGHT")
+	_ = v.BindEnv("retrieval.hybrid_bm25_weight", "RAVEN_RETRIEVAL_HYBRID_BM25_WEIGHT")
 
 	// Try to read config file but don't fail if not found
 	_ = v.ReadInConfig()
@@ -527,6 +573,31 @@ func Load() (*Config, error) {
 	// 32 bytes.
 	if cfg.EmailSummary.UnsubscribeBaseURL != "" && len(cfg.EmailSummary.UnsubscribeSecret) < 32 {
 		return nil, fmt.Errorf("emailsummary.unsubscribe_secret (UNSUBSCRIBE_TOKEN_SECRET) must be >= 32 bytes when emailsummary.unsubscribe_base_url is set")
+	}
+
+	// Retrieval validation — guard against degenerate values that would
+	// silently break HybridSearch (e.g. RRF k <= 0 produces division by a
+	// small denominator and bogus scores; negative limits would loop).
+	if cfg.Retrieval.DefaultLimit <= 0 {
+		return nil, fmt.Errorf("retrieval.default_limit must be > 0, got %d", cfg.Retrieval.DefaultLimit)
+	}
+	if cfg.Retrieval.MaxLimit <= 0 {
+		return nil, fmt.Errorf("retrieval.max_limit must be > 0, got %d", cfg.Retrieval.MaxLimit)
+	}
+	if cfg.Retrieval.MaxLimit < cfg.Retrieval.DefaultLimit {
+		return nil, fmt.Errorf("retrieval.max_limit (%d) must be >= retrieval.default_limit (%d)", cfg.Retrieval.MaxLimit, cfg.Retrieval.DefaultLimit)
+	}
+	if cfg.Retrieval.RRFK <= 0 {
+		return nil, fmt.Errorf("retrieval.rrf_k must be > 0, got %d", cfg.Retrieval.RRFK)
+	}
+	if cfg.Retrieval.CandidateMultiplier <= 0 {
+		return nil, fmt.Errorf("retrieval.candidate_multiplier must be > 0, got %d", cfg.Retrieval.CandidateMultiplier)
+	}
+	if cfg.Retrieval.HybridVectorWeight < 0 {
+		return nil, fmt.Errorf("retrieval.hybrid_vector_weight must be >= 0, got %f", cfg.Retrieval.HybridVectorWeight)
+	}
+	if cfg.Retrieval.HybridBM25Weight < 0 {
+		return nil, fmt.Errorf("retrieval.hybrid_bm25_weight must be >= 0, got %f", cfg.Retrieval.HybridBM25Weight)
 	}
 
 	return &cfg, nil

--- a/internal/integration/setup_test.go
+++ b/internal/integration/setup_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 
+	"github.com/ravencloak-org/Raven/internal/config"
 	"github.com/ravencloak-org/Raven/internal/repository"
 	"github.com/ravencloak-org/Raven/internal/service"
 )
@@ -114,7 +115,7 @@ func TestMain(m *testing.M) {
 	testSourceRepo = repository.NewSourceRepository(testPool)
 
 	// Initialize services
-	testSearchSvc = service.NewSearchService(testSearchRepo, testPool)
+	testSearchSvc = service.NewSearchService(testSearchRepo, testPool, config.RetrievalConfig{})
 	testDocSvc = service.NewDocumentService(testDocRepo, testPool)
 	testSourceSvc = service.NewSourceService(testSourceRepo, testPool)
 

--- a/internal/middleware/cors.go
+++ b/internal/middleware/cors.go
@@ -1,7 +1,10 @@
 package middleware
 
 import (
+	"context"
 	"log/slog"
+	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -43,14 +46,57 @@ func getSuperTokensCORSHeaders() []string {
 	return stCORSHeaders
 }
 
+// APIKeyOriginLookup is the narrow interface the CORS middleware needs to
+// resolve a raw widget API key into its allowed-domain list. The repository
+// layer satisfies this via APIKeyLookup; we keep a distinct interface so the
+// CORS middleware never imports the model or repository packages.
+//
+// LookupByHash MUST return (nil, nil) when the key is unknown or revoked so
+// the CORS middleware can fall back cleanly to the server allowlist; it should
+// only return an error for infrastructure-level failures (DB unreachable etc.)
+// which will be treated as "deny" to fail closed.
+type APIKeyOriginLookup interface {
+	LookupByHash(ctx context.Context, keyHash string) (*APIKeyLookupResult, error)
+}
+
 // CORSMiddleware returns a Gin handler that applies CORS policy based on the
 // provided CORSConfig. Origins are validated against cfg.AllowedOrigins.
-// AllowOriginFunc mirrors the same list so that pre-flight and actual requests
-// both use one consistent source of truth; the comment block marks the place
-// where per-key allowed_domains will be wired in during a later milestone.
-func CORSMiddleware(cfg *config.CORSConfig) gin.HandlerFunc {
+//
+// When a non-nil keyLookup is supplied, the middleware also honours the
+// per-API-key allowed_domains allowlist stored against each public widget
+// key. The match rules — applied inside AllowOriginWithContextFunc so a
+// single source of truth covers both preflight and actual requests — are:
+//
+//   - No X-API-Key header on the request  -> fall back to the server-wide
+//     RAVEN_CORS_ALLOWED_ORIGINS allowlist only (legacy behaviour).
+//   - X-API-Key present and the key has a non-empty allowed_domains -> the
+//     Origin MUST match one of those domains. The server allowlist does NOT
+//     widen this per-key set; a widget key bound to example.com is unusable
+//     from any other origin even if the server allowlist is broader.
+//   - X-API-Key present but allowed_domains is empty -> treat as "no per-key
+//     restriction" and fall back to the server allowlist.
+//
+// Domain matching is host-based and supports a single wildcard form,
+// `*.example.com`, which matches any direct or deeper sub-domain (e.g.
+// `sub.example.com`, `a.b.example.com`) plus the apex `example.com`. This
+// mirrors the rule already enforced by APIKeyAuth so per-key allowlists
+// behave identically at preflight and at request time.
+//
+// We deliberately look up the key inside the validator rather than reordering
+// middleware: CORS preflights MUST run before any auth middleware (browsers
+// strip the X-API-Key header from the OPTIONS probe via the Access-Control-
+// Request-Headers list, so APIKeyAuth cannot speak for them), and an actual
+// cross-origin POST still needs an Allow-Origin verdict before the route
+// handler runs. Keeping CORS as the global gate and pushing the lookup down
+// into AllowOriginWithContextFunc is the smaller change.
+func CORSMiddleware(cfg *config.CORSConfig, keyLookup ...APIKeyOriginLookup) gin.HandlerFunc {
 	if cfg == nil {
 		cfg = &config.CORSConfig{}
+	}
+
+	var lookup APIKeyOriginLookup
+	if len(keyLookup) > 0 {
+		lookup = keyLookup[0]
 	}
 
 	allowedSet := lo.SliceToMap(cfg.AllowedOrigins, func(o string) (string, struct{}) {
@@ -80,14 +126,85 @@ func CORSMiddleware(cfg *config.CORSConfig) gin.HandlerFunc {
 		},
 		AllowCredentials: true,
 		MaxAge:           1 * time.Hour,
-		// AllowOriginFunc takes precedence over AllowOrigins when set.
-		// It checks the request origin against the configured allow-list.
-		// TODO(M2): also check api_keys.allowed_domains from the database.
-		AllowOriginFunc: func(origin string) bool {
-			_, ok := allowedSet[origin]
-			return ok
+		// AllowOriginWithContextFunc takes precedence over AllowOrigins/
+		// AllowOriginFunc when set. It checks the request origin against the
+		// configured server allow-list AND (when an API key is presented on
+		// the request) the per-key allowed_domains stored against the widget
+		// API key. See the doc-comment on CORSMiddleware for the exact rules.
+		AllowOriginWithContextFunc: func(c *gin.Context, origin string) bool {
+			return originAllowed(c, origin, allowedSet, lookup)
 		},
 	}
 
 	return cors.New(corsConfig)
+}
+
+// originAllowed implements the per-key + server-wide CORS verdict. It is
+// pulled out of the closure to keep it directly unit-testable.
+func originAllowed(c *gin.Context, origin string, serverAllowed map[string]struct{}, lookup APIKeyOriginLookup) bool {
+	// The cors package only invokes the validator when an Origin header is
+	// present, so we don't need to special-case missing origins here.
+
+	rawKey := ""
+	if c != nil && c.Request != nil {
+		rawKey = c.Request.Header.Get("X-API-Key")
+	}
+
+	if rawKey != "" && lookup != nil {
+		// Best-effort lookup; a DB error here fails closed.
+		res, err := lookup.LookupByHash(c.Request.Context(), hashAPIKey(rawKey))
+		if err != nil {
+			slog.Warn("CORS api key lookup failed; denying origin", "err", err)
+			return false
+		}
+		// res == nil means "key not found / revoked"; treat as no per-key
+		// restriction and fall through to the server allowlist. The auth
+		// middleware will reject the request shortly anyway.
+		if res != nil && len(res.AllowedDomains) > 0 {
+			return isOriginAllowedByDomains(origin, res.AllowedDomains)
+		}
+	}
+
+	_, ok := serverAllowed[origin]
+	return ok
+}
+
+// isOriginAllowedByDomains reports whether the given Origin header value
+// matches any entry in the per-key allowed_domains list. Matching is
+// host-based; entries beginning with `*.` are treated as sub-domain wildcards
+// and also match the apex. Mirrors APIKeyAuth's isDomainAllowed semantics.
+func isOriginAllowedByDomains(origin string, allowed []string) bool {
+	host := originHost(origin)
+	if host == "" {
+		return false
+	}
+	for _, d := range allowed {
+		d = strings.TrimSpace(d)
+		if d == "" {
+			continue
+		}
+		if strings.HasPrefix(d, "*.") {
+			suffix := d[1:] // ".example.com"
+			apex := d[2:]   // "example.com"
+			if strings.EqualFold(host, apex) || strings.HasSuffix(strings.ToLower(host), strings.ToLower(suffix)) {
+				return true
+			}
+			continue
+		}
+		if strings.EqualFold(host, d) {
+			return true
+		}
+	}
+	return false
+}
+
+// originHost extracts the host portion from an Origin header value. The
+// Origin header is always a URL like "https://example.com[:port]"; if parsing
+// fails we conservatively treat it as a bare host.
+func originHost(origin string) string {
+	u, err := url.Parse(origin)
+	if err != nil || u.Host == "" {
+		return strings.TrimSpace(origin)
+	}
+	return u.Hostname()
 }

--- a/internal/middleware/cors_test.go
+++ b/internal/middleware/cors_test.go
@@ -1,6 +1,10 @@
 package middleware_test
 
 import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -136,6 +140,230 @@ func TestCORSActualRequest(t *testing.T) {
 	allowCreds := w.Header().Get("Access-Control-Allow-Credentials")
 	if allowCreds != "true" {
 		t.Errorf("Access-Control-Allow-Credentials: got %q, want %q", allowCreds, "true")
+	}
+}
+
+// --- Per-API-key origin allowlist (docs-audit #9) ----------------------------
+
+// fakeAPIKeyLookup is a test double for middleware.APIKeyOriginLookup that
+// returns canned responses keyed by the SHA-256 hash of the raw key.
+type fakeAPIKeyLookup struct {
+	byHash map[string]*middleware.APIKeyLookupResult
+	err    error
+}
+
+func (f *fakeAPIKeyLookup) LookupByHash(_ context.Context, hash string) (*middleware.APIKeyLookupResult, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	if r, ok := f.byHash[hash]; ok {
+		return r, nil
+	}
+	return nil, nil
+}
+
+func sha256Hex(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:])
+}
+
+// newKeyAwareRouter wires a CORS middleware with both a server allowlist and a
+// per-key lookup so the per-key branch can be exercised end-to-end.
+func newKeyAwareRouter(corsConfig *config.CORSConfig, lookup middleware.APIKeyOriginLookup) *gin.Engine {
+	r := gin.New()
+	r.Use(middleware.SecurityHeadersMiddleware())
+	r.Use(middleware.CORSMiddleware(corsConfig, lookup))
+	r.GET("/api/v1/ping", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	})
+	// Use Any to also serve OPTIONS via gin's NoMethod fallback path so the
+	// CORS middleware can return its own 204/403 verdict without us masking
+	// it as a 404.
+	r.NoRoute(func(c *gin.Context) { c.Status(http.StatusNotFound) })
+	return r
+}
+
+// xOriginRequest builds a test request and pins Host to a value distinct from
+// the supplied Origin so the gin-contrib/cors "same-origin" shortcut at
+// applyCors() does not silently bypass our validator. (httptest.NewRequest
+// defaults Host to "example.com", which collides with our example origins.)
+func xOriginRequest(method, target, origin string) *http.Request {
+	req := httptest.NewRequest(method, target, nil)
+	req.Host = "api.raven.test"
+	req.Header.Set("Origin", origin)
+	return req
+}
+
+// TestCORSPerKey_NoKeyOnRequest_FallsBackToServerAllowlist verifies that a
+// request without X-API-Key keeps the legacy server-allowlist semantics even
+// when a key lookup is wired in.
+func TestCORSPerKey_NoKeyOnRequest_FallsBackToServerAllowlist(t *testing.T) {
+	lookup := &fakeAPIKeyLookup{}
+	r := newKeyAwareRouter(defaultCORSConfig(), lookup)
+
+	// Allowed by server allowlist.
+	req := xOriginRequest(http.MethodGet, "/api/v1/ping", "http://localhost:5173")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for server-allowed origin without key, got %d", w.Code)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "http://localhost:5173" {
+		t.Errorf("Access-Control-Allow-Origin: got %q, want %q", got, "http://localhost:5173")
+	}
+
+	// Rejected: not in server allowlist, no key supplied.
+	req = xOriginRequest(http.MethodOptions, "/api/v1/ping", "https://example.com")
+	req.Header.Set("Access-Control-Request-Method", "GET")
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403 for unknown origin without key, got %d", w.Code)
+	}
+}
+
+// TestCORSPerKey_KeyWithEmptyAllowlist_FallsBackToServer verifies that an
+// API key whose allowed_domains is empty is treated as "no per-key
+// restriction" and the server allowlist still governs.
+func TestCORSPerKey_KeyWithEmptyAllowlist_FallsBackToServer(t *testing.T) {
+	const rawKey = "rk_test_empty"
+	lookup := &fakeAPIKeyLookup{byHash: map[string]*middleware.APIKeyLookupResult{
+		sha256Hex(rawKey): {ID: "k1", AllowedDomains: nil, Status: "active"},
+	}}
+	r := newKeyAwareRouter(defaultCORSConfig(), lookup)
+
+	// Origin is in the server allowlist -> allowed.
+	req := xOriginRequest(http.MethodGet, "/api/v1/ping", "http://localhost:5173")
+	req.Header.Set("X-API-Key", rawKey)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 (server allowlist applies), got %d", w.Code)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "http://localhost:5173" {
+		t.Errorf("Access-Control-Allow-Origin: got %q, want %q", got, "http://localhost:5173")
+	}
+
+	// Origin not in server allowlist -> rejected (empty per-key list does
+	// NOT widen the allowlist).
+	req = xOriginRequest(http.MethodOptions, "/api/v1/ping", "https://example.com")
+	req.Header.Set("X-API-Key", rawKey)
+	req.Header.Set("Access-Control-Request-Method", "GET")
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403 (empty allowlist doesn't widen server set), got %d", w.Code)
+	}
+}
+
+// TestCORSPerKey_MatchingOrigin_Allowed verifies that an Origin which matches
+// the per-key allowed_domains is accepted EVEN IF it is absent from the
+// server-wide RAVEN_CORS_ALLOWED_ORIGINS allowlist.
+func TestCORSPerKey_MatchingOrigin_Allowed(t *testing.T) {
+	const rawKey = "rk_test_example"
+	lookup := &fakeAPIKeyLookup{byHash: map[string]*middleware.APIKeyLookupResult{
+		sha256Hex(rawKey): {ID: "k1", AllowedDomains: []string{"example.com"}, Status: "active"},
+	}}
+	// Server allowlist intentionally excludes example.com.
+	r := newKeyAwareRouter(defaultCORSConfig(), lookup)
+
+	req := xOriginRequest(http.MethodGet, "/api/v1/ping", "https://example.com")
+	req.Header.Set("X-API-Key", rawKey)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for per-key allowed origin, got %d", w.Code)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "https://example.com" {
+		t.Errorf("Access-Control-Allow-Origin: got %q, want %q", got, "https://example.com")
+	}
+}
+
+// TestCORSPerKey_NonMatchingOrigin_Rejected verifies that an Origin which does
+// NOT match the per-key allowed_domains is rejected, even when the server
+// allowlist would otherwise admit it. This is the load-bearing case: a widget
+// key bound to example.com must not be usable from attacker.com.
+func TestCORSPerKey_NonMatchingOrigin_Rejected(t *testing.T) {
+	const rawKey = "rk_test_bound"
+	lookup := &fakeAPIKeyLookup{byHash: map[string]*middleware.APIKeyLookupResult{
+		sha256Hex(rawKey): {ID: "k1", AllowedDomains: []string{"example.com"}, Status: "active"},
+	}}
+	// Even though the server allowlist contains localhost:5173, a key bound
+	// to example.com must not be usable from there.
+	r := newKeyAwareRouter(defaultCORSConfig(), lookup)
+
+	req := xOriginRequest(http.MethodOptions, "/api/v1/ping", "http://localhost:5173")
+	req.Header.Set("X-API-Key", rawKey)
+	req.Header.Set("Access-Control-Request-Method", "GET")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403 for non-matching origin under bound key, got %d", w.Code)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("disallowed origin must not appear in Access-Control-Allow-Origin, got %q", got)
+	}
+
+	// And the attacker case from the task description.
+	req = xOriginRequest(http.MethodGet, "/api/v1/ping", "https://attacker.com")
+	req.Header.Set("X-API-Key", rawKey)
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("attacker origin must be rejected, got Allow-Origin %q", got)
+	}
+}
+
+// TestCORSPerKey_WildcardMatch verifies the `*.example.com` wildcard rule:
+// it matches direct sub-domains, deeper sub-domains, and the apex.
+func TestCORSPerKey_WildcardMatch(t *testing.T) {
+	const rawKey = "rk_test_wild"
+	lookup := &fakeAPIKeyLookup{byHash: map[string]*middleware.APIKeyLookupResult{
+		sha256Hex(rawKey): {ID: "k1", AllowedDomains: []string{"*.example.com"}, Status: "active"},
+	}}
+	r := newKeyAwareRouter(defaultCORSConfig(), lookup)
+
+	cases := []struct {
+		origin string
+		want   int
+	}{
+		{"https://example.com", http.StatusOK},        // apex
+		{"https://www.example.com", http.StatusOK},    // direct sub
+		{"https://a.b.example.com", http.StatusOK},    // deeper sub
+		{"https://notexample.com", http.StatusForbidden},
+		{"https://example.com.attacker.com", http.StatusForbidden},
+	}
+	for _, tc := range cases {
+		req := xOriginRequest(http.MethodOptions, "/api/v1/ping", tc.origin)
+		req.Header.Set("X-API-Key", rawKey)
+		req.Header.Set("Access-Control-Request-Method", "GET")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		// For preflight, OK preflight returns 204; we check >= 400 for deny.
+		if tc.want == http.StatusOK {
+			if w.Code != http.StatusNoContent {
+				t.Errorf("origin %q: expected 204 preflight, got %d", tc.origin, w.Code)
+			}
+		} else if w.Code < 400 {
+			t.Errorf("origin %q: expected denied preflight, got %d", tc.origin, w.Code)
+		}
+	}
+}
+
+// TestCORSPerKey_LookupError_FailsClosed verifies that an infrastructure
+// failure in the key lookup denies the request rather than silently falling
+// through to the server allowlist (which an attacker who hammered the DB
+// could otherwise weaponise).
+func TestCORSPerKey_LookupError_FailsClosed(t *testing.T) {
+	lookup := &fakeAPIKeyLookup{err: errors.New("db down")}
+	r := newKeyAwareRouter(defaultCORSConfig(), lookup)
+
+	req := xOriginRequest(http.MethodGet, "/api/v1/ping", "http://localhost:5173") // would be allowed without a key
+	req.Header.Set("X-API-Key", "rk_anything")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("lookup error must fail closed, got Allow-Origin %q", got)
 	}
 }
 

--- a/internal/service/search.go
+++ b/internal/service/search.go
@@ -9,12 +9,18 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/samber/lo"
 
+	"github.com/ravencloak-org/Raven/internal/config"
 	"github.com/ravencloak-org/Raven/internal/db"
 	"github.com/ravencloak-org/Raven/internal/model"
 	"github.com/ravencloak-org/Raven/internal/repository"
 	"github.com/ravencloak-org/Raven/pkg/apierror"
 )
 
+// Compile-time defaults used by the package-level helpers (`clampLimit`,
+// `fuseRRF`) and as the fallback when a SearchService is constructed without
+// an explicit RetrievalConfig. The runtime-effective values come from
+// `config.RetrievalConfig`, which is wired in `cmd/api/main.go` from the
+// RAVEN_RETRIEVAL_* env vars — see internal/config/config.go.
 const (
 	defaultSearchLimit = 10
 	maxSearchLimit     = 100
@@ -23,17 +29,80 @@ const (
 	// score = sum(1 / (k + rank_i)) for each retriever where the document appears.
 	// k=60 is the standard value from the original RRF paper (Cormack et al., 2009).
 	rrfK = 60
+
+	// defaultCandidateMultiplier mirrors the historical `candidateK = topK * 3`
+	// behaviour from before retrieval tuning was made env-configurable.
+	defaultCandidateMultiplier = 3
 )
+
+// defaultRetrievalConfig returns the RetrievalConfig used when a
+// SearchService is constructed without an explicit config (e.g. integration
+// tests). It must stay in sync with the package-level constants above and
+// with the `retrieval.*` defaults in config.Load.
+func defaultRetrievalConfig() config.RetrievalConfig {
+	return config.RetrievalConfig{
+		DefaultLimit:        defaultSearchLimit,
+		MaxLimit:            maxSearchLimit,
+		RRFK:                rrfK,
+		CandidateMultiplier: defaultCandidateMultiplier,
+		HybridVectorWeight:  1.0,
+		HybridBM25Weight:    1.0,
+	}
+}
 
 // SearchService contains business logic for full-text and hybrid search operations.
 type SearchService struct {
 	repo *repository.SearchRepository
 	pool *pgxpool.Pool
+	cfg  config.RetrievalConfig
 }
 
-// NewSearchService creates a new SearchService.
-func NewSearchService(repo *repository.SearchRepository, pool *pgxpool.Pool) *SearchService {
-	return &SearchService{repo: repo, pool: pool}
+// NewSearchService creates a new SearchService. The retrieval cfg controls
+// topK clamping, the RRF smoothing constant `k`, candidate-set expansion, and
+// per-leg hybrid weights — see config.RetrievalConfig. Zero-valued fields are
+// replaced with the package defaults (defaultSearchLimit, maxSearchLimit,
+// rrfK, defaultCandidateMultiplier, 1.0, 1.0) so callers that haven't been
+// updated still get the historical behaviour.
+func NewSearchService(repo *repository.SearchRepository, pool *pgxpool.Pool, cfg config.RetrievalConfig) *SearchService {
+	return &SearchService{repo: repo, pool: pool, cfg: normaliseRetrievalConfig(cfg)}
+}
+
+// normaliseRetrievalConfig backfills zero-valued fields with the historical
+// defaults. Negative weights are clamped to zero — this matches the
+// config-time validation but keeps tests that construct a SearchService
+// directly (without going through config.Load) safe.
+func normaliseRetrievalConfig(cfg config.RetrievalConfig) config.RetrievalConfig {
+	d := defaultRetrievalConfig()
+	if cfg.DefaultLimit <= 0 {
+		cfg.DefaultLimit = d.DefaultLimit
+	}
+	if cfg.MaxLimit <= 0 {
+		cfg.MaxLimit = d.MaxLimit
+	}
+	if cfg.MaxLimit < cfg.DefaultLimit {
+		cfg.MaxLimit = cfg.DefaultLimit
+	}
+	if cfg.RRFK <= 0 {
+		cfg.RRFK = d.RRFK
+	}
+	if cfg.CandidateMultiplier <= 0 {
+		cfg.CandidateMultiplier = d.CandidateMultiplier
+	}
+	if cfg.HybridVectorWeight < 0 {
+		cfg.HybridVectorWeight = 0
+	}
+	if cfg.HybridBM25Weight < 0 {
+		cfg.HybridBM25Weight = 0
+	}
+	// A zero-valued weight (caller intentionally disabling a leg) is left
+	// alone; we only refuse negatives.
+	if cfg.HybridVectorWeight == 0 && cfg.HybridBM25Weight == 0 {
+		// Both zero would null out every fused score; restore historical
+		// equal-weight behaviour rather than returning empty results.
+		cfg.HybridVectorWeight = d.HybridVectorWeight
+		cfg.HybridBM25Weight = d.HybridBM25Weight
+	}
+	return cfg
 }
 
 // sanitizeQuery trims whitespace and collapses multiple spaces.
@@ -41,13 +110,21 @@ func sanitizeQuery(q string) string {
 	return strings.Join(strings.Fields(strings.TrimSpace(q)), " ")
 }
 
-// clampLimit ensures limit is within [1, maxSearchLimit].
+// clampLimit ensures limit is within [1, maxSearchLimit] using the package
+// defaults. Used by the TextSearch* methods, which never had a per-instance
+// override, and by the existing unit tests.
 func clampLimit(limit int) int {
+	return clampLimitWith(limit, defaultSearchLimit, maxSearchLimit)
+}
+
+// clampLimitWith is the configurable equivalent of clampLimit. Used by
+// HybridSearch so the limits respect the RAVEN_RETRIEVAL_* env vars.
+func clampLimitWith(limit, defaultLimit, maxLimit int) int {
 	if limit <= 0 {
-		return defaultSearchLimit
+		return defaultLimit
 	}
-	if limit > maxSearchLimit {
-		return maxSearchLimit
+	if limit > maxLimit {
+		return maxLimit
 	}
 	return limit
 }
@@ -106,12 +183,12 @@ func (s *SearchService) TextSearchWithFilters(ctx context.Context, orgID, kbID, 
 // Results are ranked by fused RRF score in descending order.
 func (s *SearchService) HybridSearch(ctx context.Context, orgID, kbID string, query string, embedding []float32, topK int) (*model.HybridSearchResponse, error) {
 	q := sanitizeQuery(query)
-	topK = clampLimit(topK)
+	topK = clampLimitWith(topK, s.cfg.DefaultLimit, s.cfg.MaxLimit)
 
 	// Both retrievers use an expanded candidate set so RRF has enough signal.
-	candidateK := topK * 3
-	if candidateK > maxSearchLimit {
-		candidateK = maxSearchLimit
+	candidateK := topK * s.cfg.CandidateMultiplier
+	if candidateK > s.cfg.MaxLimit {
+		candidateK = s.cfg.MaxLimit
 	}
 
 	var vectorResults, bm25Results []model.HybridSearchResult
@@ -141,22 +218,33 @@ func (s *SearchService) HybridSearch(ctx context.Context, orgID, kbID string, qu
 		return nil, apierror.NewInternal("hybrid search failed: " + err.Error())
 	}
 
-	merged := fuseRRF(vectorResults, bm25Results, topK)
+	merged := fuseRRFWith(vectorResults, bm25Results, topK, s.cfg.RRFK, s.cfg.HybridVectorWeight, s.cfg.HybridBM25Weight)
 
 	return &model.HybridSearchResponse{Results: merged, Total: len(merged)}, nil
 }
 
-// fuseRRF merges vector and BM25 result lists using Reciprocal Rank Fusion.
+// fuseRRF merges vector and BM25 result lists using Reciprocal Rank Fusion
+// with the package-level defaults (k = rrfK, equal leg weights of 1.0).
 //
-// For each document appearing in either list, the RRF score is computed as:
-//
-//	score = sum(1 / (k + rank_i))
-//
-// where k = rrfK (60) and rank_i is the 1-based position in each retriever's
-// ranked list. Documents appearing in only one list receive a single RRF
-// contribution. The output is sorted by descending RRF score and truncated to
-// topK results.
+// It is a thin wrapper over fuseRRFWith kept for the existing unit tests in
+// search_test.go and for any caller that does not have a RetrievalConfig.
+// New code in this package should call fuseRRFWith directly with explicit
+// `k`, `vectorWeight`, and `bm25Weight` values so RAVEN_RETRIEVAL_* env vars
+// flow through end-to-end.
 func fuseRRF(vectorResults, bm25Results []model.HybridSearchResult, topK int) []model.HybridSearchResult {
+	return fuseRRFWith(vectorResults, bm25Results, topK, rrfK, 1.0, 1.0)
+}
+
+// fuseRRFWith is the parametrised RRF implementation. For each document
+// appearing in either list, the RRF score is computed as:
+//
+//	score = vectorWeight * 1/(k + rank_vec) + bm25Weight * 1/(k + rank_bm25)
+//
+// where rank_* is the 1-based position in the respective retriever's ranked
+// list, k is the RRF smoothing constant, and a missing rank contributes
+// nothing. The output is sorted by descending fused score and truncated to
+// topK results.
+func fuseRRFWith(vectorResults, bm25Results []model.HybridSearchResult, topK, k int, vectorWeight, bm25Weight float64) []model.HybridSearchResult {
 	type fusedEntry struct {
 		result   model.HybridSearchResult
 		rrfScore float64
@@ -173,7 +261,7 @@ func fuseRRF(vectorResults, bm25Results []model.HybridSearchResult, topK int) []
 		}
 		entry.result.VectorScore = vr.VectorScore
 		entry.result.VectorRank = rank + 1
-		entry.rrfScore += 1.0 / float64(rrfK+rank+1)
+		entry.rrfScore += vectorWeight / float64(k+rank+1)
 	}
 
 	// Process BM25 results (1-based ranking).
@@ -185,7 +273,7 @@ func fuseRRF(vectorResults, bm25Results []model.HybridSearchResult, topK int) []
 		}
 		entry.result.BM25Score = br.BM25Score
 		entry.result.BM25Rank = rank + 1
-		entry.rrfScore += 1.0 / float64(rrfK+rank+1)
+		entry.rrfScore += bm25Weight / float64(k+rank+1)
 	}
 
 	// Collect and sort by RRF score descending.

--- a/internal/service/search_test.go
+++ b/internal/service/search_test.go
@@ -2,8 +2,10 @@ package service
 
 import (
 	"math"
+	"os"
 	"testing"
 
+	"github.com/ravencloak-org/Raven/internal/config"
 	"github.com/ravencloak-org/Raven/internal/model"
 )
 
@@ -303,4 +305,256 @@ func TestRRFKConstant(t *testing.T) {
 	if rrfK != 60 {
 		t.Errorf("rrfK = %d, want 60 (standard RRF constant)", rrfK)
 	}
+}
+
+// TestRetrievalConfigEnvOverride verifies that the RAVEN_RETRIEVAL_* env
+// vars feed through config.Load into the values used by SearchService.
+// This closes finding #4 from the docs audit, which flagged these tunables
+// as hard-coded.
+func TestRetrievalConfigEnvOverride(t *testing.T) {
+	// config.Load also requires a database URL — set it to a syntactically
+	// valid value so Validate() succeeds; we never actually connect.
+	t.Setenv("RAVEN_DATABASE_URL", "postgres://test:test@localhost:5432/test")
+	t.Setenv("RAVEN_RETRIEVAL_DEFAULT_LIMIT", "20")
+	t.Setenv("RAVEN_RETRIEVAL_MAX_LIMIT", "200")
+	t.Setenv("RAVEN_RETRIEVAL_RRF_K", "42")
+	t.Setenv("RAVEN_RETRIEVAL_CANDIDATE_MULTIPLIER", "4")
+	t.Setenv("RAVEN_RETRIEVAL_HYBRID_VECTOR_WEIGHT", "2.0")
+	t.Setenv("RAVEN_RETRIEVAL_HYBRID_BM25_WEIGHT", "0.5")
+
+	// Run from a directory with no config.yaml so the env vars are the
+	// sole source of values.
+	tmp := t.TempDir()
+	prev, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatalf("chdir tmp: %v", err)
+	}
+	defer func() { _ = os.Chdir(prev) }()
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("config.Load() failed: %v", err)
+	}
+
+	if cfg.Retrieval.DefaultLimit != 20 {
+		t.Errorf("DefaultLimit = %d, want 20", cfg.Retrieval.DefaultLimit)
+	}
+	if cfg.Retrieval.MaxLimit != 200 {
+		t.Errorf("MaxLimit = %d, want 200", cfg.Retrieval.MaxLimit)
+	}
+	if cfg.Retrieval.RRFK != 42 {
+		t.Errorf("RRFK = %d, want 42", cfg.Retrieval.RRFK)
+	}
+	if cfg.Retrieval.CandidateMultiplier != 4 {
+		t.Errorf("CandidateMultiplier = %d, want 4", cfg.Retrieval.CandidateMultiplier)
+	}
+	if cfg.Retrieval.HybridVectorWeight != 2.0 {
+		t.Errorf("HybridVectorWeight = %f, want 2.0", cfg.Retrieval.HybridVectorWeight)
+	}
+	if cfg.Retrieval.HybridBM25Weight != 0.5 {
+		t.Errorf("HybridBM25Weight = %f, want 0.5", cfg.Retrieval.HybridBM25Weight)
+	}
+
+	// Construct a SearchService from the loaded config and verify the env
+	// values flowed through normaliseRetrievalConfig unchanged.
+	svc := NewSearchService(nil, nil, cfg.Retrieval)
+	if svc.cfg.DefaultLimit != 20 || svc.cfg.MaxLimit != 200 ||
+		svc.cfg.RRFK != 42 || svc.cfg.CandidateMultiplier != 4 ||
+		svc.cfg.HybridVectorWeight != 2.0 || svc.cfg.HybridBM25Weight != 0.5 {
+		t.Errorf("SearchService.cfg did not preserve env-var-driven values: %+v", svc.cfg)
+	}
+}
+
+// TestRetrievalConfigDefaults verifies the zero-input defaults match the
+// historical hard-coded constants — protects against accidental drift when
+// the defaults are edited.
+func TestRetrievalConfigDefaults(t *testing.T) {
+	t.Setenv("RAVEN_DATABASE_URL", "postgres://test:test@localhost:5432/test")
+	// Make sure no stray RAVEN_RETRIEVAL_* values leak in from the host.
+	for _, k := range []string{
+		"RAVEN_RETRIEVAL_DEFAULT_LIMIT",
+		"RAVEN_RETRIEVAL_MAX_LIMIT",
+		"RAVEN_RETRIEVAL_RRF_K",
+		"RAVEN_RETRIEVAL_CANDIDATE_MULTIPLIER",
+		"RAVEN_RETRIEVAL_HYBRID_VECTOR_WEIGHT",
+		"RAVEN_RETRIEVAL_HYBRID_BM25_WEIGHT",
+	} {
+		t.Setenv(k, "")
+		_ = os.Unsetenv(k)
+	}
+
+	tmp := t.TempDir()
+	prev, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatalf("chdir tmp: %v", err)
+	}
+	defer func() { _ = os.Chdir(prev) }()
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("config.Load() failed: %v", err)
+	}
+
+	if cfg.Retrieval.DefaultLimit != defaultSearchLimit {
+		t.Errorf("DefaultLimit default = %d, want %d", cfg.Retrieval.DefaultLimit, defaultSearchLimit)
+	}
+	if cfg.Retrieval.MaxLimit != maxSearchLimit {
+		t.Errorf("MaxLimit default = %d, want %d", cfg.Retrieval.MaxLimit, maxSearchLimit)
+	}
+	if cfg.Retrieval.RRFK != rrfK {
+		t.Errorf("RRFK default = %d, want %d", cfg.Retrieval.RRFK, rrfK)
+	}
+	if cfg.Retrieval.CandidateMultiplier != defaultCandidateMultiplier {
+		t.Errorf("CandidateMultiplier default = %d, want %d", cfg.Retrieval.CandidateMultiplier, defaultCandidateMultiplier)
+	}
+	if cfg.Retrieval.HybridVectorWeight != 1.0 || cfg.Retrieval.HybridBM25Weight != 1.0 {
+		t.Errorf("hybrid weight defaults = (%f, %f), want (1.0, 1.0)", cfg.Retrieval.HybridVectorWeight, cfg.Retrieval.HybridBM25Weight)
+	}
+}
+
+// TestClampLimitWithConfig verifies that clampLimitWith respects the
+// per-instance MaxLimit so the RAVEN_RETRIEVAL_MAX_LIMIT override actually
+// caps topK.
+func TestClampLimitWithConfig(t *testing.T) {
+	tests := []struct {
+		name                  string
+		input, def, max, want int
+	}{
+		{"zero returns default", 0, 25, 200, 25},
+		{"within range", 50, 25, 200, 50},
+		{"at max", 200, 25, 200, 200},
+		{"over max clamps to max", 5000, 25, 200, 200},
+		{"negative returns default", -1, 25, 200, 25},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := clampLimitWith(tt.input, tt.def, tt.max)
+			if got != tt.want {
+				t.Errorf("clampLimitWith(%d, %d, %d) = %d, want %d", tt.input, tt.def, tt.max, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFuseRRFWith_RespectsWeights verifies that fuseRRFWith honours the
+// per-leg weights so the RAVEN_RETRIEVAL_HYBRID_*_WEIGHT overrides change
+// the fused ranking as documented.
+func TestFuseRRFWith_RespectsWeights(t *testing.T) {
+	vectorResults := []model.HybridSearchResult{
+		{ChunkID: "V", VectorScore: 0.9},
+	}
+	bm25Results := []model.HybridSearchResult{
+		{ChunkID: "B", BM25Score: 4.0},
+	}
+
+	// Heavy vector weighting → V should outrank B even though both are at
+	// rank 1 in their respective legs.
+	results := fuseRRFWith(vectorResults, bm25Results, 10, 60, 5.0, 1.0)
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if results[0].ChunkID != "V" {
+		t.Errorf("with vector weight 5.0, expected V first, got %q", results[0].ChunkID)
+	}
+
+	// Inverting the weights flips the order.
+	results = fuseRRFWith(vectorResults, bm25Results, 10, 60, 1.0, 5.0)
+	if results[0].ChunkID != "B" {
+		t.Errorf("with bm25 weight 5.0, expected B first, got %q", results[0].ChunkID)
+	}
+
+	// A custom k changes the magnitude of the score but not the ordering.
+	rWithDefaultK := fuseRRFWith(vectorResults, nil, 10, 60, 1.0, 1.0)
+	rWithBigK := fuseRRFWith(vectorResults, nil, 10, 600, 1.0, 1.0)
+	if !(rWithDefaultK[0].RRFScore > rWithBigK[0].RRFScore) {
+		t.Errorf("expected score with k=60 (%f) to exceed score with k=600 (%f)", rWithDefaultK[0].RRFScore, rWithBigK[0].RRFScore)
+	}
+}
+
+// TestNormaliseRetrievalConfig verifies that zero-valued or partial configs
+// fall back to the historical defaults so callers (notably the integration
+// test harness) that pass a zero RetrievalConfig still get sane behaviour.
+func TestNormaliseRetrievalConfig(t *testing.T) {
+	got := normaliseRetrievalConfig(config.RetrievalConfig{})
+	want := defaultRetrievalConfig()
+	if got != want {
+		t.Errorf("normaliseRetrievalConfig(zero) = %+v, want %+v", got, want)
+	}
+
+	// MaxLimit < DefaultLimit is rewritten to MaxLimit = DefaultLimit so
+	// HybridSearch never receives a degenerate ceiling. Validation in
+	// config.Load also rejects this combination up front.
+	got = normaliseRetrievalConfig(config.RetrievalConfig{
+		DefaultLimit:        50,
+		MaxLimit:            10,
+		RRFK:                60,
+		CandidateMultiplier: 3,
+		HybridVectorWeight:  1.0,
+		HybridBM25Weight:    1.0,
+	})
+	if got.MaxLimit < got.DefaultLimit {
+		t.Errorf("MaxLimit (%d) < DefaultLimit (%d) after normalise", got.MaxLimit, got.DefaultLimit)
+	}
+}
+
+// TestRetrievalConfigValidationRejectsBadValues exercises the config-time
+// guards added alongside RetrievalConfig.
+func TestRetrievalConfigValidationRejectsBadValues(t *testing.T) {
+	cases := []struct {
+		name    string
+		env     map[string]string
+		wantErr string
+	}{
+		{
+			name:    "negative default limit",
+			env:     map[string]string{"RAVEN_RETRIEVAL_DEFAULT_LIMIT": "-1"},
+			wantErr: "retrieval.default_limit",
+		},
+		{
+			name:    "rrf k zero",
+			env:     map[string]string{"RAVEN_RETRIEVAL_RRF_K": "0"},
+			wantErr: "retrieval.rrf_k",
+		},
+		{
+			name:    "max below default",
+			env:     map[string]string{"RAVEN_RETRIEVAL_DEFAULT_LIMIT": "50", "RAVEN_RETRIEVAL_MAX_LIMIT": "10"},
+			wantErr: "retrieval.max_limit",
+		},
+		{
+			name:    "negative weight",
+			env:     map[string]string{"RAVEN_RETRIEVAL_HYBRID_VECTOR_WEIGHT": "-0.1"},
+			wantErr: "retrieval.hybrid_vector_weight",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("RAVEN_DATABASE_URL", "postgres://test:test@localhost:5432/test")
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+			tmp := t.TempDir()
+			prev, _ := os.Getwd()
+			if err := os.Chdir(tmp); err != nil {
+				t.Fatalf("chdir tmp: %v", err)
+			}
+			defer func() { _ = os.Chdir(prev) }()
+
+			_, err := config.Load()
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !contains(err.Error(), tc.wantErr) {
+				t.Errorf("error = %q, want substring %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary

Three findings from the docs audit, each fully verified locally. Builds on Bucket A (#501).

| # | Commit | Fix |
|---|---|---|
| 4 | retrieval-env | **Hybrid-search tuning now env-configurable.** New `config.RetrievalConfig` struct (prefix `RAVEN_RETRIEVAL_`) with `DEFAULT_LIMIT`, `MAX_LIMIT`, `RRF_K`, `CANDIDATE_MULTIPLIER`, `HYBRID_VECTOR_WEIGHT`, `HYBRID_BM25_WEIGHT`. Python side: `retrieval_rrf_k` + `retrieval_default_top_n` in `Settings`. Existing constants stay as defaults via `normaliseRetrievalConfig`. |
| 9 | widget-cors | **Per-API-key `allowed_domains` now enforced in CORS.** Two-layer check inside `AllowOriginWithContextFunc`: server-level `RAVEN_CORS_ALLOWED_ORIGINS` is the outer gate; widget keys with non-empty `allowed_domains` impose an inner check. Wildcards (`*.example.com`) match the existing `APIKeyAuth` rule. 6 new test cases incl. fail-closed lookup-error path. Removes the `TODO(M2)`. |
| 5 | hardening-compose | **Container hardening defaults on every service in compose.** `security_opt: ["no-new-privileges:true"]` + `cap_drop: [ALL]` + minimum `cap_add` per service (e.g. Traefik gets `NET_BIND_SERVICE`, Postgres gets `CHOWN,DAC_OVERRIDE,FOWNER,SETGID,SETUID`). `read_only` + tmpfs deferred to a follow-up. Each cap set verified by running the image standalone. |

## Docs touched (alongside code)

- `concepts/hybrid-retrieval` + `reference/configuration` — document the new env vars
- `get-started/embed-the-chat-widget` — replace the TODO(M2) qualifier with the actual behaviour
- `guides/self-hosting/hardening` — replace "not bundled" with the per-service cap_add table

## Test plan
- [ ] `go test ./internal/service/... ./internal/middleware/... ./internal/config/...` passes
- [ ] `golangci-lint run ./...` passes
- [ ] `docker compose -f docker-compose.yml config --quiet` and `... -f docker-compose.edge.yml config --quiet` exit 0
- [ ] Bring up the full compose stack on a clean host (not done in-sandbox due to pre-existing host port clashes) and confirm all 14 services reach healthy
- [ ] Setting `RAVEN_RETRIEVAL_RRF_K=30` overrides the default 60 in both Go and Python paths

## Side-note: host environment recovery during this session

While committing this PR, we hit a confusing-looking issue: golangci-lint was being SIGKILLed instantly on startup. Root cause turned out to be a corrupted code signature on the locally-installed v1 binary plus a schema mismatch with the repo's v2 `.golangci.yml`. Fixed by reinstalling v2.12.2 via `go install`. Documented for future spelunkers.

## Out of scope (Bucket C — biggest items)

Each of these deserves a small spec first:
- #6 SuperTokens MFA recipe
- #8 Hybrid-search standalone endpoint
- #10 STT/TTS plugins on LiveKit agent (#59/#60)
- #11 Invitation endpoint + email
- #13 Wire `WebhookService.Dispatch` to event sites
- #14 Subscription lifecycle states
- #16 Auto-migrate option