### PR TITLE
ci(desktop): cache Tauri CLI binary and enable cache-on-failure

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -70,9 +70,18 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: desktop -> desktop/target
+          cache-on-failure: true
+
+      - name: Cache Tauri CLI binary
+        id: cache-tauri-cli
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.cargo/bin/cargo-tauri
+          key: tauri-cli-2.11.1-${{ runner.os }}-${{ runner.arch }}
 
       - name: Install Tauri CLI
-        run: cargo install tauri-cli --version '^2.0' --locked
+        if: steps.cache-tauri-cli.outputs.cache-hit != 'true'
+        run: cargo install tauri-cli --version '=2.11.1' --locked
 
       # ── macOS signing + notarization ──────────────────────────────────────
       # Requires these secrets in the repo (Settings → Secrets → Actions):


### PR DESCRIPTION
## What

Two targeted speed-ups for the Desktop release workflow:

### 1. Cache `cargo-tauri` binary (~8 min saved per run)

`cargo install tauri-cli` was recompiling Tauri CLI from source every run because `Swatinem/rust-cache` only covers `~/.cargo/registry` and the workspace target dir — not `~/.cargo/bin`.

Added a dedicated `actions/cache` step keyed on `tauri-cli-2.11.1-{OS}-{arch}`. On a warm cache the install step is skipped entirely. Also pinned the version from `'^2.0'` (floating) to `=2.11.1` (exact) so the cache key is stable and won't silently pick up a new version.

### 2. `cache-on-failure: true` on `Swatinem/rust-cache`

Without this, a failed build discards the partially-compiled Rust dependency cache. Retries (and debugging iterations) had to recompile everything. With this flag the cache is saved even on failure, so the next run starts warm.

## Impact

| Scenario | Before | After |
|----------|--------|-------|
| Cold build (first run / version bump) | full compile | full compile |
| Warm build (no Cargo.lock change) | ~8 min tauri-cli install | ~10 s cache restore |
| Failed build retry | cold deps cache | warm deps cache |