### PR TITLE
fix(ci): clear post-rename lint residuals (frontend + actionlint)

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -92,12 +92,12 @@ jobs:
         continue-on-error: true
         run: |
           set -e
-          DMG=$(ls desktop/target/universal-apple-darwin/release/bundle/dmg/*.dmg | head -1)
+          DMG=$(find desktop/target/universal-apple-darwin/release/bundle/dmg -maxdepth 1 -name '*.dmg' -print -quit)
           echo "DMG: $DMG"
 
           # Mount the DMG, copy the .app to /Applications, eject.
           hdiutil attach -nobrowse -readonly "$DMG"
-          VOL=$(ls -d /Volumes/Raven* | head -1)
+          VOL=$(find /Volumes -maxdepth 1 -name 'Raven*' -print -quit)
           cp -R "$VOL"/Raven*.app /Applications/
           hdiutil detach "$VOL" || true
 
@@ -108,7 +108,7 @@ jobs:
           open -a "Raven AI" || echo "::warning::open -a failed"
 
           # Wait for the process to appear.
-          for i in {1..15}; do
+          for _ in $(seq 1 15); do
             if pgrep -f "Raven AI" >/dev/null; then
               echo "App process is alive"
               break
@@ -182,7 +182,7 @@ jobs:
           set -e
           sudo apt-get install -y --no-install-recommends xvfb x11-apps imagemagick
 
-          APPIMAGE=$(ls desktop/target/release/bundle/appimage/*.AppImage | head -1)
+          APPIMAGE=$(find desktop/target/release/bundle/appimage -maxdepth 1 -name '*.AppImage' -print -quit)
           echo "AppImage: $APPIMAGE"
           chmod +x "$APPIMAGE"
 

--- a/frontend/e2e/raven-ai-onboarding.spec.ts
+++ b/frontend/e2e/raven-ai-onboarding.spec.ts
@@ -105,6 +105,7 @@ async function installTauriBridge(
           listeners[event].add(handler)
           return () => listeners[event].delete(handler)
         },
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         emit: async (_event: string, _payload: unknown) => {},
       }
 


### PR DESCRIPTION
Two lint gates went red on main after #529 (Raven Local → Raven AI rename) merged. Both fixed here.

**Frontend ESLint** — `raven-ai-onboarding.spec.ts:108` had `emit: async (_event: string, _payload: unknown) => {}` in the Tauri-bus shim. Project ESLint config doesn't enable `argsIgnorePattern: '^_'`, so the underscore convention doesn't help. Added `// eslint-disable-next-line` to keep the signature explicit (for documentation) while satisfying the rule.

**Actionlint shellcheck** — my smoke steps in `desktop-release.yml` (from #522) used `ls *.dmg | head -1` (SC2012) and `for i in {1..15}` with unused `i` (SC2034). Both are warning-level; actionlint's `fail_level=warning` treated them as failures. Switched to `find -maxdepth 1 -name pattern -print -quit` and `for _ in $(seq 1 15)`.

The **Python CI** failure (pydantic-core==2.46.4 conflict with requirements-dev.txt deps) is a separate pre-existing dependency issue — not caused by my rename. Not addressed here.