### PR TITLE
fix(ci): repin actions/upload-artifact to real v4 SHA in desktop-release

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -225,7 +225,7 @@ jobs:
 
       - name: Upload smoke artefacts
         if: always()
-        uses: actions/upload-artifact@b04ad4d27f4f9bdfcd3e87a5f6cf9c0e9c9c5e07 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: smoke-${{ matrix.os }}
           path: smoke-out/


### PR DESCRIPTION
## Summary

- The pin `b04ad4d2...` in `desktop-release.yml` does not exist in `actions/upload-artifact`, so every matrix leg of [run 25797164278](https://github.com/ravencloak-org/Raven/actions/runs/25797164278) (raven-ai-v0.1.5) failed at "Set up job" with `Unable to resolve action`.
- Repinned to `ea165f8d` — the actual head of the `v4` tag.
- Verified the other two pinned actions in this file (`attest-build-provenance`, `softprops/action-gh-release`) point at real commits.

After this merges I'll delete + re-push the `raven-ai-v0.1.5` tag to retrigger the release.

## Test plan

- [x] `gh api /repos/actions/upload-artifact/git/refs/tags/v4` returns `ea165f8d...`
- [ ] Re-tagged release produces DMG / MSI / AppImage artefacts