### PR TITLE
fix(cask): dot-separated asset filename + bump to 0.1.4

### DIFF
--- a/.github/workflows/update-cask.yml
+++ b/.github/workflows/update-cask.yml
@@ -27,7 +27,11 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="${TAG#raven-local-v}"
-          FILE="Raven%20Local_${VERSION}_universal.dmg"
+          # GitHub Releases normalises spaces in asset filenames to dots,
+          # so the download URL uses "Raven.Local_*" rather than the on-disk
+          # "Raven Local_*". Don't URL-encode — the asset *name* itself has
+          # the dot.
+          FILE="Raven.Local_${VERSION}_universal.dmg"
           URL="https://github.com/${{ github.repository }}/releases/download/${TAG}/${FILE}"
           echo "Downloading $URL"
           curl -fsSL -o raven-local.dmg "$URL"

--- a/Casks/raven-local.rb
+++ b/Casks/raven-local.rb
@@ -1,8 +1,11 @@
 cask "raven-local" do
-  version "0.1.3"
+  version "0.1.4"
   sha256 "0000000000000000000000000000000000000000000000000000000000000000"
 
-  url "https://github.com/ravencloak-org/Raven/releases/download/raven-local-v#{version}/Raven%20Local_#{version}_universal.dmg",
+  # GitHub Releases normalises spaces to dots in asset URLs, so the
+  # download path uses "Raven.Local_*", not "Raven Local_*" or the
+  # URL-encoded "Raven%20Local_*".
+  url "https://github.com/ravencloak-org/Raven/releases/download/raven-local-v#{version}/Raven.Local_#{version}_universal.dmg",
       verified: "github.com/ravencloak-org/Raven/"
   name "Raven Local"
   desc "Privacy-first desktop edition of Raven that runs locally with Ollama"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Raven Local",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "identifier": "io.ravencloak.local",
   "build": {
     "beforeDevCommand": "",


### PR DESCRIPTION
Two coupling bugs from #525 that the v0.1.3 draft release exposed:

1. **Asset filenames use dots, not spaces.** GitHub Releases normalises spaces in uploaded asset names, so the public URL is `Raven.Local_*.dmg`, not `Raven Local_*` or URL-encoded `Raven%20Local_*`. Fixed in both `Casks/raven-local.rb` and `.github/workflows/update-cask.yml`.
2. **tauri.conf.json version was stale.** That field is what Tauri bakes into the bundle filename. Bumping 0.1.3 → 0.1.4 here so the next tag we cut produces `Raven.Local_0.1.4_*.dmg` matching the cask's `#{version}` pattern.

After merge, tag `raven-local-v0.1.4` to exercise the full path end-to-end: build → release → auto-bump cask PR → `brew install --cask raven-local` works.