### PR TITLE
fix(e2e): patch window.fetch for robust onboarding config mocking

### DIFF
--- a/frontend/e2e/raven-ai-onboarding.spec.ts
+++ b/frontend/e2e/raven-ai-onboarding.spec.ts
@@ -109,6 +109,36 @@ async function installTauriBridge(
         emit: async (_event: string, _payload: unknown) => {},
       }
 
+      // Patch window.fetch BEFORE the app boots so /api/v1/config and the
+      // workspace POST resolve with mocked payloads regardless of
+      // VITE_API_BASE_URL. Playwright's page.route also intercepts but is
+      // unreliable when the base URL differs across CI vs local dev — this
+      // is the surgical hammer.
+      const originalFetch = window.fetch.bind(window)
+      window.fetch = async (input, init) => {
+        const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+        if (url.includes('/api/v1/config')) {
+          return new Response(JSON.stringify({ single_user: true }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        }
+        if (/\/api\/v1\/orgs\/[^/]+\/workspaces$/.test(url)) {
+          const method = (init?.method ?? 'GET').toUpperCase()
+          if (method === 'POST') {
+            return new Response(
+              JSON.stringify({ id: 'ws-local', name: 'Personal', org_id: 'local' }),
+              { status: 201, headers: { 'Content-Type': 'application/json' } },
+            )
+          }
+          return new Response('[]', {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        }
+        return originalFetch(input, init)
+      }
+
       // Replay the initial precheck:result so the model picker has a
       // RAM tier ready immediately after subscribe.
       setTimeout(() => {


### PR DESCRIPTION
## Root cause

PR #531 (testIdAttribute fix) was necessary but not sufficient. After that landed, getByTestId() worked — but the model picker still wasn't rendering because the wizard fell back to the cloud branch (isDesktop=false).

Why? `serverConfig.singleUser` was false because the config endpoint mock didn't intercept. `page.route('**/api/v1/config', ...)` depends on the URL pattern; `VITE_API_BASE_URL` differs between vite-preview CI and local dev, and the glob can miss.

## Fix

Patch `window.fetch` in the `addInitScript` block (runs before any page script). Intercepts `/api/v1/config` and `POST /api/v1/orgs/:org_id/workspaces` by URL substring, glob-pattern-independent. Other calls fall through to real fetch.

## Note on auth.spec.ts pre-existing failure

Same run shows `auth.spec.ts › login page shows Raven branding` failing too. Different root cause: that test doesn't mock config, so `serverConfig.load()` returns singleUser=false; SuperTokens inits; the test aborts `/auth/**`; `authStore.init()` hangs forever; app never mounts; login page never renders.

That issue existed since #422 reorganised `main.ts` to gate mount on `auth.init()`. Not addressed here — surfaced when the rename PR finally cleared lint and let Playwright run.

## Test plan

- [x] `vue-tsc --noEmit` clean
- [ ] All 4 raven-ai-onboarding scenarios pass in CI
- [ ] auth.spec.ts continues failing (pre-existing) — track separately

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced E2E test infrastructure to improve mock API handling during app initialization, providing more reliable testing of configuration and workspace features.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ravencloak-org/Raven/pull/532)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->