### PR TITLE
chore(lint): clear pre-existing noctx + revive violations

### DIFF
--- a/internal/ebpf/xdp/stub.go
+++ b/internal/ebpf/xdp/stub.go
@@ -17,8 +17,14 @@ type Config struct {
 // Controller is a no-op on non-Linux.
 type Controller struct{}
 
+// NewController is a no-op constructor on non-Linux targets so callers can
+// share the same wiring code across platforms without build-tag gymnastics.
 func NewController(_ Objects, _ any, _ metric.Meter, _ Config) (*Controller, error) {
 	return &Controller{}, nil
 }
+
+// SyncBlocklist is a no-op on non-Linux targets.
 func (c *Controller) SyncBlocklist(_ []string) {}
-func (c *Controller) Close() error              { return nil }
+
+// Close is a no-op on non-Linux targets and always returns nil.
+func (c *Controller) Close() error { return nil }

--- a/internal/middleware/apikey_test.go
+++ b/internal/middleware/apikey_test.go
@@ -205,7 +205,7 @@ func TestAPIKeyAuth(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			r := setupAPIKeyRouter(tc.lookup)
 			w := httptest.NewRecorder()
-			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/test", nil)
 			if tc.apiKey != "" {
 				req.Header.Set("X-API-Key", tc.apiKey)
 			}

--- a/internal/middleware/cors_test.go
+++ b/internal/middleware/cors_test.go
@@ -43,7 +43,7 @@ func defaultCORSConfig() *config.CORSConfig {
 func TestSecurityHeaders(t *testing.T) {
 	r := newTestRouter(defaultCORSConfig())
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/ping", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/v1/ping", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
@@ -74,7 +74,7 @@ func TestSecurityHeaders(t *testing.T) {
 func TestCORSAllowedOrigin(t *testing.T) {
 	r := newTestRouter(defaultCORSConfig())
 
-	req := httptest.NewRequest(http.MethodOptions, "/api/v1/ping", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodOptions, "/api/v1/ping", nil)
 	req.Header.Set("Origin", "http://localhost:5173")
 	req.Header.Set("Access-Control-Request-Method", "GET")
 	req.Header.Set("Access-Control-Request-Headers", "Authorization")
@@ -102,7 +102,7 @@ func TestCORSAllowedOrigin(t *testing.T) {
 func TestCORSDisallowedOrigin(t *testing.T) {
 	r := newTestRouter(defaultCORSConfig())
 
-	req := httptest.NewRequest(http.MethodOptions, "/api/v1/ping", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodOptions, "/api/v1/ping", nil)
 	req.Header.Set("Origin", "https://evil.example.com")
 	req.Header.Set("Access-Control-Request-Method", "GET")
 	w := httptest.NewRecorder()
@@ -123,7 +123,7 @@ func TestCORSDisallowedOrigin(t *testing.T) {
 func TestCORSActualRequest(t *testing.T) {
 	r := newTestRouter(defaultCORSConfig())
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/ping", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/v1/ping", nil)
 	req.Header.Set("Origin", "http://localhost:5173")
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -187,8 +187,9 @@ func newKeyAwareRouter(corsConfig *config.CORSConfig, lookup middleware.APIKeyOr
 // the supplied Origin so the gin-contrib/cors "same-origin" shortcut at
 // applyCors() does not silently bypass our validator. (httptest.NewRequest
 // defaults Host to "example.com", which collides with our example origins.)
-func xOriginRequest(method, target, origin string) *http.Request {
-	req := httptest.NewRequest(method, target, nil)
+func xOriginRequest(t *testing.T, method, target, origin string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequestWithContext(t.Context(), method, target, nil)
 	req.Host = "api.raven.test"
 	req.Header.Set("Origin", origin)
 	return req
@@ -202,7 +203,7 @@ func TestCORSPerKey_NoKeyOnRequest_FallsBackToServerAllowlist(t *testing.T) {
 	r := newKeyAwareRouter(defaultCORSConfig(), lookup)
 
 	// Allowed by server allowlist.
-	req := xOriginRequest(http.MethodGet, "/api/v1/ping", "http://localhost:5173")
+	req := xOriginRequest(t, http.MethodGet, "/api/v1/ping", "http://localhost:5173")
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
@@ -213,7 +214,7 @@ func TestCORSPerKey_NoKeyOnRequest_FallsBackToServerAllowlist(t *testing.T) {
 	}
 
 	// Rejected: not in server allowlist, no key supplied.
-	req = xOriginRequest(http.MethodOptions, "/api/v1/ping", "https://example.com")
+	req = xOriginRequest(t, http.MethodOptions, "/api/v1/ping", "https://example.com")
 	req.Header.Set("Access-Control-Request-Method", "GET")
 	w = httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -233,7 +234,7 @@ func TestCORSPerKey_KeyWithEmptyAllowlist_FallsBackToServer(t *testing.T) {
 	r := newKeyAwareRouter(defaultCORSConfig(), lookup)
 
 	// Origin is in the server allowlist -> allowed.
-	req := xOriginRequest(http.MethodGet, "/api/v1/ping", "http://localhost:5173")
+	req := xOriginRequest(t, http.MethodGet, "/api/v1/ping", "http://localhost:5173")
 	req.Header.Set("X-API-Key", rawKey)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -246,7 +247,7 @@ func TestCORSPerKey_KeyWithEmptyAllowlist_FallsBackToServer(t *testing.T) {
 
 	// Origin not in server allowlist -> rejected (empty per-key list does
 	// NOT widen the allowlist).
-	req = xOriginRequest(http.MethodOptions, "/api/v1/ping", "https://example.com")
+	req = xOriginRequest(t, http.MethodOptions, "/api/v1/ping", "https://example.com")
 	req.Header.Set("X-API-Key", rawKey)
 	req.Header.Set("Access-Control-Request-Method", "GET")
 	w = httptest.NewRecorder()
@@ -267,7 +268,7 @@ func TestCORSPerKey_MatchingOrigin_Allowed(t *testing.T) {
 	// Server allowlist intentionally excludes example.com.
 	r := newKeyAwareRouter(defaultCORSConfig(), lookup)
 
-	req := xOriginRequest(http.MethodGet, "/api/v1/ping", "https://example.com")
+	req := xOriginRequest(t, http.MethodGet, "/api/v1/ping", "https://example.com")
 	req.Header.Set("X-API-Key", rawKey)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -292,7 +293,7 @@ func TestCORSPerKey_NonMatchingOrigin_Rejected(t *testing.T) {
 	// to example.com must not be usable from there.
 	r := newKeyAwareRouter(defaultCORSConfig(), lookup)
 
-	req := xOriginRequest(http.MethodOptions, "/api/v1/ping", "http://localhost:5173")
+	req := xOriginRequest(t, http.MethodOptions, "/api/v1/ping", "http://localhost:5173")
 	req.Header.Set("X-API-Key", rawKey)
 	req.Header.Set("Access-Control-Request-Method", "GET")
 	w := httptest.NewRecorder()
@@ -305,7 +306,7 @@ func TestCORSPerKey_NonMatchingOrigin_Rejected(t *testing.T) {
 	}
 
 	// And the attacker case from the task description.
-	req = xOriginRequest(http.MethodGet, "/api/v1/ping", "https://attacker.com")
+	req = xOriginRequest(t, http.MethodGet, "/api/v1/ping", "https://attacker.com")
 	req.Header.Set("X-API-Key", rawKey)
 	w = httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -334,7 +335,7 @@ func TestCORSPerKey_WildcardMatch(t *testing.T) {
 		{"https://example.com.attacker.com", http.StatusForbidden},
 	}
 	for _, tc := range cases {
-		req := xOriginRequest(http.MethodOptions, "/api/v1/ping", tc.origin)
+		req := xOriginRequest(t, http.MethodOptions, "/api/v1/ping", tc.origin)
 		req.Header.Set("X-API-Key", rawKey)
 		req.Header.Set("Access-Control-Request-Method", "GET")
 		w := httptest.NewRecorder()
@@ -358,7 +359,7 @@ func TestCORSPerKey_LookupError_FailsClosed(t *testing.T) {
 	lookup := &fakeAPIKeyLookup{err: errors.New("db down")}
 	r := newKeyAwareRouter(defaultCORSConfig(), lookup)
 
-	req := xOriginRequest(http.MethodGet, "/api/v1/ping", "http://localhost:5173") // would be allowed without a key
+	req := xOriginRequest(t, http.MethodGet, "/api/v1/ping", "http://localhost:5173") // would be allowed without a key
 	req.Header.Set("X-API-Key", "rk_anything")
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -371,7 +372,7 @@ func TestCORSPerKey_LookupError_FailsClosed(t *testing.T) {
 func TestCORSSecondAllowedOrigin(t *testing.T) {
 	r := newTestRouter(defaultCORSConfig())
 
-	req := httptest.NewRequest(http.MethodOptions, "/api/v1/ping", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodOptions, "/api/v1/ping", nil)
 	req.Header.Set("Origin", "https://raven-frontend.pages.dev")
 	req.Header.Set("Access-Control-Request-Method", "POST")
 	w := httptest.NewRecorder()

--- a/internal/middleware/deadline_test.go
+++ b/internal/middleware/deadline_test.go
@@ -26,7 +26,7 @@ func TestDeadline_AppliesTimeoutToRequestContext(t *testing.T) {
 		c.Status(http.StatusOK)
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 }
@@ -46,7 +46,7 @@ func TestDeadline_PropagatesCancellation(t *testing.T) {
 		c.Status(http.StatusOK)
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 

--- a/internal/middleware/otel_test.go
+++ b/internal/middleware/otel_test.go
@@ -59,7 +59,7 @@ func TestSpanCreatedForRequest(t *testing.T) {
 
 	router := newTestRouter()
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/healthz", nil)
 	router.ServeHTTP(w, req)
 
 	spans := spanExporter.GetSpans()
@@ -73,7 +73,7 @@ func TestTraceIDHeaderSet(t *testing.T) {
 
 	router := newTestRouter()
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/healthz", nil)
 	router.ServeHTTP(w, req)
 
 	traceID := w.Header().Get("X-Trace-ID")
@@ -90,7 +90,7 @@ func TestSpanAttributes(t *testing.T) {
 
 	router := newTestRouter()
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/healthz", nil)
 	router.ServeHTTP(w, req)
 
 	spans := spanExporter.GetSpans()
@@ -127,7 +127,7 @@ func TestRequestDurationMetric(t *testing.T) {
 
 	router := newTestRouter()
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/healthz", nil)
 	router.ServeHTTP(w, req)
 
 	var rm metricdata.ResourceMetrics
@@ -165,7 +165,7 @@ func TestNoOpModeNoPanic(t *testing.T) {
 
 	router := newTestRouter()
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/healthz", nil)
 
 	// Must not panic.
 	router.ServeHTTP(w, req)

--- a/internal/middleware/ratelimit_test.go
+++ b/internal/middleware/ratelimit_test.go
@@ -40,9 +40,10 @@ func newRateLimitRouter(mw gin.HandlerFunc) *gin.Engine {
 }
 
 // doRequest fires a GET /test against the router and returns the recorder.
-func doRequest(r *gin.Engine) *httptest.ResponseRecorder {
+func doRequest(t *testing.T, r *gin.Engine) *httptest.ResponseRecorder {
+	t.Helper()
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/test", nil)
 	r.ServeHTTP(w, req)
 	return w
 }
@@ -60,7 +61,7 @@ func TestRateLimitBasic(t *testing.T) {
 	r := newRateLimitRouter(mw)
 
 	for i := 1; i <= 5; i++ {
-		w := doRequest(r)
+		w := doRequest(t, r)
 		if w.Code != http.StatusOK {
 			t.Fatalf("request %d: expected 200, got %d", i, w.Code)
 		}
@@ -89,14 +90,14 @@ func TestRateLimitExceeded(t *testing.T) {
 
 	// Exhaust the limit.
 	for i := 0; i < limit; i++ {
-		w := doRequest(r)
+		w := doRequest(t, r)
 		if w.Code != http.StatusOK {
 			t.Fatalf("request %d should succeed, got %d", i+1, w.Code)
 		}
 	}
 
 	// Next request should be rejected.
-	w := doRequest(r)
+	w := doRequest(t, r)
 	if w.Code != http.StatusTooManyRequests {
 		t.Fatalf("expected 429, got %d", w.Code)
 	}
@@ -144,14 +145,14 @@ func TestRateLimitWindowReset(t *testing.T) {
 
 	// Exhaust the limit.
 	for i := 0; i < limit; i++ {
-		w := doRequest(r)
+		w := doRequest(t, r)
 		if w.Code != http.StatusOK {
 			t.Fatalf("request %d should succeed, got %d", i+1, w.Code)
 		}
 	}
 
 	// Verify we're now blocked.
-	w := doRequest(r)
+	w := doRequest(t, r)
 	if w.Code != http.StatusTooManyRequests {
 		t.Fatalf("expected 429, got %d", w.Code)
 	}
@@ -161,7 +162,7 @@ func TestRateLimitWindowReset(t *testing.T) {
 	mr.FastForward(61 * time.Second)
 
 	// The window has reset; a new request should succeed.
-	w = doRequest(r)
+	w = doRequest(t, r)
 	if w.Code != http.StatusOK {
 		t.Fatalf("after window reset expected 200, got %d", w.Code)
 	}
@@ -181,7 +182,7 @@ func TestRateLimitValkeyFailureFallback(t *testing.T) {
 	}, keyPrefixFallback)
 	r := newRateLimitRouter(mw)
 
-	w := doRequest(r)
+	w := doRequest(t, r)
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected fail-open (200) when Valkey is unavailable, got %d", w.Code)
 	}
@@ -215,17 +216,17 @@ func TestRateLimitDifferentKeysIndependent(t *testing.T) {
 
 	// Exhaust key A.
 	for i := 0; i < limit; i++ {
-		doRequest(r1)
+		doRequest(t, r1)
 	}
 
 	// Key A is now blocked.
-	w := doRequest(r1)
+	w := doRequest(t, r1)
 	if w.Code != http.StatusTooManyRequests {
 		t.Fatalf("keyA: expected 429, got %d", w.Code)
 	}
 
 	// Key B should still be freely accessible.
-	w = doRequest(r2)
+	w = doRequest(t, r2)
 	if w.Code != http.StatusOK {
 		t.Fatalf("keyB: expected 200, got %d", w.Code)
 	}
@@ -244,7 +245,7 @@ func TestRateLimitRemainingDecrement(t *testing.T) {
 
 	prev := limit
 	for i := 0; i < limit; i++ {
-		w := doRequest(r)
+		w := doRequest(t, r)
 		if w.Code != http.StatusOK {
 			t.Fatalf("request %d: expected 200, got %d", i+1, w.Code)
 		}
@@ -277,12 +278,12 @@ func TestByUserID(t *testing.T) {
 	r.GET("/test", func(c *gin.Context) { c.Status(http.StatusOK) })
 
 	for i := 0; i < limit; i++ {
-		w := doRequest(r)
+		w := doRequest(t, r)
 		if w.Code != http.StatusOK {
 			t.Fatalf("ByUserID request %d: expected 200, got %d", i+1, w.Code)
 		}
 	}
-	w := doRequest(r)
+	w := doRequest(t, r)
 	if w.Code != http.StatusTooManyRequests {
 		t.Fatalf("ByUserID: expected 429 after limit, got %d", w.Code)
 	}
@@ -304,12 +305,12 @@ func TestByOrgID(t *testing.T) {
 	r.GET("/test", func(c *gin.Context) { c.Status(http.StatusOK) })
 
 	for i := 0; i < limit; i++ {
-		w := doRequest(r)
+		w := doRequest(t, r)
 		if w.Code != http.StatusOK {
 			t.Fatalf("ByOrgID request %d: expected 200, got %d", i+1, w.Code)
 		}
 	}
-	w := doRequest(r)
+	w := doRequest(t, r)
 	if w.Code != http.StatusTooManyRequests {
 		t.Fatalf("ByOrgID: expected 429 after limit, got %d", w.Code)
 	}
@@ -333,12 +334,12 @@ func TestByAPIKey(t *testing.T) {
 	r.GET("/test", func(c *gin.Context) { c.Status(http.StatusOK) })
 
 	for i := 0; i < limit; i++ {
-		w := doRequest(r)
+		w := doRequest(t, r)
 		if w.Code != http.StatusOK {
 			t.Fatalf("ByAPIKey request %d: expected 200, got %d", i+1, w.Code)
 		}
 	}
-	w := doRequest(r)
+	w := doRequest(t, r)
 	if w.Code != http.StatusTooManyRequests {
 		t.Fatalf("ByAPIKey: expected 429 after limit, got %d", w.Code)
 	}
@@ -382,14 +383,14 @@ func TestNoKeyUsesFallbackKey(t *testing.T) {
 
 	// Requests up to the limit should succeed (fallback key is rate-limited).
 	for i := 0; i < limit; i++ {
-		w := doRequest(r)
+		w := doRequest(t, r)
 		if w.Code != http.StatusOK {
 			t.Fatalf("fallback key: request %d expected 200, got %d", i+1, w.Code)
 		}
 	}
 
 	// Once the fallback key's limit is exhausted the request must be rejected.
-	w := doRequest(r)
+	w := doRequest(t, r)
 	if w.Code != http.StatusTooManyRequests {
 		t.Fatalf("fallback key: expected 429 after limit, got %d", w.Code)
 	}
@@ -405,7 +406,7 @@ func TestResetHeaderIsUnixTimestamp(t *testing.T) {
 	}, keyPrefixFallback)
 	r := newRateLimitRouter(mw)
 
-	w := doRequest(r)
+	w := doRequest(t, r)
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
 	}
@@ -453,14 +454,14 @@ func TestByOrgTierFreeGeneral(t *testing.T) {
 
 	// 3 requests should succeed.
 	for i := 0; i < 3; i++ {
-		w := doRequest(r)
+		w := doRequest(t, r)
 		if w.Code != http.StatusOK {
 			t.Fatalf("request %d: expected 200, got %d", i+1, w.Code)
 		}
 	}
 
 	// 4th should be rejected.
-	w := doRequest(r)
+	w := doRequest(t, r)
 	if w.Code != http.StatusTooManyRequests {
 		t.Fatalf("expected 429 after free tier limit, got %d", w.Code)
 	}
@@ -481,13 +482,13 @@ func TestByOrgTierFreeCompletion(t *testing.T) {
 	r := newOrgTierRouter(rl, resolver, cfg, RouteGroupCompletion, "org-free-comp")
 
 	for i := 0; i < 2; i++ {
-		w := doRequest(r)
+		w := doRequest(t, r)
 		if w.Code != http.StatusOK {
 			t.Fatalf("completion request %d: expected 200, got %d", i+1, w.Code)
 		}
 	}
 
-	w := doRequest(r)
+	w := doRequest(t, r)
 	if w.Code != http.StatusTooManyRequests {
 		t.Fatalf("expected 429 after completion limit, got %d", w.Code)
 	}
@@ -505,13 +506,13 @@ func TestByOrgTierProHigherLimit(t *testing.T) {
 
 	// Pro tier should allow 5 requests (vs 2 for free).
 	for i := 0; i < 5; i++ {
-		w := doRequest(r)
+		w := doRequest(t, r)
 		if w.Code != http.StatusOK {
 			t.Fatalf("pro request %d: expected 200, got %d", i+1, w.Code)
 		}
 	}
 
-	w := doRequest(r)
+	w := doRequest(t, r)
 	if w.Code != http.StatusTooManyRequests {
 		t.Fatalf("expected 429 after pro tier limit, got %d", w.Code)
 	}
@@ -529,7 +530,7 @@ func TestByOrgTierEnterpriseUnlimited(t *testing.T) {
 
 	// Even 50 requests should succeed (unlimited).
 	for i := 0; i < 50; i++ {
-		w := doRequest(r)
+		w := doRequest(t, r)
 		if w.Code != http.StatusOK {
 			t.Fatalf("enterprise unlimited request %d: expected 200, got %d", i+1, w.Code)
 		}
@@ -547,13 +548,13 @@ func TestByOrgTierWidgetStricterLimit(t *testing.T) {
 	r := newOrgTierRouter(rl, resolver, cfg, RouteGroupWidget, "org-widget-1")
 
 	for i := 0; i < 2; i++ {
-		w := doRequest(r)
+		w := doRequest(t, r)
 		if w.Code != http.StatusOK {
 			t.Fatalf("widget request %d: expected 200, got %d", i+1, w.Code)
 		}
 	}
 
-	w := doRequest(r)
+	w := doRequest(t, r)
 	if w.Code != http.StatusTooManyRequests {
 		t.Fatalf("expected 429 after widget limit, got %d", w.Code)
 	}
@@ -571,14 +572,14 @@ func TestByOrgTierWindowReset(t *testing.T) {
 
 	// Exhaust the limit.
 	for i := 0; i < 2; i++ {
-		w := doRequest(r)
+		w := doRequest(t, r)
 		if w.Code != http.StatusOK {
 			t.Fatalf("request %d should succeed, got %d", i+1, w.Code)
 		}
 	}
 
 	// Should be blocked now.
-	w := doRequest(r)
+	w := doRequest(t, r)
 	if w.Code != http.StatusTooManyRequests {
 		t.Fatalf("expected 429, got %d", w.Code)
 	}
@@ -587,7 +588,7 @@ func TestByOrgTierWindowReset(t *testing.T) {
 	mr.FastForward(61 * time.Second)
 
 	// Should be allowed again.
-	w = doRequest(r)
+	w = doRequest(t, r)
 	if w.Code != http.StatusOK {
 		t.Fatalf("after window reset expected 200, got %d", w.Code)
 	}
@@ -607,15 +608,15 @@ func TestByOrgTierDifferentOrgsIndependent(t *testing.T) {
 
 	// Exhaust org A.
 	for i := 0; i < 2; i++ {
-		doRequest(r1)
+		doRequest(t, r1)
 	}
-	w := doRequest(r1)
+	w := doRequest(t, r1)
 	if w.Code != http.StatusTooManyRequests {
 		t.Fatalf("org-A: expected 429, got %d", w.Code)
 	}
 
 	// Org B should still succeed.
-	w = doRequest(r2)
+	w = doRequest(t, r2)
 	if w.Code != http.StatusOK {
 		t.Fatalf("org-B: expected 200, got %d", w.Code)
 	}
@@ -633,13 +634,13 @@ func TestByOrgTierNoOrgFallsBackToIP(t *testing.T) {
 	r := newOrgTierRouter(rl, resolver, cfg, RouteGroupGeneral, "")
 
 	for i := 0; i < 2; i++ {
-		w := doRequest(r)
+		w := doRequest(t, r)
 		if w.Code != http.StatusOK {
 			t.Fatalf("anon request %d: expected 200, got %d", i+1, w.Code)
 		}
 	}
 
-	w := doRequest(r)
+	w := doRequest(t, r)
 	if w.Code != http.StatusTooManyRequests {
 		t.Fatalf("expected 429 for anonymous fallback, got %d", w.Code)
 	}
@@ -656,7 +657,7 @@ func TestByOrgTierRateLimitHeaders(t *testing.T) {
 	r := newOrgTierRouter(rl, resolver, cfg, RouteGroupGeneral, "org-headers")
 
 	// First request — check headers on admitted response.
-	w := doRequest(r)
+	w := doRequest(t, r)
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
 	}
@@ -671,8 +672,8 @@ func TestByOrgTierRateLimitHeaders(t *testing.T) {
 	}
 
 	// Exhaust and check 429 headers.
-	doRequest(r)
-	w = doRequest(r)
+	doRequest(t, r)
+	w = doRequest(t, r)
 	if w.Code != http.StatusTooManyRequests {
 		t.Fatalf("expected 429, got %d", w.Code)
 	}
@@ -758,15 +759,15 @@ func TestRouteGroupSeparation(t *testing.T) {
 
 	// Exhaust general limit.
 	for i := 0; i < 2; i++ {
-		doRequest(rGeneral)
+		doRequest(t, rGeneral)
 	}
-	w := doRequest(rGeneral)
+	w := doRequest(t, rGeneral)
 	if w.Code != http.StatusTooManyRequests {
 		t.Fatalf("general: expected 429, got %d", w.Code)
 	}
 
 	// Completion should still be available.
-	w = doRequest(rCompletion)
+	w = doRequest(t, rCompletion)
 	if w.Code != http.StatusOK {
 		t.Fatalf("completion should still be available, got %d", w.Code)
 	}


### PR DESCRIPTION
## Summary

The `.githooks/pre-commit` runs `golangci-lint run ./...` on the whole repo for every commit. Right now any PR touching a `.go` file fails the hook due to unrelated pre-existing violations, forcing PRs into tempdir-hook workarounds.

This PR clears the remaining lint backlog so future commits hit a green hook.

| Linter | Files | Fix |
|---|---|---|
| `noctx` | `internal/middleware/{apikey,cors,deadline,otel,ratelimit}_test.go` | Swap `httptest.NewRequest(...)` for `httptest.NewRequestWithContext(t.Context(), ...)`. `xOriginRequest` and `doRequest` helpers take a `*testing.T` so `t.Context()` is in scope; callers updated. |
| `revive` (exported) | `internal/ebpf/xdp/stub.go` | Godoc comments on the non-Linux no-op `NewController`, `SyncBlocklist`, `Close`. |

The `contextcheck` violations called out in earlier audits were already addressed by other recent PRs (resilience plumbing landed in #510 etc.); the only remaining classes were these.

## Verification
- `golangci-lint run --concurrency=1 --timeout=10m ./...` → `0 issues.`
- `go build ./...` clean
- `go test ./internal/middleware/...` passes