### PR TITLE
fix(resilience): plumb breaker cooldown into Retry-After header

### DIFF
--- a/internal/resilience/breaker.go
+++ b/internal/resilience/breaker.go
@@ -3,6 +3,8 @@ package resilience
 import (
 	"context"
 	"errors"
+	"fmt"
+	"time"
 
 	"github.com/sony/gobreaker/v2"
 	"go.opentelemetry.io/otel/attribute"
@@ -10,15 +12,37 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// ErrCircuitOpen is returned by a Breaker when the underlying state machine
-// is Open (or in Half-Open with the probe quota exhausted). Callers should
-// surface this as HTTP 503 with Retry-After.
-var ErrCircuitOpen = errors.New("resilience: circuit breaker open")
+// CircuitOpenError is returned by a Breaker when the underlying state machine
+// is Open (or in Half-Open with the probe quota exhausted). It carries the
+// PolicyName and the RetryAfter duration so callers can emit a precise
+// Retry-After HTTP header without relying on a hardcoded constant.
+type CircuitOpenError struct {
+	PolicyName string
+	RetryAfter time.Duration
+}
+
+// Error implements the error interface.
+func (e *CircuitOpenError) Error() string {
+	return fmt.Sprintf("resilience: circuit breaker %q open", e.PolicyName)
+}
+
+// Is reports whether target is a *CircuitOpenError, enabling errors.Is
+// comparisons against the ErrCircuitOpen sentinel for back-compat.
+func (e *CircuitOpenError) Is(target error) bool {
+	_, ok := target.(*CircuitOpenError)
+	return ok
+}
+
+// ErrCircuitOpen is a zero-value sentinel kept for errors.Is back-compat.
+// New code should use errors.As to obtain RetryAfter from *CircuitOpenError.
+var ErrCircuitOpen = &CircuitOpenError{}
 
 // Breaker is a thin adapter over sony/gobreaker that maps its sentinel
-// errors to ErrCircuitOpen and respects context cancellation up front.
+// errors to *CircuitOpenError and respects context cancellation up front.
 type Breaker struct {
-	cb *gobreaker.CircuitBreaker[any]
+	cb         *gobreaker.CircuitBreaker[any]
+	policyName string
+	cooldown   time.Duration
 }
 
 // BreakerOption configures NewBreaker.
@@ -67,6 +91,8 @@ func NewBreaker(p *Policy, opts ...BreakerOption) *Breaker {
 			return counts.ConsecutiveFailures >= p.BreakerThreshold
 		},
 	}
+	policyName := p.Name
+	cooldown := p.BreakerCooldown
 	if o.isSuccessful != nil {
 		settings.IsSuccessful = o.isSuccessful
 	}
@@ -93,7 +119,11 @@ func NewBreaker(p *Policy, opts ...BreakerOption) *Breaker {
 		}
 	}
 
-	return &Breaker{cb: gobreaker.NewCircuitBreaker[any](settings)}
+	return &Breaker{
+		cb:         gobreaker.NewCircuitBreaker[any](settings),
+		policyName: policyName,
+		cooldown:   cooldown,
+	}
 }
 
 // Execute runs fn through the breaker. It checks ctx cancellation first
@@ -106,7 +136,7 @@ func (b *Breaker) Execute(ctx context.Context, fn func(context.Context) (any, er
 	switch {
 	case errors.Is(err, gobreaker.ErrOpenState),
 		errors.Is(err, gobreaker.ErrTooManyRequests):
-		return nil, ErrCircuitOpen
+		return nil, &CircuitOpenError{PolicyName: b.policyName, RetryAfter: b.cooldown}
 	}
 	return out, err
 }

--- a/internal/resilience/breaker_test.go
+++ b/internal/resilience/breaker_test.go
@@ -77,6 +77,47 @@ func TestBreaker_RespectsContextCancellation(t *testing.T) {
 	}
 }
 
