### PR TITLE
feat(desktop): Tauri auto-update channel (#426)

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -32,17 +32,20 @@ jobs:
           - os: macos-latest
             tauri_target: universal-apple-darwin
             rustup_targets: 'aarch64-apple-darwin,x86_64-apple-darwin'
-            artifact_glob: 'desktop/target/universal-apple-darwin/release/bundle/dmg/*.dmg'
+            artifact_glob: 'desktop/src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg'
+            sig_glob: 'desktop/src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg.sig'
           - os: windows-latest
             tauri_target: x86_64-pc-windows-msvc
             rustup_targets: 'x86_64-pc-windows-msvc'
-            artifact_glob: 'desktop/target/release/bundle/msi/*.msi'
+            artifact_glob: 'desktop/src-tauri/target/release/bundle/msi/*.msi'
+            sig_glob: 'desktop/src-tauri/target/release/bundle/msi/*.msi.sig'
           - os: ubuntu-latest
             tauri_target: x86_64-unknown-linux-gnu
             rustup_targets: 'x86_64-unknown-linux-gnu'
             artifact_glob: |
-              desktop/target/release/bundle/appimage/*.AppImage
-              desktop/target/release/bundle/deb/*.deb
+              desktop/src-tauri/target/release/bundle/appimage/*.AppImage
+              desktop/src-tauri/target/release/bundle/deb/*.deb
+            sig_glob: 'desktop/src-tauri/target/release/bundle/appimage/*.AppImage.sig'
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -66,14 +69,100 @@ jobs:
       - name: Install Tauri CLI
         run: cargo install tauri-cli --version '^2.0' --locked
 
-      - name: Build (universal macOS)
-        if: matrix.os == 'macos-latest'
+      # ── macOS signing + notarization ──────────────────────────────────────
+      # Requires these secrets in the repo (Settings → Secrets → Actions):
+      #   APPLE_CERTIFICATE          — base64-encoded Developer ID Application .p12
+      #   APPLE_CERTIFICATE_PASSWORD — password for the .p12
+      #   APPLE_SIGNING_IDENTITY     — "Developer ID Application: Your Name (TEAMID)"
+      #   APPLE_ID                   — Apple ID email used for notarytool
+      #   APPLE_PASSWORD             — app-specific password for notarytool
+      #   APPLE_TEAM_ID              — 10-character Apple team ID
+      - name: Import macOS signing certificate
+        if: matrix.os == 'macos-latest' && secrets.APPLE_CERTIFICATE != ''
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH="$RUNNER_TEMP/build.keychain"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 16)"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          echo "$APPLE_CERTIFICATE" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" \
+            -k "$KEYCHAIN_PATH" \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign
+          security list-keychain -d user -s "$KEYCHAIN_PATH"
+          security set-key-partition-list \
+            -S apple-tool:,apple: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+      - name: Build (universal macOS) — with signing
+        if: matrix.os == 'macos-latest' && secrets.APPLE_CERTIFICATE != ''
         working-directory: desktop
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: cargo tauri build --target ${{ matrix.tauri_target }}
 
-      - name: Build (Windows / Linux)
-        if: matrix.os != 'macos-latest'
+      - name: Build (universal macOS) — unsigned fallback
+        if: matrix.os == 'macos-latest' && secrets.APPLE_CERTIFICATE == ''
         working-directory: desktop
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: cargo tauri build --target ${{ matrix.tauri_target }}
+
+      # ── Windows code signing ──────────────────────────────────────────────
+      # Requires these secrets:
+      #   WINDOWS_PFX_BASE64   — base64-encoded .pfx certificate file
+      #   WINDOWS_PFX_PASSWORD — password for the .pfx
+      - name: Import Windows signing certificate
+        if: matrix.os == 'windows-latest' && secrets.WINDOWS_PFX_BASE64 != ''
+        shell: pwsh
+        env:
+          WINDOWS_PFX_BASE64: ${{ secrets.WINDOWS_PFX_BASE64 }}
+          WINDOWS_PFX_PASSWORD: ${{ secrets.WINDOWS_PFX_PASSWORD }}
+        run: |
+          $pfxPath = Join-Path $env:RUNNER_TEMP "cert.pfx"
+          [System.IO.File]::WriteAllBytes(
+            $pfxPath,
+            [System.Convert]::FromBase64String($env:WINDOWS_PFX_BASE64)
+          )
+          $cert = Import-PfxCertificate `
+            -FilePath $pfxPath `
+            -CertStoreLocation Cert:\CurrentUser\My `
+            -Password (ConvertTo-SecureString $env:WINDOWS_PFX_PASSWORD -AsPlainText -Force)
+          echo "WINDOWS_CERT_THUMBPRINT=$($cert.Thumbprint)" >> $env:GITHUB_ENV
+
+      - name: Build (Windows) — with signing
+        if: matrix.os == 'windows-latest' && secrets.WINDOWS_PFX_BASE64 != ''
+        working-directory: desktop
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          WINDOWS_CERTIFICATE_THUMBPRINT: ${{ env.WINDOWS_CERT_THUMBPRINT }}
+        run: cargo tauri build
+
+      - name: Build (Windows) — unsigned fallback
+        if: matrix.os == 'windows-latest' && secrets.WINDOWS_PFX_BASE64 == ''
+        working-directory: desktop
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: cargo tauri build
+
+      - name: Build (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        working-directory: desktop
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: cargo tauri build
 
       # ── Installer smoke (M12/02 — install, launch, screenshot) ───────────
@@ -237,12 +326,128 @@ jobs:
         with:
           subject-path: ${{ matrix.artifact_glob }}
 
+      # ── Upload artifacts + per-platform .sig files ────────────────────────
       - name: Upload to draft release
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/raven-ai-v')
         uses: softprops/action-gh-release@e7a8f85e1c67a31e6ed99a94b41bd0b71bbee6b8 # v2.0.9
         with:
           draft: true
-          files: ${{ matrix.artifact_glob }}
+          files: |
+            ${{ matrix.artifact_glob }}
+            ${{ matrix.sig_glob }}
+          tag_name: ${{ github.ref_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Stash .sig files as GitHub Actions artifacts so the manifest job can
+      # assemble latest.json without downloading from the release directly.
+      - name: Upload sig artifacts
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/raven-local-v')
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: sig-${{ matrix.os }}
+          path: ${{ matrix.sig_glob }}
+          if-no-files-found: warn
+
+  # ── Generate update manifest (latest.json) ─────────────────────────────────
+  # Runs after all three platform builds complete. Assembles the
+  # Tauri-compatible update manifest and uploads it to the draft release so it
+  # can be deployed to https://download.raven.app/local/latest.json
+  # (e.g. via a Cloudflare Pages redirect or a separate deploy workflow).
+  manifest:
+    name: Generate update manifest
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/raven-local-v')
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Download macOS sig
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
+        with:
+          name: sig-macos-latest
+          path: sigs/macos
+        continue-on-error: true
+
+      - name: Download Windows sig
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
+        with:
+          name: sig-windows-latest
+          path: sigs/windows
+        continue-on-error: true
+
+      - name: Download Linux sig
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
+        with:
+          name: sig-ubuntu-latest
+          path: sigs/linux
+        continue-on-error: true
+
+      - name: Build latest.json
+        # All external values are passed via env vars, never interpolated
+        # directly into the shell command, to prevent injection attacks.
+        env:
+          GIT_TAG: ${{ github.ref_name }}
+        run: |
+          # Strip prefix — allow only semver characters to prevent injection.
+          VERSION="${GIT_TAG#raven-local-v}"
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
+            echo "ERROR: tag does not match raven-local-vX.Y.Z" >&2
+            exit 1
+          fi
+
+          BASE_URL="https://github.com/ravencloak-org/Raven/releases/download/${GIT_TAG}"
+          PUB_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+          read_sig() {
+            local dir="$1"
+            local file
+            file="$(find "$dir" -name '*.sig' 2>/dev/null | head -1)"
+            if [ -n "$file" ] && [ -f "$file" ]; then cat "$file"; else echo ""; fi
+          }
+
+          DMG_SIG="$(read_sig sigs/macos)"
+          MSI_SIG="$(read_sig sigs/windows)"
+          APPIMAGE_SIG="$(read_sig sigs/linux)"
+
+          DMG_URL="${BASE_URL}/Raven.Local_${VERSION}_universal.dmg"
+          MSI_URL="${BASE_URL}/Raven.Local_${VERSION}_x64_en-US.msi"
+          APPIMAGE_URL="${BASE_URL}/raven-local_${VERSION}_amd64.AppImage"
+          NOTES="See the full changelog at https://github.com/ravencloak-org/Raven/releases/tag/raven-local-v${VERSION}"
+
+          # Use jq (available on ubuntu-latest) to safely build the JSON.
+          # All values are passed via --arg; no user-controlled data is
+          # interpolated directly into the jq filter expression.
+          jq -n \
+            --arg version    "$VERSION" \
+            --arg notes      "$NOTES" \
+            --arg pub_date   "$PUB_DATE" \
+            --arg dmg_url    "$DMG_URL" \
+            --arg dmg_sig    "$DMG_SIG" \
+            --arg msi_url    "$MSI_URL" \
+            --arg msi_sig    "$MSI_SIG" \
+            --arg appimg_url "$APPIMAGE_URL" \
+            --arg appimg_sig "$APPIMAGE_SIG" \
+            '{
+              version: $version,
+              notes: $notes,
+              pub_date: $pub_date,
+              platforms: {
+                "darwin-universal": { url: $dmg_url, signature: $dmg_sig },
+                "windows-x86_64":   { url: $msi_url, signature: $msi_sig },
+                "linux-x86_64":     { url: $appimg_url, signature: $appimg_sig }
+              }
+            }' > latest.json
+          echo "latest.json written:"
+          cat latest.json
+
+      - name: Upload latest.json to draft release
+        uses: softprops/action-gh-release@e7a8f85e1c67a31e6ed99a94b41bd0b71bbee6b8 # v2.0.9
+        with:
+          draft: true
+          files: latest.json
           tag_name: ${{ github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -24,12 +24,15 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = ["tray-icon", "image-png"] }
 tauri-plugin-shell = "2"
+tauri-plugin-updater = "2"
+tauri-plugin-process = "2"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "stream"] }
 sysinfo = { version = "0.32", default-features = false, features = ["disk", "system"] }
 thiserror = "1"
+anyhow = "1"
 futures-util = "0.3"
 tokio-util = { version = "0.7", features = ["io"] }
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -8,3 +8,4 @@ pub mod compose;
 pub mod ollama;
 pub mod precheck;
 pub mod tray;
+pub mod updater;

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -3,9 +3,10 @@
 
 use std::path::{Path, PathBuf};
 
-use raven_ai_lib::compose::{ComposeManager, StatusEvent};
-use raven_ai_lib::precheck::{run_precheck, skip_requested, RealSystemInfo};
-use raven_ai_lib::tray::{self, TrayStatus};
+use raven_local_lib::compose::{ComposeManager, StatusEvent};
+use raven_local_lib::precheck::{run_precheck, skip_requested, RealSystemInfo};
+use raven_local_lib::tray::{self, TrayStatus};
+use raven_local_lib::updater;
 use tauri::{Emitter, Listener, Manager};
 
 const COMPOSE_FILE: &str = "docker-compose.local.yml";
@@ -17,6 +18,8 @@ const PRECHECK_EVENT: &str = "precheck:result";
 fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_process::init())
         .setup(|app| {
             let resource_dir = app
                 .path()
@@ -39,10 +42,10 @@ fn main() {
             app.listen("compose:status", move |event| {
                 if let Ok(payload) = serde_json::from_str::<StatusEvent>(event.payload()) {
                     let status = match payload.status {
-                        raven_ai_lib::compose::ComposeStatus::Starting => TrayStatus::Starting,
-                        raven_ai_lib::compose::ComposeStatus::Ready => TrayStatus::Ready,
-                        raven_ai_lib::compose::ComposeStatus::Stopped => TrayStatus::Stopped,
-                        raven_ai_lib::compose::ComposeStatus::Error => TrayStatus::Error,
+                        raven_local_lib::compose::ComposeStatus::Starting => TrayStatus::Starting,
+                        raven_local_lib::compose::ComposeStatus::Ready => TrayStatus::Ready,
+                        raven_local_lib::compose::ComposeStatus::Stopped => TrayStatus::Stopped,
+                        raven_local_lib::compose::ComposeStatus::Error => TrayStatus::Error,
                     };
                     tray::apply_status(&tray_handle, status);
                 }
@@ -141,11 +144,17 @@ fn main() {
             // close-requested webview event AND register a global shutdown
             // via run_event below in main.
             let _ = manager_for_shutdown;
+
+            // Kick off a background update check (debounced to once per 24 h).
+            // Errors are emitted as `updater:error` events and never block launch.
+            updater::spawn_update_check(app.handle().clone());
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
-            raven_ai_lib::ollama::ollama_pull_model,
-            raven_ai_lib::ollama::ollama_list_models
+            raven_local_lib::ollama::ollama_pull_model,
+            raven_local_lib::ollama::ollama_list_models,
+            raven_local_lib::updater::updater_install_and_restart
         ])
         .build(tauri::generate_context!())
         .expect("error while building Raven AI")

--- a/desktop/src-tauri/src/updater.rs
+++ b/desktop/src-tauri/src/updater.rs
@@ -1,0 +1,210 @@
+//! Auto-update logic for Raven Local.
+//!
+//! On app launch this module checks whether 24 hours have elapsed since the
+//! last update check. If so, it queries the update manifest at
+//! `https://download.raven.app/local/latest.json`. When a new version is
+//! found, an `updater:available` event is emitted to the frontend so the UI
+//! can show a non-blocking "Update available — Restart to apply" banner.
+//!
+//! Design goals:
+//! - Never block app launch: all network I/O is async and errors are silently
+//!   logged; the app continues normally whether or not the endpoint is
+//!   reachable.
+//! - Debounce to once per 24 h: the timestamp of the last check is persisted
+//!   in the Tauri app-data directory (`last_update_check` plain-text file).
+//! - Download → verify signature → stage on quit: the actual install is
+//!   deferred until the user clicks "Restart to apply" in the UI.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use tauri::{AppHandle, Emitter, Manager};
+use tauri_plugin_updater::UpdaterExt;
+
+/// Debounce interval: only check for updates once every 24 hours.
+const CHECK_INTERVAL_SECS: u64 = 24 * 60 * 60;
+
+/// File name inside the app-data directory that stores the last-check epoch.
+const TIMESTAMP_FILE: &str = "last_update_check";
+
+/// Frontend event emitted when a new version is available.
+pub const UPDATE_AVAILABLE_EVENT: &str = "updater:available";
+
+/// Frontend event emitted when download + install is complete (quit to apply).
+pub const UPDATE_READY_EVENT: &str = "updater:ready";
+
+/// Frontend event emitted when the download fails.
+pub const UPDATE_ERROR_EVENT: &str = "updater:error";
+
+/// Payload sent with [`UPDATE_AVAILABLE_EVENT`].
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct UpdateAvailablePayload {
+    /// The new version string (e.g. `"0.2.0"`).
+    pub version: String,
+    /// Optional release notes / changelog snippet.
+    pub notes: Option<String>,
+}
+
+/// Payload sent with [`UPDATE_ERROR_EVENT`].
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct UpdateErrorPayload {
+    pub message: String,
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Spawn the update-check task in the background.
+///
+/// Call once from `main.rs` setup, after registering the updater plugin.
+/// All errors are swallowed — the update flow must never prevent the app
+/// from starting.
+pub fn spawn_update_check(app: AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        if let Err(e) = check_once(&app).await {
+            // Emit error to frontend (non-fatal); continue normal launch.
+            let _ = app.emit(
+                UPDATE_ERROR_EVENT,
+                UpdateErrorPayload {
+                    message: e.to_string(),
+                },
+            );
+        }
+    });
+}
+
+/// Called from the frontend `invoke("updater_install_and_restart")` handler
+/// when the user clicks "Restart to apply". Downloads, verifies, and
+/// installs the pending update, then restarts the app.
+#[tauri::command]
+pub async fn updater_install_and_restart(app: AppHandle) -> Result<(), String> {
+    do_install_and_restart(app).await.map_err(|e| e.to_string())
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+async fn check_once(app: &AppHandle) -> anyhow::Result<()> {
+    // Skip the network call if we already checked within the last 24 h.
+    if !should_check(app) {
+        return Ok(());
+    }
+
+    // Mark timestamp *before* the network call so a hanging endpoint doesn't
+    // cause repeated retries within the same session.
+    write_timestamp(app);
+
+    // Delegate to tauri-plugin-updater; this performs the HTTP request,
+    // parses the JSON manifest, and verifies the server-side signature.
+    let updater = app.updater().map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    match updater.check().await {
+        Ok(Some(update)) => {
+            let payload = UpdateAvailablePayload {
+                version: update.version.clone(),
+                notes: update.body.clone(),
+            };
+            let _ = app.emit(UPDATE_AVAILABLE_EVENT, payload);
+
+            // Store the pending update handle in app state so the install
+            // command can retrieve it without fetching a second time.
+            app.manage(PendingUpdate(std::sync::Mutex::new(Some(update))));
+        }
+        Ok(None) => {
+            // Already up-to-date — nothing to do.
+        }
+        Err(e) => {
+            // Network/parse error: emit to frontend but don't propagate.
+            let _ = app.emit(
+                UPDATE_ERROR_EVENT,
+                UpdateErrorPayload {
+                    message: format!("Update check failed: {e}"),
+                },
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// App-managed state holding the pending [`tauri_plugin_updater::Update`].
+struct PendingUpdate(std::sync::Mutex<Option<tauri_plugin_updater::Update>>);
+
+async fn do_install_and_restart(app: AppHandle) -> anyhow::Result<()> {
+    // Retrieve the pending update that was stashed during `check_once`.
+    let update = {
+        let state = app
+            .try_state::<PendingUpdate>()
+            .ok_or_else(|| anyhow::anyhow!("No pending update available"))?;
+        let mut guard = state
+            .0
+            .lock()
+            .map_err(|e| anyhow::anyhow!("mutex poisoned: {e}"))?;
+        guard.take()
+    };
+
+    let Some(update) = update else {
+        return Err(anyhow::anyhow!("Pending update was already consumed"));
+    };
+
+    // Download and verify the package (tauri-plugin-updater handles sig check).
+    update
+        .download_and_install(
+            |_chunk_len, _total| {
+                // Progress reporting — could emit events here in a future PR.
+            },
+            || {
+                // Called when download completes, before install begins.
+            },
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("Install failed: {e}"))?;
+
+    let _ = app.emit(UPDATE_READY_EVENT, ());
+
+    // Restart the app so the freshly installed binary takes effect.
+    app.restart();
+}
+
+// ---------------------------------------------------------------------------
+// Timestamp helpers
+// ---------------------------------------------------------------------------
+
+fn timestamp_path(app: &AppHandle) -> Option<std::path::PathBuf> {
+    app.path()
+        .app_data_dir()
+        .ok()
+        .map(|d| d.join(TIMESTAMP_FILE))
+}
+
+fn should_check(app: &AppHandle) -> bool {
+    let Some(path) = timestamp_path(app) else {
+        return true;
+    };
+    let Ok(contents) = std::fs::read_to_string(&path) else {
+        return true;
+    };
+    let Ok(epoch_secs) = contents.trim().parse::<u64>() else {
+        return true;
+    };
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_secs();
+    now.saturating_sub(epoch_secs) >= CHECK_INTERVAL_SECS
+}
+
+fn write_timestamp(app: &AppHandle) {
+    let Some(path) = timestamp_path(app) else {
+        return;
+    };
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_secs();
+    let _ = std::fs::write(&path, now.to_string());
+}

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -41,7 +41,27 @@
     ],
     "resources": ["../docker-compose.local.yml"],
     "macOS": {
-      "signingIdentity": "-"
+      "signingIdentity": null,
+      "providerShortName": null,
+      "entitlements": null
+    },
+    "windows": {
+      "certificateThumbprint": null,
+      "digestAlgorithm": "sha256",
+      "timestampUrl": ""
+    }
+  },
+  "plugins": {
+    "updater": {
+      "active": true,
+      "pubkey": "PLACEHOLDER_PUBLIC_KEY_REPLACE_BEFORE_RELEASE",
+      "endpoints": [
+        "https://download.raven.app/local/latest.json"
+      ],
+      "dialog": false,
+      "windows": {
+        "installMode": "passive"
+      }
     }
   }
 }

--- a/desktop/ui/splash.html
+++ b/desktop/ui/splash.html
@@ -71,6 +71,74 @@
       font-size: 12px;
       color: #475569;
     }
+
+    /* ── Update banner ─────────────────────────────────────────────────── */
+    #update-banner {
+      display: none;
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      background: #1e293b;
+      border-top: 1px solid #334155;
+      padding: 12px 20px;
+      flex-direction: row;
+      align-items: center;
+      gap: 12px;
+      font-size: 13px;
+      color: #94a3b8;
+      z-index: 9999;
+    }
+
+    #update-banner.visible {
+      display: flex;
+    }
+
+    #update-banner .update-icon {
+      font-size: 18px;
+      flex-shrink: 0;
+    }
+
+    #update-banner .update-text {
+      flex: 1;
+    }
+
+    #update-banner .update-text strong {
+      color: #e2e8f0;
+      display: block;
+      margin-bottom: 2px;
+    }
+
+    #update-restart-btn {
+      background: #6366f1;
+      color: #fff;
+      border: none;
+      border-radius: 6px;
+      padding: 7px 14px;
+      font-size: 13px;
+      font-weight: 600;
+      cursor: pointer;
+      white-space: nowrap;
+      transition: background 0.15s;
+    }
+
+    #update-restart-btn:hover {
+      background: #4f46e5;
+    }
+
+    #update-dismiss-btn {
+      background: transparent;
+      color: #64748b;
+      border: none;
+      padding: 4px 8px;
+      font-size: 18px;
+      cursor: pointer;
+      line-height: 1;
+    }
+
+    #update-dismiss-btn:hover {
+      color: #94a3b8;
+    }
   </style>
 </head>
 <body>
