### PR TITLE
fix(ai-worker): ruff lint cleanup from #537

### DIFF
--- a/ai-worker/tests/retrieval/test_embedding.py
+++ b/ai-worker/tests/retrieval/test_embedding.py
@@ -31,7 +31,7 @@ class TestEmbeddingGeneration:
         from raven_worker.providers.anthropic_provider import AnthropicEmbeddingProvider
 
         provider = AnthropicEmbeddingProvider(api_key="sk-ant-test")
-        with pytest.raises(NotImplementedError, match="Anthropic does not publish a public embeddings API"):
+        with pytest.raises(NotImplementedError, match="Anthropic does not publish"):
             await provider.embed("hello")
 
     async def test_openai_embed_batch_returns_list_of_vectors(self, mock_openai_provider):
@@ -71,5 +71,5 @@ class TestEmbeddingGeneration:
         from raven_worker.providers.anthropic_provider import AnthropicEmbeddingProvider
 
         provider = AnthropicEmbeddingProvider(api_key="sk-ant-test")
-        with pytest.raises(NotImplementedError, match="Anthropic does not publish a public embeddings API"):
+        with pytest.raises(NotImplementedError, match="Anthropic does not publish"):
             await provider.embed_batch(["text1", "text2"])

--- a/ai-worker/tests/test_embedding_providers.py
+++ b/ai-worker/tests/test_embedding_providers.py
@@ -196,7 +196,7 @@ def test_cohere_provider_model_name() -> None:
 async def test_anthropic_provider_embed_raises() -> None:
     """Anthropic embed() must raise NotImplementedError."""
     provider = AnthropicEmbeddingProvider(api_key="sk-ant-test")
-    with pytest.raises(NotImplementedError, match="Anthropic does not publish a public embeddings API"):
+    with pytest.raises(NotImplementedError, match="Anthropic does not publish"):
         await provider.embed("hello anthropic")
 
 
@@ -204,5 +204,5 @@ async def test_anthropic_provider_embed_raises() -> None:
 async def test_anthropic_provider_embed_batch_raises() -> None:
     """Anthropic embed_batch() must raise NotImplementedError."""
     provider = AnthropicEmbeddingProvider(api_key="sk-ant-test")
-    with pytest.raises(NotImplementedError, match="Anthropic does not publish a public embeddings API"):
+    with pytest.raises(NotImplementedError, match="Anthropic does not publish"):
         await provider.embed_batch(["text1", "text2"])

--- a/ai-worker/tests/test_server.py
+++ b/ai-worker/tests/test_server.py
@@ -1,5 +1,7 @@
 """Basic tests for server startup and configuration."""
 
+import re
+
 from raven_worker.config import Settings
 
 
@@ -46,5 +48,4 @@ class TestImports:
     def test_version(self) -> None:
         from raven_worker import __version__
 
-        import re
         assert re.fullmatch(r"\d+\.\d+\.\d+", __version__)


### PR DESCRIPTION
#537's stale-test fixes tripped ruff: 4× E501 line-length on the new anthropic match strings + I001 unsorted import. Shortened the regex to `'Anthropic does not publish'` (still unique) and moved `import re` to the top of the file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions for embedding provider error handling to improve test consistency across multiple test files.
  * Reorganized module-level imports in test files for better code structure.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ravencloak-org/Raven/pull/538)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->