### PR TITLE
fix(ci): pin golangci-lint to v2.11.4 in CI and local hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -22,12 +22,30 @@ if ! command -v golangci-lint >/dev/null 2>&1; then
     cat >&2 <<'EOF'
 WARNING: golangci-lint not found in PATH; skipping pre-commit lint check.
 
-Install it so this hook can protect your commits:
-  brew install golangci-lint               # macOS
-  go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+Install the pinned version so this hook can protect your commits:
+  go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
 
 EOF
     exit 0
+fi
+
+# Enforce the pinned version so local behaviour matches CI exactly.
+# CI uses golangci-lint-action with version: v2.11.4; a different local
+# binary can detect violations the CI version doesn't (or vice-versa),
+# causing spurious hook failures or missed issues.
+REQUIRED_VERSION="2.11.4"
+INSTALLED_VERSION="$(golangci-lint --version 2>/dev/null | sed -nE 's/.*has version ([^ ]+) .*/\1/p')"
+if [ "${INSTALLED_VERSION}" != "${REQUIRED_VERSION}" ]; then
+    cat >&2 <<EOF
+ERROR: golangci-lint version mismatch.
+  required : v${REQUIRED_VERSION}
+  installed: v${INSTALLED_VERSION:-unknown}
+
+Pin to the correct version to match CI:
+  go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v${REQUIRED_VERSION}
+
+EOF
+    exit 1
 fi
 
 # `--new-from-rev=HEAD` tells golangci-lint to suppress findings on lines

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,13 @@ git config core.hooksPath .githooks
 | `pre-commit` | every `git commit` | `golangci-lint run --new-from-rev=HEAD ./...` when staged changes include `.go` files. Only NEW violations introduced by this commit fail the hook; pre-existing repo-wide debt is tracked separately. Matches CI's `only-new-issues: true`. |
 | `pre-push` | every `git push` | every commit being sent carries a `Signed-off-by:` trailer |
 
-`pre-commit` skips silently if `golangci-lint` is not installed; install it via `brew install golangci-lint` (macOS) or `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest`.
+`pre-commit` requires **golangci-lint v2.11.4** (pinned to match CI). Install the exact version:
+
+```bash
+go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
+```
+
+The hook will error if a different version is detected, to prevent local/CI drift.
 
 To retroactively sign off a branch that was made before the hook existed:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,14 @@ All of these must pass **locally** before pushing. CI will reject if they don't.
 
 ### Go (backend)
 
+**golangci-lint v2.11.4 is required** — this version is pinned in CI and enforced by the pre-commit hook. A mismatched version will block your commits.
+
+Install the pinned version:
+
+```bash
+go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
+```
+
 ```bash
 # Build
 go build ./...


### PR DESCRIPTION
## Summary

Fixes #521 — golangci-lint version drift between local contributors and CI.

- **`.githooks/pre-commit`**: adds a version guard that reads the installed `golangci-lint` version and exits 1 with a clear error + install command if it doesn't match `v2.11.4`. The "not installed" warning is updated to reference the pinned version instead of `@latest`.
- **`CONTRIBUTING.md`**: documents that golangci-lint v2.11.4 is required, with the exact `go install` command, in the Go quality-gates section.
- **`CLAUDE.md`**: updates the local hooks section to reference the pinned version and install command.

CI (`go.yml`) already has `golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9` with `version: v2.11.4` — no changes needed there.

## Test plan

- [ ] Install a mismatched version (e.g. v2.12.2), stage a `.go` file, run `git commit` — hook should print the version error and exit 1
- [ ] Install v2.11.4, stage a `.go` file, run `git commit` — hook should proceed to lint normally
- [ ] CI lint job passes unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution and local development guides with golangci-lint v2.11.4 version requirements and installation instructions.

* **Chores**
  * Pre-commit hook now enforces specific golangci-lint version; errors on mismatch and provides installation guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ravencloak-org/Raven/pull/541)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->