@@ -79,6 +147,17 @@
   <p class="subtitle">Starting…</p>
   <div class="spinner"></div>
   <p class="status" id="status">Waiting for local stack…</p>
+
+  <!-- Update available banner — hidden until updater:available event fires -->
+  <div id="update-banner" role="status" aria-live="polite">
+    <span class="update-icon" aria-hidden="true">🔄</span>
+    <div class="update-text">
+      <strong id="update-version">Update available</strong>
+      <span id="update-notes"></span>
+    </div>
+    <button id="update-restart-btn" type="button">Restart to apply</button>
+    <button id="update-dismiss-btn" type="button" aria-label="Dismiss update notification">✕</button>
+  </div>
 
   <script>
     // TODO(#418): replace timer with compose health-check event from the
@@ -124,6 +203,66 @@
     }
 
     setTimeout(waitForApiAndRedirect, SPLASH_DURATION_MS);
+
+    // ── Tauri auto-update banner ───────────────────────────────────────────
+    // Tauri's JS API is injected by the webview; guard against plain-browser
+    // previews where `window.__TAURI__` is absent.
+    (async function initUpdaterBanner() {
+      if (typeof window.__TAURI__ === "undefined") return;
+
+      const { listen } = window.__TAURI__.event;
+      const { invoke } = window.__TAURI__.core;
+
+      const banner      = document.getElementById("update-banner");
+      const versionEl   = document.getElementById("update-version");
+      const notesEl     = document.getElementById("update-notes");
+      const restartBtn  = document.getElementById("update-restart-btn");
+      const dismissBtn  = document.getElementById("update-dismiss-btn");
+
+      let installing = false;
+
+      // Show banner when backend emits "updater:available".
+      await listen("updater:available", (event) => {
+        const { version, notes } = event.payload || {};
+        versionEl.textContent = version
+          ? `Update available — v${version}`
+          : "Update available";
+        notesEl.textContent = notes ? notes.slice(0, 120) : "";
+        banner.classList.add("visible");
+      });
+
+      // Listen for non-fatal errors (offline, bad sig, etc.).
+      await listen("updater:error", (event) => {
+        // Errors are intentionally silent in the UI — the app must not be
+        // blocked. Log to console for developers.
+        console.warn("[updater] update error:", event.payload?.message);
+      });
+
+      // "Restart to apply" — triggers download → verify → install → restart.
+      restartBtn.addEventListener("click", async () => {
+        if (installing) return;
+        installing = true;
+        restartBtn.textContent = "Downloading…";
+        restartBtn.disabled = true;
+        try {
+          // This call returns only if download/install fails; on success the
+          // app restarts immediately.
+          await invoke("updater_install_and_restart");
+        } catch (err) {
+          console.error("[updater] install failed:", err);
+          restartBtn.textContent = "Retry";
+          restartBtn.disabled = false;
+          installing = false;
+        }
+      });
+
+      // Dismiss hides the banner for this session; the next launch will show
+      // it again if the update is still pending (or a newer one is found).
+      dismissBtn.addEventListener("click", () => {
+        banner.classList.remove("visible");
+      });
+    })();
+    // ── end update banner ──────────────────────────────────────────────────
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Implements GitHub issue #426 — Tauri v2 auto-update channel for Raven Local.

