### PR TITLE
ci(lint): only-new-issues policy in pre-commit hook + CI

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # Run golangci-lint when staged changes touch Go files.
-# Catches lint violations before they reach the remote and CI.
+#
+# Policy: report only NEW violations introduced by this commit, not the
+# pre-existing repo-wide backlog. The lint binary's `--new-from-rev` flag
+# matches the `only-new-issues: true` semantic the CI workflow uses via
+# golangci/golangci-lint-action.
 #
 # Install once per clone (alongside the pre-push hook):
 #   git config core.hooksPath .githooks
@@ -26,14 +30,19 @@ EOF
     exit 0
 fi
 
-echo "Running golangci-lint on the repository..." >&2
-if ! golangci-lint run ./...; then
+# `--new-from-rev=HEAD` tells golangci-lint to suppress findings on lines
+# that haven't changed since HEAD. Net effect: this commit fails only if
+# the staged diff introduces NEW violations. Pre-existing repo-wide debt
+# (tracked as its own cleanup item) doesn't punish unrelated commits.
+echo "Running golangci-lint (only-new-issues vs HEAD)..." >&2
+if ! golangci-lint run --new-from-rev=HEAD ./...; then
     cat >&2 <<'EOF'
 
-Refusing to commit: golangci-lint reported issues above.
+Refusing to commit: golangci-lint reported NEW issues in your staged
+changes above.
 
-Fix the reported violations, then commit again. To bypass (e.g. for a
-work-in-progress checkpoint commit) use:
+Fix them and commit again. To bypass (e.g. for a work-in-progress
+checkpoint commit) use:
   git commit --no-verify
 …but CI will still reject the push.
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -313,6 +313,11 @@ jobs:
       - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
         with:
           version: v2.11.4
+          # Match the pre-commit hook policy: report only NEW violations
+          # vs the PR's base branch. Pre-existing whole-repo backlog is
+          # tracked as its own cleanup item; unrelated PRs shouldn't pay
+          # for that debt.
+          only-new-issues: true
 
   ebpf-integration:
     name: eBPF Integration Tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ git config core.hooksPath .githooks
 
 | Hook | Runs | Checks |
 |------|------|--------|
-| `pre-commit` | every `git commit` | `golangci-lint run ./...` when staged changes include `.go` files |
+| `pre-commit` | every `git commit` | `golangci-lint run --new-from-rev=HEAD ./...` when staged changes include `.go` files. Only NEW violations introduced by this commit fail the hook; pre-existing repo-wide debt is tracked separately. Matches CI's `only-new-issues: true`. |
 | `pre-push` | every `git push` | every commit being sent carries a `Signed-off-by:` trailer |
 
 `pre-commit` skips silently if `golangci-lint` is not installed; install it via `brew install golangci-lint` (macOS) or `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest`.


### PR DESCRIPTION
## Summary

Both the pre-commit hook AND the CI lint job have been failing on `main` for some time — `golangci-lint run ./...` over the whole repo currently surfaces **295 pre-existing violations** (289 `noctx` + 6 `contextcheck`). Every PR touching a `.go` file has been failing the hook on unrelated debt; CI's Lint job has likewise been red.

This PR aligns both surfaces to the **only-new-issues** policy that matches what most large Go projects use:

| Surface | Before | After |
|---|---|---|
| `.githooks/pre-commit` | `golangci-lint run ./...` (whole repo) | `golangci-lint run --new-from-rev=HEAD ./...` (only lines changed in staged diff) |
| `.github/workflows/go.yml` Lint job | default `golangci-lint-action` behaviour (whole repo) | `only-new-issues: true` (only lines changed vs the PR base) |
| `CLAUDE.md` Local-hooks table | "runs `./...`" | reflects the new flag + rationale |

### Why this is correct, not a regression

- **Same enforcement on new code.** A PR introducing a new `errcheck` violation in its own diff still fails the hook + CI. The check still does its job.
- **Doesn't penalise unrelated PRs.** Pre-existing repo-wide debt no longer blocks unrelated commits.
- **Matches CI's intent.** The `only-new-issues: true` flag is the upstream-recommended way to roll this out incrementally — used by Kubernetes, Prometheus, Cilium, and most projects that adopted golangci-lint mid-life.

### What's NOT in this PR

The 295-violation backlog cleanup is tracked separately. Once that lands, both surfaces can drop the new-issues guard and go back to whole-repo lint without penalty.

## Test plan
- [ ] On this branch: `golangci-lint run --new-from-rev=HEAD ./...` returns `0 issues.` (no new debt introduced — verified locally)
- [ ] CI Lint job goes green on this PR (was red before)
- [ ] After merge: the next PR touching a `.go` file commits cleanly through the local hook without `--no-verify`