### PR TITLE
fix(e2e): point Playwright getByTestId at data-test attribute

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -9,6 +9,10 @@ export default defineConfig({
   use: {
     baseURL: process.env.CI ? 'http://localhost:4173' : 'http://localhost:3000',
     trace: 'on-first-retry',
+    // Components in this repo use `data-test="..."` (not the Playwright
+    // default `data-testid`). Tell `getByTestId(...)` to look for our
+    // attribute so the existing convention works.
+    testIdAttribute: 'data-test',
   },
   projects: [
     {


### PR DESCRIPTION
Post-rename Playwright job (from #520) failed with 4 onboarding tests, all 'element not found' on getByTestId selectors.

Root cause: components use `data-test="..."` (repo convention); Playwright's getByTestId defaults to `data-testid`. One-line fix: `testIdAttribute: 'data-test'` in playwright.config.ts.