### PR TITLE
ci(docker): trigger on requirements*.txt + add workflow_dispatch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,6 +8,8 @@ on:
     paths:
       - 'Dockerfile'
       - 'ai-worker/Dockerfile'
+      - 'ai-worker/requirements.txt'
+      - 'ai-worker/requirements-dev.txt'
       - 'frontend/Dockerfile'
       - 'frontend/nginx.conf'
       - 'docker-compose.yml'
@@ -16,6 +18,8 @@ on:
     paths:
       - 'Dockerfile'
       - 'ai-worker/Dockerfile'
+      - 'ai-worker/requirements.txt'
+      - 'ai-worker/requirements-dev.txt'
       - 'frontend/Dockerfile'
       - 'frontend/nginx.conf'
       - 'docker-compose.yml'
@@ -23,7 +27,11 @@ on:
       # filter trigger. Internal edits to this workflow (Dependabot SHA
       # bumps, refactors) shouldn't fire a 25-minute multi-arch build that
       # produces no useful signal. Regressions surface on the next push
-      # that actually touches a Dockerfile.
+      # that actually touches a Dockerfile or a build-input file.
+  # Allow manual re-runs from the UI / gh CLI when a build needs to be
+  # exercised without a code change (e.g., to verify a deps fix didn't
+  # break the image).
+  workflow_dispatch:
 
 permissions: {}
 


### PR DESCRIPTION
Two gaps the pydantic resolver saga surfaced:

1. `requirements.txt` and `requirements-dev.txt` aren't in the path filter, so #534 fixing the resolver didn't re-run Docker even though the image build is gated on those exact files.
2. No `workflow_dispatch` — no way to verify a deps change against the image build without a Dockerfile touch.

Both fixed here. Image builds will now run on requirements bumps (Dependabot will exercise them too), and `gh workflow run docker.yml` works for manual re-runs.