### PR TITLE
chore(desktop): update Tauri updater public key (regenerated)

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -55,7 +55,7 @@
   "plugins": {
     "updater": {
       "active": true,
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDQ0NkU1MTk3REM2QTg0N0QKUldSOWhHcmNsMUZ1Uk9ldEJkaDg3dGhTaTZ5WjM1VGduT1dOMHV4d3ppUG9NTDVKdm9YdDhjMFoK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEE2RjkzQzFDNUY1MzFDQgpSV1RMTWZYRndaTnZDb1JxWjFya2VITXNUUWFVWE5LcnpzV3dOKzlXbGVMTHJUL1NpcEtqeFphNgo=",
       "endpoints": [
         "https://download.raven.app/local/latest.json"
       ],


### PR DESCRIPTION
## Summary

The previous signing key was regenerated (password was lost). Updates `tauri.conf.json` with the new public key (Key ID: `A6F93C1C5F531CB`).

`TAURI_SIGNING_PRIVATE_KEY` GitHub secret has already been updated to match.

Remaining manual step: set the password via `gh secret set TAURI_SIGNING_PRIVATE_KEY_PASSWORD --repo ravencloak-org/Raven`