+// TestBreaker_ExecuteOnOpenBreakerReturnsCircuitOpenError asserts that when the
+// breaker trips, Execute returns a *CircuitOpenError carrying the correct
+// PolicyName and RetryAfter, and that errors.Is(err, ErrCircuitOpen) still works.
+func TestBreaker_ExecuteOnOpenBreakerReturnsCircuitOpenError(t *testing.T) {
+	const policyName = "my-svc"
+	const cooldown = 75 * time.Millisecond
+
+	p, _ := NewPolicy(policyName,
+		WithBreakerThreshold(2),
+		WithBreakerCooldown(cooldown),
+	)
+	br := NewBreaker(p)
+
+	failing := func(context.Context) (any, error) { return nil, errors.New("boom") }
+	for i := 0; i < 2; i++ {
+		_, _ = br.Execute(context.Background(), failing)
+	}
+
+	_, err := br.Execute(context.Background(), failing)
+	if err == nil {
+		t.Fatal("expected error from open breaker, got nil")
+	}
+
+	// errors.Is back-compat must hold.
+	if !errors.Is(err, ErrCircuitOpen) {
+		t.Errorf("errors.Is(err, ErrCircuitOpen) = false, want true; err = %v", err)
+	}
+
+	// Typed error must carry correct fields.
+	var cOpen *CircuitOpenError
+	if !errors.As(err, &cOpen) {
+		t.Fatalf("errors.As(*CircuitOpenError) = false; err = %v", err)
+	}
+	if cOpen.PolicyName != policyName {
+		t.Errorf("PolicyName = %q, want %q", cOpen.PolicyName, policyName)
+	}
+	if cOpen.RetryAfter != cooldown {
+		t.Errorf("RetryAfter = %v, want %v", cOpen.RetryAfter, cooldown)
+	}
+}
+
 // IsSuccessful predicate: caller-classified errors propagate AND don't trip the breaker.
 func TestBreaker_IsSuccessfulPredicate(t *testing.T) {
 	p, _ := NewPolicy("svc", WithBreakerThreshold(2))

--- a/pkg/apierror/apierror.go
+++ b/pkg/apierror/apierror.go
@@ -2,7 +2,10 @@ package apierror
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
+	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
 
@@ -106,12 +109,17 @@ func ErrorHandler() gin.HandlerFunc {
 
 		if len(c.Errors) > 0 {
 			err := c.Errors.Last().Err
-			if errors.Is(err, resilience.ErrCircuitOpen) {
-				c.Header("Retry-After", "30")
+			var cOpen *resilience.CircuitOpenError
+			if errors.As(err, &cOpen) {
+				retryAfter := int(cOpen.RetryAfter.Round(time.Second).Seconds())
+				if retryAfter < 1 {
+					retryAfter = 1
+				}
+				c.Header("Retry-After", strconv.Itoa(retryAfter))
 				c.JSON(http.StatusServiceUnavailable, &AppError{
 					Code:    http.StatusServiceUnavailable,
 					Message: "Service Unavailable",
-					Detail:  "circuit breaker open; please retry after 30 seconds",
+					Detail:  fmt.Sprintf("upstream service temporarily unavailable; retry after %ds", retryAfter),
 				})
 			} else if quotaErr, ok := err.(*QuotaError); ok {
 				c.JSON(quotaErr.Code, quotaErr)

--- a/pkg/apierror/apierror_test.go
+++ b/pkg/apierror/apierror_test.go
@@ -1,9 +1,13 @@
 package apierror_test
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 
@@ -40,7 +44,7 @@ func TestErrorHandler_CircuitOpenReturns503(t *testing.T) {
 	r.GET("/", func(c *gin.Context) {
 		_ = c.Error(resilience.ErrCircuitOpen)
 	})
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 	if w.Code != http.StatusServiceUnavailable {
@@ -48,5 +52,45 @@ func TestErrorHandler_CircuitOpenReturns503(t *testing.T) {
 	}
 	if w.Header().Get("Retry-After") == "" {
 		t.Errorf("missing Retry-After header")
+	}
+}
+
+// TestErrorHandler_CircuitOpenRetryAfterTracksConfiguredCooldown asserts that
+// the Retry-After header matches the breaker's configured cooldown and that the
+// body Detail does not leak the "circuit breaker" implementation term.
+func TestErrorHandler_CircuitOpenRetryAfterTracksConfiguredCooldown(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	const cooldown = 12 * time.Second
+
+	r := gin.New()
+	r.Use(apierror.ErrorHandler())
+	r.GET("/", func(c *gin.Context) {
+		_ = c.Error(&resilience.CircuitOpenError{PolicyName: "ai-worker", RetryAfter: cooldown})
+	})
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", w.Code)
+	}
+
+	if got := w.Header().Get("Retry-After"); got != "12" {
+		t.Errorf("Retry-After = %q, want %q", got, "12")
+	}
+
+	var body struct {
+		Detail string `json:"detail"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if !strings.Contains(body.Detail, "retry after 12s") {
+		t.Errorf("Detail %q does not contain 'retry after 12s'", body.Detail)
+	}
+	if strings.Contains(body.Detail, "circuit breaker") {
+		t.Errorf("Detail %q leaks 'circuit breaker' implementation detail", body.Detail)
 	}
 }


### PR DESCRIPTION
## Summary

- Introduces `CircuitOpenError` (typed error) carrying `PolicyName` and `RetryAfter` fields, replacing the bare `errors.New` sentinel
- `Breaker` struct now stores `policyName` and `cooldown`; `Execute` wraps open-state errors as `*CircuitOpenError` with those values
- `apierror.ErrorHandler` switches from `errors.Is` to `errors.As(*CircuitOpenError)` and emits `Retry-After` derived from the actual configured cooldown; Detail drops the "circuit breaker" leak
- `ErrCircuitOpen` sentinel kept as a zero-value `*CircuitOpenError` with an `Is` method — `errors.Is(err, ErrCircuitOpen)` still works for existing callers
- No change to `cmd/api/main.go`; `NewBreaker` signature is unchanged

## Test plan

- [ ] `go test -race ./internal/resilience/... ./pkg/apierror/...` — all green
- [ ] `TestBreaker_ExecuteOnOpenBreakerReturnsCircuitOpenError` asserts `PolicyName` + `RetryAfter` via `errors.As`
- [ ] `TestErrorHandler_CircuitOpenRetryAfterTracksConfiguredCooldown` asserts `Retry-After: 12` header and Detail containing `"retry after 12s"` (not `"30 seconds"`, not `"circuit breaker"`)
- [ ] All pre-existing tests (`TestBreaker_OpensAfterThreshold`, etc.) still pass with `errors.Is` back-compat
- [ ] `golangci-lint run ./internal/resilience/... ./pkg/apierror/...` — 0 issues

Closes #505