### PR TITLE
fix(auth): make init() resilient to SuperTokens being unreachable

### DIFF
--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -13,8 +13,26 @@ export const useAuthStore = defineStore('auth', () => {
   const isAuthenticated = computed(() => sessionExists.value)
   const hasOrg = computed(() => !!orgId.value)
 
+  /**
+   * Probe SuperTokens for an existing session before the app mounts.
+   *
+   * Defensive: SuperTokens' session check can hang (network stall) or
+   * throw (5xx, aborted fetch) if the auth service is unreachable. Both
+   * are bad UX — the app would never mount and the user would see a
+   * blank page. A 5s timeout + try/catch falls back to "no session" so
+   * the router guard sends the user to /login as expected.
+   */
   async function init() {
-    sessionExists.value = await Session.doesSessionExist()
+    try {
+      sessionExists.value = await Promise.race([
+        Session.doesSessionExist(),
+        new Promise<boolean>((_, reject) =>
+          setTimeout(() => reject(new Error('SuperTokens session check timed out')), 5000),
+        ),
+      ])
+    } catch {
+      sessionExists.value = false
+    }
   }
 
   async function loginWithGoogle() {


### PR DESCRIPTION
Pre-existing latent bug surfaced when the rename-PR chain finally let Playwright run on main: `auth.spec.ts › login page shows Raven branding` — element not found.

## Trace

`serverConfig.load()` returns `single_user=false` (no mock in auth.spec.ts) → main.ts calls `initSuperTokens()` then `authStore.init()`. `init()` calls `Session.doesSessionExist()` which hits a network endpoint the test blocks (`page.route('**/auth/**', abort)`). Fetch hangs → promise never resolves → `.then()` never fires → app never mounts → login page never renders.

The same failure mode bites real users when SuperTokens is unreachable in production (network stall, 5xx, DNS).

## Fix

5s `Promise.race` timeout + `try/catch` falls back to `sessionExists=false`. The router guard then sends the user to `/login`, which is the safe behaviour when session can't be verified.

## History

Latent since #422 reorganised `main.ts` to gate `app.mount` on `auth.init()` resolving. Surfaced now because Playwright never got to run on main until the post-rename lint chain cleared.

## Test plan

- [x] `vue-tsc --noEmit` clean
- [ ] `auth.spec.ts` 2 tests pass in CI