### PR TITLE
chore(desktop): wire real Tauri updater public key

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -55,7 +55,7 @@
   "plugins": {
     "updater": {
       "active": true,
-      "pubkey": "PLACEHOLDER_PUBLIC_KEY_REPLACE_BEFORE_RELEASE",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDQ0NkU1MTk3REM2QTg0N0QKUldSOWhHcmNsMUZ1Uk9ldEJkaDg3dGhTaTZ5WjM1VGduT1dOMHV4d3ppUG9NTDVKdm9YdDhjMFoK",
       "endpoints": [
         "https://download.raven.app/local/latest.json"
       ],


### PR DESCRIPTION
## Summary

- Replaces the `PLACEHOLDER_PUBLIC_KEY_REPLACE_BEFORE_RELEASE` stub in `desktop/src-tauri/tauri.conf.json` with the real minisign public key (Key ID: `446E5197DC6A847D`)
- Generated with: `cargo tauri signer generate -w ~/.tauri/raven-local.key`
- `TAURI_SIGNING_PRIVATE_KEY` is now set as a GitHub Actions secret
- `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` must be set manually via `gh secret set TAURI_SIGNING_PRIVATE_KEY_PASSWORD --repo ravencloak-org/Raven`

Apple and Windows signing secrets can be added later when those certificates are available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the updater plugin configuration with required security credentials to enable automatic application updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ravencloak-org/Raven/pull/583)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->