### PR TITLE
feat(db): opt-in auto-migrate on API startup (RAVEN_DB_AUTO_MIGRATE)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -256,6 +256,17 @@ func main() {
 	}()
 	// queueClient is passed to services that enqueue async jobs.
 
+	// --- Database migrations (opt-in via RAVEN_DB_AUTO_MIGRATE) ---
+	// Off by default: operators run `make migrate-up` (or equivalent) themselves.
+	// Useful for dev / single-node deployments where the API is the only writer.
+	if cfg.Database.AutoMigrate {
+		slog.Info("running database migrations (RAVEN_DB_AUTO_MIGRATE=true)")
+		if mErr := db.RunMigrations(context.Background(), cfg.Database.URL); mErr != nil {
+			log.Fatalf("auto-migrate failed: %v", mErr)
+		}
+		slog.Info("database migrations applied")
+	}
+
 	// --- Database pool ---
 	pool, err := db.New(context.Background(), cfg.Database.URL)
 	if err != nil {

--- a/docs-site/stubs/guides/self-hosting/upgrades.md
+++ b/docs-site/stubs/guides/self-hosting/upgrades.md
@@ -171,11 +171,11 @@ v3, files in `migrations/` numbered `00001_*.sql` through `00039_*.sql`
 (at time of writing — count grows with each release). The in-DB state
 table is `goose_db_version`.
 
-**Migrations are NOT applied automatically on `go-api` startup.** The
-production binary (`/app/api` in the container) does not import goose at
-all — `github.com/pressly/goose/v3` only appears under
-`internal/testutil/db.go` and other test-only paths. The wired operator
-path is the `Makefile` target:
+**Migrations are NOT applied automatically on `go-api` startup by default.**
+The production binary uses an opt-in `RAVEN_DB_AUTO_MIGRATE` env var: when
+set to `true`, the API runs `goose up` against the embedded migration set
+before serving traffic. When unset or `false` (default), operators must
+apply migrations themselves via the `Makefile`:
 
 ```bash
 # Apply all pending migrations.
@@ -190,6 +190,28 @@ Both targets delegate to:
 ```bash
 dotenvx run -- goose -dir migrations postgres "$DATABASE_URL" up
 ```
+
+### Auto-migrate (opt-in)
+
+Set `RAVEN_DB_AUTO_MIGRATE=true` in the API's environment to have the
+binary run all pending migrations during startup. The migration set is
+embedded in the binary via `//go:embed` (see `migrations/embed.go`), so
+no extra files need to ship with the container.
+
+```bash
+# Same upgrade flow, but skip the manual migrate-up:
+RAVEN_DB_AUTO_MIGRATE=true docker compose up -d
+```
+
+**When to enable it:** dev, single-node deployments, edge / Raspberry Pi
+where the API is the only writer. **When to leave it off:** production
+multi-replica deployments — let exactly one process apply migrations,
+typically a CI job or a dedicated migrate container, so a rolling
+restart cannot run multiple instances of `goose up` concurrently against
+the same DB.
+
+Backups still happen *before* the migration regardless of which path
+you take.
 
 Inspect migration state at any time:
 

--- a/docs-site/stubs/reference/configuration.md
+++ b/docs-site/stubs/reference/configuration.md
@@ -106,6 +106,7 @@ Durations accept Go `time.Duration` syntax (`5s`, `500ms`, `2m`).
 | Env var | Type | Default | Required | Description |
 |---|---|---|---|---|
 | `RAVEN_DATABASE_URL` | URL | — | yes | PostgreSQL DSN (with `pgvector`). Validated as non-empty in `Load()`. |
+| `RAVEN_DB_AUTO_MIGRATE` | bool | `false` | no | When `true`, the API runs all pending goose migrations against `RAVEN_DATABASE_URL` on startup before serving traffic. Migrations are embedded in the binary via `//go:embed`; no on-disk `migrations/` directory required. **Leave off in multi-replica production**; see [Upgrades — Auto-migrate](/guides/self-hosting/upgrades#auto-migrate-opt-in). |
 | `RAVEN_VALKEY_URL` | URL | — | no | Valkey/Redis DSN, used by Asynq + rate-limit buckets + cache. |
 
 `config.Load()` returns an error if `RAVEN_DATABASE_URL` is unset:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -287,6 +287,13 @@ type ServerConfig struct {
 // DatabaseConfig holds database connection settings.
 type DatabaseConfig struct {
 	URL string `mapstructure:"url"`
+	// AutoMigrate, when true, makes the API run all pending goose migrations
+	// against URL on startup before serving traffic. Default false; operators
+	// should run `make migrate-up` (or equivalent) themselves in production
+	// unless they explicitly opt in. Migrations are embedded in the binary
+	// via the migrations package, so no on-disk migrations/ directory is
+	// required at runtime.
+	AutoMigrate bool `mapstructure:"auto_migrate"`
 }
 
 // ValkeyConfig holds Valkey (Redis-compatible) connection settings.
@@ -321,6 +328,7 @@ func Load() (*Config, error) {
 	v.SetDefault("server.ai_worker_breaker_threshold", 5)
 	v.SetDefault("server.ai_worker_breaker_cooldown", "30s")
 	v.SetDefault("server.single_user", false)
+	v.SetDefault("database.auto_migrate", false)
 	v.SetDefault("grpc.worker_addr", "localhost:50051")
 	v.SetDefault("otel.endpoint", "")
 	v.SetDefault("otel.service_name", "raven-api")
@@ -449,6 +457,7 @@ func Load() (*Config, error) {
 	// Explicitly bind nested keys — AutomaticEnv alone does not reliably surface
 	// dotted keys during Unmarshal in all viper versions.
 	_ = v.BindEnv("database.url", "RAVEN_DATABASE_URL")
+	_ = v.BindEnv("database.auto_migrate", "RAVEN_DB_AUTO_MIGRATE")
 	_ = v.BindEnv("valkey.url", "RAVEN_VALKEY_URL")
 	_ = v.BindEnv("grpc.worker_addr", "RAVEN_GRPC_WORKER_ADDR")
 	_ = v.BindEnv("supertokens.connection_uri", "RAVEN_SUPERTOKENS_CONNECTION_URI")

--- a/internal/config/config_db_test.go
+++ b/internal/config/config_db_test.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDatabaseConfig_AutoMigrate_DefaultsOff(t *testing.T) {
+	t.Setenv("RAVEN_DATABASE_URL", "postgres://x:x@localhost/x")
+	t.Setenv("RAVEN_RATELIMIT_DEFAULT_USER_LIMIT", "100")
+	t.Setenv("RAVEN_RATELIMIT_DEFAULT_ORG_LIMIT", "1000")
+
+	cfg, err := Load()
+	require.NoError(t, err)
+
+	assert.False(t, cfg.Database.AutoMigrate,
+		"AutoMigrate must default to false so operators never run migrations by accident")
+}
+
+func TestDatabaseConfig_AutoMigrate_EnvOverride(t *testing.T) {
+	t.Setenv("RAVEN_DATABASE_URL", "postgres://x:x@localhost/x")
+	t.Setenv("RAVEN_RATELIMIT_DEFAULT_USER_LIMIT", "100")
+	t.Setenv("RAVEN_RATELIMIT_DEFAULT_ORG_LIMIT", "1000")
+	t.Setenv("RAVEN_DB_AUTO_MIGRATE", "true")
+
+	cfg, err := Load()
+	require.NoError(t, err)
+
+	assert.True(t, cfg.Database.AutoMigrate,
+		"RAVEN_DB_AUTO_MIGRATE=true must flip the flag on")
+}

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -1,0 +1,44 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	_ "github.com/lib/pq" // postgres driver for the database/sql handle goose requires
+	"github.com/pressly/goose/v3"
+
+	"github.com/ravencloak-org/Raven/migrations"
+)
+
+// RunMigrations applies every pending goose migration against the database
+// pointed to by databaseURL. Migrations are read from the embedded filesystem
+// in the migrations package, so the API binary is self-contained — operators
+// do not need to ship the migrations/ directory alongside it.
+//
+// Called from cmd/api/main.go when cfg.Database.AutoMigrate is true. Returns
+// the first error it encounters; partial-state DBs are the operator's problem
+// to recover from (typically via pgBackRest restore — see the Upgrades and
+// Backups docs).
+func RunMigrations(ctx context.Context, databaseURL string) error {
+	sqlDB, err := sql.Open("postgres", databaseURL)
+	if err != nil {
+		return fmt.Errorf("open postgres for migration: %w", err)
+	}
+	defer func() { _ = sqlDB.Close() }()
+
+	if err := sqlDB.PingContext(ctx); err != nil {
+		return fmt.Errorf("ping postgres for migration: %w", err)
+	}
+
+	goose.SetBaseFS(migrations.FS)
+	defer goose.SetBaseFS(nil)
+
+	if err := goose.SetDialect("postgres"); err != nil {
+		return fmt.Errorf("goose.SetDialect: %w", err)
+	}
+	if err := goose.UpContext(ctx, sqlDB, "."); err != nil {
+		return fmt.Errorf("goose.Up: %w", err)
+	}
+	return nil
+}

--- a/migrations/embed.go
+++ b/migrations/embed.go
@@ -1,0 +1,15 @@
+// Package migrations exposes the goose-managed SQL migration files via an
+// embedded filesystem so the API binary can apply them at startup when
+// RAVEN_DB_AUTO_MIGRATE=true is set.
+//
+// Operators still run `make migrate-up` (which uses the on-disk files
+// directly via the goose CLI) by default; the embed is opt-in.
+package migrations
+
+import "embed"
+
+// FS holds every .sql migration file at the time of build. Goose reads from
+// this via goose.SetBaseFS when db.RunMigrations is invoked.
+//
+//go:embed *.sql
+var FS embed.FS


### PR DESCRIPTION
## Summary

Closes finding **#16** from the docs audit. Production binary now optionally runs `goose up` against the embedded migration set before serving traffic.

| Change | Why |
|---|---|
| \`migrations/embed.go\` — \`//go:embed *.sql\` exposes SQL files as a Go \`embed.FS\` | Binary self-contained; no on-disk \`migrations/\` directory at runtime |
| \`internal/db/migrate.go\` — \`RunMigrations(ctx, databaseURL)\` calls \`goose.SetBaseFS\` + \`UpContext\` against the embedded set | Single entry point for prod migration application |
| \`internal/config/config.go\` — \`DatabaseConfig.AutoMigrate bool\` (env \`RAVEN_DB_AUTO_MIGRATE\`), default false | Opt-in only |
| \`cmd/api/main.go\` — when \`cfg.Database.AutoMigrate\`, call \`RunMigrations\` before opening the pool | Fatal on failure |
| \`internal/config/config_db_test.go\` — defaults-off + env-override tests | Verifies the Viper plumbing |

## Defaults

| Mode | Default | Recommended for |
|---|---|---|
| \`RAVEN_DB_AUTO_MIGRATE\` unset / \`false\` | OFF | Multi-replica production. Use a dedicated CI job or migrate container to avoid concurrent \`goose up\` races. |
| \`RAVEN_DB_AUTO_MIGRATE=true\` | ON | Dev, single-node, edge / Raspberry Pi where the API is the only writer. |

## Docs touched

- \`/guides/self-hosting/upgrades\` — flipped the "NOT auto-run" section to "default still manual; opt-in via env"; added a per-mode usage table
- \`/reference/configuration\` — added \`RAVEN_DB_AUTO_MIGRATE\` to the Database table

## Pre-existing lint surface

While committing this PR, the repo's whole-repo \`golangci-lint run ./...\` hook surfaced unrelated pre-existing issues (contextcheck in \`internal/service/{billing,document,security}.go\` + \`internal/repository/semantic_cache.go\`; noctx in \`internal/handler/airbyte_test.go\` etc.). Lint of the packages this PR actually touches passes cleanly. The repo-wide cleanup is a separate tracked item — flagged here so reviewers know the existing hook is grumpy.

## Test plan
- [ ] \`go test ./internal/config/...\` — new tests pass
- [ ] \`go build ./...\` — clean
- [ ] In a local stack with a fresh DB: \`RAVEN_DB_AUTO_MIGRATE=true docker compose up -d go-api postgres\` brings the API up with the schema applied; \`\\d\` in psql shows the expected tables
- [ ] With \`RAVEN_DB_AUTO_MIGRATE=false\` (default), \`make migrate-up\` continues to work; the API starts but doesn't touch the schema