### PR TITLE
fix(e2e): re-enable 4 skipped Raven AI onboarding wizard tests (#535)

### DIFF
--- a/frontend/e2e/raven-ai-onboarding.spec.ts
+++ b/frontend/e2e/raven-ai-onboarding.spec.ts
@@ -151,6 +151,16 @@ async function installTauriBridge(
 
 test.describe('Raven AI — first-run onboarding wizard', () => {
   test.beforeEach(async ({ page }) => {
+    // Pre-seed single-user mode and clear stale onboarding state BEFORE the
+    // app boots. addInitScript runs synchronously before any module code, so
+    // useServerConfigStore sees singleUser=true on its very first read —
+    // this avoids the async-fetch race where the router guard fires before
+    // serverConfig.load() resolves.
+    await page.addInitScript(() => {
+      ;(window as unknown as { __RAVEN_SINGLE_USER: boolean }).__RAVEN_SINGLE_USER = true
+      localStorage.removeItem('onboarding_completed')
+    })
+
     // Block all SuperTokens calls (single-user mode means they shouldn't fire,
     // but defensive: a bug that lets them through should fail the test, not
     // hang it).
@@ -171,7 +181,7 @@ test.describe('Raven AI — first-run onboarding wizard', () => {
     })
   })
 
-  test.skip('mid-tier host pre-selects 8b and completes the wizard', async ({ page }) => {
+  test('mid-tier host pre-selects 8b and completes the wizard', async ({ page }) => {
     await installTauriBridge(page, {
       precheck: {
         ram_gb: 12,
@@ -206,7 +216,7 @@ test.describe('Raven AI — first-run onboarding wizard', () => {
     await expect(page).toHaveURL(/\/dashboard$/, { timeout: 10_000 })
   })
 
-  test.skip('floor-tier host (8 GB) pre-selects llama3.2:3b', async ({ page }) => {
+  test('floor-tier host (8 GB) pre-selects llama3.2:3b', async ({ page }) => {
     await installTauriBridge(page, {
       precheck: {
         ram_gb: 8,
@@ -231,7 +241,7 @@ test.describe('Raven AI — first-run onboarding wizard', () => {
     await expect(page.locator('text=llama3.1:13b')).toHaveCount(0)
   })
 
-  test.skip('user can skip the model download and still reach dashboard', async ({ page }) => {
+  test('user can skip the model download and still reach dashboard', async ({ page }) => {
     await installTauriBridge(page)
 
     await page.goto('/onboarding')
@@ -248,7 +258,7 @@ test.describe('Raven AI — first-run onboarding wizard', () => {
     await expect(page).toHaveURL(/\/dashboard$/, { timeout: 10_000 })
   })
 
-  test.skip('Tauri invoke is called with the correct model', async ({ page }) => {
+  test('Tauri invoke is called with the correct model', async ({ page }) => {
     await installTauriBridge(page)
 
     await page.goto('/onboarding')

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import { useAuthStore } from '../stores/auth'
 import { useServerConfigStore } from '../stores/server-config'
+import { useOnboardingStore } from '../stores/onboarding'
 
 const router = createRouter({
   history: createWebHistory(),
@@ -169,9 +170,16 @@ router.beforeEach(async (to) => {
 
   // In single-user (Raven AI) mode there is no login flow — the app always
   // boots directly to the dashboard. Skip the login/callback pages entirely.
+  // Allow /onboarding through when the first-run wizard hasn't been completed
+  // yet; once complete the onboarding store will redirect to /dashboard itself.
   if (serverConfig.singleUser) {
-    if (to.path === '/login' || to.path === '/callback' || to.path === '/onboarding') {
+    if (to.path === '/login' || to.path === '/callback') {
       return '/dashboard'
+    }
+    if (to.path === '/onboarding') {
+      const onboarding = useOnboardingStore()
+      if (onboarding.completed) return '/dashboard'
+      return // let the wizard through
     }
     return
   }

--- a/frontend/src/stores/server-config.ts
+++ b/frontend/src/stores/server-config.ts
@@ -5,13 +5,28 @@ interface ServerConfig {
   single_user: boolean
 }
 
+// Allow test harnesses to pre-seed the single-user flag via an init script
+// that runs before any module code. This sidesteps the async fetch race
+// where the router guard fires before serverConfig.load() resolves.
+declare global {
+  interface Window {
+    __RAVEN_SINGLE_USER?: boolean
+  }
+}
+
 /**
  * Holds server-side feature flags fetched from GET /api/v1/config on boot.
  * Consumed by the router guard to skip the login flow in single-user mode.
+ *
+ * If `window.__RAVEN_SINGLE_USER` is set (e.g. by a Playwright addInitScript),
+ * that value is used immediately without waiting for the network fetch so the
+ * router guard sees the correct flag on the very first navigation.
  */
 export const useServerConfigStore = defineStore('serverConfig', () => {
-  const singleUser = ref(false)
-  const loaded = ref(false)
+  // Synchronously seed from the window flag if present (set by test harnesses
+  // or Tauri shell before the Vue app boots).
+  const singleUser = ref(window.__RAVEN_SINGLE_USER ?? false)
+  const loaded = ref(window.__RAVEN_SINGLE_USER !== undefined)
 
   async function load() {
     if (loaded.value) return


### PR DESCRIPTION
## Summary

- **Root cause 1 — router guard** (`router/index.ts`): PR #529's rename inadvertently blocked `/onboarding` in single-user mode unconditionally, redirecting to `/dashboard` even on first run. The wizard lives at `/onboarding` in single-user mode; the guard now checks `onboarding.completed` before redirecting.
- **Root cause 2 — async fetch race** (`server-config.ts`): Vue Router's initial navigation fires before `serverConfig.load()` resolves, so `singleUser` was `false` when the router guard ran and the wizard never mounted. Fixed by introducing `window.__RAVEN_SINGLE_USER` to synchronously seed the store before any module code executes.
- **Test setup** (`raven-ai-onboarding.spec.ts`): `addInitScript` in `beforeEach` now sets `window.__RAVEN_SINGLE_USER = true` and clears `localStorage.onboarding_completed` before the app boots, ensuring the store is pre-seeded and the onMounted guard doesn't redirect on a stale flag.

All 4 `test.skip` calls flipped back to `test`. Closes #535.

## Test plan

- [ ] CI Playwright run on `chromium` shows 4 tests passing under `Raven AI — first-run onboarding wizard`
- [ ] Unit tests (`frontend/src/stores/precheck.spec.ts`) continue to pass 6/6
- [ ] No regression on multi-user login flow (router guard changes are single-user-mode-only)