### PR TITLE
fix(e2e): use high-tier RAM (16 GB) for llama3.1:8b preselection test

### DIFF
--- a/frontend/e2e/raven-ai-onboarding.spec.ts
+++ b/frontend/e2e/raven-ai-onboarding.spec.ts
@@ -181,10 +181,10 @@ test.describe('Raven AI — first-run onboarding wizard', () => {
     })
   })
 
-  test('mid-tier host pre-selects 8b and completes the wizard', async ({ page }) => {
+  test('high-tier host pre-selects 8b and completes the wizard', async ({ page }) => {
     await installTauriBridge(page, {
       precheck: {
-        ram_gb: 12,
+        ram_gb: 16,
         free_disk_gb: 80,
         cpu_cores: 8,
         ok: true,
@@ -194,7 +194,7 @@ test.describe('Raven AI — first-run onboarding wizard', () => {
 
     await page.goto('/onboarding')
 
-    // 1. Model picker: 8b preselected (mid tier).
+    // 1. Model picker: 8b preselected (high tier, 16 GB RAM).
     await expect(page.getByTestId('selected-model')).toContainText('llama3.1:8b', {
       timeout: 10_000,
     })


### PR DESCRIPTION
## Summary

- `ramTier(12)` = `'mid'` which maps to `llama3.2:3b`, not `llama3.1:8b`
- `llama3.1:8b` is only pre-selected at high tier (16+ GB RAM)
- Update the precheck fixture from 12 GB → 16 GB and rename the test accordingly

Fixes the Playwright E2E failure from #544 which re-enabled these tests with incorrect tier assumptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end onboarding wizard regression test to reflect high-tier host configuration with adjusted RAM requirements and model picker validation expectations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ravencloak-org/Raven/pull/579)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->