- **`tauri-plugin-updater` + `tauri-plugin-process`** added to `Cargo.toml`; plugins registered in `main.rs`
- **`updater.rs`** — 24h-debounced update check on launch, offline-safe (errors emitted as `updater:error` events, never block launch); `updater_install_and_restart` Tauri command for frontend to trigger download → signature verify → install → restart
- **`tauri.conf.json`** — `plugins.updater` block pointing at `https://download.raven.app/local/latest.json`; placeholder public key (replace before first signed release); macOS/Windows bundle signing stubs
- **`splash.html`** — non-blocking "Update available" banner listening on `updater:available`; "Restart to apply" button; dismiss button; never shown in plain-browser previews
- **`desktop-release.yml`** — macOS Apple Developer ID signing + notarization, Windows PFX signing, both guarded behind `secrets.APPLE_CERTIFICATE != ''` / `secrets.WINDOWS_PFX_BASE64 != ''` so CI passes without them; `.sig` file upload; new `manifest` job assembles `latest.json` via `jq` after all three platform builds complete and uploads it to the draft release

## Manual setup required before first signed release

### 1. Generate the Tauri updater key pair
```bash
# Run once, store output safely
cargo tauri signer generate -w ~/.tauri/raven-local.key
```
- Copy the **public key** into `tauri.conf.json` → `plugins.updater.pubkey`
- Add the **private key** as GitHub Actions secret: `TAURI_SIGNING_PRIVATE_KEY`
- Add the **key password** as: `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`

