### PR TITLE
test(ai-worker): fix 5 stale test assertions unmasked by #534

### DIFF
--- a/ai-worker/tests/retrieval/test_embedding.py
+++ b/ai-worker/tests/retrieval/test_embedding.py
@@ -31,7 +31,7 @@ class TestEmbeddingGeneration:
         from raven_worker.providers.anthropic_provider import AnthropicEmbeddingProvider
 
         provider = AnthropicEmbeddingProvider(api_key="sk-ant-test")
-        with pytest.raises(NotImplementedError, match="Anthropic embedding not yet available"):
+        with pytest.raises(NotImplementedError, match="Anthropic does not publish a public embeddings API"):
             await provider.embed("hello")
 
     async def test_openai_embed_batch_returns_list_of_vectors(self, mock_openai_provider):
@@ -71,5 +71,5 @@ class TestEmbeddingGeneration:
         from raven_worker.providers.anthropic_provider import AnthropicEmbeddingProvider
 
         provider = AnthropicEmbeddingProvider(api_key="sk-ant-test")
-        with pytest.raises(NotImplementedError, match="Anthropic embedding not yet available"):
+        with pytest.raises(NotImplementedError, match="Anthropic does not publish a public embeddings API"):
             await provider.embed_batch(["text1", "text2"])

--- a/ai-worker/tests/test_embedding_providers.py
+++ b/ai-worker/tests/test_embedding_providers.py
@@ -196,7 +196,7 @@ def test_cohere_provider_model_name() -> None:
 async def test_anthropic_provider_embed_raises() -> None:
     """Anthropic embed() must raise NotImplementedError."""
     provider = AnthropicEmbeddingProvider(api_key="sk-ant-test")
-    with pytest.raises(NotImplementedError, match="Anthropic embedding not yet available"):
+    with pytest.raises(NotImplementedError, match="Anthropic does not publish a public embeddings API"):
         await provider.embed("hello anthropic")
 
 
@@ -204,5 +204,5 @@ async def test_anthropic_provider_embed_raises() -> None:
 async def test_anthropic_provider_embed_batch_raises() -> None:
     """Anthropic embed_batch() must raise NotImplementedError."""
     provider = AnthropicEmbeddingProvider(api_key="sk-ant-test")
-    with pytest.raises(NotImplementedError, match="Anthropic embedding not yet available"):
+    with pytest.raises(NotImplementedError, match="Anthropic does not publish a public embeddings API"):
         await provider.embed_batch(["text1", "text2"])

--- a/ai-worker/tests/test_server.py
+++ b/ai-worker/tests/test_server.py
@@ -46,4 +46,5 @@ class TestImports:
     def test_version(self) -> None:
         from raven_worker import __version__
 
-        assert __version__ == "0.1.0"
+        import re
+        assert re.fullmatch(r"\d+\.\d+\.\d+", __version__)


### PR DESCRIPTION
#534 unblocked the pip resolver, which let pytest actually run for the first time in days. Five pre-existing test failures surfaced:

- `test_version` — asserted `__version__ == '0.1.0'`, but the package was bumped to 0.3.0 long ago. Switched to a semver regex so future bumps don't break it again.
- 4× anthropic-provider tests — `pytest.raises(match='Anthropic embedding not yet available')` but the provider raises `'Anthropic does not publish a public embeddings API…'`. Regex updated to match actual message.

Both are mechanical sync-up between tests and implementation. Not regressions from #534 — the implementation diverged from the tests at some earlier point and was masked by the resolver failure.