### PR TITLE
feat(webhooks): wire WebhookService.Dispatch into producer call sites

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -388,7 +388,7 @@ func main() {
 	identitySvc := service.NewIdentityService(identityRepo, posthogClient)
 	notifSvc := service.NewNotificationService(notifRepo, queueClient)
 	webhookSvc := service.NewWebhookService(webhookRepo, pool, queueClient)
-	leadSvc := service.NewLeadService(leadRepo)
+	leadSvc := service.NewLeadService(leadRepo).WithWebhookDispatcher(webhookSvc)
 	whatsappSvc := service.NewWhatsAppService(whatsappRepo, pool)
 	hsClient := hyperswitch.NewClient(cfg.Hyperswitch.BaseURL, cfg.Hyperswitch.APIKey)
 	billingSvc := service.NewBillingService(billingRepo, pool, hsClient, cfg.Hyperswitch.WebhookSecret)

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ravencloak-org/Raven/internal/posthog"
 	"github.com/ravencloak-org/Raven/internal/queue"
 	"github.com/ravencloak-org/Raven/internal/repository"
+	"github.com/ravencloak-org/Raven/internal/service"
 	"github.com/ravencloak-org/Raven/internal/storage"
 )
 
@@ -39,7 +40,14 @@ func main() {
 	notifRepo := repository.NewNotificationRepository(pool)
 	docRepo := repository.NewDocumentRepository(pool)
 	chunkRepo := repository.NewChunkRepository(pool)
+	airbyteRepo := repository.NewAirbyteRepository(pool)
 	storageClient := storage.NewSeaweedFSClient(cfg.SeaweedFS.MasterURL, nil)
+
+	// Queue client used by webhook dispatch fan-out when job handlers emit
+	// outbound webhook events. Re-uses the same Valkey/Asynq instance as the
+	// server: deliveries land back on the worker mux's webhook handler.
+	queueClient := queue.NewClient(cfg.Valkey.URL)
+	defer func() { _ = queueClient.Close() }()
 
 	srv := queue.NewServer(queue.ServerConfig{
 		RedisAddr:   cfg.Valkey.URL,
@@ -61,9 +69,17 @@ func main() {
 	webhookDeliveryHandler := jobs.NewWebhookDeliveryHandler(pool, webhookRepo, logger)
 	srv.Mux().Handle(queue.TypeWebhookDelivery, webhookDeliveryHandler)
 
+	// Webhook dispatcher reused by document and Airbyte handlers to fan out
+	// `document.processed` and `sync.completed` events on the success path.
+	webhookSvc := service.NewWebhookService(webhookRepo, pool, queueClient)
+
 	// Register document processing handler (overrides the stub in queue.Server).
 	srv.Mux().HandleFunc(queue.TypeDocumentProcess,
-		jobs.NewDocumentProcessHandler(pool, docRepo, chunkRepo, storageClient, logger))
+		jobs.NewDocumentProcessHandler(pool, docRepo, chunkRepo, storageClient, logger, webhookSvc))
+
+	// Register the Airbyte sync handler so connector runs fire `sync.completed`.
+	airbyteSyncHandler := jobs.NewAirbyteSyncHandler(pool, airbyteRepo, logger, webhookSvc)
+	srv.Mux().Handle(queue.TypeAirbyteSync, airbyteSyncHandler)
 
 	// --- M9: post-session email summaries (#257) ---
 	// Reuses the ConversationRepository landed in #349; SetSummary is added

--- a/docs-site/stubs/guides/webhooks-and-events.md
+++ b/docs-site/stubs/guides/webhooks-and-events.md
@@ -9,24 +9,19 @@ workspace by sending a signed JSON `POST` to a URL you register. This page
 documents the data model, the HTTP contract, the signing scheme, the
 delivery semantics, and the current state of the implementation.
 
-::: warning Current state — schema + plumbing, no live emission
-The webhook **data model**, **management API**, **delivery worker**, and
-**HMAC signing** are implemented in the Go backend (`internal/handler/webhook.go`,
-`internal/service/webhook.go`, `internal/jobs/webhook_delivery.go`,
-`migrations/00024_webhook_configs.sql`).
+::: info Current state — three of four event types fire from production code
+The webhook **data model**, **management API**, **delivery worker**,
+**HMAC signing**, **and** the producer call sites for three of the four
+event types are implemented in the Go backend
+(`internal/handler/webhook.go`, `internal/service/webhook.go`,
+`internal/jobs/webhook_delivery.go`,
+`migrations/00024_webhook_configs.sql`, plus the wiring listed below).
 
-What is **not** wired today: the application code that calls
-`WebhookService.Dispatch` when an event actually occurs. The function is
-defined and unit-tested, but it has no production call sites — grep
-`internal/` and `cmd/` and you will only see the constructor wiring.
-The enterprise emitter package (`internal/ee/webhooks`) is a doc-comment
-placeholder.
-
-Treat this page as the **reference for the data model and the contract a
-receiver must implement**. Event types listed below are the ones the
-backend will *accept* during webhook registration; whether they fire in
-your build depends on whether the corresponding code path has been wired
-to call `Dispatch`. As of this writing, none of them do.
+The remaining event (`conversation.escalated`) has **no producer code
+path in OSS** today — the conversation lifecycle does not yet have an
+"escalate to human" verb. The event type is still accepted at
+registration so receivers can subscribe in anticipation of the EE
+emitter (`internal/ee/webhooks`, currently a doc-comment placeholder).
 :::
 
 ## What's wired
@@ -37,8 +32,11 @@ to call `Dispatch`. As of this writing, none of them do.
 | CRUD API (`/orgs/:org_id/webhooks`) | `internal/handler/webhook.go`, `cmd/api/main.go` | Real, admin-only |
 | List deliveries (`/orgs/:org_id/webhooks/:id/deliveries`) | `internal/handler/webhook.go` | Real, last 50 |
 | Async delivery worker with HMAC-SHA256 signing, SSRF guard, retries | `internal/jobs/webhook_delivery.go` | Real |
-| Dispatch fan-out (look up active subscribers and enqueue) | `internal/service/webhook.go` `WebhookService.Dispatch` | Defined, **no callers** |
-| Event emission from feature code (leads, conversations, etc.) | — | **Not wired** |
+| Dispatch fan-out (look up active subscribers and enqueue) | `internal/service/webhook.go` `WebhookService.Dispatch` | Real, called from three producers |
+| `document.processed` emission | `internal/jobs/document_process.go` | Real, end of success path |
+| `sync.completed` emission | `internal/jobs/airbyte_sync.go` | Real, end of success path |
+| `lead.generated` emission | `internal/service/lead.go` `LeadService.Upsert` | Real, on each successful upsert |
+| `conversation.escalated` emission | — | **Not wired** (no escalation verb in OSS) |
 | Replay / resend endpoint | — | Not implemented |
 
 ## Event types
@@ -47,12 +45,47 @@ Defined in `internal/model/webhook.go` and enforced by
 `supportedWebhookEvents` in `internal/handler/webhook.go`. Subscribing to
 any other name is rejected with HTTP 400.
 
-| Event | Will fire when (planned) |
-|-------|--------------------------|
-| `lead.generated` | A lead intelligence pipeline run produces a new lead row. |
-| `conversation.escalated` | A conversation is escalated to a human operator. |
-| `document.processed` | A document ingestion job finishes successfully. |
-| `sync.completed` | A data source sync (connector) finishes. |
+| Event | Fires when | Status |
+|-------|-----------|--------|
+| `lead.generated` | `LeadService.Upsert` succeeds (capture or merge by org+email). | Wired |
+| `conversation.escalated` | A conversation is escalated to a human operator. | **Not wired** — no escalation verb in OSS today; reserved for the EE emitter. |
+| `document.processed` | The document processing job finishes successfully (with or without chunks). | Wired |
+| `sync.completed` | An Airbyte connector sync run completes successfully. | Wired |
+
+### Wired payload shapes
+
+```json
+// document.processed
+{
+  "document_id": "uuid",
+  "knowledge_base_id": "uuid",
+  "status": "ready",
+  "chunk_count": 7
+}
+
+// sync.completed
+{
+  "connector_id": "uuid",
+  "source_id": "uuid",            // knowledge_base_id of the connector
+  "sync_run_id": "uuid",
+  "records_synced": 0,             // placeholder until real Airbyte API lands (TODO #111)
+  "status": "completed"
+}
+
+// lead.generated
+{
+  "lead_id": "uuid",
+  "email": "visitor@example.com",
+  "name": "Visitor Name",
+  "knowledge_base_id": "uuid",
+  "session_ids": ["uuid", "..."]
+}
+```
+
+`lead.generated` is emitted on every successful `UpsertLead` call — the
+repo merges by `(org_id, email)` so receivers may see repeated events
+for the same `lead_id` as the visitor's profile is enriched. Dedupe on
+`lead_id` plus the delivery row's `id`.
 
 No other event names are accepted. Billing webhooks (`payment_succeeded`,
 etc.) and the Meta / WhatsApp webhook endpoints (`/webhooks/meta`,
@@ -131,8 +164,8 @@ X-Raven-Signature: sha256=<hex-encoded HMAC>
 ```
 
 The `data` field is a free-form `map[string]any` chosen by the caller of
-`Dispatch`. Concrete shapes for each event type will be specified when
-the corresponding emitter is wired.
+`Dispatch`. Concrete shapes per wired event are listed under
+[Event types](#event-types) above.
 
 ## Signing + verification
 

--- a/internal/jobs/airbyte_sync.go
+++ b/internal/jobs/airbyte_sync.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/ravencloak-org/Raven/internal/db"
+	"github.com/ravencloak-org/Raven/internal/model"
 	"github.com/ravencloak-org/Raven/internal/queue"
 	"github.com/ravencloak-org/Raven/internal/repository"
 )
@@ -21,14 +22,19 @@ import (
 // logs a placeholder message (real Airbyte API integration is a follow-up),
 // and completes the sync run.
 type AirbyteSyncHandler struct {
-	pool   *pgxpool.Pool
-	repo   *repository.AirbyteRepository
-	logger *slog.Logger
+	pool              *pgxpool.Pool
+	repo              *repository.AirbyteRepository
+	logger            *slog.Logger
+	webhookDispatcher WebhookDispatcher
 }
 
 // NewAirbyteSyncHandler creates a new AirbyteSyncHandler.
-func NewAirbyteSyncHandler(pool *pgxpool.Pool, repo *repository.AirbyteRepository, logger *slog.Logger) *AirbyteSyncHandler {
-	return &AirbyteSyncHandler{pool: pool, repo: repo, logger: logger}
+//
+// If webhookDispatcher is non-nil, the handler fires a `sync.completed`
+// webhook event after a successful sync run. Pass nil to disable webhook
+// emission (e.g. in tests).
+func NewAirbyteSyncHandler(pool *pgxpool.Pool, repo *repository.AirbyteRepository, logger *slog.Logger, webhookDispatcher WebhookDispatcher) *AirbyteSyncHandler {
+	return &AirbyteSyncHandler{pool: pool, repo: repo, logger: logger, webhookDispatcher: webhookDispatcher}
 }
 
 // ProcessTask implements asynq.Handler for Airbyte sync tasks.
@@ -96,6 +102,19 @@ func (h *AirbyteSyncHandler) ProcessTask(ctx context.Context, t *asynq.Task) err
 		"connector_id", payload.ConnectorID,
 		"sync_run_id", syncRunID,
 	)
+
+	// Fire `sync.completed` webhook (best-effort; never blocks the success path).
+	// records_synced is 0 until real Airbyte integration lands (TODO #111);
+	// the field is included so receivers can rely on its presence today.
+	dispatchAsync(ctx, h.webhookDispatcher, h.logger, payload.OrgID,
+		string(model.WebhookEventSyncCompleted),
+		map[string]any{
+			"connector_id":    payload.ConnectorID,
+			"source_id":       payload.KnowledgeBaseID,
+			"sync_run_id":     syncRunID,
+			"records_synced":  0,
+			"status":          "completed",
+		})
 
 	return nil
 }

--- a/internal/jobs/document_process.go
+++ b/internal/jobs/document_process.go
@@ -64,15 +64,48 @@ func SplitMarkdownByHeadings(content string) []MarkdownSection {
 	return sections
 }
 
+// WebhookDispatcher is the slice of WebhookService this job needs to fire
+// outbound events. Defined as a local interface so the jobs package does not
+// import service, and so tests can substitute a fake. A nil dispatcher is
+// supported and means "do not emit webhooks" — useful for unit tests and for
+// callers that have not finished wiring webhook delivery.
+type WebhookDispatcher interface {
+	Dispatch(ctx context.Context, orgID, eventType string, payload map[string]any) error
+}
+
+// dispatchAsync runs WebhookDispatcher.Dispatch in a goroutine using a
+// detached context (cancellation severed, trace IDs preserved) so that the
+// producer's success path never blocks on webhook delivery and never fails
+// when delivery fails. Dispatch itself enqueues Asynq tasks, so the actual
+// HTTP send is already async; this goroutine only covers the synchronous
+// fan-out work (DB insert per delivery, one Asynq enqueue per webhook).
+func dispatchAsync(ctx context.Context, d WebhookDispatcher, logger *slog.Logger, orgID, eventType string, payload map[string]any) {
+	if d == nil {
+		return
+	}
+	detached := context.WithoutCancel(ctx)
+	go func() {
+		if err := d.Dispatch(detached, orgID, eventType, payload); err != nil {
+			logger.WarnContext(detached, "webhook dispatch failed",
+				"event_type", eventType, "org_id", orgID, "error", err)
+		}
+	}()
+}
+
 // NewDocumentProcessHandler returns an asynq.HandlerFunc that processes a queued
 // document: downloads markdown from SeaweedFS, splits it into chunks by heading,
 // inserts each chunk into the DB, and marks the document as ready.
+//
+// If webhookDispatcher is non-nil, the handler fires a `document.processed`
+// webhook event after the success path completes. Pass nil to disable webhook
+// emission (e.g. in tests).
 func NewDocumentProcessHandler(
 	pool *pgxpool.Pool,
 	docRepo *repository.DocumentRepository,
 	chunkRepo *repository.ChunkRepository,
 	store storage.Client,
 	logger *slog.Logger,
+	webhookDispatcher WebhookDispatcher,
 ) asynq.HandlerFunc {
 	return func(ctx context.Context, task *asynq.Task) error {
 		var p queue.DocumentProcessPayload
@@ -137,6 +170,15 @@ func NewDocumentProcessHandler(
 			if err := updateDocStatus(ctx, pool, p.OrgID, p.DocumentID, docRepo, model.ProcessingStatusReady, ""); err != nil {
 				return fmt.Errorf("set status ready (empty): %w", err)
 			}
+			// Fire `document.processed` webhook (best-effort; never blocks the success path).
+			dispatchAsync(ctx, webhookDispatcher, logger, p.OrgID,
+				string(model.WebhookEventDocumentProcessed),
+				map[string]any{
+					"document_id":       p.DocumentID,
+					"knowledge_base_id": p.KnowledgeBaseID,
+					"status":            string(model.ProcessingStatusReady),
+					"chunk_count":       0,
+				})
 			return nil
 		}
 
@@ -177,6 +219,16 @@ func NewDocumentProcessHandler(
 			"document_id", p.DocumentID,
 			"chunks", len(sections),
 		)
+
+		// Fire `document.processed` webhook (best-effort; never blocks the success path).
+		dispatchAsync(ctx, webhookDispatcher, logger, p.OrgID,
+			string(model.WebhookEventDocumentProcessed),
+			map[string]any{
+				"document_id":       p.DocumentID,
+				"knowledge_base_id": p.KnowledgeBaseID,
+				"status":            string(model.ProcessingStatusReady),
+				"chunk_count":       len(sections),
+			})
 
 		return nil
 	}

--- a/internal/jobs/webhook_emitter_test.go
+++ b/internal/jobs/webhook_emitter_test.go
@@ -1,0 +1,148 @@
+package jobs
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ravencloak-org/Raven/internal/model"
+)
+
+// fakeJobDispatcher captures Dispatch calls so tests can verify that the
+// document and Airbyte job handlers fan out the right webhook events with
+// the right payloads.
+type fakeJobDispatcher struct {
+	mu     sync.Mutex
+	calls  []jobDispatchCall
+	doneCh chan struct{}
+	err    error
+}
+
+type jobDispatchCall struct {
+	orgID     string
+	eventType string
+	payload   map[string]any
+}
+
+func newFakeJobDispatcher() *fakeJobDispatcher {
+	return &fakeJobDispatcher{doneCh: make(chan struct{}, 1)}
+}
+
+func (f *fakeJobDispatcher) Dispatch(_ context.Context, orgID, eventType string, payload map[string]any) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, jobDispatchCall{orgID: orgID, eventType: eventType, payload: payload})
+	select {
+	case f.doneCh <- struct{}{}:
+	default:
+	}
+	return f.err
+}
+
+func (f *fakeJobDispatcher) waitForCall(t *testing.T) {
+	t.Helper()
+	select {
+	case <-f.doneCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for dispatcher to be called")
+	}
+}
+
+func (f *fakeJobDispatcher) snapshot() []jobDispatchCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]jobDispatchCall, len(f.calls))
+	copy(out, f.calls)
+	return out
+}
+
+func TestDispatchAsync_FiresDocumentProcessedEvent(t *testing.T) {
+	disp := newFakeJobDispatcher()
+	logger := slog.New(slog.DiscardHandler)
+
+	dispatchAsync(context.Background(), disp, logger, "org-1",
+		string(model.WebhookEventDocumentProcessed),
+		map[string]any{
+			"document_id":       "doc-1",
+			"knowledge_base_id": "kb-1",
+			"status":            "ready",
+			"chunk_count":       7,
+		})
+	disp.waitForCall(t)
+
+	calls := disp.snapshot()
+	require.Len(t, calls, 1)
+	assert.Equal(t, "org-1", calls[0].orgID)
+	assert.Equal(t, "document.processed", calls[0].eventType)
+	assert.Equal(t, "doc-1", calls[0].payload["document_id"])
+	assert.Equal(t, "kb-1", calls[0].payload["knowledge_base_id"])
+	assert.Equal(t, "ready", calls[0].payload["status"])
+	assert.Equal(t, 7, calls[0].payload["chunk_count"])
+}
+
+func TestDispatchAsync_FiresSyncCompletedEvent(t *testing.T) {
+	disp := newFakeJobDispatcher()
+	logger := slog.New(slog.DiscardHandler)
+
+	dispatchAsync(context.Background(), disp, logger, "org-2",
+		string(model.WebhookEventSyncCompleted),
+		map[string]any{
+			"connector_id":   "conn-1",
+			"source_id":      "kb-2",
+			"sync_run_id":    "run-1",
+			"records_synced": 0,
+			"status":         "completed",
+		})
+	disp.waitForCall(t)
+
+	calls := disp.snapshot()
+	require.Len(t, calls, 1)
+	assert.Equal(t, "org-2", calls[0].orgID)
+	assert.Equal(t, "sync.completed", calls[0].eventType)
+	assert.Equal(t, "conn-1", calls[0].payload["connector_id"])
+	assert.Equal(t, "kb-2", calls[0].payload["source_id"])
+	assert.Equal(t, "run-1", calls[0].payload["sync_run_id"])
+	assert.Equal(t, 0, calls[0].payload["records_synced"])
+	assert.Equal(t, "completed", calls[0].payload["status"])
+}
+
+func TestDispatchAsync_NilDispatcherIsNoOp(t *testing.T) {
+	// A nil dispatcher must not panic and must not start a goroutine.
+	dispatchAsync(context.Background(), nil, slog.New(slog.DiscardHandler),
+		"org", "document.processed", map[string]any{"k": "v"})
+}
+
+func TestDispatchAsync_ErrorIsSwallowed(t *testing.T) {
+	disp := newFakeJobDispatcher()
+	disp.err = errors.New("downstream failure")
+	logger := slog.New(slog.DiscardHandler)
+
+	// Producer must not panic or block even when Dispatch returns an
+	// error — the error path only logs and the goroutine completes.
+	dispatchAsync(context.Background(), disp, logger, "org",
+		"document.processed", map[string]any{"document_id": "d"})
+	disp.waitForCall(t)
+	assert.Len(t, disp.snapshot(), 1)
+}
+
+// TestDispatchAsync_DetachesFromCallerContext verifies that cancelling the
+// caller's context does not prevent Dispatch from running. This is the
+// `context.WithoutCancel` guarantee documented in the dispatcher.
+func TestDispatchAsync_DetachesFromCallerContext(t *testing.T) {
+	disp := newFakeJobDispatcher()
+	logger := slog.New(slog.DiscardHandler)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancelled
+
+	dispatchAsync(ctx, disp, logger, "org",
+		"document.processed", map[string]any{"document_id": "d"})
+	disp.waitForCall(t)
+	require.Len(t, disp.snapshot(), 1)
+}

--- a/internal/service/lead.go
+++ b/internal/service/lead.go
@@ -33,14 +33,57 @@ func mapLeadDBError(err error) error {
 	return apierror.NewInternal("an unexpected error occurred")
 }
 
+// LeadWebhookDispatcher is the slice of WebhookService that LeadService needs
+// in order to fire outbound `lead.generated` events. Defined as a local
+// interface so tests can substitute a fake. A nil dispatcher is supported and
+// means "do not emit webhooks".
+type LeadWebhookDispatcher interface {
+	Dispatch(ctx context.Context, orgID, eventType string, payload map[string]any) error
+}
+
 // LeadService contains business logic for lead profile management.
 type LeadService struct {
-	repo *repository.LeadRepository
+	repo              *repository.LeadRepository
+	webhookDispatcher LeadWebhookDispatcher
 }
 
 // NewLeadService creates a new LeadService.
 func NewLeadService(repo *repository.LeadRepository) *LeadService {
 	return &LeadService{repo: repo}
+}
+
+// WithWebhookDispatcher attaches a webhook dispatcher so that successful
+// upserts fan out a `lead.generated` event. Chainable at wiring time.
+func (s *LeadService) WithWebhookDispatcher(d LeadWebhookDispatcher) *LeadService {
+	s.webhookDispatcher = d
+	return s
+}
+
+// dispatchLeadGenerated fires a `lead.generated` webhook in a detached
+// goroutine. Errors are logged and swallowed — webhook delivery never blocks
+// or fails the producer's success path. Note that today the repo's Upsert
+// merges by (org, email) so an event is emitted on both first capture and
+// subsequent merges; receivers should be idempotent on `lead_id`.
+func (s *LeadService) dispatchLeadGenerated(ctx context.Context, orgID string, lead *model.LeadProfile) {
+	if s.webhookDispatcher == nil || lead == nil {
+		return
+	}
+	detached := context.WithoutCancel(ctx)
+	payload := map[string]any{
+		"lead_id":           lead.ID,
+		"email":             lead.Email,
+		"name":              lead.Name,
+		"knowledge_base_id": lead.KnowledgeBaseID,
+		"session_ids":       lead.SessionIDs,
+	}
+	go func() {
+		if err := s.webhookDispatcher.Dispatch(detached, orgID,
+			string(model.WebhookEventLeadGenerated), payload); err != nil {
+			slog.WarnContext(detached, "webhook dispatch failed",
+				"event_type", string(model.WebhookEventLeadGenerated),
+				"org_id", orgID, "lead_id", lead.ID, "error", err)
+		}
+	}()
 }
 
 // Upsert validates and persists a lead profile, creating or merging by org+email.
@@ -49,6 +92,7 @@ func (s *LeadService) Upsert(ctx context.Context, orgID string, req model.Upsert
 	if err != nil {
 		return nil, mapLeadDBError(err)
 	}
+	s.dispatchLeadGenerated(ctx, orgID, lead)
 	return lead, nil
 }
 

--- a/internal/service/lead_test.go
+++ b/internal/service/lead_test.go
@@ -1,0 +1,118 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ravencloak-org/Raven/internal/model"
+)
+
+// fakeLeadDispatcher captures Dispatch calls so tests can assert that
+// LeadService fires the right event with the right payload.
+type fakeLeadDispatcher struct {
+	mu     sync.Mutex
+	calls  []dispatchCall
+	doneCh chan struct{}
+	err    error
+}
+
+type dispatchCall struct {
+	orgID     string
+	eventType string
+	payload   map[string]any
+}
+
+func newFakeLeadDispatcher() *fakeLeadDispatcher {
+	return &fakeLeadDispatcher{doneCh: make(chan struct{}, 1)}
+}
+
+func (f *fakeLeadDispatcher) Dispatch(_ context.Context, orgID, eventType string, payload map[string]any) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, dispatchCall{orgID: orgID, eventType: eventType, payload: payload})
+	select {
+	case f.doneCh <- struct{}{}:
+	default:
+	}
+	return f.err
+}
+
+func (f *fakeLeadDispatcher) waitForCall(t *testing.T) {
+	t.Helper()
+	select {
+	case <-f.doneCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for dispatcher to be called")
+	}
+}
+
+func (f *fakeLeadDispatcher) snapshot() []dispatchCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]dispatchCall, len(f.calls))
+	copy(out, f.calls)
+	return out
+}
+
+func TestLeadService_dispatchLeadGenerated_FiresEvent(t *testing.T) {
+	disp := newFakeLeadDispatcher()
+	svc := (&LeadService{}).WithWebhookDispatcher(disp)
+
+	lead := &model.LeadProfile{
+		ID:              "lead-uuid",
+		OrgID:           "org-uuid",
+		KnowledgeBaseID: "kb-uuid",
+		Email:           "alice@example.com",
+		Name:            "Alice",
+		SessionIDs:      []string{"sess-1", "sess-2"},
+	}
+	svc.dispatchLeadGenerated(context.Background(), "org-uuid", lead)
+	disp.waitForCall(t)
+
+	calls := disp.snapshot()
+	require.Len(t, calls, 1)
+	assert.Equal(t, "org-uuid", calls[0].orgID)
+	assert.Equal(t, string(model.WebhookEventLeadGenerated), calls[0].eventType)
+	assert.Equal(t, "lead-uuid", calls[0].payload["lead_id"])
+	assert.Equal(t, "alice@example.com", calls[0].payload["email"])
+	assert.Equal(t, "Alice", calls[0].payload["name"])
+	assert.Equal(t, "kb-uuid", calls[0].payload["knowledge_base_id"])
+	assert.Equal(t, []string{"sess-1", "sess-2"}, calls[0].payload["session_ids"])
+}
+
+func TestLeadService_dispatchLeadGenerated_NoDispatcherIsNoOp(t *testing.T) {
+	svc := &LeadService{}
+	// Must not panic and must not block when no dispatcher is configured.
+	svc.dispatchLeadGenerated(context.Background(), "org", &model.LeadProfile{ID: "lead"})
+}
+
+func TestLeadService_dispatchLeadGenerated_DispatcherErrorSwallowed(t *testing.T) {
+	disp := newFakeLeadDispatcher()
+	disp.err = errors.New("queue unavailable")
+	svc := (&LeadService{}).WithWebhookDispatcher(disp)
+
+	// The producer must not panic or block even when Dispatch returns an
+	// error — the error path only logs and carries on.
+	svc.dispatchLeadGenerated(context.Background(), "org", &model.LeadProfile{ID: "lead"})
+	disp.waitForCall(t)
+	assert.Len(t, disp.snapshot(), 1)
+}
+
+func TestLeadService_dispatchLeadGenerated_NilLeadIsNoOp(t *testing.T) {
+	disp := newFakeLeadDispatcher()
+	svc := (&LeadService{}).WithWebhookDispatcher(disp)
+	svc.dispatchLeadGenerated(context.Background(), "org", nil)
+	// No call expected.
+	select {
+	case <-disp.doneCh:
+		t.Fatal("dispatcher should not be called when lead is nil")
+	case <-time.After(50 * time.Millisecond):
+	}
+	assert.Empty(t, disp.snapshot())
+}


### PR DESCRIPTION
## Summary

Closes docs-audit finding **#13**. The webhook delivery pipeline already had HMAC signing, SSRF guard, and an Asynq queue — but `WebhookService.Dispatch` had **zero production callers**. This PR wires the three live event producers and documents the fourth honestly.

## Per-event status

| Event | Producer | Status |
|---|---|---|
| `document.processed` | `internal/jobs/document_process.go` (after `updateDocStatus -> ready` in both empty-content + chunked paths) | ✅ wired |
| `sync.completed` | `internal/jobs/airbyte_sync.go` (end of `ProcessTask` success) | ✅ wired |
| `lead.generated` | `internal/service/lead.go` (`Upsert` → `dispatchLeadGenerated` on every repo merge) | ✅ wired |
| `conversation.escalated` | — | ⏸ skipped: **no escalation verb exists in OSS today**. Receivers can register for the event in anticipation; the EE producer is still a doc-comment placeholder in `internal/ee/webhooks`. |

## Plumbing rules applied
- `dispatchAsync` / `dispatchLeadGenerated` use `context.WithoutCancel(ctx)` and run in a goroutine — fire-and-forget, never block/fail the producer
- Dispatch errors → `WarnContext` + swallowed
- Nil dispatcher → no-op (tests cover)
- Idempotency: `WebhookService.Dispatch` already mints a UUIDv4 per delivery row; receivers dedupe on `delivery.id` + the event's natural key

## Tests added (8)
- `internal/jobs/webhook_emitter_test.go` (5): `DispatchAsync_FiresDocumentProcessedEvent`, `DispatchAsync_FiresSyncCompletedEvent`, `DispatchAsync_NilDispatcherIsNoOp`, `DispatchAsync_ErrorIsSwallowed`, `DispatchAsync_DetachesFromCallerContext`
- `internal/service/lead_test.go` (3): `LeadService_dispatchLeadGenerated_FiresEvent`, `..._NoDispatcherIsNoOp`, `..._DispatcherErrorSwallowed`, `..._NilLeadIsNoOp`

## Docs
`docs-site/stubs/guides/webhooks-and-events.md` rewritten: dropped the "zero call sites" warning, added per-event status table + wired payload shapes for the three live events. Inbound Meta / WhatsApp / Hyperswitch sections untouched.

## Test plan
- [ ] Receiver registered for `document.processed` actually receives an HTTP POST when a document finishes ingestion
- [ ] Same for `sync.completed` after an Airbyte sync run
- [ ] Same for `lead.generated` after a lead upsert
- [ ] HMAC `X-Raven-Signature` validates with the configured secret