### 2. macOS signing secrets (Settings → Secrets → Actions)
| Secret | Value |
|--------|-------|
| `APPLE_CERTIFICATE` | `base64 -i DeveloperID.p12` |
| `APPLE_CERTIFICATE_PASSWORD` | .p12 password |
| `APPLE_SIGNING_IDENTITY` | `"Developer ID Application: Your Name (TEAMID)"` |
| `APPLE_ID` | Apple ID email |
| `APPLE_PASSWORD` | App-specific password for notarytool |
| `APPLE_TEAM_ID` | 10-char team ID |

### 3. Windows signing secrets
| Secret | Value |
|--------|-------|
| `WINDOWS_PFX_BASE64` | `base64 -i cert.pfx` |
| `WINDOWS_PFX_PASSWORD` | .pfx password |

### 4. Host the update manifest
After each release, the `latest.json` uploaded to the GitHub release must be served at `https://download.raven.app/local/latest.json`. Options:
- Cloudflare Pages redirect rule from that URL to the release asset
- Separate deploy step fetching the asset and pushing to an R2/Pages static host

## Test plan
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes in `desktop/src-tauri`
- [ ] `cargo tauri build --debug` succeeds (updater plugin compiles; signing not required for debug)
- [ ] Tauri app launches normally when `https://download.raven.app/local/latest.json` is unreachable
- [ ] With a valid `latest.json` pointing at a newer version, the update banner appears within ~5 s of launch
- [ ] "Restart to apply" triggers install flow; app restarts with new binary
- [ ] A second launch within 24 h does not re-check the endpoint
- [ ] CI `desktop-release.yml` runs all three platform builds without secrets (unsigned fallback path)