### PR TITLE
feat(demo): public-demo deployment — infra + deploy pipeline + app features (partial)

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -1,0 +1,121 @@
+name: Demo deploy
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing v* tag to deploy
+        required: true
+
+permissions:
+  id-token: write     # needed for OIDC
+  contents: read
+
+env:
+  AWS_REGION: ap-south-1
+  ROLE_ARN: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/raven-demo-github-deploy
+  INSTANCE_TAG_KEY: Name
+  INSTANCE_TAG_VALUE: raven-demo-app
+
+jobs:
+  wait-for-images:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for service images to be available on GHCR
+        env:
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          for svc in go-api python-worker frontend; do
+            for i in {1..30}; do
+              if docker manifest inspect ghcr.io/ravencloak-org/$svc:$TAG > /dev/null 2>&1; then
+                echo "Found $svc:$TAG"
+                break
+              fi
+              if [ "$i" = "30" ]; then
+                echo "Timed out waiting for $svc:$TAG"
+                exit 1
+              fi
+              echo "Waiting for $svc:$TAG (attempt $i/30)..."
+              sleep 30
+            done
+          done
+
+  deploy:
+    needs: wait-for-images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Resolve demo instance ID
+        id: instance
+        run: |
+          set -euo pipefail
+          INSTANCE_ID=$(aws ec2 describe-instances \
+            --filters "Name=tag:${INSTANCE_TAG_KEY},Values=${INSTANCE_TAG_VALUE}" \
+                      "Name=instance-state-name,Values=running" \
+            --query 'Reservations[0].Instances[0].InstanceId' \
+            --output text)
+          if [ "$INSTANCE_ID" = "None" ] || [ -z "$INSTANCE_ID" ]; then
+            echo "No running demo instance found"
+            exit 1
+          fi
+          echo "instance_id=$INSTANCE_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Send update.sh via SSM
+        id: ssm
+        env:
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+          INSTANCE_ID: ${{ steps.instance.outputs.instance_id }}
+        run: |
+          set -euo pipefail
+          CMD_ID=$(aws ssm send-command \
+            --instance-ids "$INSTANCE_ID" \
+            --document-name AWS-RunShellScript \
+            --comment "demo deploy $TAG" \
+            --parameters "commands=[\"cd /opt/raven && git fetch --tags && git checkout $TAG && bash deploy/ec2/update.sh --tag $TAG\"]" \
+            --timeout-seconds 1800 \
+            --query 'Command.CommandId' --output text)
+          echo "command_id=$CMD_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for SSM command to complete
+        env:
+          CMD_ID: ${{ steps.ssm.outputs.command_id }}
+          INSTANCE_ID: ${{ steps.instance.outputs.instance_id }}
+        run: |
+          set -euo pipefail
+          for i in {1..60}; do
+            STATUS=$(aws ssm get-command-invocation \
+              --command-id "$CMD_ID" --instance-id "$INSTANCE_ID" \
+              --query Status --output text)
+            echo "[$i] Status: $STATUS"
+            case "$STATUS" in
+              Success) exit 0 ;;
+              Failed|Cancelled|TimedOut)
+                aws ssm get-command-invocation \
+                  --command-id "$CMD_ID" --instance-id "$INSTANCE_ID" \
+                  --query '{stdout:StandardOutputContent,stderr:StandardErrorContent}'
+                exit 1
+                ;;
+            esac
+            sleep 30
+          done
+          echo "Timed out waiting for SSM command"
+          exit 1
+
+      - name: Smoke-test /healthz
+        run: |
+          for i in {1..20}; do
+            if curl -fsS https://demo.raven.ravencloak.org/healthz; then
+              echo "OK"; exit 0
+            fi
+            sleep 15
+          done
+          echo "Health check never went green"
+          exit 1

--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -119,3 +119,25 @@ jobs:
           done
           echo "Health check never went green"
           exit 1
+
+  notify:
+    needs: deploy
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send result email via Resend API
+        env:
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+          OUTCOME: ${{ needs.deploy.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          curl -fsS -X POST https://api.resend.com/emails \
+            -H "Authorization: Bearer $RESEND_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"from\": \"noreply@ravencloak.org\",
+              \"to\": [\"jobinlawrance@gmail.com\"],
+              \"subject\": \"[demo] $TAG deploy $OUTCOME\",
+              \"text\": \"Tag: $TAG\\nResult: $OUTCOME\\nRun: $RUN_URL\"
+            }"

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,9 @@ bin/api-cover
 
 # Test results
 frontend/test-results/
+
+# Terraform
+**/.terraform/
+*.tfstate
+*.tfstate.backup
+*.tfplan

--- a/ai-worker/pyproject.toml
+++ b/ai-worker/pyproject.toml
@@ -88,3 +88,8 @@ fail_under = 70
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+
+[dependency-groups]
+dev = [
+    "fakeredis>=2.35.1",
+]

--- a/ai-worker/raven_worker/config.py
+++ b/ai-worker/raven_worker/config.py
@@ -41,6 +41,10 @@ class Settings(BaseSettings):
     # ordering out of the box.
     retrieval_rrf_k: int = 60
     retrieval_default_top_n: int = 10
+    # Demo daily LLM spend ceiling in USD. The LLMSpendFuse refuses to
+    # charge once the running total for the current UTC day exceeds this
+    # value, returning a "demo limit reached" error to the caller.
+    llm_daily_usd_cap: float = 5.00
     model_config = SettingsConfigDict(env_prefix="RAVEN_")
 
 

--- a/ai-worker/raven_worker/llm_fuse.py
+++ b/ai-worker/raven_worker/llm_fuse.py
@@ -1,0 +1,99 @@
+"""Daily LLM spend circuit breaker backed by Redis/Valkey.
+
+The counter is keyed by UTC date and given a 26-hour TTL so the value
+expires cleanly even across DST transitions. Reads use ``GET`` (and
+parse the returned bytes as a float); writes use ``INCRBYFLOAT``.
+
+Two entry points:
+
+* :meth:`LLMSpendFuse.guard` — check whether charging ``estimated_cost``
+  would exceed the cap. Raises :class:`FuseTripped` without mutating
+  state. Call this *before* issuing the LLM request.
+* :meth:`LLMSpendFuse.charge` — atomically add ``actual_cost`` to the
+  counter and raise :class:`FuseTripped` if the new total crossed the
+  cap. Call this *after* the LLM response is received, with the real
+  observed cost.
+
+Using both gives correct behaviour for bursty concurrent callers: guard
+prevents new requests from starting once the cap is near, and charge is
+the source-of-truth for the running total.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Protocol
+
+
+class FuseTripped(Exception):  # noqa: N818 — domain term, "Tripped" reads more naturally than "TrippedError"
+    """Raised when the daily spend cap would be exceeded."""
+
+
+class _Redis(Protocol):
+    """Minimal Redis client surface used by LLMSpendFuse."""
+
+    def incrbyfloat(self, key: str, amount: float) -> float: ...
+    def expire(self, key: str, seconds: int) -> bool: ...
+    def get(self, key: str) -> bytes | None: ...
+
+
+class LLMSpendFuse:
+    """Daily $-cap circuit breaker.
+
+    Args:
+        redis: A Redis/Valkey client implementing :class:`_Redis`.
+        daily_cap_usd: Hard ceiling in dollars for the current UTC day.
+        key_prefix: Base for the counter key. The current ``YYYYMMDD``
+            is appended so a new counter starts at UTC midnight.
+    """
+
+    # 26 hours covers DST shifts and clock skew while still guaranteeing
+    # the counter expires before the next-next day's writes.
+    _TTL_SECONDS = 60 * 60 * 26
+
+    def __init__(
+        self,
+        redis: _Redis,
+        daily_cap_usd: float,
+        key_prefix: str = "raven:llm:spend",
+    ) -> None:
+        self.redis = redis
+        self.cap = daily_cap_usd
+        self.key_prefix = key_prefix
+
+    def _key(self) -> str:
+        day = datetime.now(UTC).strftime("%Y%m%d")
+        return f"{self.key_prefix}:{day}"
+
+    def spent_today(self) -> float:
+        """Return the running total in USD for the current UTC day."""
+        raw = self.redis.get(self._key())
+        return float(raw) if raw else 0.0
+
+    def guard(self, estimated_cost_usd: float) -> None:
+        """Raise :class:`FuseTripped` if charging would exceed the cap.
+
+        Does not mutate state. Safe to call from many concurrent callers
+        — only the actual :meth:`charge` is authoritative.
+        """
+        if self.spent_today() + estimated_cost_usd > self.cap:
+            raise FuseTripped(
+                f"Daily LLM cap ${self.cap:.2f} would be exceeded "
+                f"(spent ${self.spent_today():.4f}, "
+                f"+${estimated_cost_usd:.4f})"
+            )
+
+    def charge(self, actual_cost_usd: float) -> None:
+        """Add ``actual_cost_usd`` to the counter.
+
+        Raises :class:`FuseTripped` if the new total crossed the cap.
+        The increment is applied even when the fuse trips — the caller
+        already issued the LLM request and was billed.
+        """
+        new_total = self.redis.incrbyfloat(self._key(), actual_cost_usd)
+        self.redis.expire(self._key(), self._TTL_SECONDS)
+        if float(new_total) > self.cap:
+            raise FuseTripped(
+                f"Daily LLM cap ${self.cap:.2f} exceeded "
+                f"(total ${new_total:.4f})"
+            )

--- a/ai-worker/tests/test_llm_fuse.py
+++ b/ai-worker/tests/test_llm_fuse.py
@@ -1,0 +1,55 @@
+"""Tests for the LLMSpendFuse daily $-cap circuit breaker."""
+
+from __future__ import annotations
+
+import fakeredis
+import pytest
+
+from raven_worker.llm_fuse import FuseTripped, LLMSpendFuse
+
+
+@pytest.fixture
+def fuse() -> LLMSpendFuse:
+    r = fakeredis.FakeRedis()
+    return LLMSpendFuse(redis=r, daily_cap_usd=1.0, key_prefix="test:llm")
+
+
+def test_charge_below_cap_allowed(fuse: LLMSpendFuse) -> None:
+    fuse.charge(0.30)
+    fuse.charge(0.40)
+    assert fuse.spent_today() == pytest.approx(0.70)
+
+
+def test_charge_over_cap_trips(fuse: LLMSpendFuse) -> None:
+    fuse.charge(0.60)
+    fuse.charge(0.30)
+    with pytest.raises(FuseTripped):
+        fuse.charge(0.20)
+
+
+def test_guard_check_only_does_not_increment(fuse: LLMSpendFuse) -> None:
+    fuse.charge(0.60)
+    fuse.guard(0.30)  # would still be under cap; no increment
+    assert fuse.spent_today() == pytest.approx(0.60)
+
+
+def test_guard_raises_when_would_exceed(fuse: LLMSpendFuse) -> None:
+    fuse.charge(0.80)
+    with pytest.raises(FuseTripped):
+        fuse.guard(0.30)
+
+
+def test_spent_today_empty_returns_zero(fuse: LLMSpendFuse) -> None:
+    assert fuse.spent_today() == 0.0
+
+
+def test_charge_sets_ttl_on_counter() -> None:
+    r = fakeredis.FakeRedis()
+    fuse = LLMSpendFuse(redis=r, daily_cap_usd=10.0, key_prefix="ttl-check")
+    fuse.charge(0.10)
+    # find the day-keyed counter and verify TTL was set
+    keys = list(r.scan_iter("ttl-check:*"))
+    assert len(keys) == 1
+    ttl = r.ttl(keys[0])
+    # TTL should be the 26-hour ceiling we set; allow a slack of 60 seconds.
+    assert 26 * 3600 - 60 <= ttl <= 26 * 3600

--- a/ai-worker/uv.lock
+++ b/ai-worker/uv.lock
@@ -602,6 +602,19 @@ wheels = [
 ]
 
 [[package]]
+name = "fakeredis"
+version = "2.35.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "redis" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/50/b748233c02fa77e5105238190cc9bb58b852eb1c8b1d0763230d3a5b745a/fakeredis-2.35.1.tar.gz", hash = "sha256:5bae5eba7b9d93cb968944ac40936373cf2397ff71667d4b595df65c3d2e413f", size = 189118, upload-time = "2026-04-12T17:05:58.539Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/27/b8b057a23f7777177e92d3a602fd866751b6b45014964548997e92e048fd/fakeredis-2.35.1-py3-none-any.whl", hash = "sha256:67d97e11f562b7870e11e5c30cf182270bfb2dd37f6707dba47cc6d91628d1b9", size = 129678, upload-time = "2026-04-12T17:05:56.86Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.136.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2249,6 +2262,11 @@ dev = [
     { name = "ruff" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "fakeredis" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.40.0" },
@@ -2286,6 +2304,9 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
 ]
 provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "fakeredis", specifier = ">=2.35.1" }]
 
 [[package]]
 name = "redis"
@@ -2398,6 +2419,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -27,6 +27,7 @@ import (
 	"log"
 	"log/slog"
 	"net/http"
+	"os"
 	"os/signal"
 	"syscall"
 	"time"
@@ -48,6 +49,7 @@ import (
 	"github.com/ravencloak-org/Raven/internal/handler"
 	"github.com/ravencloak-org/Raven/internal/resilience"
 	"github.com/ravencloak-org/Raven/internal/hyperswitch"
+	"github.com/ravencloak-org/Raven/internal/mail"
 	"github.com/ravencloak-org/Raven/internal/middleware"
 	"github.com/ravencloak-org/Raven/internal/model"
 	"github.com/ravencloak-org/Raven/internal/posthog"
@@ -498,6 +500,22 @@ func main() {
 	notifHandler := handler.NewNotificationHandler(notifSvc)
 	notifPrefsRepo := repository.NewNotificationPreferencesRepository(pool)
 	notifPrefsHandler := handler.NewNotificationPrefsHandler(notifPrefsRepo, &userExternalIDResolver{repo: userRepo}, cfg.EmailSummary.UnsubscribeSecret)
+
+	// Demo transactional mailer (Resend HTTP API). Used by DSAR delete
+	// confirmations and the retention purge warning emails. Distinct from
+	// internal/email (SES SMTP) which serves the M9 post-session summary
+	// pipeline — see docs/superpowers/specs/2026-05-12-public-demo-deployment-design.md §8.
+	var demoMailer mail.Sender
+	if key := os.Getenv("RESEND_API_KEY"); key != "" {
+		from := os.Getenv("RESEND_FROM_ADDRESS")
+		if from == "" {
+			from = "noreply@ravencloak.org"
+		}
+		demoMailer = mail.NewResendSender(key, from)
+	} else {
+		demoMailer = &mail.NoopSender{}
+	}
+	_ = demoMailer // consumed by DSAR + retention wiring (plan #3 task 40)
 	webhookHandler := handler.NewWebhookHandler(webhookSvc)
 	chatHandler := handler.NewChatHandler(chatSvc)
 	semCacheHandler := handler.NewSemanticCacheHandler(semCacheRepo)

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	_ "github.com/ravencloak-org/Raven/docs/swagger" // swagger docs
+	"github.com/ravencloak-org/Raven/internal/account"
 	"github.com/ravencloak-org/Raven/internal/auth"
 	"github.com/ravencloak-org/Raven/internal/cache"
 	"github.com/ravencloak-org/Raven/internal/config"
@@ -515,7 +516,14 @@ func main() {
 	} else {
 		demoMailer = &mail.NoopSender{}
 	}
-	_ = demoMailer // consumed by DSAR + retention wiring (plan #3 task 40)
+
+	// DSAR handlers — wired in the /api/v1 group below. The repo's
+	// HardDelete is currently gated (see internal/account/repo_sql.go);
+	// ScheduleDelete + ExportUser + retention warning paths are live.
+	accountRepo := account.NewSQLRepo(pool)
+	dsarHandler := account.NewDSARHandler(accountRepo, demoMailer)
+	retentionPurger := account.NewRetentionPurger(accountRepo, demoMailer)
+	_ = retentionPurger // exposed via /api/v1/admin/retention/run once admin auth gate is decided (spec §6)
 	webhookHandler := handler.NewWebhookHandler(webhookSvc)
 	chatHandler := handler.NewChatHandler(chatSvc)
 	semCacheHandler := handler.NewSemanticCacheHandler(semCacheRepo)
@@ -875,6 +883,34 @@ func main() {
 		api.PUT("/me/notification-preferences/:ws_id", resolveWSRole, notifPrefsHandler.UpsertUserPreference)
 		api.GET("/users/:user_id", middleware.RequireOrgRole("org_admin"), userHandler.GetUser)
 
+		// --- DSAR routes ---
+		// GET /account/export → JSON download of the caller's data.
+		// POST /account/delete → schedules 24h-grace hard delete and emails
+		// the user for confirmation. Distinct from DELETE /me (immediate
+		// soft-delete) — the demo's privacy posture promises explicit
+		// erasure with a cooling-off window.
+		api.GET("/account/export", func(c *gin.Context) {
+			uid := c.GetString(string(middleware.ContextKeyUserID))
+			if uid == "" {
+				c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthenticated"})
+				return
+			}
+			r := c.Request.WithContext(account.WithUserID(c.Request.Context(), uid))
+			dsarHandler.Export(c.Writer, r)
+		})
+		api.POST("/account/delete", func(c *gin.Context) {
+			uid := c.GetString(string(middleware.ContextKeyUserID))
+			if uid == "" {
+				c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthenticated"})
+				return
+			}
+			ctx := account.WithUserID(c.Request.Context(), uid)
+			if u, err := userRepo.GetByID(c.Request.Context(), uid); err == nil && u != nil {
+				ctx = account.WithUserEmail(ctx, u.Email)
+			}
+			r := c.Request.WithContext(ctx)
+			dsarHandler.Delete(c.Writer, r)
+		})
 	}
 
 	// Public chat routes — API key authentication (for embeddable chat widget).

--- a/deploy/ansible/group_vars/demo.yml
+++ b/deploy/ansible/group_vars/demo.yml
@@ -1,0 +1,22 @@
+---
+# Demo-specific Ansible variables. Loaded explicitly by cloud-init.
+raven_env: demo
+raven_domain: demo.raven.ravencloak.org
+raven_observability_domain: observability.demo.raven.ravencloak.org
+
+# Compose overlay file applied on top of docker-compose.yml
+raven_compose_overlay: docker-compose.demo.yml
+
+# Voice services kept running but UI hidden
+raven_voice_enabled: false
+
+# LLM cost fuse
+raven_llm_daily_usd_cap: "{{ lookup('env', 'RAVEN_LLM_DAILY_USD_CAP') | default('5.00', true) }}"
+
+# Backup config
+raven_backup_s3_bucket: raven-demo-backups
+raven_backup_pg_schedule: "*-*-* 18:30:00"        # 18:30 UTC daily
+raven_backup_clickhouse_schedule: "*-*-* 19:00:00" # 19:00 UTC daily
+
+# Cloudflared
+cloudflared_credentials_path: /etc/cloudflared

--- a/deploy/ansible/playbook.yml
+++ b/deploy/ansible/playbook.yml
@@ -11,4 +11,5 @@
     - pm2
     - cloudflared
     - raven-stack
+    - raven-backup
     - admin-tools

--- a/deploy/ansible/roles/raven-backup/files/raven-clickhouse-backup.service
+++ b/deploy/ansible/roles/raven-backup/files/raven-clickhouse-backup.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Raven ClickHouse backup to S3
+Wants=network-online.target docker.service
+After=raven-pg-backup.service
+
+[Service]
+Type=oneshot
+EnvironmentFile=/etc/raven/env
+ExecStart=/usr/local/bin/raven-clickhouse-backup.sh raven-demo-backups
+StandardOutput=journal
+StandardError=journal

--- a/deploy/ansible/roles/raven-backup/files/raven-clickhouse-backup.sh
+++ b/deploy/ansible/roles/raven-backup/files/raven-clickhouse-backup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+S3_BUCKET="${1:-raven-demo-backups}"
+DATE=$(date -u +%Y-%m-%dT%H-%M-%SZ)
+BACKUP_NAME="clickhouse-$DATE"
+
+docker exec raven-clickhouse-1 clickhouse-backup create "$BACKUP_NAME"
+docker exec raven-clickhouse-1 clickhouse-backup upload "$BACKUP_NAME"
+docker exec raven-clickhouse-1 clickhouse-backup delete local "$BACKUP_NAME"
+
+echo "OK: uploaded clickhouse $BACKUP_NAME"

--- a/deploy/ansible/roles/raven-backup/files/raven-clickhouse-backup.timer
+++ b/deploy/ansible/roles/raven-backup/files/raven-clickhouse-backup.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Raven ClickHouse backup timer
+
+[Timer]
+OnCalendar=*-*-* 19:00:00 UTC
+RandomizedDelaySec=300
+Persistent=true
+Unit=raven-clickhouse-backup.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/ansible/roles/raven-backup/files/raven-pg-backup.service
+++ b/deploy/ansible/roles/raven-backup/files/raven-pg-backup.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Raven Postgres logical backup to S3
+Wants=network-online.target docker.service
+After=network-online.target docker.service
+
+[Service]
+Type=oneshot
+EnvironmentFile=/etc/raven/env
+ExecStart=/usr/local/bin/raven-pg-backup.sh raven-demo-backups
+StandardOutput=journal
+StandardError=journal

--- a/deploy/ansible/roles/raven-backup/files/raven-pg-backup.sh
+++ b/deploy/ansible/roles/raven-backup/files/raven-pg-backup.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+S3_BUCKET="${1:-raven-demo-backups}"
+DATE=$(date -u +%Y-%m-%dT%H-%M-%SZ)
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+DUMP="$TMP/postgres-$DATE.dump"
+
+docker exec raven-postgres-1 pg_dump -U raven -d raven -Fc > "$DUMP"
+
+if [ ! -s "$DUMP" ]; then
+  echo "ERROR: pg_dump produced an empty file" >&2
+  exit 1
+fi
+
+aws s3 cp "$DUMP" "s3://$S3_BUCKET/postgres/postgres-$DATE.dump"
+echo "OK: uploaded postgres/postgres-$DATE.dump"

--- a/deploy/ansible/roles/raven-backup/files/raven-pg-backup.timer
+++ b/deploy/ansible/roles/raven-backup/files/raven-pg-backup.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Raven Postgres backup timer
+
+[Timer]
+OnCalendar=*-*-* 18:30:00 UTC
+RandomizedDelaySec=300
+Persistent=true
+Unit=raven-pg-backup.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/ansible/roles/raven-backup/tasks/main.yml
+++ b/deploy/ansible/roles/raven-backup/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+- name: Install pg backup script
+  ansible.builtin.copy:
+    src: raven-pg-backup.sh
+    dest: /usr/local/bin/raven-pg-backup.sh
+    mode: "0755"
+
+- name: Install pg backup service
+  ansible.builtin.copy:
+    src: raven-pg-backup.service
+    dest: /etc/systemd/system/raven-pg-backup.service
+    mode: "0644"
+
+- name: Install pg backup timer
+  ansible.builtin.copy:
+    src: raven-pg-backup.timer
+    dest: /etc/systemd/system/raven-pg-backup.timer
+    mode: "0644"
+
+- name: Enable pg backup timer
+  ansible.builtin.systemd:
+    name: raven-pg-backup.timer
+    enabled: true
+    state: started
+    daemon_reload: true

--- a/deploy/ansible/roles/raven-backup/tasks/main.yml
+++ b/deploy/ansible/roles/raven-backup/tasks/main.yml
@@ -23,3 +23,28 @@
     enabled: true
     state: started
     daemon_reload: true
+
+- name: Install clickhouse backup script
+  ansible.builtin.copy:
+    src: raven-clickhouse-backup.sh
+    dest: /usr/local/bin/raven-clickhouse-backup.sh
+    mode: "0755"
+
+- name: Install clickhouse backup service
+  ansible.builtin.copy:
+    src: raven-clickhouse-backup.service
+    dest: /etc/systemd/system/raven-clickhouse-backup.service
+    mode: "0644"
+
+- name: Install clickhouse backup timer
+  ansible.builtin.copy:
+    src: raven-clickhouse-backup.timer
+    dest: /etc/systemd/system/raven-clickhouse-backup.timer
+    mode: "0644"
+
+- name: Enable clickhouse backup timer
+  ansible.builtin.systemd:
+    name: raven-clickhouse-backup.timer
+    enabled: true
+    state: started
+    daemon_reload: true

--- a/deploy/ec2/.env.example
+++ b/deploy/ec2/.env.example
@@ -60,3 +60,4 @@ OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic <base64(email:password)>,organiza
 # Updated automatically by deploy/ec2/update.sh
 GO_API_IMAGE=ghcr.io/ravencloak-org/go-api:latest
 PYTHON_WORKER_IMAGE=ghcr.io/ravencloak-org/python-worker:latest
+FRONTEND_IMAGE=ghcr.io/ravencloak-org/frontend:latest

--- a/deploy/ec2/update.sh
+++ b/deploy/ec2/update.sh
@@ -3,7 +3,8 @@
 #
 # Usage:
 #   ./deploy/ec2/update.sh
-#   ./deploy/ec2/update.sh --sha abc1234   # pin to a specific commit SHA
+#   ./deploy/ec2/update.sh --sha abc1234     # pin to a specific commit SHA
+#   ./deploy/ec2/update.sh --tag v0.3.0      # pin to a release tag
 
 set -euo pipefail
 
@@ -12,15 +13,37 @@ COMPOSE="docker -H ${RAVEN_SOCK} compose"
 ENV_FILE=".env.server"
 COMPOSE_FILE="deploy/ec2/docker-compose.server.yml"
 
-SHA="${1:-}"
-if [[ "$SHA" == "--sha" ]]; then
-  SHA="$2"
-  GO_API_IMAGE="ghcr.io/ravencloak-org/go-api:${SHA}"
-  PYTHON_WORKER_IMAGE="ghcr.io/ravencloak-org/python-worker:${SHA}"
-  # Patch env file
+REF=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --sha)
+      REF="sha-${2::7}"
+      shift 2
+      ;;
+    --tag)
+      REF="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -n "${REF}" ]; then
+  GO_API_IMAGE="ghcr.io/ravencloak-org/go-api:${REF}"
+  PYTHON_WORKER_IMAGE="ghcr.io/ravencloak-org/python-worker:${REF}"
+  FRONTEND_IMAGE="ghcr.io/ravencloak-org/frontend:${REF}"
+
   sed -i "s|^GO_API_IMAGE=.*|GO_API_IMAGE=${GO_API_IMAGE}|" "$ENV_FILE"
   sed -i "s|^PYTHON_WORKER_IMAGE=.*|PYTHON_WORKER_IMAGE=${PYTHON_WORKER_IMAGE}|" "$ENV_FILE"
-  echo "Pinned to SHA: ${SHA}"
+  if grep -q '^FRONTEND_IMAGE=' "$ENV_FILE"; then
+    sed -i "s|^FRONTEND_IMAGE=.*|FRONTEND_IMAGE=${FRONTEND_IMAGE}|" "$ENV_FILE"
+  else
+    echo "FRONTEND_IMAGE=${FRONTEND_IMAGE}" >> "$ENV_FILE"
+  fi
+  echo "Pinned to ref: ${REF}"
 fi
 
 echo "Pulling latest images..."

--- a/deploy/terraform/demo/.terraform.lock.hcl
+++ b/deploy/terraform/demo/.terraform.lock.hcl
@@ -1,0 +1,48 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/cloudflare/cloudflare" {
+  version     = "4.52.7"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:uUUa9dY0XQOycI8pxg16PFFtL0WCTi9uEJz8trTQ7pU=",
+    "zh:0c904ce31a4c6c4a5b3bf7ff1560e77c0cc7e2450c8553ded8e8c90398e1418b",
+    "zh:36183d310c36373fe4cb936b83c595c6fd3b0a94bc7827f28e5789ccbf59752e",
+    "zh:556a568a6f0235e8f41647de9e4d3a1e7b1d6502df8b19b54ec441f1c653ea10",
+    "zh:633ebbd5b0245e75e500ef9be4d9e62288f97e8da3baaa51323892a786d90285",
+    "zh:6acfe60cf52a65ba8f044f748548d2119e7f4fd7f8ebcb14698960d87c68f529",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:904acc31ebb9d6ef68c792074b30532ee61bf515f19e0a3c75b46f126cca1f13",
+    "zh:a1d0a81246afc8750286d3f6fe7a8fbe6460dd2662407b28dbfbabb612e5fa9d",
+    "zh:a41a36fe253fc365fe2b7ffc749624688b2693b4634862fda161179ab100029f",
+    "zh:a7ef269e77ffa8715c8945a2c14322c7ff159ea44c15f62505f3cbb2cae3b32d",
+    "zh:b01aa3bed30610633b762df64332b26f8844a68c3960cebcb30f04918efc67fe",
+    "zh:b069cc2cd18cae10757df3ae030508eac8d55de7e49eda7a5e3e11f2f7fe6455",
+    "zh:b2d2c6313729ebb7465dceece374049e2d08bda34473901be9ff46a8836d42b2",
+    "zh:db0e114edaf4bc2f3d4769958807c83022bfbc619a00bdf4c4bd17faa4ab2d8b",
+    "zh:ecc0aa8b9044f664fd2aaf8fa992d976578f78478980555b4b8f6148e8d1a5fe",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/deploy/terraform/demo/backup.tf
+++ b/deploy/terraform/demo/backup.tf
@@ -1,0 +1,51 @@
+resource "aws_backup_vault" "demo" {
+  name = "${local.name_prefix}-vault"
+  tags = local.tags
+}
+
+resource "aws_iam_role" "backup" {
+  name = "${local.name_prefix}-backup"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "backup.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "backup" {
+  role       = aws_iam_role.backup.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup"
+}
+
+resource "aws_backup_plan" "demo" {
+  name = "${local.name_prefix}-daily"
+
+  rule {
+    rule_name         = "daily-ebs"
+    target_vault_name = aws_backup_vault.demo.name
+    schedule          = "cron(0 18 * * ? *)" # 18:00 UTC = 23:30 IST
+    lifecycle {
+      delete_after = 14
+    }
+  }
+
+  tags = local.tags
+}
+
+resource "aws_backup_selection" "demo" {
+  iam_role_arn = aws_iam_role.backup.arn
+  name         = "${local.name_prefix}-selection"
+  plan_id      = aws_backup_plan.demo.id
+
+  selection_tag {
+    type  = "STRINGEQUALS"
+    key   = "BackupPlan"
+    value = "raven-demo-daily"
+  }
+}

--- a/deploy/terraform/demo/cloudflare.tf
+++ b/deploy/terraform/demo/cloudflare.tf
@@ -1,0 +1,116 @@
+resource "random_id" "tunnel_secret" {
+  byte_length = 35
+}
+
+resource "cloudflare_tunnel" "demo" {
+  account_id = var.cloudflare_account_id
+  name       = "raven-demo"
+  secret     = random_id.tunnel_secret.b64_std
+}
+
+resource "cloudflare_tunnel_config" "demo" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_tunnel.demo.id
+
+  config {
+    ingress_rule {
+      hostname = var.demo_hostname
+      service  = "http://localhost:8180"
+      path     = "/api/.*"
+    }
+    ingress_rule {
+      hostname = var.demo_hostname
+      service  = "http://localhost:8080"
+    }
+    ingress_rule {
+      hostname = var.observability_hostname
+      service  = "http://localhost:5080"
+    }
+    ingress_rule {
+      service = "http_status:404"
+    }
+  }
+}
+
+resource "cloudflare_record" "demo" {
+  zone_id = var.cloudflare_zone_id
+  name    = var.demo_hostname
+  content = "${cloudflare_tunnel.demo.id}.cfargotunnel.com"
+  type    = "CNAME"
+  proxied = true
+}
+
+resource "cloudflare_record" "observability" {
+  zone_id = var.cloudflare_zone_id
+  name    = var.observability_hostname
+  content = "${cloudflare_tunnel.demo.id}.cfargotunnel.com"
+  type    = "CNAME"
+  proxied = true
+}
+
+# Cloudflare Access: gate observability subdomain to your email only
+resource "cloudflare_access_application" "observability" {
+  account_id       = var.cloudflare_account_id
+  name             = "raven-demo-observability"
+  domain           = var.observability_hostname
+  session_duration = "24h"
+}
+
+resource "cloudflare_access_policy" "observability_allow" {
+  account_id     = var.cloudflare_account_id
+  application_id = cloudflare_access_application.observability.id
+  name           = "allow-operator"
+  precedence     = 1
+  decision       = "allow"
+
+  include {
+    email = [var.access_email]
+  }
+}
+
+# Phase 1 gate on the whole demo hostname — set var.phase1_access_enabled=false to lift.
+variable "phase1_access_enabled" {
+  description = "Set true during Phase 1 to gate demo.* behind Cloudflare Access"
+  type        = bool
+  default     = true
+}
+
+resource "cloudflare_access_application" "demo_phase1" {
+  count            = var.phase1_access_enabled ? 1 : 0
+  account_id       = var.cloudflare_account_id
+  name             = "raven-demo-phase1"
+  domain           = var.demo_hostname
+  session_duration = "24h"
+}
+
+resource "cloudflare_access_policy" "demo_phase1_allow" {
+  count          = var.phase1_access_enabled ? 1 : 0
+  account_id     = var.cloudflare_account_id
+  application_id = cloudflare_access_application.demo_phase1[0].id
+  name           = "allow-operator"
+  precedence     = 1
+  decision       = "allow"
+
+  include {
+    email = [var.access_email]
+  }
+}
+
+# Persist tunnel credentials to SSM so the EC2 box can fetch them at cloud-init.
+resource "aws_ssm_parameter" "tunnel_credentials" {
+  name = "/raven/demo/cloudflared_credentials_json"
+  type = "SecureString"
+  value = jsonencode({
+    AccountTag   = var.cloudflare_account_id
+    TunnelID     = cloudflare_tunnel.demo.id
+    TunnelSecret = random_id.tunnel_secret.b64_std
+  })
+  tags = local.tags
+}
+
+resource "aws_ssm_parameter" "tunnel_id" {
+  name  = "/raven/demo/cloudflared_tunnel_id"
+  type  = "String"
+  value = cloudflare_tunnel.demo.id
+  tags  = local.tags
+}

--- a/deploy/terraform/demo/ebs.tf
+++ b/deploy/terraform/demo/ebs.tf
@@ -1,0 +1,20 @@
+resource "aws_ebs_volume" "data" {
+  availability_zone = "${var.aws_region}a"
+  size              = var.data_volume_size_gb
+  type              = "gp3"
+  encrypted         = true
+  tags = merge(local.tags, {
+    Name       = "${local.name_prefix}-data"
+    BackupPlan = "raven-demo-daily"
+  })
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_volume_attachment" "data" {
+  device_name = "/dev/sdf"
+  volume_id   = aws_ebs_volume.data.id
+  instance_id = aws_instance.demo.id
+}

--- a/deploy/terraform/demo/ec2.tf
+++ b/deploy/terraform/demo/ec2.tf
@@ -1,0 +1,32 @@
+resource "aws_instance" "demo" {
+  ami                    = data.aws_ami.al2023_arm.id
+  instance_type          = var.instance_type
+  subnet_id              = aws_subnet.demo.id
+  vpc_security_group_ids = [aws_security_group.demo.id]
+  iam_instance_profile   = aws_iam_instance_profile.demo.name
+
+  root_block_device {
+    volume_size = 30
+    volume_type = "gp3"
+    encrypted   = true
+  }
+
+  user_data = templatefile("${path.module}/user_data.sh.tpl", {
+    aws_region = var.aws_region
+    deploy_tag = var.deploy_tag
+  })
+
+  metadata_options {
+    http_tokens   = "required"
+    http_endpoint = "enabled"
+  }
+
+  tags = merge(local.tags, { Name = "${local.name_prefix}-app" })
+
+  lifecycle {
+    ignore_changes = [
+      ami,       # don't replace box when AL2023 publishes a new image
+      user_data, # cloud-init runs once; later changes are via Ansible/deploy
+    ]
+  }
+}

--- a/deploy/terraform/demo/iam.tf
+++ b/deploy/terraform/demo/iam.tf
@@ -1,0 +1,74 @@
+resource "aws_iam_role" "demo" {
+  name = "${local.name_prefix}-instance"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "ssm_core" {
+  role       = aws_iam_role.demo.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role_policy" "ssm_read" {
+  name = "ssm-read-demo-params"
+  role = aws_iam_role.demo.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "ssm:GetParameter",
+        "ssm:GetParameters",
+        "ssm:GetParametersByPath"
+      ]
+      Resource = "arn:aws:ssm:${var.aws_region}:*:parameter/raven/demo/*"
+      }, {
+      Effect   = "Allow"
+      Action   = "kms:Decrypt"
+      Resource = "*"
+      Condition = {
+        StringEquals = {
+          "kms:ViaService" = "ssm.${var.aws_region}.amazonaws.com"
+        }
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "s3_backups" {
+  name = "s3-write-backups"
+  role = aws_iam_role.demo.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:ListBucket",
+        "s3:DeleteObject"
+      ]
+      Resource = [
+        aws_s3_bucket.backups.arn,
+        "${aws_s3_bucket.backups.arn}/*"
+      ]
+    }]
+  })
+}
+
+resource "aws_iam_instance_profile" "demo" {
+  name = "${local.name_prefix}-instance"
+  role = aws_iam_role.demo.name
+  tags = local.tags
+}

--- a/deploy/terraform/demo/main.tf
+++ b/deploy/terraform/demo/main.tf
@@ -1,0 +1,29 @@
+provider "aws" {
+  region = var.aws_region
+}
+
+provider "cloudflare" {
+  # CLOUDFLARE_API_TOKEN env var is read automatically
+}
+
+locals {
+  name_prefix = "raven-demo"
+  tags = {
+    Project     = "raven"
+    Environment = "demo"
+    ManagedBy   = "terraform"
+  }
+}
+
+data "aws_ami" "al2023_arm" {
+  most_recent = true
+  owners      = [var.ami_owner]
+  filter {
+    name   = "name"
+    values = ["al2023-ami-2023*-arm64"]
+  }
+  filter {
+    name   = "architecture"
+    values = ["arm64"]
+  }
+}

--- a/deploy/terraform/demo/oidc.tf
+++ b/deploy/terraform/demo/oidc.tf
@@ -1,0 +1,81 @@
+# GitHub Actions OIDC provider (one per AWS account; create if absent)
+data "aws_iam_openid_connect_provider" "github" {
+  url = "https://token.actions.githubusercontent.com"
+}
+
+# If the provider does not yet exist, comment the data source above and
+# uncomment this resource:
+# resource "aws_iam_openid_connect_provider" "github" {
+#   url             = "https://token.actions.githubusercontent.com"
+#   client_id_list  = ["sts.amazonaws.com"]
+#   thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+# }
+
+resource "aws_iam_role" "github_demo_deploy" {
+  name = "${local.name_prefix}-github-deploy"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Federated = data.aws_iam_openid_connect_provider.github.arn
+      }
+      Action = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+        }
+        StringLike = {
+          "token.actions.githubusercontent.com:sub" = "repo:ravencloak-org/Raven:ref:refs/tags/v*"
+        }
+      }
+    }]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy" "github_demo_deploy" {
+  name = "ssm-send-command-demo"
+  role = aws_iam_role.github_demo_deploy.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ssm:SendCommand",
+          "ssm:GetCommandInvocation",
+          "ssm:ListCommandInvocations"
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "aws:ResourceTag/Environment" = "demo"
+          }
+        }
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["ssm:SendCommand"]
+        Resource = "arn:aws:ssm:*::document/AWS-RunShellScript"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ec2:DescribeInstances",
+          "ssm:GetCommandInvocation",
+          "ssm:ListCommandInvocations"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+output "github_deploy_role_arn" {
+  description = "ARN of the role GitHub Actions assumes for demo deploys"
+  value       = aws_iam_role.github_demo_deploy.arn
+}

--- a/deploy/terraform/demo/outputs.tf
+++ b/deploy/terraform/demo/outputs.tf
@@ -1,0 +1,24 @@
+output "instance_id" {
+  description = "EC2 instance id"
+  value       = aws_instance.demo.id
+}
+
+output "instance_role_arn" {
+  description = "ARN of the instance role"
+  value       = aws_iam_role.demo.arn
+}
+
+output "backup_bucket" {
+  description = "S3 bucket holding logical backups"
+  value       = aws_s3_bucket.backups.id
+}
+
+output "data_volume_id" {
+  description = "EBS volume ID for /var/lib/raven-data"
+  value       = aws_ebs_volume.data.id
+}
+
+output "tunnel_id" {
+  description = "Cloudflare Tunnel UUID"
+  value       = cloudflare_tunnel.demo.id
+}

--- a/deploy/terraform/demo/s3.tf
+++ b/deploy/terraform/demo/s3.tf
@@ -1,0 +1,42 @@
+resource "aws_s3_bucket" "backups" {
+  bucket = "${local.name_prefix}-backups"
+  tags   = local.tags
+}
+
+resource "aws_s3_bucket_versioning" "backups" {
+  bucket = aws_s3_bucket.backups.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "backups" {
+  bucket = aws_s3_bucket.backups.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "backups" {
+  bucket                  = aws_s3_bucket.backups.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "backups" {
+  bucket = aws_s3_bucket.backups.id
+  rule {
+    id     = "expire-old-backups"
+    status = "Enabled"
+    expiration {
+      days = 30
+    }
+    noncurrent_version_expiration {
+      noncurrent_days = 7
+    }
+  }
+}

--- a/deploy/terraform/demo/security_group.tf
+++ b/deploy/terraform/demo/security_group.tf
@@ -1,0 +1,15 @@
+resource "aws_security_group" "demo" {
+  name        = "${local.name_prefix}-sg"
+  description = "Egress-only SG for the Raven demo box. Cloudflared dials out - no inbound."
+  vpc_id      = aws_vpc.demo.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "All outbound - needed for image pulls, Cloudflared, SSM, OAuth, LLM APIs"
+  }
+
+  tags = merge(local.tags, { Name = "${local.name_prefix}-sg" })
+}

--- a/deploy/terraform/demo/user_data.sh.tpl
+++ b/deploy/terraform/demo/user_data.sh.tpl
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -euxo pipefail
+
+# ── 1. System deps ─────────────────────────────────────────────────────────
+dnf -y update
+dnf -y install git docker ansible-core jq awscli amazon-ssm-agent
+systemctl enable --now docker
+systemctl enable --now amazon-ssm-agent
+usermod -aG docker ec2-user
+
+# ── 2. Mount data volume ──────────────────────────────────────────────────
+DEVICE=/dev/nvme1n1
+MOUNT=/var/lib/raven-data
+if ! blkid "$DEVICE"; then
+  mkfs.ext4 -L raven-data "$DEVICE"
+fi
+mkdir -p "$MOUNT"
+echo "LABEL=raven-data $MOUNT ext4 defaults,nofail 0 2" >> /etc/fstab
+mount "$MOUNT"
+
+# ── 3. Pull SSM params into /etc/raven/env ────────────────────────────────
+mkdir -p /etc/raven
+PARAMS=$(aws ssm get-parameters-by-path \
+  --region ${aws_region} \
+  --path /raven/demo \
+  --with-decryption \
+  --recursive \
+  --query 'Parameters[].[Name,Value]' --output text)
+
+: > /etc/raven/env.tmp
+while IFS=$'\t' read -r name value; do
+  key=$(basename "$name" | tr '[:lower:]' '[:upper:]')
+  # don't expose cloudflared_credentials_json this way — handled separately
+  if [ "$key" = "CLOUDFLARED_CREDENTIALS_JSON" ]; then continue; fi
+  printf '%s=%s\n' "$key" "$value" >> /etc/raven/env.tmp
+done <<< "$PARAMS"
+
+mv /etc/raven/env.tmp /etc/raven/env
+chmod 0600 /etc/raven/env
+chown root:root /etc/raven/env
+
+# ── 4. Cloudflared credentials ────────────────────────────────────────────
+mkdir -p /etc/cloudflared
+TUNNEL_ID=$(aws ssm get-parameter --region ${aws_region} \
+  --name /raven/demo/cloudflared_tunnel_id --query Parameter.Value --output text)
+aws ssm get-parameter --region ${aws_region} \
+  --name /raven/demo/cloudflared_credentials_json \
+  --with-decryption --query Parameter.Value --output text \
+  > /etc/cloudflared/$TUNNEL_ID.json
+chmod 0600 /etc/cloudflared/$TUNNEL_ID.json
+echo "TUNNEL_ID=$TUNNEL_ID" >> /etc/raven/env
+
+# ── 5. Clone repo and run Ansible ─────────────────────────────────────────
+cd /opt
+git clone https://github.com/ravencloak-org/Raven.git raven
+cd raven
+git checkout ${deploy_tag}
+
+ansible-playbook deploy/ansible/playbook.yml \
+  -i 'localhost,' -c local \
+  -e ansible_group_vars_file=group_vars/demo.yml
+
+echo "raven-stack: ok"

--- a/deploy/terraform/demo/variables.tf
+++ b/deploy/terraform/demo/variables.tf
@@ -1,0 +1,57 @@
+variable "aws_region" {
+  description = "AWS region for the demo stack"
+  type        = string
+  default     = "ap-south-1"
+}
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+  default     = "t4g.xlarge"
+}
+
+variable "data_volume_size_gb" {
+  description = "Size of /var/lib/raven-data EBS volume"
+  type        = number
+  default     = 100
+}
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID for ravencloak.org"
+  type        = string
+}
+
+variable "demo_hostname" {
+  description = "Public hostname for the demo"
+  type        = string
+  default     = "demo.raven.ravencloak.org"
+}
+
+variable "observability_hostname" {
+  description = "Public hostname for the OpenObserve UI"
+  type        = string
+  default     = "observability.demo.raven.ravencloak.org"
+}
+
+variable "access_email" {
+  description = "Email allowed through Cloudflare Access during Phase 1 and to observability"
+  type        = string
+  default     = "jobinlawrance@gmail.com"
+}
+
+variable "deploy_tag" {
+  description = "Git tag to clone at bootstrap"
+  type        = string
+  default     = "main"
+}
+
+variable "ami_owner" {
+  description = "Owner ID for Amazon Linux 2023 ARM AMI"
+  type        = string
+  default     = "amazon"
+}

--- a/deploy/terraform/demo/versions.tf
+++ b/deploy/terraform/demo/versions.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.7.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.0"
+    }
+  }
+
+  backend "s3" {
+    bucket         = "raven-tf-state"
+    key            = "demo/terraform.tfstate"
+    region         = "ap-south-1"
+    encrypt        = true
+    dynamodb_table = "raven-tf-locks"
+  }
+}

--- a/deploy/terraform/demo/vpc.tf
+++ b/deploy/terraform/demo/vpc.tf
@@ -1,0 +1,33 @@
+resource "aws_vpc" "demo" {
+  cidr_block           = "10.42.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+  tags                 = merge(local.tags, { Name = "${local.name_prefix}-vpc" })
+}
+
+resource "aws_subnet" "demo" {
+  vpc_id                  = aws_vpc.demo.id
+  cidr_block              = "10.42.1.0/24"
+  availability_zone       = "${var.aws_region}a"
+  map_public_ip_on_launch = true
+  tags                    = merge(local.tags, { Name = "${local.name_prefix}-subnet" })
+}
+
+resource "aws_internet_gateway" "demo" {
+  vpc_id = aws_vpc.demo.id
+  tags   = merge(local.tags, { Name = "${local.name_prefix}-igw" })
+}
+
+resource "aws_route_table" "demo" {
+  vpc_id = aws_vpc.demo.id
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.demo.id
+  }
+  tags = merge(local.tags, { Name = "${local.name_prefix}-rt" })
+}
+
+resource "aws_route_table_association" "demo" {
+  subnet_id      = aws_subnet.demo.id
+  route_table_id = aws_route_table.demo.id
+}

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -1,0 +1,18 @@
+# Overlay applied on top of docker-compose.yml for the public demo.
+# Voice services (livekit-server, stt, tts) remain running so the
+# python-worker's depends_on chain holds, but no Cloudflared route
+# is published for them and the frontend hides voice UI.
+services:
+  frontend:
+    environment:
+      RAVEN_VOICE_ENABLED: "false"
+      RAVEN_TURNSTILE_SITE_KEY: "${TURNSTILE_SITE_KEY}"
+
+  go-api:
+    environment:
+      RAVEN_VOICE_ENABLED: "false"
+      RAVEN_TURNSTILE_SECRET_KEY: "${TURNSTILE_SECRET_KEY}"
+
+  python-worker:
+    environment:
+      RAVEN_LLM_DAILY_USD_CAP: "${RAVEN_LLM_DAILY_USD_CAP}"

--- a/docs/runbooks/demo-app-features.md
+++ b/docs/runbooks/demo-app-features.md
@@ -1,0 +1,33 @@
+# Demo App Features — Codebase Inventory
+
+Audit date: 2026-05-13. Recorded before implementing the rest of plan #3.
+
+## Insertion points
+
+| Concept | File / path | Notes |
+|---|---|---|
+| API bootstrap (Gin engine, route registration) | `cmd/api/main.go` (line 506 `router := gin.Default()`) | All middlewares + routes assembled here. New DSAR / admin routes mount here. |
+| SuperTokens recipe init | `internal/auth/supertokens_init.go` (function `InitSuperTokens`, line 24) | Currently builds `recipeList` with `thirdparty` + `session`. No user-create hook exists yet — to fire the sample-workspace seed on signup we need to override `RecipeImpl` and wrap `SignInUpPOST` (or equivalent) and call our seeder after a successful sign-up. |
+| Auth proxy / SuperTokens HTTP catchall | `cmd/api/main.go:543` (`router.Any("/auth/*path", handler.SuperTokensMiddleware())`) | Turnstile gate has to wrap this — either add a Gin middleware in front of the same `/auth/*` group, or check `cf-turnstile-token` inside `handler.SuperTokensMiddleware()`. |
+| Python worker LLM call sites | `ai-worker/raven_worker/agent.py`, `ai-worker/raven_worker/services/rag_service.py` (Anthropic `messages.stream`, OpenAI `chat.completions.create`) | LLM-fuse guard wraps each call site. |
+| Frontend signup page | `frontend/src/pages/LoginPage.vue` | Combined login/signup page. Turnstile widget mounts here. |
+| Frontend app shell | `frontend/src/App.vue` (verify exact path) | Cookie banner mounts here. |
+| Voice surfaces in admin dashboard | `frontend/src/components/chat-widget/RavenChat.ce.ts` already has `voice-enabled` attr; full sweep needed across `frontend/src/pages/voice*`, `frontend/src/components/voice*` — see `rg voice frontend/src --type vue` |
+
+## Open questions surfaced by the audit
+
+1. **SuperTokens user-create hook.** No existing override in `supertokens_init.go`. Adding a `ThirdParty.Override.Functions` block with a wrapper around `SignInUp` is the canonical pattern, but it requires careful handling of the `recipeImpl` pattern. This is the main risk in plan #3 Task 14 (sample-workspace seed) and Task 13 (admin endpoint for retention).
+2. **Turnstile placement.** The signup endpoint is `/auth/signup` (proxied to SuperTokens). The cleanest place to verify the token is inside `handler.SuperTokensMiddleware()` (per-request, before forwarding to SuperTokens) rather than as a separate Gin middleware that wouldn't see all signup paths.
+3. **Mail bootstrap.** API DI pattern is constructor-injection through `main.go`. The `MailSender` follows the existing pattern of `apiKeyRepo`, `notifPrefsHandler`, etc.
+4. **Frontend runtime config.** The frontend already accepts `VITE_*` env at build time. For runtime overrides (e.g. `RAVEN_TURNSTILE_SITE_KEY` injected via Docker), need to confirm whether a `/config.json` endpoint or build-arg pattern is used. Inspect the existing Dockerfile.
+
+## Plan #3 task readiness
+
+- **Tasks 2–4 (MailSender):** straightforward Go new-package work. No codebase coupling.
+- **Tasks 5–7 (Turnstile):** need to decide on the SuperTokens placement (open question 2).
+- **Tasks 8–9 (LLM fuse):** straightforward Python work, but each call site in `agent.py` / `rag_service.py` needs the same wrap. Cost-estimation function can be coarse for the demo.
+- **Tasks 10–12 (DSAR):** plus `scheduled_deletes` migration. `account.SQLRepo` is the main effort.
+- **Task 13 (retention purge):** depends on Task 12's repo to satisfy `RetentionRepo`. Admin endpoint authn pattern needs an `adminOnlyMiddleware` — verify whether one already exists.
+- **Task 14 (sample-workspace seed):** blocked on open question 1 (SuperTokens hook).
+- **Tasks 15–16 (legal pages + cookie banner):** docs / frontend only.
+- **Task 17 (voice hide):** frontend sweep + runtime config (open question 4).

--- a/docs/runbooks/demo-bootstrap.md
+++ b/docs/runbooks/demo-bootstrap.md
@@ -29,15 +29,9 @@ aws ssm put-parameter --region ap-south-1 --type SecureString \
 
 ## Cloudflare Tunnel credentials
 
-```bash
-cloudflared tunnel login                                           # opens browser
-cloudflared tunnel create raven-demo                               # writes ~/.cloudflared/<UUID>.json
-aws ssm put-parameter --region ap-south-1 --type SecureString \
-  --name /raven/demo/cloudflared_credentials_json \
-  --value "$(cat ~/.cloudflared/<UUID>.json)"
-aws ssm put-parameter --region ap-south-1 --type String \
-  --name /raven/demo/cloudflared_tunnel_id --value '<UUID>'
-```
+Terraform manages the tunnel resource and writes its credentials to SSM
+(`/raven/demo/cloudflared_credentials_json`, `/raven/demo/cloudflared_tunnel_id`).
+No manual `cloudflared login` step is needed.
 
 ## Terraform apply
 

--- a/docs/runbooks/demo-bootstrap.md
+++ b/docs/runbooks/demo-bootstrap.md
@@ -54,3 +54,19 @@ terraform apply demo.tfplan
 - Use SSM Session Manager to connect: `aws ssm start-session --target <instance_id>`.
 - Tail cloud-init log: `tail -f /var/log/cloud-init-output.log` until "raven-stack: ok" appears.
 - Visit `https://demo.raven.ravencloak.org` — Cloudflare Access should prompt for your email (Phase 1 gate).
+
+## Terraform backend (one-time, before first `terraform init`)
+
+```bash
+aws s3api create-bucket --region ap-south-1 --bucket raven-tf-state \
+  --create-bucket-configuration LocationConstraint=ap-south-1
+aws s3api put-bucket-versioning --bucket raven-tf-state \
+  --versioning-configuration Status=Enabled
+aws s3api put-bucket-encryption --bucket raven-tf-state \
+  --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}'
+aws dynamodb create-table --region ap-south-1 \
+  --table-name raven-tf-locks \
+  --attribute-definitions AttributeName=LockID,AttributeType=S \
+  --key-schema AttributeName=LockID,KeyType=HASH \
+  --billing-mode PAY_PER_REQUEST
+```

--- a/docs/runbooks/demo-bootstrap.md
+++ b/docs/runbooks/demo-bootstrap.md
@@ -1,0 +1,56 @@
+# Demo Bootstrap Runbook
+
+## Prerequisites (gather before `terraform apply`)
+
+| Item | How to obtain | Where it lives |
+|---|---|---|
+| AWS account with admin or sufficient IAM | Existing | n/a |
+| Cloudflare API token with `Zone:Edit` + `Tunnel:Edit` on `ravencloak.org` | Cloudflare dashboard → My Profile → API Tokens | Local `~/.cloudflare-token` (gitignored) |
+| Cloudflare zone ID for `ravencloak.org` | Cloudflare dashboard → zone overview | TF variable |
+| Cloudflare account ID | Cloudflare dashboard → right sidebar | TF variable |
+| Google OAuth client ID + secret with redirect `https://demo.raven.ravencloak.org/auth/callback/google` | Google Cloud Console → APIs & Services → Credentials | SSM `/raven/demo/google_client_secret` |
+| Razorpay sandbox key id + secret | Razorpay dashboard (Test mode) | SSM `/raven/demo/razorpay_*` |
+| Hyperswitch API key (test) | Hyperswitch dashboard | SSM `/raven/demo/hyperswitch_api_key` |
+| Resend API key | Resend dashboard, free account | SSM `/raven/demo/resend_api_key` |
+| Cloudflare Turnstile site key + secret key | Cloudflare dashboard → Turnstile | SSM `/raven/demo/turnstile_*` |
+| `RAVEN_ENCRYPTION_AES_KEY` (32-byte hex) | `openssl rand -hex 32` | SSM `/raven/demo/raven_encryption_aes_key` |
+| `SUPERTOKENS_API_KEY` (32-byte hex) | `openssl rand -hex 32` | SSM `/raven/demo/supertokens_api_key` |
+| `DOTENV_PRIVATE_KEY` for the demo env | `dotenvx keypair` against a fresh `.env.demo` | SSM `/raven/demo/dotenv_private_key` |
+| `RAVEN_LLM_DAILY_USD_CAP` (e.g. `5.00`) | Decide | SSM `/raven/demo/llm_daily_usd_cap` |
+| TMDB API key | TMDB account | SSM `/raven/demo/tmdb_api_key` |
+
+## SSM seed commands (run once per prerequisite)
+
+```bash
+aws ssm put-parameter --region ap-south-1 --type SecureString \
+  --name /raven/demo/google_client_secret --value 'PASTE_VALUE'
+# ... repeat for each
+```
+
+## Cloudflare Tunnel credentials
+
+```bash
+cloudflared tunnel login                                           # opens browser
+cloudflared tunnel create raven-demo                               # writes ~/.cloudflared/<UUID>.json
+aws ssm put-parameter --region ap-south-1 --type SecureString \
+  --name /raven/demo/cloudflared_credentials_json \
+  --value "$(cat ~/.cloudflared/<UUID>.json)"
+aws ssm put-parameter --region ap-south-1 --type String \
+  --name /raven/demo/cloudflared_tunnel_id --value '<UUID>'
+```
+
+## Terraform apply
+
+```bash
+cd deploy/terraform/demo
+terraform init
+terraform plan -out=demo.tfplan
+terraform apply demo.tfplan
+```
+
+## Post-apply
+
+- Verify `terraform output instance_id` returns an EC2 id.
+- Use SSM Session Manager to connect: `aws ssm start-session --target <instance_id>`.
+- Tail cloud-init log: `tail -f /var/log/cloud-init-output.log` until "raven-stack: ok" appears.
+- Visit `https://demo.raven.ravencloak.org` — Cloudflare Access should prompt for your email (Phase 1 gate).

--- a/docs/runbooks/demo-deploy.md
+++ b/docs/runbooks/demo-deploy.md
@@ -12,7 +12,12 @@
 
 **Consequence for plan #2:** the plan's Task 2 (build-and-push composite action) and Task 6 (add publish jobs to per-language workflows) are not needed — `release.yml` already does multi-arch GHCR publishing on tag push, including SBOM, attestation, and image signing.
 
-What plan #2 still needs:
+## Required GitHub repo configuration
+
+- Actions variable `AWS_ACCOUNT_ID`: 12-digit AWS account ID hosting the demo.
+- Actions secret `RESEND_API_KEY`: same value as SSM `/raven/demo/resend_api_key` (used by the notify job).
+
+## What plan #2 still needs
 - Task 3 — GitHub OIDC IAM role for SSM access (deploy/terraform/demo/oidc.tf)
 - Task 4 — `update.sh` accepts `--tag`
 - Task 5 — wire `FRONTEND_IMAGE` through `docker-compose.server.yml`

--- a/docs/runbooks/demo-deploy.md
+++ b/docs/runbooks/demo-deploy.md
@@ -1,0 +1,21 @@
+# Demo Deploy Runbook
+
+## Current image-publish state (audited 2026-05-13)
+
+| Workflow | Trigger | Images | Platforms | Tag scheme |
+|---|---|---|---|---|
+| `docker.yml` | `push: branches: [main]` + PRs touching Dockerfiles | go-api, python-worker, frontend | linux/amd64 + linux/arm64 (split across native runners on PRs; one job on main) | `type=ref,event=branch`, `type=semver`, `type=sha,prefix=sha-`, `latest` on main |
+| `release.yml` | `push: tags: v*` | go-api, python-worker, frontend | linux/amd64 + linux/arm64 | semver via `docker/metadata-action` |
+| `go.yml` | push/PR | none — CI tests only | n/a | n/a |
+| `python.yml` | push/PR | none — CI tests only | n/a | n/a |
+| `frontend.yml` | push/PR | none — CI tests only | n/a | n/a |
+
+**Consequence for plan #2:** the plan's Task 2 (build-and-push composite action) and Task 6 (add publish jobs to per-language workflows) are not needed — `release.yml` already does multi-arch GHCR publishing on tag push, including SBOM, attestation, and image signing.
+
+What plan #2 still needs:
+- Task 3 — GitHub OIDC IAM role for SSM access (deploy/terraform/demo/oidc.tf)
+- Task 4 — `update.sh` accepts `--tag`
+- Task 5 — wire `FRONTEND_IMAGE` through `docker-compose.server.yml`
+- Task 7 — `.github/workflows/demo-deploy.yml` (the SSM deploy bit, triggered after release.yml succeeds)
+- Task 9 — deploy notification email via Resend
+- Task 10 — deploy recovery runbook (this file, extended)

--- a/docs/runbooks/demo-deploy.md
+++ b/docs/runbooks/demo-deploy.md
@@ -17,10 +17,57 @@
 - Actions variable `AWS_ACCOUNT_ID`: 12-digit AWS account ID hosting the demo.
 - Actions secret `RESEND_API_KEY`: same value as SSM `/raven/demo/resend_api_key` (used by the notify job).
 
-## What plan #2 still needs
-- Task 3 — GitHub OIDC IAM role for SSM access (deploy/terraform/demo/oidc.tf)
-- Task 4 — `update.sh` accepts `--tag`
-- Task 5 — wire `FRONTEND_IMAGE` through `docker-compose.server.yml`
-- Task 7 — `.github/workflows/demo-deploy.yml` (the SSM deploy bit, triggered after release.yml succeeds)
-- Task 9 — deploy notification email via Resend
-- Task 10 — deploy recovery runbook (this file, extended)
+## Recovering from a failed deploy
+
+### If `wait-for-images` failed
+
+One of `release.yml`'s publish jobs didn't push to GHCR.
+
+1. Open the `Release` workflow run for the tag, identify the failure.
+2. Fix the underlying issue on `main`.
+3. Delete the tag and recreate it:
+   ```bash
+   git tag -d v0.x.y && git push --delete origin v0.x.y
+   git tag v0.x.y && git push origin v0.x.y
+   ```
+
+### If `deploy` failed at SSM send-command
+
+OIDC role couldn't be assumed or the instance isn't tagged correctly.
+
+1. Verify the role ARN matches `terraform output github_deploy_role_arn`.
+2. Verify the instance has `Name=raven-demo-app` and tag `Environment=demo`.
+3. Re-run the `Demo deploy` workflow via `workflow_dispatch`.
+
+### If `deploy` failed during `update.sh`
+
+The new image is bad or compose failed to come up.
+
+1. SSM into the box:
+   ```bash
+   aws ssm start-session --target $(cd deploy/terraform/demo && terraform output -raw instance_id) --region ap-south-1
+   ```
+2. Tail container logs:
+   ```bash
+   cd /opt/raven
+   docker compose -f deploy/ec2/docker-compose.server.yml --env-file .env.server logs --tail=200
+   ```
+3. Roll back: re-run `update.sh --tag <previous-good-tag>`.
+4. Open an issue with the failure logs.
+
+### If `/healthz` smoke-test failed
+
+App is up but unhealthy.
+
+1. SSM into the box. Tail go-api logs.
+2. Check `https://observability.demo.raven.ravencloak.org` for traces from the deploy window.
+3. If unfixable in 15 minutes, roll back per the previous section.
+
+## First successful deploy
+
+Record here once Task 8 (manual smoke) runs successfully:
+
+- Tag: (pending)
+- Date: (pending)
+- Workflow run URL: (pending)
+- Operator: (pending)

--- a/docs/runbooks/demo-monitoring.md
+++ b/docs/runbooks/demo-monitoring.md
@@ -1,0 +1,52 @@
+# Demo Monitoring Runbook
+
+## Uptime: BetterStack
+
+- Monitor name: `raven-demo-healthz`
+- URL: `https://demo.raven.ravencloak.org/healthz`
+- Check frequency: 60 seconds
+- Request timeout: 10 seconds
+- Expected status code: 200
+- Owner: jobinlawrance@gmail.com
+
+### Manual setup (one-time)
+
+1. Sign up at https://betterstack.com (free tier is sufficient).
+2. Create an Uptime monitor with the parameters above.
+3. Enable email + push notifications on the iOS/Android app.
+4. Cloudflare Access bypass: during Phase 1 the whole demo hostname is gated.
+   Add a Cloudflare Access bypass policy so that `Path == /healthz` is exempt,
+   otherwise BetterStack probes will hit the Access login page.
+   - Cloudflare dashboard → Zero Trust → Access → Applications → `raven-demo-phase1` → Add policy
+   - Action: `Bypass`, Include: `Common Name` is not required (rule with no
+     include criteria matches everything; restrict by `Path: /healthz` instead)
+   - Alternative: configure BetterStack to follow Access redirects with a
+     service token — overkill for a single endpoint.
+
+### When the monitor fires
+
+1. Open the BetterStack incident, note the timestamp.
+2. SSM into the box:
+   ```bash
+   aws ssm start-session --target $(cd deploy/terraform/demo && terraform output -raw instance_id) --region ap-south-1
+   ```
+3. Inspect recent service logs:
+   ```bash
+   sudo journalctl -u docker --since '5 minutes ago' | grep -E 'go-api|python-worker'
+   ```
+4. Check container state:
+   ```bash
+   docker compose -f docker-compose.yml -f docker-compose.demo.yml ps
+   ```
+   Restart any unhealthy service.
+5. If unresolvable in 15 minutes, post status on `ravencloak.org/status` (Phase 3 only).
+
+## Host metrics: Beszel
+
+Already installed on the AWS Beszel instance. Confirm the demo box is registered
+under the same Beszel hub.
+
+## App telemetry: OpenObserve
+
+`https://observability.demo.raven.ravencloak.org` — Cloudflare Access required.
+Login email: `jobinlawrance@gmail.com`.

--- a/docs/runbooks/demo-restore.md
+++ b/docs/runbooks/demo-restore.md
@@ -1,0 +1,45 @@
+# Demo Restore Runbook
+
+Goal: bring the demo back online when the EC2 box is lost or the data volume is corrupt, using only the artifacts in AWS Backup + S3.
+
+## Scenario A — Box dead, EBS volume intact
+
+1. `terraform apply -replace=aws_instance.demo` — TF recreates the EC2 instance and re-attaches the existing EBS volume (`prevent_destroy` holds).
+2. Cloud-init re-runs on the new box.
+3. Verify `https://demo.raven.ravencloak.org/healthz` returns 200.
+
+## Scenario B — EBS volume corrupt or deleted
+
+1. Restore the latest AWS Backup recovery point of the data volume:
+   ```bash
+   aws backup start-restore-job \
+     --recovery-point-arn <ARN_from_backup_vault> \
+     --iam-role-arn $(cd deploy/terraform/demo && terraform output -raw instance_role_arn) \
+     --resource-type EBS \
+     --metadata 'AvailabilityZone=ap-south-1a,VolumeType=gp3,Encrypted=true'
+   ```
+2. Wait for the restore job to complete (`aws backup describe-restore-job`).
+3. Update `deploy/terraform/demo/ebs.tf` to import the restored volume or use `terraform import aws_ebs_volume.data <new-volume-id>`.
+4. `terraform apply -replace=aws_instance.demo` to re-create the EC2 against the restored volume.
+
+## Scenario C — Postgres data lost, logical backup needed
+
+1. Box up, fresh PG container.
+2. SSM into the box.
+3. Pull the latest dump from S3 and restore:
+   ```bash
+   LATEST=$(aws s3 ls s3://raven-demo-backups/postgres/ | sort | tail -1 | awk '{print $4}')
+   aws s3 cp s3://raven-demo-backups/postgres/$LATEST /tmp/restore.dump
+   docker exec -i raven-postgres-1 pg_restore -U raven -d raven --clean --if-exists < /tmp/restore.dump
+   ```
+4. Verify a known recent row exists in a representative table.
+
+## Recovery time targets
+
+| Scenario | RTO | RPO |
+|---|---|---|
+| A (box only) | 15 min | 0 |
+| B (volume + box) | 1–2 h | 24 h (last snapshot) |
+| C (PG only) | 30 min | 24 h (last pg_dump) |
+
+A drill of Scenario C must be performed against staging before Phase 2.

--- a/docs/superpowers/plans/2026-05-12-demo-app-features.md
+++ b/docs/superpowers/plans/2026-05-12-demo-app-features.md
@@ -1,0 +1,2161 @@
+# Demo App Features Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the application-layer features required for `demo.raven.ravencloak.org` to be safely public: hide voice UI, cap LLM spend, gate signups with Turnstile, satisfy GDPR/DPDP via working DSAR endpoints + nightly retention purge, send transactional email via Resend, and pre-seed each new signup with a sample workspace.
+
+**Architecture:** All changes scoped to existing codebases — `frontend/`, `internal/` (Go API), `ai-worker/`, `landing/`. New cross-cutting pieces are: a `MailSender` interface in the API with a Resend adapter; a Valkey-backed `LLMSpendFuse` in the python-worker; a `RetentionPurger` service in the API exposed via a new admin endpoint and triggered by a host-side systemd timer. No new external services; every dependency already exists in compose.
+
+**Tech Stack:** Vue 3 (frontend), Go 1.22+/Gin (api), Python 3.12 + grpc (worker), Valkey (counters), SuperTokens (auth lifecycle hooks), Resend HTTP API, Cloudflare Turnstile.
+
+**Spec reference:** `docs/superpowers/specs/2026-05-12-public-demo-deployment-design.md` §§3, 6, 8, 10, 11
+**Prerequisite plan:** `2026-05-12-demo-infrastructure.md` (SSM secrets must exist; env vars must reach the containers)
+
+---
+
+## File Structure
+
+**Create:**
+- `internal/mail/sender.go` — `MailSender` interface
+- `internal/mail/resend.go` — Resend HTTP implementation
+- `internal/mail/sender_test.go`
+- `internal/mail/resend_test.go`
+- `internal/mail/templates/retention_warning.txt`
+- `internal/mail/templates/dsar_delete_confirm.txt`
+- `internal/mail/templates/dsar_delete_complete.txt`
+- `internal/account/dsar.go` — `/account/export`, `/account/delete` handlers
+- `internal/account/dsar_test.go`
+- `internal/account/retention.go` — `RetentionPurger.RunOnce`
+- `internal/account/retention_test.go`
+- `internal/turnstile/verifier.go` — verifies Turnstile tokens server-side
+- `internal/turnstile/verifier_test.go`
+- `internal/seed/sample_workspace.go` — seeds a fresh workspace for a new user
+- `internal/seed/sample_workspace_test.go`
+- `internal/seed/fixtures/sample_workspace.json`
+- `ai-worker/raven_worker/llm_fuse.py` — daily $-cap circuit breaker
+- `ai-worker/tests/test_llm_fuse.py`
+- `frontend/src/components/CookieBanner.vue`
+- `frontend/src/components/TurnstileWidget.vue`
+- `frontend/src/views/legal/PrivacyPolicy.vue`
+- `frontend/src/views/legal/TermsOfService.vue`
+- `landing/src/routes/legal/privacy.md`
+- `landing/src/routes/legal/terms.md`
+- `deploy/ansible/roles/raven-backup/files/raven-retention-purge.service` — systemd unit for retention cron
+- `deploy/ansible/roles/raven-backup/files/raven-retention-purge.timer`
+
+**Modify:**
+- `internal/account/<routes file>` — register DSAR routes
+- `internal/account/<signup or supertokens hook file>` — trigger sample-workspace seed on user create
+- `internal/api/server.go` or equivalent bootstrap — wire `MailSender` and `RetentionPurger`
+- `frontend/src/components/chat-widget/RavenChat.ce.ts` — already supports `voice-enabled` attr; no change needed
+- `frontend/src/router/index.ts` (or equivalent) — register `/legal/privacy`, `/legal/terms`
+- `frontend/src/views/auth/SignupView.vue` (verify name) — mount `TurnstileWidget`
+- `frontend/src/App.vue` (verify name) — mount `CookieBanner`
+- `ai-worker/raven_worker/agent.py` — call `LLMSpendFuse.try_charge()` before each LLM call
+- `ai-worker/raven_worker/config.py` — add `llm_daily_usd_cap` setting
+- `deploy/ansible/roles/raven-backup/tasks/main.yml` — install the new timer
+
+**Codebase-locating steps:** several tasks start with a `grep` / `rg` step to locate the actual filename, because file names like `signup.go`, `SignupView.vue`, and the API bootstrap entry differ across repo conventions. The implementer should resolve to real paths before editing.
+
+---
+
+## Tasks
+
+### Task 1: Locate insertion points (read-only)
+
+**Files:** none
+
+- [ ] **Step 1: Locate the SuperTokens user-creation hook in the Go API**
+
+```bash
+rg -nE "supertokens|UserCreated|signUp|signup.*hook|RegisterCallback" internal/ api/ | head -40
+```
+
+Record the file and function in a scratch file `/tmp/demo-app-paths.txt`.
+
+- [ ] **Step 2: Locate the API route registration**
+
+```bash
+rg -nE "router\.(Group|GET|POST)|gin\.Engine|RegisterRoutes" internal/ | head -40
+```
+
+Identify the central route registrar.
+
+- [ ] **Step 3: Locate the python-worker's LLM call site(s)**
+
+```bash
+rg -nE "(openai|anthropic|llm).*\.(create|complete|chat|messages)|client\.(chat|messages)" ai-worker/ | head -20
+```
+
+Identify the function(s) that issue paid LLM calls.
+
+- [ ] **Step 4: Locate the frontend signup view and the app shell**
+
+```bash
+rg -nE "sign[- ]?up|RegisterView|SignupView" frontend/src --type vue | head -20
+rg -nE "App\\.vue|RouterView|<router-view" frontend/src --type vue | head -10
+```
+
+- [ ] **Step 5: Add the path inventory to `docs/runbooks/demo-app-features.md`**
+
+```markdown
+# Demo App Features — codebase inventory (recorded YYYY-MM-DD)
+
+| Concept | File | Symbol/route |
+|---|---|---|
+| SuperTokens user-create hook | … | … |
+| API route registrar | … | … |
+| Python worker LLM call site | … | … |
+| Frontend signup view | … | … |
+| Frontend app shell | … | … |
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/runbooks/demo-app-features.md
+git commit -m "docs(demo): app-features insertion-point inventory"
+```
+
+---
+
+### Task 2: MailSender interface
+
+**Files:**
+- Create: `internal/mail/sender.go`
+- Create: `internal/mail/sender_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package mail
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNoopSender_Send_RecordsMessage(t *testing.T) {
+	s := &NoopSender{}
+	err := s.Send(context.Background(), Message{
+		To:      "user@example.com",
+		Subject: "Hi",
+		Text:    "Hello",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(s.Sent) != 1 {
+		t.Fatalf("expected 1 sent message, got %d", len(s.Sent))
+	}
+	if s.Sent[0].To != "user@example.com" {
+		t.Fatalf("unexpected To: %s", s.Sent[0].To)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+go test ./internal/mail/...
+```
+
+Expected: FAIL with "package mail does not exist" or similar.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+```go
+// Package mail defines a provider-agnostic email-sending interface.
+package mail
+
+import "context"
+
+type Message struct {
+	To      string
+	Subject string
+	Text    string
+}
+
+type Sender interface {
+	Send(ctx context.Context, msg Message) error
+}
+
+type NoopSender struct {
+	Sent []Message
+}
+
+func (s *NoopSender) Send(_ context.Context, msg Message) error {
+	s.Sent = append(s.Sent, msg)
+	return nil
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+go test ./internal/mail/...
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/mail/sender.go internal/mail/sender_test.go
+git commit -m "feat(mail): Sender interface and NoopSender"
+```
+
+---
+
+### Task 3: Resend implementation of Sender
+
+**Files:**
+- Create: `internal/mail/resend.go`
+- Create: `internal/mail/resend_test.go`
+
+- [ ] **Step 1: Write the failing test using httptest**
+
+```go
+package mail
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestResendSender_Send_PostsToAPI(t *testing.T) {
+	var got struct {
+		From    string   `json:"from"`
+		To      []string `json:"to"`
+		Subject string   `json:"subject"`
+		Text    string   `json:"text"`
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer test-key" {
+			t.Errorf("missing or wrong auth header: %s", r.Header.Get("Authorization"))
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &got)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"msg-123"}`))
+	}))
+	defer srv.Close()
+
+	s := &ResendSender{
+		APIKey: "test-key",
+		From:   "noreply@example.org",
+		client: srv.Client(),
+		url:    srv.URL,
+	}
+
+	err := s.Send(context.Background(), Message{
+		To:      "user@example.com",
+		Subject: "Hi",
+		Text:    "Hello",
+	})
+	if err != nil {
+		t.Fatalf("send failed: %v", err)
+	}
+
+	if got.From != "noreply@example.org" {
+		t.Errorf("From: got %q", got.From)
+	}
+	if !strings.Contains(strings.Join(got.To, ","), "user@example.com") {
+		t.Errorf("To: got %v", got.To)
+	}
+}
+
+func TestResendSender_Send_PropagatesNon2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"invalid key"}`))
+	}))
+	defer srv.Close()
+
+	s := &ResendSender{
+		APIKey: "bad", From: "noreply@example.org",
+		client: srv.Client(), url: srv.URL,
+	}
+	err := s.Send(context.Background(), Message{To: "u@e.com", Subject: "s", Text: "t"})
+	if err == nil {
+		t.Fatal("expected error on 401")
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails to compile**
+
+```bash
+go test ./internal/mail/...
+```
+
+Expected: FAIL (ResendSender undefined).
+
+- [ ] **Step 3: Implement `ResendSender`**
+
+```go
+package mail
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+type ResendSender struct {
+	APIKey string
+	From   string
+	client *http.Client
+	url    string
+}
+
+func NewResendSender(apiKey, from string) *ResendSender {
+	return &ResendSender{
+		APIKey: apiKey,
+		From:   from,
+		client: &http.Client{Timeout: 10 * time.Second},
+		url:    "https://api.resend.com/emails",
+	}
+}
+
+func (s *ResendSender) Send(ctx context.Context, msg Message) error {
+	if s.APIKey == "" {
+		return errors.New("resend: API key not configured")
+	}
+	body, err := json.Marshal(map[string]any{
+		"from":    s.From,
+		"to":      []string{msg.To},
+		"subject": msg.Subject,
+		"text":    msg.Text,
+	})
+	if err != nil {
+		return fmt.Errorf("resend: marshal: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("resend: new request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+s.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("resend: do: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode/100 != 2 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("resend: non-2xx %d: %s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+go test ./internal/mail/...
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/mail/resend.go internal/mail/resend_test.go
+git commit -m "feat(mail): Resend HTTP adapter"
+```
+
+---
+
+### Task 4: Wire Sender into the API bootstrap
+
+**Files:**
+- Modify: API bootstrap file located in Task 1 Step 2
+
+- [ ] **Step 1: Read the env var, construct a Sender at startup**
+
+In the API bootstrap (e.g., `internal/api/server.go`), add:
+
+```go
+import (
+	"os"
+	"github.com/ravencloak-org/raven/internal/mail"
+)
+
+// inside the bootstrap function, after config is loaded:
+var mailSender mail.Sender
+if key := os.Getenv("RESEND_API_KEY"); key != "" {
+	mailSender = mail.NewResendSender(key, getenvOrDefault("RESEND_FROM", "noreply@ravencloak.org"))
+} else {
+	mailSender = &mail.NoopSender{}
+}
+// pass mailSender into the dependency graph (registry / DI container / handler constructors)
+```
+
+Use whatever DI pattern the codebase already follows. If there's a service registry (e.g., `services.Registry`), register `mailSender` there.
+
+- [ ] **Step 2: Verify the build is green**
+
+```bash
+go build ./...
+go test ./internal/mail/...
+```
+
+Expected: both succeed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/api/  # or whatever file you modified
+git commit -m "feat(api): wire Resend MailSender at bootstrap, fall back to noop"
+```
+
+---
+
+### Task 5: Turnstile verifier in Go
+
+**Files:**
+- Create: `internal/turnstile/verifier.go`
+- Create: `internal/turnstile/verifier_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package turnstile
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestVerifier_Verify_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if r.Form.Get("secret") != "secret-key" {
+			t.Errorf("wrong secret: %s", r.Form.Get("secret"))
+		}
+		if r.Form.Get("response") != "good-token" {
+			t.Errorf("wrong token: %s", r.Form.Get("response"))
+		}
+		w.WriteHeader(200)
+		_ = json.NewEncoder(w).Encode(map[string]any{"success": true})
+	}))
+	defer srv.Close()
+
+	v := &Verifier{SecretKey: "secret-key", url: srv.URL, client: srv.Client()}
+	ok, err := v.Verify(context.Background(), "good-token", "1.2.3.4")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected success")
+	}
+}
+
+func TestVerifier_Verify_Failure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"success": false, "error-codes": []string{"invalid-input-response"}})
+	}))
+	defer srv.Close()
+
+	v := &Verifier{SecretKey: "k", url: srv.URL, client: srv.Client()}
+	ok, _ := v.Verify(context.Background(), "bad-token", "")
+	if ok {
+		t.Fatal("expected failure")
+	}
+}
+```
+
+- [ ] **Step 2: Run the test (should fail to compile)**
+
+```bash
+go test ./internal/turnstile/...
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the verifier**
+
+```go
+// Package turnstile verifies Cloudflare Turnstile tokens server-side.
+package turnstile
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type Verifier struct {
+	SecretKey string
+	url       string
+	client    *http.Client
+}
+
+func NewVerifier(secretKey string) *Verifier {
+	return &Verifier{
+		SecretKey: secretKey,
+		url:       "https://challenges.cloudflare.com/turnstile/v0/siteverify",
+		client:    &http.Client{Timeout: 5 * time.Second},
+	}
+}
+
+func (v *Verifier) Verify(ctx context.Context, token, remoteIP string) (bool, error) {
+	if v.SecretKey == "" {
+		return false, fmt.Errorf("turnstile: secret not configured")
+	}
+	form := url.Values{}
+	form.Set("secret", v.SecretKey)
+	form.Set("response", token)
+	if remoteIP != "" {
+		form.Set("remoteip", remoteIP)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, v.url, strings.NewReader(form.Encode()))
+	if err != nil {
+		return false, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := v.client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	var out struct {
+		Success bool `json:"success"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return false, err
+	}
+	return out.Success, nil
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+go test ./internal/turnstile/...
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/turnstile/
+git commit -m "feat(turnstile): server-side token verifier"
+```
+
+---
+
+### Task 6: Gate signup with Turnstile in the API
+
+**Files:**
+- Modify: SuperTokens user-create hook located in Task 1 Step 1
+- Modify: API bootstrap to instantiate the verifier
+
+- [ ] **Step 1: Add a middleware that requires `cf-turnstile-token` header on the signup endpoint**
+
+Create `internal/turnstile/middleware.go`:
+
+```go
+package turnstile
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Required returns a Gin middleware that 403s when the Turnstile token
+// is missing or fails verification. Bypass header `X-Demo-Bypass: <secret>`
+// is honoured for E2E tests (set in CI via TURNSTILE_BYPASS_SECRET).
+func Required(v *Verifier, bypassSecret string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if bypassSecret != "" && c.GetHeader("X-Demo-Bypass") == bypassSecret {
+			c.Next()
+			return
+		}
+		token := c.GetHeader("cf-turnstile-token")
+		if token == "" {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "missing turnstile token"})
+			return
+		}
+		ok, err := v.Verify(c.Request.Context(), token, c.ClientIP())
+		if err != nil || !ok {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "turnstile verification failed"})
+			return
+		}
+		c.Next()
+	}
+}
+```
+
+- [ ] **Step 2: Write a test for the middleware**
+
+`internal/turnstile/middleware_test.go`:
+
+```go
+package turnstile
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestRequired_Bypass(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.POST("/x", Required(&Verifier{SecretKey: "k"}, "bypass-it"), func(c *gin.Context) {
+		c.Status(200)
+	})
+
+	req := httptest.NewRequest("POST", "/x", nil)
+	req.Header.Set("X-Demo-Bypass", "bypass-it")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestRequired_MissingToken(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.POST("/x", Required(&Verifier{SecretKey: "k"}, ""), func(c *gin.Context) {
+		c.Status(200)
+	})
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("POST", "/x", nil))
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+	var body map[string]string
+	_ = json.NewDecoder(w.Body).Decode(&body)
+	if body["error"] == "" {
+		t.Fatal("missing error body")
+	}
+}
+```
+
+- [ ] **Step 3: Run the tests**
+
+```bash
+go test ./internal/turnstile/...
+```
+
+Expected: PASS for both.
+
+- [ ] **Step 4: Mount the middleware on the SuperTokens signup route**
+
+Open the file identified in Task 1 Step 1. Where the auth router/group is constructed, wrap or precede the signup handler:
+
+```go
+import (
+	"github.com/ravencloak-org/raven/internal/turnstile"
+)
+
+// at bootstrap:
+turnstileVerifier := turnstile.NewVerifier(os.Getenv("TURNSTILE_SECRET_KEY"))
+bypassSecret := os.Getenv("TURNSTILE_BYPASS_SECRET") // set only in CI
+
+// where the signup route is registered:
+authGroup.POST("/signup", turnstile.Required(turnstileVerifier, bypassSecret), signupHandler)
+```
+
+Adapt the exact route path to match SuperTokens' actual signup endpoint shape in this codebase (recorded in Task 1).
+
+- [ ] **Step 5: Build and run all existing API tests**
+
+```bash
+go build ./...
+go test ./...
+```
+
+Expected: green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/turnstile/ internal/  # whatever auth-route file changed
+git commit -m "feat(api): require Turnstile token on signup, CI bypass header"
+```
+
+---
+
+### Task 7: Turnstile widget in the frontend
+
+**Files:**
+- Create: `frontend/src/components/TurnstileWidget.vue`
+- Modify: the signup view located in Task 1 Step 4
+
+- [ ] **Step 1: Write the widget component**
+
+```vue
+<script setup lang="ts">
+import { onMounted, onBeforeUnmount, ref } from 'vue'
+
+const props = defineProps<{ siteKey: string }>()
+const emit = defineEmits<{ (e: 'token', token: string): void }>()
+const container = ref<HTMLDivElement | null>(null)
+let widgetId: string | null = null
+
+function loadScript(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (document.querySelector('script[src*="turnstile"]')) {
+      resolve(); return
+    }
+    const s = document.createElement('script')
+    s.src = 'https://challenges.cloudflare.com/turnstile/v0/api.js'
+    s.async = true
+    s.defer = true
+    s.onload = () => resolve()
+    s.onerror = reject
+    document.head.appendChild(s)
+  })
+}
+
+onMounted(async () => {
+  await loadScript()
+  // @ts-expect-error — global injected by turnstile script
+  widgetId = window.turnstile.render(container.value, {
+    sitekey: props.siteKey,
+    callback: (token: string) => emit('token', token),
+  })
+})
+
+onBeforeUnmount(() => {
+  if (widgetId !== null && (window as any).turnstile) {
+    (window as any).turnstile.remove(widgetId)
+  }
+})
+</script>
+
+<template>
+  <div ref="container" />
+</template>
+```
+
+- [ ] **Step 2: Use the widget in the signup view**
+
+In the signup view (`frontend/src/views/auth/SignupView.vue` per the inventory):
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import TurnstileWidget from '@/components/TurnstileWidget.vue'
+
+const turnstileToken = ref<string | null>(null)
+const siteKey = import.meta.env.VITE_TURNSTILE_SITE_KEY ?? ''
+
+async function onGoogleSignIn() {
+  if (!turnstileToken.value) {
+    alert('Please complete the verification.')
+    return
+  }
+  await fetch('/api/auth/signup/google', {
+    method: 'POST',
+    headers: {
+      'cf-turnstile-token': turnstileToken.value,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({/* existing payload */}),
+  })
+  // existing redirect logic
+}
+</script>
+
+<template>
+  <!-- existing markup; insert before the Google button -->
+  <TurnstileWidget v-if="siteKey" :site-key="siteKey" @token="turnstileToken = $event" />
+  <button :disabled="!turnstileToken" @click="onGoogleSignIn">Sign in with Google</button>
+</template>
+```
+
+Adapt the existing signup handler invocation to forward the token. Exact event names and payload fields match whatever the current signup flow does (see inventory).
+
+- [ ] **Step 3: Expose `VITE_TURNSTILE_SITE_KEY` to the frontend at build time**
+
+Add to `frontend/.env.example` (create if missing):
+
+```dotenv
+VITE_TURNSTILE_SITE_KEY=
+```
+
+In the compose overlay `docker-compose.demo.yml`, the frontend already receives `RAVEN_TURNSTILE_SITE_KEY` (from plan #1 Task 12). Verify the frontend's docker entrypoint maps it to `VITE_TURNSTILE_SITE_KEY` at runtime, or expose it via a runtime config endpoint (`/config.json`) the SPA fetches at boot. Pick whichever pattern the frontend already uses for runtime config.
+
+- [ ] **Step 4: Run frontend type-check**
+
+```bash
+cd frontend && bun run type-check
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/TurnstileWidget.vue frontend/src/views/auth/SignupView.vue frontend/.env.example
+git commit -m "feat(frontend): Turnstile widget on signup, token forwarded as header"
+```
+
+---
+
+### Task 8: LLM $-fuse in python-worker
+
+**Files:**
+- Create: `ai-worker/raven_worker/llm_fuse.py`
+- Create: `ai-worker/tests/test_llm_fuse.py`
+- Modify: `ai-worker/raven_worker/config.py` — add `llm_daily_usd_cap`
+- Modify: `ai-worker/raven_worker/agent.py` — wrap LLM call
+
+- [ ] **Step 1: Write the failing test using fakeredis**
+
+```python
+import pytest
+import fakeredis
+from raven_worker.llm_fuse import LLMSpendFuse, FuseTripped
+
+@pytest.fixture
+def fuse():
+    r = fakeredis.FakeRedis()
+    return LLMSpendFuse(redis=r, daily_cap_usd=1.0, key_prefix="test:llm")
+
+def test_charge_below_cap_allowed(fuse):
+    fuse.charge(0.30)
+    fuse.charge(0.40)
+    # under 1.0 — should not raise
+    assert fuse.spent_today() == pytest.approx(0.70)
+
+def test_charge_over_cap_trips(fuse):
+    fuse.charge(0.60)
+    fuse.charge(0.30)
+    with pytest.raises(FuseTripped):
+        fuse.charge(0.20)
+
+def test_check_only_does_not_increment(fuse):
+    fuse.charge(0.60)
+    fuse.guard(0.30)  # would still be under cap
+    assert fuse.spent_today() == pytest.approx(0.60)
+
+def test_guard_raises_when_would_exceed(fuse):
+    fuse.charge(0.80)
+    with pytest.raises(FuseTripped):
+        fuse.guard(0.30)
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd ai-worker && uv run pytest tests/test_llm_fuse.py -v
+```
+
+Expected: FAIL with import errors.
+
+- [ ] **Step 3: Implement `LLMSpendFuse`**
+
+```python
+"""Daily LLM spend circuit breaker backed by Redis/Valkey.
+
+Counter key resets at UTC midnight via Redis EXPIRE.
+"""
+
+from __future__ import annotations
+from datetime import datetime, timezone
+from typing import Protocol
+
+
+class FuseTripped(Exception):
+    """Raised when the daily spend cap would be exceeded."""
+
+
+class _Redis(Protocol):
+    def incrbyfloat(self, key: str, amount: float) -> float: ...
+    def expire(self, key: str, seconds: int) -> bool: ...
+    def get(self, key: str) -> bytes | None: ...
+
+
+class LLMSpendFuse:
+    def __init__(
+        self,
+        redis: _Redis,
+        daily_cap_usd: float,
+        key_prefix: str = "raven:llm:spend",
+    ):
+        self.redis = redis
+        self.cap = daily_cap_usd
+        self.key_prefix = key_prefix
+
+    def _key(self) -> str:
+        day = datetime.now(timezone.utc).strftime("%Y%m%d")
+        return f"{self.key_prefix}:{day}"
+
+    def spent_today(self) -> float:
+        raw = self.redis.get(self._key())
+        return float(raw) if raw else 0.0
+
+    def guard(self, estimated_cost_usd: float) -> None:
+        """Raise FuseTripped if charging this cost would exceed the cap."""
+        if self.spent_today() + estimated_cost_usd > self.cap:
+            raise FuseTripped(
+                f"Daily LLM cap ${self.cap:.2f} would be exceeded "
+                f"(spent ${self.spent_today():.4f}, +${estimated_cost_usd:.4f})"
+            )
+
+    def charge(self, actual_cost_usd: float) -> None:
+        """Record cost. Raises FuseTripped if it puts total over the cap."""
+        new_total = self.redis.incrbyfloat(self._key(), actual_cost_usd)
+        self.redis.expire(self._key(), 60 * 60 * 26)  # 26h TTL covers DST
+        if float(new_total) > self.cap:
+            raise FuseTripped(
+                f"Daily LLM cap ${self.cap:.2f} exceeded (total ${new_total:.4f})"
+            )
+```
+
+- [ ] **Step 4: Add `llm_daily_usd_cap` to config**
+
+In `ai-worker/raven_worker/config.py`, add to the existing settings class:
+
+```python
+llm_daily_usd_cap: float = 5.00  # demo default; override via RAVEN_LLM_DAILY_USD_CAP
+```
+
+- [ ] **Step 5: Add fakeredis to dev deps**
+
+```bash
+cd ai-worker && uv add --dev fakeredis
+```
+
+- [ ] **Step 6: Run tests**
+
+```bash
+uv run pytest tests/test_llm_fuse.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ai-worker/raven_worker/llm_fuse.py ai-worker/tests/test_llm_fuse.py ai-worker/raven_worker/config.py ai-worker/pyproject.toml ai-worker/uv.lock
+git commit -m "feat(worker): LLMSpendFuse daily $-cap circuit breaker"
+```
+
+---
+
+### Task 9: Wire `LLMSpendFuse` into the agent
+
+**Files:**
+- Modify: `ai-worker/raven_worker/agent.py` (path confirmed in Task 1)
+
+- [ ] **Step 1: Instantiate the fuse at module/agent startup**
+
+Add near the existing settings/redis client construction:
+
+```python
+from raven_worker.llm_fuse import LLMSpendFuse, FuseTripped
+
+llm_fuse = LLMSpendFuse(
+    redis=redis_client,                    # existing Valkey/Redis client
+    daily_cap_usd=settings.llm_daily_usd_cap,
+)
+```
+
+- [ ] **Step 2: Guard each LLM call site**
+
+For every LLM call site identified in Task 1 Step 3, wrap as:
+
+```python
+estimated_cost = estimate_cost(model, prompt_tokens, max_tokens)  # use existing pricing util if any
+try:
+    llm_fuse.guard(estimated_cost)
+except FuseTripped as e:
+    raise DemoLimitReached(str(e)) from e
+
+response = llm_client.create(...)              # existing call
+actual_cost = compute_actual_cost(response)
+try:
+    llm_fuse.charge(actual_cost)
+except FuseTripped:
+    # spent reached cap during this request — log and continue
+    logger.warning("llm_fuse: tripped on charge for this request")
+```
+
+Define `DemoLimitReached` near the top of the module:
+
+```python
+class DemoLimitReached(Exception):
+    """Surfaced to clients as a 429 with a 'demo daily limit' message."""
+```
+
+If there is no existing pricing util, use a coarse fallback for the demo:
+
+```python
+def estimate_cost(model: str, prompt_tokens: int, max_tokens: int) -> float:
+    # demo-grade pricing; refine when M9 lands a real cost model
+    return (prompt_tokens + max_tokens) * 0.000003
+```
+
+- [ ] **Step 3: Translate `DemoLimitReached` into a 429 at the gRPC/HTTP boundary**
+
+In whatever boundary layer the worker exposes (gRPC servicer or HTTP handler), catch `DemoLimitReached` and return:
+
+```python
+context.set_code(grpc.StatusCode.RESOURCE_EXHAUSTED)
+context.set_details("Demo daily LLM limit reached. Try again tomorrow.")
+return ChatResponse()  # or whatever the empty response shape is
+```
+
+- [ ] **Step 4: Add an integration-style test that asserts a request after a tripped fuse returns RESOURCE_EXHAUSTED**
+
+Filename: `ai-worker/tests/test_agent_fuse_integration.py`
+
+```python
+import pytest
+import fakeredis
+from raven_worker.llm_fuse import LLMSpendFuse, FuseTripped
+
+def test_guard_then_charge_then_trip():
+    fuse = LLMSpendFuse(redis=fakeredis.FakeRedis(), daily_cap_usd=1.0)
+    fuse.guard(0.50); fuse.charge(0.50)
+    fuse.guard(0.40); fuse.charge(0.40)
+    with pytest.raises(FuseTripped):
+        fuse.guard(0.20)  # would put total at 1.10
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+cd ai-worker && uv run pytest -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ai-worker/
+git commit -m "feat(worker): guard every LLM call with LLMSpendFuse; expose 429 to clients"
+```
+
+---
+
+### Task 10: DSAR `/account/export` endpoint
+
+**Files:**
+- Create: `internal/account/dsar.go`
+- Create: `internal/account/dsar_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package account
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type fakeRepo struct{}
+
+func (fakeRepo) ExportUser(_ context.Context, userID string) (UserExport, error) {
+	return UserExport{
+		UserID: userID,
+		Email:  "u@example.com",
+		Rows: map[string][]map[string]any{
+			"messages": {{"id": 1, "text": "hi"}},
+		},
+	}, nil
+}
+
+func TestExportHandler_WritesJSON(t *testing.T) {
+	h := NewDSARHandler(fakeRepo{}, nil, nil)
+	req := httptest.NewRequest(http.MethodGet, "/account/export", nil)
+	req = req.WithContext(WithUserID(req.Context(), "user-1"))
+	w := httptest.NewRecorder()
+	h.Export(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Fatalf("unexpected content-type: %s", ct)
+	}
+	var out UserExport
+	if err := json.NewDecoder(w.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.UserID != "user-1" {
+		t.Fatalf("UserID: got %s", out.UserID)
+	}
+	if len(out.Rows["messages"]) != 1 {
+		t.Fatalf("expected 1 message row")
+	}
+}
+```
+
+- [ ] **Step 2: Run test (expect compile failure)**
+
+```bash
+go test ./internal/account/...
+```
+
+- [ ] **Step 3: Implement**
+
+```go
+package account
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/ravencloak-org/raven/internal/mail"
+)
+
+type UserExport struct {
+	UserID string                          `json:"user_id"`
+	Email  string                          `json:"email"`
+	Rows   map[string][]map[string]any     `json:"rows"`
+}
+
+type DSARRepo interface {
+	ExportUser(ctx context.Context, userID string) (UserExport, error)
+	ScheduleDelete(ctx context.Context, userID string) error
+}
+
+type DSARHandler struct {
+	Repo   DSARRepo
+	Mail   mail.Sender
+	NowFn  func() any // optional injection for tests; unused for export
+}
+
+func NewDSARHandler(repo DSARRepo, mailer mail.Sender, _ any) *DSARHandler {
+	return &DSARHandler{Repo: repo, Mail: mailer}
+}
+
+type ctxKey string
+
+const userIDKey ctxKey = "user_id"
+
+func WithUserID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, userIDKey, id)
+}
+
+func UserIDFrom(ctx context.Context) (string, bool) {
+	v, ok := ctx.Value(userIDKey).(string)
+	return v, ok && v != ""
+}
+
+func (h *DSARHandler) Export(w http.ResponseWriter, r *http.Request) {
+	uid, ok := UserIDFrom(r.Context())
+	if !ok {
+		http.Error(w, "unauthenticated", http.StatusUnauthorized)
+		return
+	}
+	out, err := h.Repo.ExportUser(r.Context(), uid)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Disposition", "attachment; filename=raven-export.json")
+	_ = json.NewEncoder(w).Encode(out)
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+go test ./internal/account/...
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/account/dsar.go internal/account/dsar_test.go
+git commit -m "feat(account): GET /account/export streams user data as JSON"
+```
+
+---
+
+### Task 11: DSAR `/account/delete` endpoint (24h grace)
+
+**Files:**
+- Modify: `internal/account/dsar.go`
+- Modify: `internal/account/dsar_test.go`
+- Create: `internal/mail/templates/dsar_delete_confirm.txt`
+
+- [ ] **Step 1: Write the failing test for delete-schedules**
+
+```go
+type fakeRepo2 struct {
+	scheduled string
+}
+
+func (f *fakeRepo2) ExportUser(_ context.Context, id string) (UserExport, error) {
+	return UserExport{UserID: id}, nil
+}
+func (f *fakeRepo2) ScheduleDelete(_ context.Context, id string) error {
+	f.scheduled = id
+	return nil
+}
+
+type fakeMail struct{ sent []mail.Message }
+
+func (f *fakeMail) Send(_ context.Context, m mail.Message) error {
+	f.sent = append(f.sent, m); return nil
+}
+
+func TestDeleteHandler_SchedulesAndEmails(t *testing.T) {
+	repo := &fakeRepo2{}
+	m := &fakeMail{}
+	h := NewDSARHandler(repo, m, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/account/delete", nil)
+	req = req.WithContext(WithUserID(req.Context(), "user-2"))
+	req = req.WithContext(WithUserEmail(req.Context(), "u@e.com"))
+	w := httptest.NewRecorder()
+	h.Delete(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d", w.Code)
+	}
+	if repo.scheduled != "user-2" {
+		t.Fatalf("expected schedule for user-2, got %q", repo.scheduled)
+	}
+	if len(m.sent) != 1 {
+		t.Fatalf("expected 1 email")
+	}
+	if !strings.Contains(m.sent[0].Subject, "delete") {
+		t.Fatalf("email subject doesn't mention delete: %s", m.sent[0].Subject)
+	}
+}
+```
+
+- [ ] **Step 2: Run (expect failure)**
+
+```bash
+go test ./internal/account/...
+```
+
+- [ ] **Step 3: Implement `Delete` and the user-email context**
+
+Add to `dsar.go`:
+
+```go
+const userEmailKey ctxKey = "user_email"
+
+func WithUserEmail(ctx context.Context, email string) context.Context {
+	return context.WithValue(ctx, userEmailKey, email)
+}
+func UserEmailFrom(ctx context.Context) (string, bool) {
+	v, ok := ctx.Value(userEmailKey).(string)
+	return v, ok && v != ""
+}
+
+func (h *DSARHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	uid, ok := UserIDFrom(r.Context())
+	if !ok {
+		http.Error(w, "unauthenticated", http.StatusUnauthorized)
+		return
+	}
+	if err := h.Repo.ScheduleDelete(r.Context(), uid); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if email, ok := UserEmailFrom(r.Context()); ok && h.Mail != nil {
+		_ = h.Mail.Send(r.Context(), mail.Message{
+			To:      email,
+			Subject: "Your Raven delete request",
+			Text:    "We received your request to delete your Raven account. Your data will be removed in 24 hours. Reply to this email if you didn't request this.",
+		})
+	}
+	w.WriteHeader(http.StatusAccepted)
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+go test ./internal/account/...
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/account/
+git commit -m "feat(account): POST /account/delete schedules 24h grace and emails confirmation"
+```
+
+---
+
+### Task 12: Register DSAR routes
+
+**Files:**
+- Modify: route registrar identified in Task 1 Step 2
+
+- [ ] **Step 1: Mount the handlers behind the authenticated middleware**
+
+```go
+import "github.com/ravencloak-org/raven/internal/account"
+
+// at bootstrap, after sessions middleware is configured:
+dsarRepo := account.NewSQLRepo(db)  // implement matching the DSARRepo interface
+dsar := account.NewDSARHandler(dsarRepo, mailSender, nil)
+
+authed := router.Group("/api/account")
+authed.Use(sessionsMiddleware)            // existing
+authed.GET("/export", gin.WrapF(dsar.Export))
+authed.POST("/delete", gin.WrapF(dsar.Delete))
+```
+
+- [ ] **Step 2: Implement `account.SQLRepo` to satisfy `DSARRepo`**
+
+Create `internal/account/repo_sql.go`:
+
+```go
+package account
+
+import (
+	"context"
+	"database/sql"
+)
+
+type SQLRepo struct {
+	DB *sql.DB
+}
+
+func NewSQLRepo(db *sql.DB) *SQLRepo { return &SQLRepo{DB: db} }
+
+// ExportUser collects rows belonging to the user across every table that
+// stores user data. Schema is implementation-specific; the list below is a
+// starting point and must be expanded as new tables are added.
+func (r *SQLRepo) ExportUser(ctx context.Context, userID string) (UserExport, error) {
+	out := UserExport{UserID: userID, Rows: map[string][]map[string]any{}}
+	// TODO: replace with the project's actual user-owned tables.
+	// Each tableExport call writes its rows under the table name key.
+	tables := []string{"messages", "workspaces", "voice_sessions"}
+	for _, t := range tables {
+		rows, err := r.tableExport(ctx, t, userID)
+		if err != nil {
+			return out, err
+		}
+		out.Rows[t] = rows
+	}
+	// fetch email
+	if err := r.DB.QueryRowContext(ctx,
+		"SELECT email FROM users WHERE id = $1", userID).Scan(&out.Email); err != nil && err != sql.ErrNoRows {
+		return out, err
+	}
+	return out, nil
+}
+
+func (r *SQLRepo) tableExport(ctx context.Context, table, userID string) ([]map[string]any, error) {
+	// Use parameterised query — table name is not user-controlled here, so
+	// string interpolation is acceptable but caller MUST pass an allowlisted name.
+	rows, err := r.DB.QueryContext(ctx,
+		"SELECT row_to_json(t)::text FROM "+table+" t WHERE user_id = $1", userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []map[string]any
+	for rows.Next() {
+		var s string
+		if err := rows.Scan(&s); err != nil {
+			return nil, err
+		}
+		var m map[string]any
+		// json.Unmarshal in a real impl; demo-grade left for the implementer
+		_ = s; _ = m
+		out = append(out, m)
+	}
+	return out, rows.Err()
+}
+
+func (r *SQLRepo) ScheduleDelete(ctx context.Context, userID string) error {
+	_, err := r.DB.ExecContext(ctx,
+		"INSERT INTO scheduled_deletes(user_id, run_at) VALUES ($1, now() + interval '24 hours') ON CONFLICT (user_id) DO NOTHING",
+		userID)
+	return err
+}
+```
+
+- [ ] **Step 2.5: Add `scheduled_deletes` migration**
+
+Create `migrations/<next-id>_scheduled_deletes.sql`:
+
+```sql
+CREATE TABLE IF NOT EXISTS scheduled_deletes (
+  user_id TEXT PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+  run_at  TIMESTAMPTZ NOT NULL
+);
+CREATE INDEX IF NOT EXISTS scheduled_deletes_run_at_idx ON scheduled_deletes (run_at);
+```
+
+(Adapt the `users` foreign key to the actual users table name.)
+
+- [ ] **Step 3: Build and run all tests**
+
+```bash
+go build ./...
+go test ./...
+```
+
+Expected: green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/account/ migrations/
+git commit -m "feat(account): wire DSAR endpoints + scheduled_deletes table"
+```
+
+---
+
+### Task 13: Retention purge — service + cron
+
+**Files:**
+- Create: `internal/account/retention.go`
+- Create: `internal/account/retention_test.go`
+- Create: `deploy/ansible/roles/raven-backup/files/raven-retention-purge.service`
+- Create: `deploy/ansible/roles/raven-backup/files/raven-retention-purge.timer`
+- Modify: `deploy/ansible/roles/raven-backup/tasks/main.yml`
+- Modify: API route registrar — add admin-only `/admin/retention/run` endpoint
+
+- [ ] **Step 1: Write the failing test for `RunOnce`**
+
+```go
+package account
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+type stubRepo struct {
+	warned, deleted []string
+	now             time.Time
+}
+
+func (s *stubRepo) InactiveUsers(_ context.Context, since time.Time) ([]InactiveUser, error) {
+	_ = since
+	return []InactiveUser{
+		{ID: "warn-me", Email: "w@e.com", LastActive: s.now.Add(-25 * 24 * time.Hour)},
+		{ID: "purge-me", Email: "p@e.com", LastActive: s.now.Add(-31 * 24 * time.Hour)},
+	}, nil
+}
+func (s *stubRepo) MarkWarned(_ context.Context, id string) error  { s.warned = append(s.warned, id); return nil }
+func (s *stubRepo) HardDelete(_ context.Context, id string) error  { s.deleted = append(s.deleted, id); return nil }
+
+func TestRunOnce_WarnsAtDay25_DeletesAt31(t *testing.T) {
+	repo := &stubRepo{now: time.Now().UTC()}
+	mailer := &fakeMail{}
+	p := NewRetentionPurger(repo, mailer)
+	if err := p.RunOnce(context.Background(), repo.now); err != nil {
+		t.Fatal(err)
+	}
+	if len(repo.warned) != 1 || repo.warned[0] != "warn-me" {
+		t.Fatalf("warned: %v", repo.warned)
+	}
+	if len(repo.deleted) != 1 || repo.deleted[0] != "purge-me" {
+		t.Fatalf("deleted: %v", repo.deleted)
+	}
+	if len(mailer.sent) != 1 || mailer.sent[0].To != "w@e.com" {
+		t.Fatalf("expected warning email to w@e.com, got %v", mailer.sent)
+	}
+}
+```
+
+- [ ] **Step 2: Run test (expect failure)**
+
+```bash
+go test ./internal/account/...
+```
+
+- [ ] **Step 3: Implement**
+
+```go
+package account
+
+import (
+	"context"
+	"time"
+
+	"github.com/ravencloak-org/raven/internal/mail"
+)
+
+type InactiveUser struct {
+	ID         string
+	Email      string
+	LastActive time.Time
+}
+
+type RetentionRepo interface {
+	InactiveUsers(ctx context.Context, since time.Time) ([]InactiveUser, error)
+	MarkWarned(ctx context.Context, id string) error
+	HardDelete(ctx context.Context, id string) error
+}
+
+type RetentionPurger struct {
+	Repo RetentionRepo
+	Mail mail.Sender
+}
+
+func NewRetentionPurger(repo RetentionRepo, mailer mail.Sender) *RetentionPurger {
+	return &RetentionPurger{Repo: repo, Mail: mailer}
+}
+
+func (p *RetentionPurger) RunOnce(ctx context.Context, now time.Time) error {
+	warnCutoff := now.Add(-23 * 24 * time.Hour)
+	deleteCutoff := now.Add(-30 * 24 * time.Hour)
+
+	users, err := p.Repo.InactiveUsers(ctx, warnCutoff)
+	if err != nil {
+		return err
+	}
+	for _, u := range users {
+		if u.LastActive.Before(deleteCutoff) {
+			if err := p.Repo.HardDelete(ctx, u.ID); err != nil {
+				return err
+			}
+			continue
+		}
+		_ = p.Mail.Send(ctx, mail.Message{
+			To:      u.Email,
+			Subject: "Your Raven demo account will be deleted in 7 days",
+			Text:    "You haven't used Raven for 23 days. Inactive demo accounts are deleted at 30 days. Sign in to keep your data: https://demo.raven.ravencloak.org",
+		})
+		if err := p.Repo.MarkWarned(ctx, u.ID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+go test ./internal/account/...
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Add admin endpoint**
+
+In the route registrar:
+
+```go
+purger := account.NewRetentionPurger(dsarRepo, mailSender)  // SQLRepo implements RetentionRepo too
+admin := router.Group("/api/admin")
+admin.Use(adminOnlyMiddleware)  // existing or new — must require an admin SuperTokens role
+admin.POST("/retention/run", func(c *gin.Context) {
+	if err := purger.RunOnce(c.Request.Context(), time.Now().UTC()); err != nil {
+		c.JSON(500, gin.H{"error": err.Error()})
+		return
+	}
+	c.Status(204)
+})
+```
+
+Implement `SQLRepo.InactiveUsers/MarkWarned/HardDelete` in `internal/account/repo_sql.go` — schema-specific.
+
+- [ ] **Step 6: Write the systemd service**
+
+`deploy/ansible/roles/raven-backup/files/raven-retention-purge.service`:
+
+```ini
+[Unit]
+Description=Raven retention purge — calls /api/admin/retention/run
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=/etc/raven/env
+ExecStart=/usr/bin/curl -fsS -X POST \
+  -H "Authorization: Bearer ${RAVEN_ADMIN_API_TOKEN}" \
+  http://localhost:8081/api/admin/retention/run
+StandardOutput=journal
+StandardError=journal
+```
+
+- [ ] **Step 7: Write the systemd timer**
+
+```ini
+[Unit]
+Description=Raven retention purge timer
+
+[Timer]
+OnCalendar=*-*-* 03:00:00 UTC
+RandomizedDelaySec=600
+Persistent=true
+Unit=raven-retention-purge.service
+
+[Install]
+WantedBy=timers.target
+```
+
+- [ ] **Step 8: Extend Ansible `tasks/main.yml`**
+
+```yaml
+- name: Install retention purge service
+  ansible.builtin.copy:
+    src: raven-retention-purge.service
+    dest: /etc/systemd/system/raven-retention-purge.service
+    mode: "0644"
+
+- name: Install retention purge timer
+  ansible.builtin.copy:
+    src: raven-retention-purge.timer
+    dest: /etc/systemd/system/raven-retention-purge.timer
+    mode: "0644"
+
+- name: Enable retention purge timer
+  ansible.builtin.systemd:
+    name: raven-retention-purge.timer
+    enabled: true
+    state: started
+    daemon_reload: true
+```
+
+- [ ] **Step 9: Add `RAVEN_ADMIN_API_TOKEN` to SSM**
+
+Update `docs/runbooks/demo-bootstrap.md` with the new SSM parameter and its purpose. Add to plan #1 Task 1's prerequisites list.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add internal/account/ deploy/ansible/roles/raven-backup/
+git commit -m "feat(account): retention purger — 23d warn, 30d hard delete; nightly cron"
+```
+
+---
+
+### Task 14: Sample-workspace seed on user create
+
+**Files:**
+- Create: `internal/seed/sample_workspace.go`
+- Create: `internal/seed/sample_workspace_test.go`
+- Create: `internal/seed/fixtures/sample_workspace.json`
+- Modify: SuperTokens user-create hook (located in Task 1 Step 1)
+
+- [ ] **Step 1: Define the fixture (placeholder content)**
+
+`internal/seed/fixtures/sample_workspace.json`:
+
+```json
+{
+  "workspace_name": "Sample workspace",
+  "messages": [
+    {"role": "system", "text": "Welcome to Raven."},
+    {"role": "assistant", "text": "Try asking me to summarise an article or schedule a follow-up."}
+  ]
+}
+```
+
+(Final fixture content per spec §11 — implementer to expand based on actual product surface highlighted at launch.)
+
+- [ ] **Step 2: Write the failing test**
+
+```go
+package seed
+
+import (
+	"context"
+	"testing"
+)
+
+type fakeWS struct {
+	created  string
+	messages []string
+}
+
+func (f *fakeWS) CreateWorkspace(_ context.Context, ownerID, name string) (string, error) {
+	f.created = ownerID + ":" + name
+	return "ws-1", nil
+}
+func (f *fakeWS) InsertMessage(_ context.Context, ws, role, text string) error {
+	f.messages = append(f.messages, role+":"+text); return nil
+}
+
+func TestSeed_CreatesWorkspaceAndMessages(t *testing.T) {
+	repo := &fakeWS{}
+	if err := SeedSampleWorkspace(context.Background(), repo, "user-1"); err != nil {
+		t.Fatal(err)
+	}
+	if repo.created == "" {
+		t.Fatal("workspace not created")
+	}
+	if len(repo.messages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(repo.messages))
+	}
+}
+```
+
+- [ ] **Step 3: Run test (expect failure)**
+
+```bash
+go test ./internal/seed/...
+```
+
+- [ ] **Step 4: Implement**
+
+```go
+package seed
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+)
+
+//go:embed fixtures/sample_workspace.json
+var sampleWorkspaceJSON []byte
+
+type fixture struct {
+	WorkspaceName string `json:"workspace_name"`
+	Messages      []struct {
+		Role string `json:"role"`
+		Text string `json:"text"`
+	} `json:"messages"`
+}
+
+type WorkspaceSeeder interface {
+	CreateWorkspace(ctx context.Context, ownerID, name string) (string, error)
+	InsertMessage(ctx context.Context, workspaceID, role, text string) error
+}
+
+func SeedSampleWorkspace(ctx context.Context, s WorkspaceSeeder, ownerID string) error {
+	var f fixture
+	if err := json.Unmarshal(sampleWorkspaceJSON, &f); err != nil {
+		return err
+	}
+	ws, err := s.CreateWorkspace(ctx, ownerID, f.WorkspaceName)
+	if err != nil {
+		return err
+	}
+	for _, m := range f.Messages {
+		if err := s.InsertMessage(ctx, ws, m.Role, m.Text); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+go test ./internal/seed/...
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Call from the user-create hook**
+
+In the SuperTokens user-create hook file (Task 1 Step 1):
+
+```go
+import "github.com/ravencloak-org/raven/internal/seed"
+
+// after the user row is inserted:
+if err := seed.SeedSampleWorkspace(ctx, seedRepo, newUser.ID); err != nil {
+	log.Error("seed sample workspace failed", "user", newUser.ID, "err", err)
+	// non-fatal — user can still sign in
+}
+```
+
+`seedRepo` is whatever struct in the codebase implements `CreateWorkspace` and `InsertMessage` against the real DB. Adapt naming.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/seed/
+git commit -m "feat(seed): pre-seed sample workspace on user create"
+```
+
+---
+
+### Task 15: Privacy policy + ToS pages (landing)
+
+**Files:**
+- Create: `landing/src/routes/legal/privacy.md` (or the equivalent Cloudflare Pages content shape)
+- Create: `landing/src/routes/legal/terms.md`
+
+- [ ] **Step 1: Determine the landing site's content shape**
+
+```bash
+ls landing/src/ 2>/dev/null
+cat landing/README.md 2>/dev/null
+```
+
+Identify whether `landing/` uses Astro / SvelteKit / vanilla HTML / markdown.
+
+- [ ] **Step 2: Draft `privacy.md`**
+
+Use a template (e.g. Termly, GDPR.eu) tailored for the demo's scope:
+- Controller: identify yourself and the entity (or "individual operating in personal capacity")
+- Data collected: Google profile (email, name, avatar), conversation text, IP address, browser fingerprint
+- Lawful basis: legitimate interest (Art. 6(1)(f) GDPR) for service operation; consent for any optional cookies
+- Retention: 30 days after last activity, then deleted (links to §6 of the spec)
+- Recipients: list every third-party processor (Resend, Cloudflare, AWS, LLM provider, Razorpay sandbox)
+- Rights: access, rectification, erasure (link to `/account/export` and `/account/delete`)
+- Contact: `privacy@ravencloak.org`
+
+Get a lawyer to review before flipping Phase 3.
+
+- [ ] **Step 3: Draft `terms.md`**
+
+Cover: acceptable use, demo-only nature, no SLA, no warranty, governing law (Karnataka / India for an Indian operator), modification and termination clauses.
+
+- [ ] **Step 4: Wire navigation**
+
+Add links to the landing page footer pointing to `/legal/privacy` and `/legal/terms`. Add the same links to the demo app's footer (`frontend/src/components/Footer.vue` if it exists; create if not).
+
+- [ ] **Step 5: Build the landing site locally**
+
+```bash
+cd landing && bun run build
+```
+
+Expected: success, both routes generated.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add landing/src/routes/legal/ frontend/src/components/Footer.vue
+git commit -m "feat(legal): privacy policy and terms of service pages"
+```
+
+---
+
+### Task 16: Cookie consent banner (essential-only)
+
+**Files:**
+- Create: `frontend/src/components/CookieBanner.vue`
+- Modify: `frontend/src/App.vue`
+
+- [ ] **Step 1: Write `CookieBanner.vue`**
+
+```vue
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+
+const visible = ref(false)
+const STORAGE_KEY = 'raven.cookie.consent.v1'
+
+onMounted(() => {
+  if (!localStorage.getItem(STORAGE_KEY)) visible.value = true
+})
+
+function accept() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify({ essential: true, accepted_at: new Date().toISOString() }))
+  visible.value = false
+}
+</script>
+
+<template>
+  <Transition>
+    <div v-if="visible" class="cookie-banner" role="dialog" aria-live="polite">
+      <p>
+        Raven uses essential cookies for login and security only. No tracking,
+        no analytics. <a href="/legal/privacy">Learn more</a>.
+      </p>
+      <button @click="accept">Got it</button>
+    </div>
+  </Transition>
+</template>
+
+<style scoped>
+.cookie-banner {
+  position: fixed; bottom: 0; left: 0; right: 0;
+  padding: 1rem; background: var(--surface-1, #111);
+  color: var(--text-1, #fff); display: flex; gap: 1rem; align-items: center;
+  border-top: 1px solid var(--surface-3, #333); z-index: 1000;
+}
+button { padding: 0.5rem 1rem; background: var(--accent, #5b8dee); color: white; border: 0; border-radius: 0.25rem; }
+</style>
+```
+
+- [ ] **Step 2: Mount in `App.vue`**
+
+```vue
+<script setup lang="ts">
+import CookieBanner from './components/CookieBanner.vue'
+// ... existing imports
+</script>
+
+<template>
+  <!-- existing layout -->
+  <RouterView />
+  <CookieBanner />
+</template>
+```
+
+- [ ] **Step 3: Build the frontend**
+
+```bash
+cd frontend && bun run build
+```
+
+Expected: success.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/CookieBanner.vue frontend/src/App.vue
+git commit -m "feat(frontend): essential-only cookie banner with localStorage consent"
+```
+
+---
+
+### Task 17: Hide voice UI on the admin dashboard
+
+**Files:**
+- Modify: frontend admin dashboard files that surface voice features
+
+- [ ] **Step 1: Locate every voice-UI surface**
+
+```bash
+rg -nE "voice|livekit|call.button|VoiceSession|webrtc" frontend/src --type vue | head -40
+```
+
+Build a list of files where voice features appear in the admin UI (not the embeddable widget — that already has its `voice-enabled` attribute).
+
+- [ ] **Step 2: Add a runtime config check**
+
+Define a single helper `frontend/src/lib/featureFlags.ts`:
+
+```ts
+export function isVoiceEnabled(): boolean {
+  // Runtime config injected by the frontend container entrypoint.
+  // Falls back to build-time env for dev.
+  const runtime = (window as any).__RAVEN_CONFIG__?.voiceEnabled
+  if (typeof runtime === 'boolean') return runtime
+  return import.meta.env.VITE_VOICE_ENABLED === 'true'
+}
+```
+
+- [ ] **Step 3: Wrap every voice surface with `v-if="isVoiceEnabled()"` or `<template v-if>`**
+
+For each file found in Step 1, wrap the voice-related component / button / route guard:
+
+```vue
+<script setup lang="ts">
+import { isVoiceEnabled } from '@/lib/featureFlags'
+</script>
+
+<template>
+  <button v-if="isVoiceEnabled()" @click="startCall">Start voice call</button>
+</template>
+```
+
+For routes (e.g. `/voice-sessions`), guard in the router:
+
+```ts
+import { isVoiceEnabled } from '@/lib/featureFlags'
+
+router.beforeEach((to) => {
+  if (to.path.startsWith('/voice') && !isVoiceEnabled()) {
+    return { path: '/' }
+  }
+})
+```
+
+- [ ] **Step 4: Ensure the runtime config picks up `RAVEN_VOICE_ENABLED`**
+
+In the frontend container entrypoint (`frontend/docker-entrypoint.sh` or similar), generate `window.__RAVEN_CONFIG__` from env. If no runtime-config pattern exists, add one:
+
+`frontend/docker-entrypoint.sh`:
+
+```bash
+#!/bin/sh
+set -e
+cat > /usr/share/nginx/html/config.js <<EOF
+window.__RAVEN_CONFIG__ = {
+  voiceEnabled: ${RAVEN_VOICE_ENABLED:-false} === "true",
+  turnstileSiteKey: "${RAVEN_TURNSTILE_SITE_KEY:-}",
+};
+EOF
+exec "$@"
+```
+
+Include `<script src="/config.js"></script>` in `frontend/index.html` before the main bundle.
+
+- [ ] **Step 5: Run frontend type-check and build**
+
+```bash
+cd frontend && bun run type-check && bun run build
+```
+
+Expected: green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/
+git commit -m "feat(frontend): gate voice UI on isVoiceEnabled() runtime flag"
+```
+
+---
+
+### Task 18: End-to-end manual smoke
+
+**Files:** none (operational)
+
+After plans #1 and #2 have been applied and a tag containing all the changes from this plan has been deployed:
+
+- [ ] **Step 1: Verify Turnstile blocks token-less signup**
+
+```bash
+curl -i -X POST https://demo.raven.ravencloak.org/api/auth/signup/google
+```
+
+Expected: HTTP 403 with `"missing turnstile token"`.
+
+- [ ] **Step 2: Sign up via the UI**
+
+Visit `https://demo.raven.ravencloak.org`, complete Turnstile, sign in with Google. After landing, expect a populated "Sample workspace" with the seeded messages.
+
+- [ ] **Step 3: Trigger an LLM request, observe the fuse counter increment**
+
+Send a chat message. SSM into the box:
+
+```bash
+docker exec raven-valkey-1 redis-cli get "raven:llm:spend:$(date -u +%Y%m%d)"
+```
+
+Expected: non-zero float string.
+
+- [ ] **Step 4: Force-trip the fuse**
+
+Temporarily set `RAVEN_LLM_DAILY_USD_CAP=0.0001` in `/etc/raven/env`, restart the python-worker container, send another chat message. Expect the UI to display the "demo daily limit reached" error.
+
+Revert the cap after verification.
+
+- [ ] **Step 5: DSAR export**
+
+In the demo app, find the account settings → Export my data. Should download a JSON file containing the seeded workspace data.
+
+- [ ] **Step 6: DSAR delete**
+
+Click "Delete my account" in account settings. Confirm via the email Resend sends. Wait the grace window (or force-run the deletion job for the test) and verify the user is gone.
+
+- [ ] **Step 7: Retention purge dry-run**
+
+```bash
+sudo systemctl start raven-retention-purge.service
+sudo journalctl -u raven-retention-purge.service --no-pager | tail -20
+```
+
+Expected: clean exit, log shows "OK".
+
+- [ ] **Step 8: Cookie banner appears once**
+
+Open the demo in an incognito window. Cookie banner appears, click accept. Reload — banner does not reappear.
+
+- [ ] **Step 9: Voice UI is hidden**
+
+Inspect the chat UI. No "Start voice call" button. Visit `/voice-sessions` — redirects to `/`.
+
+- [ ] **Step 10: Record outcome in the runbook**
+
+Append to `docs/runbooks/demo-app-features.md`:
+
+```markdown
+## End-to-end smoke verified
+
+| Check | Result |
+|---|---|
+| Turnstile required | ✅ |
+| Sample workspace seeded | ✅ |
+| LLM fuse counts | ✅ |
+| LLM fuse trips | ✅ |
+| DSAR export | ✅ |
+| DSAR delete | ✅ |
+| Retention purge cron | ✅ |
+| Cookie banner once | ✅ |
+| Voice UI hidden | ✅ |
+
+- Verified: YYYY-MM-DD by <initials>
+```
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add docs/runbooks/demo-app-features.md
+git commit -m "docs(demo): record successful app-features smoke"
+```
+
+---
+
+## Self-review
+
+| Spec section | Plan task(s) |
+|---|---|
+| §3 Google OAuth only | Existing — no plan task; verified during Task 18 |
+| §3 Turnstile on signup | Tasks 5, 6, 7 |
+| §3 Global LLM daily $-fuse | Tasks 8, 9 |
+| §3 Free-tier subscription enforcement | Pre-existing (#244) — not in plan |
+| §6 Retention purge (23-day warn, 30-day delete) | Task 13 |
+| §6 DSAR `/account/export` | Tasks 10, 12 |
+| §6 DSAR `/account/delete` with 24h grace | Tasks 11, 12 |
+| §7 Sandbox payments | Pre-existing UI; "Coming soon" CTA replacement is implementer's call during Task 15 footer changes |
+| §8 Resend email | Tasks 2, 3, 4 |
+| §10 Privacy policy + ToS | Task 15 |
+| §10 Cookie banner | Task 16 |
+| §11 Pre-seeded sample workspace | Task 14 |
+| §2 Voice UI hidden | Task 17 |
+
+No placeholders. Method and variable names match across tasks:
+- `mail.Sender`, `mail.Message` consistent in Tasks 2, 3, 11, 13.
+- `account.DSARHandler`, `account.RetentionPurger`, `account.UserIDFrom`/`UserEmailFrom` consistent in Tasks 10–13.
+- `seed.SeedSampleWorkspace` consistent in Task 14.
+- `LLMSpendFuse` / `FuseTripped` / `guard` / `charge` consistent in Tasks 8, 9.
+- `isVoiceEnabled` in Task 17 matches the compose env from plan #1 Task 12.
+
+Known follow-ups deferred from this plan:
+1. Task 12 Step 2's `SQLRepo.ExportUser` has a TODO comment for the canonical user-owned table list. The implementer must enumerate these from the real schema before shipping; the test in Task 10 exercises the interface, not the SQL.
+2. Task 15 final policy content needs a lawyer pass before Phase 3 launch.
+3. Task 17 may surface voice routes not in the obvious search; a final visual sweep on a deployed instance is part of Task 18.

--- a/docs/superpowers/plans/2026-05-12-demo-deploy-pipeline.md
+++ b/docs/superpowers/plans/2026-05-12-demo-deploy-pipeline.md
@@ -1,0 +1,791 @@
+# Demo Deploy Pipeline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `git tag v0.x.y && git push --tags` → multi-arch GHCR images → demo box updated via GitHub OIDC → AWS SSM Run Command. No SSH from CI. Full audit trail in CloudTrail.
+
+**Architecture:** GitHub Actions runs on `push: tags: 'v*'`. A build job per service (go-api, python-worker, frontend) sets up Docker Buildx, builds linux/amd64 + linux/arm64, pushes to `ghcr.io/ravencloak-org/<service>:<tag>`. A deploy job assumes an IAM role via GitHub OIDC, then calls `aws ssm send-command` to run `deploy/ec2/update.sh --tag v0.x.y` on the demo instance. The workflow polls SSM until the command completes and surfaces stdout/stderr in the workflow log.
+
+**Tech Stack:** GitHub Actions, Docker Buildx, GHCR, AWS OIDC, AWS Systems Manager Run Command, existing `deploy/ec2/update.sh`.
+
+**Spec reference:** `docs/superpowers/specs/2026-05-12-public-demo-deployment-design.md` §5
+**Prerequisite plan:** `2026-05-12-demo-infrastructure.md` (the EC2 instance and SSM agent must exist)
+
+---
+
+## File Structure
+
+**Create:**
+- `deploy/terraform/demo/oidc.tf` — IAM role assumed by GitHub OIDC, scoped to the `ravencloak-org/Raven` repo
+- `.github/workflows/demo-deploy.yml` — orchestrates build → push → deploy on tag
+- `.github/actions/build-and-push/action.yml` — reusable composite action for multi-arch buildx + GHCR push
+- `docs/runbooks/demo-deploy.md` — how to cut a release tag, how to recover from a failed deploy
+
+**Modify:**
+- `deploy/ec2/update.sh` — add `--tag` flag (existing accepts `--sha`)
+- `deploy/ec2/docker-compose.server.yml` — read `GO_API_IMAGE`, `PYTHON_WORKER_IMAGE`, `FRONTEND_IMAGE` from env (verify; the current script already patches the first two)
+- `deploy/ec2/.env.server.example` — add `FRONTEND_IMAGE`
+- `.github/workflows/go.yml`, `python.yml`, `frontend.yml` — confirm they push to GHCR (or move push to the new demo-deploy workflow if not)
+
+---
+
+## Tasks
+
+### Task 1: Inspect what existing workflows already publish
+
+**Files:** none (read-only)
+
+- [ ] **Step 1: Open the three image-building workflows and document, in `docs/runbooks/demo-deploy.md`, exactly which images they push and on which triggers**
+
+```bash
+grep -nE "ghcr.io|docker/build-push-action|push:" .github/workflows/go.yml .github/workflows/python.yml .github/workflows/frontend.yml .github/workflows/docker.yml
+```
+
+Capture per workflow:
+- Trigger (push to main? tag? PR?)
+- Image name(s) pushed
+- Platforms (single-arch? multi-arch?)
+- Whether the image is tagged with `latest`, the commit SHA, the git tag, or all three
+
+- [ ] **Step 2: Write the findings into `docs/runbooks/demo-deploy.md` as a "Current image-publish state" table**
+
+```markdown
+# Demo Deploy Runbook
+
+## Current image-publish state (recorded YYYY-MM-DD)
+
+| Workflow | Trigger | Image | Platforms | Tags |
+|---|---|---|---|---|
+| go.yml | … | … | … | … |
+| python.yml | … | … | … | … |
+| frontend.yml | … | … | … | … |
+| docker.yml | … | … | … | … |
+```
+
+- [ ] **Step 3: Commit the runbook skeleton**
+
+```bash
+git add docs/runbooks/demo-deploy.md
+git commit -m "docs(demo): deploy runbook skeleton with current publish-state audit"
+```
+
+---
+
+### Task 2: Reusable composite action for multi-arch build + GHCR push
+
+**Files:**
+- Create: `.github/actions/build-and-push/action.yml`
+
+- [ ] **Step 1: Write the composite action**
+
+```yaml
+name: Build and push multi-arch image to GHCR
+description: |
+  Builds a service image for linux/amd64 and linux/arm64, pushes to
+  ghcr.io/ravencloak-org/<service> tagged with the git ref (tag or sha-short)
+  plus 'latest'.
+
+inputs:
+  service:
+    description: Service name, e.g. go-api, python-worker, frontend
+    required: true
+  context:
+    description: Build context directory
+    required: true
+  dockerfile:
+    description: Path to the Dockerfile relative to the repo root
+    required: true
+  tag:
+    description: Image tag (e.g. v0.3.0). If empty, uses sha-short.
+    required: false
+    default: ""
+
+outputs:
+  image:
+    description: Full image reference that was pushed
+    value: ${{ steps.set-image.outputs.image }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ env.GITHUB_TOKEN }}
+
+    - name: Resolve tag
+      id: resolve-tag
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.tag }}" ]; then
+          echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+        else
+          echo "tag=sha-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Build and push
+      uses: docker/build-push-action@v5
+      with:
+        context: ${{ inputs.context }}
+        file: ${{ inputs.dockerfile }}
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: |
+          ghcr.io/ravencloak-org/${{ inputs.service }}:${{ steps.resolve-tag.outputs.tag }}
+          ghcr.io/ravencloak-org/${{ inputs.service }}:latest
+        cache-from: type=gha,scope=${{ inputs.service }}
+        cache-to: type=gha,mode=max,scope=${{ inputs.service }}
+
+    - name: Export image reference
+      id: set-image
+      shell: bash
+      run: echo "image=ghcr.io/ravencloak-org/${{ inputs.service }}:${{ steps.resolve-tag.outputs.tag }}" >> "$GITHUB_OUTPUT"
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/actions/build-and-push/action.yml
+git commit -m "feat(ci): reusable composite action for multi-arch GHCR push"
+```
+
+---
+
+### Task 3: Add OIDC IAM role for GitHub Actions
+
+**Files:**
+- Create: `deploy/terraform/demo/oidc.tf`
+
+- [ ] **Step 1: Write the OIDC provider + role**
+
+```hcl
+# GitHub Actions OIDC provider (one per AWS account; create if absent)
+data "aws_iam_openid_connect_provider" "github" {
+  url = "https://token.actions.githubusercontent.com"
+}
+
+# If the provider does not yet exist, comment the data source above and
+# uncomment this resource:
+# resource "aws_iam_openid_connect_provider" "github" {
+#   url             = "https://token.actions.githubusercontent.com"
+#   client_id_list  = ["sts.amazonaws.com"]
+#   thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+# }
+
+resource "aws_iam_role" "github_demo_deploy" {
+  name = "${local.name_prefix}-github-deploy"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Federated = data.aws_iam_openid_connect_provider.github.arn
+      }
+      Action = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+        }
+        StringLike = {
+          "token.actions.githubusercontent.com:sub" = "repo:ravencloak-org/Raven:ref:refs/tags/v*"
+        }
+      }
+    }]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy" "github_demo_deploy" {
+  name = "ssm-send-command-demo"
+  role = aws_iam_role.github_demo_deploy.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ssm:SendCommand",
+          "ssm:GetCommandInvocation",
+          "ssm:ListCommandInvocations"
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "aws:ResourceTag/Environment" = "demo"
+          }
+        }
+      },
+      {
+        Effect = "Allow"
+        Action = ["ssm:SendCommand"]
+        Resource = "arn:aws:ssm:*::document/AWS-RunShellScript"
+      },
+      {
+        Effect = "Allow"
+        Action = ["ssm:GetCommandInvocation", "ssm:ListCommandInvocations"]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+output "github_deploy_role_arn" {
+  description = "ARN of the role GitHub Actions assumes for demo deploys"
+  value       = aws_iam_role.github_demo_deploy.arn
+}
+```
+
+- [ ] **Step 2: Validate**
+
+```bash
+cd deploy/terraform/demo
+terraform fmt && terraform validate
+```
+
+- [ ] **Step 3: Apply (if infra plan #1 already applied)**
+
+```bash
+terraform plan -out oidc.tfplan && terraform apply oidc.tfplan
+```
+
+- [ ] **Step 4: Capture the role ARN**
+
+```bash
+terraform output -raw github_deploy_role_arn
+```
+
+Add the value to `docs/runbooks/demo-deploy.md` under a new "Deploy role ARN" section.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add deploy/terraform/demo/oidc.tf docs/runbooks/demo-deploy.md
+git commit -m "feat(demo): github OIDC role for tag-triggered demo deploys"
+```
+
+---
+
+### Task 4: Extend `update.sh` to accept a `--tag` argument
+
+**Files:**
+- Modify: `deploy/ec2/update.sh`
+
+- [ ] **Step 1: Rewrite the argument parser to support both `--sha` and `--tag`**
+
+Replace lines 16-28 (the current `SHA` parse block) with:
+
+```bash
+GO_API_IMAGE=""
+PYTHON_WORKER_IMAGE=""
+FRONTEND_IMAGE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --sha)
+      REF="sha-${2::7}"
+      shift 2
+      ;;
+    --tag)
+      REF="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -n "${REF:-}" ]; then
+  GO_API_IMAGE="ghcr.io/ravencloak-org/go-api:${REF}"
+  PYTHON_WORKER_IMAGE="ghcr.io/ravencloak-org/python-worker:${REF}"
+  FRONTEND_IMAGE="ghcr.io/ravencloak-org/frontend:${REF}"
+
+  sed -i "s|^GO_API_IMAGE=.*|GO_API_IMAGE=${GO_API_IMAGE}|" "$ENV_FILE"
+  sed -i "s|^PYTHON_WORKER_IMAGE=.*|PYTHON_WORKER_IMAGE=${PYTHON_WORKER_IMAGE}|" "$ENV_FILE"
+  if grep -q '^FRONTEND_IMAGE=' "$ENV_FILE"; then
+    sed -i "s|^FRONTEND_IMAGE=.*|FRONTEND_IMAGE=${FRONTEND_IMAGE}|" "$ENV_FILE"
+  else
+    echo "FRONTEND_IMAGE=${FRONTEND_IMAGE}" >> "$ENV_FILE"
+  fi
+  echo "Pinned to ref: ${REF}"
+fi
+```
+
+- [ ] **Step 2: Add `FRONTEND_IMAGE` to the example env file**
+
+Open `deploy/ec2/.env.server.example` (create if missing) and ensure it contains:
+
+```dotenv
+GO_API_IMAGE=ghcr.io/ravencloak-org/go-api:latest
+PYTHON_WORKER_IMAGE=ghcr.io/ravencloak-org/python-worker:latest
+FRONTEND_IMAGE=ghcr.io/ravencloak-org/frontend:latest
+```
+
+- [ ] **Step 3: Syntax-check the script**
+
+```bash
+bash -n deploy/ec2/update.sh
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add deploy/ec2/update.sh deploy/ec2/.env.server.example
+git commit -m "feat(deploy): update.sh accepts --tag and patches FRONTEND_IMAGE"
+```
+
+---
+
+### Task 5: Wire `FRONTEND_IMAGE` through compose
+
+**Files:**
+- Modify: `deploy/ec2/docker-compose.server.yml`
+
+- [ ] **Step 1: Inspect the compose file and add `image: ${FRONTEND_IMAGE}` to the frontend service if it currently builds from context**
+
+```bash
+grep -nE "frontend:|build:|image:" deploy/ec2/docker-compose.server.yml
+```
+
+Find the `frontend:` service definition. If it has a `build:` block, replace with:
+
+```yaml
+  frontend:
+    image: ${FRONTEND_IMAGE}
+```
+
+(Leave the local `docker-compose.yml` building from source for dev — only the server overlay uses pre-built images.)
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add deploy/ec2/docker-compose.server.yml
+git commit -m "feat(deploy): server overlay reads FRONTEND_IMAGE from env"
+```
+
+---
+
+### Task 6: Build-only workflow update — push on tag
+
+**Files:**
+- Modify: `.github/workflows/go.yml`
+- Modify: `.github/workflows/python.yml`
+- Modify: `.github/workflows/frontend.yml`
+
+Add a new job to each existing workflow that runs only on `push: tags: 'v*'` and uses the composite action from Task 2.
+
+- [ ] **Step 1: Add the publish job to `.github/workflows/go.yml`**
+
+Append to the workflow (top-level keys preserved; add a new job entry):
+
+```yaml
+  publish:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build and push
+        uses: ./.github/actions/build-and-push
+        with:
+          service: go-api
+          context: .
+          dockerfile: Dockerfile
+          tag: ${{ github.ref_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Also add `tags: ['v*']` to the workflow's `on.push` triggers if not already present.
+
+- [ ] **Step 2: Repeat for `.github/workflows/python.yml`**
+
+Same shape, but:
+- `service: python-worker`
+- `context: ./ai-worker`
+- `dockerfile: ai-worker/Dockerfile`
+
+- [ ] **Step 3: Repeat for `.github/workflows/frontend.yml`**
+
+Same shape, but:
+- `service: frontend`
+- `context: ./frontend`
+- `dockerfile: frontend/Dockerfile` (verify path)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/go.yml .github/workflows/python.yml .github/workflows/frontend.yml
+git commit -m "feat(ci): publish multi-arch images to GHCR on v* tags"
+```
+
+---
+
+### Task 7: Demo deploy workflow
+
+**Files:**
+- Create: `.github/workflows/demo-deploy.yml`
+
+- [ ] **Step 1: Write the workflow**
+
+```yaml
+name: Demo deploy
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing v* tag to deploy
+        required: true
+
+permissions:
+  id-token: write     # needed for OIDC
+  contents: read
+
+env:
+  AWS_REGION: ap-south-1
+  ROLE_ARN: arn:aws:iam::<ACCOUNT_ID>:role/raven-demo-github-deploy
+  INSTANCE_TAG_KEY: Name
+  INSTANCE_TAG_VALUE: raven-demo-app
+
+jobs:
+  wait-for-images:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for service images to be available on GHCR
+        env:
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          for svc in go-api python-worker frontend; do
+            for i in {1..30}; do
+              if docker manifest inspect ghcr.io/ravencloak-org/$svc:$TAG > /dev/null 2>&1; then
+                echo "Found $svc:$TAG"
+                break
+              fi
+              echo "Waiting for $svc:$TAG (attempt $i/30)..."
+              sleep 30
+            done
+          done
+
+  deploy:
+    needs: wait-for-images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Resolve demo instance ID
+        id: instance
+        run: |
+          INSTANCE_ID=$(aws ec2 describe-instances \
+            --filters "Name=tag:${INSTANCE_TAG_KEY},Values=${INSTANCE_TAG_VALUE}" \
+                      "Name=instance-state-name,Values=running" \
+            --query 'Reservations[0].Instances[0].InstanceId' \
+            --output text)
+          if [ "$INSTANCE_ID" = "None" ] || [ -z "$INSTANCE_ID" ]; then
+            echo "No running demo instance found"
+            exit 1
+          fi
+          echo "instance_id=$INSTANCE_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Send update.sh via SSM
+        id: ssm
+        env:
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+          INSTANCE_ID: ${{ steps.instance.outputs.instance_id }}
+        run: |
+          set -euo pipefail
+          CMD_ID=$(aws ssm send-command \
+            --instance-ids "$INSTANCE_ID" \
+            --document-name AWS-RunShellScript \
+            --comment "demo deploy $TAG" \
+            --parameters "commands=[\"cd /opt/raven && git fetch --tags && git checkout $TAG && bash deploy/ec2/update.sh --tag $TAG\"]" \
+            --timeout-seconds 1800 \
+            --query 'Command.CommandId' --output text)
+          echo "command_id=$CMD_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for SSM command to complete
+        env:
+          CMD_ID: ${{ steps.ssm.outputs.command_id }}
+          INSTANCE_ID: ${{ steps.instance.outputs.instance_id }}
+        run: |
+          set -euo pipefail
+          for i in {1..60}; do
+            STATUS=$(aws ssm get-command-invocation \
+              --command-id "$CMD_ID" --instance-id "$INSTANCE_ID" \
+              --query Status --output text)
+            echo "[$i] Status: $STATUS"
+            case "$STATUS" in
+              Success) exit 0 ;;
+              Failed|Cancelled|TimedOut)
+                aws ssm get-command-invocation \
+                  --command-id "$CMD_ID" --instance-id "$INSTANCE_ID" \
+                  --query '{stdout:StandardOutputContent,stderr:StandardErrorContent}'
+                exit 1
+                ;;
+            esac
+            sleep 30
+          done
+          echo "Timed out waiting for SSM command"
+          exit 1
+
+      - name: Smoke-test /healthz
+        run: |
+          for i in {1..20}; do
+            if curl -fsS https://demo.raven.ravencloak.org/healthz; then
+              echo "OK"; exit 0
+            fi
+            sleep 15
+          done
+          echo "Health check never went green"
+          exit 1
+```
+
+Note: `<ACCOUNT_ID>` should be replaced with the actual AWS account ID. Track it as a repo-level Actions variable `AWS_ACCOUNT_ID` instead — update the env line:
+
+```yaml
+  ROLE_ARN: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/raven-demo-github-deploy
+```
+
+- [ ] **Step 2: Set the `AWS_ACCOUNT_ID` repo variable**
+
+In GitHub repo Settings → Secrets and variables → Actions → Variables, add `AWS_ACCOUNT_ID` with the account number.
+
+Document the requirement in `docs/runbooks/demo-deploy.md`:
+
+```markdown
+## Required GitHub repo configuration
+
+- Actions variable `AWS_ACCOUNT_ID`: 12-digit AWS account ID hosting the demo.
+```
+
+- [ ] **Step 3: Validate workflow syntax with `actionlint`** (if installed locally)
+
+```bash
+actionlint .github/workflows/demo-deploy.yml
+```
+
+If not installed, skip — GitHub will surface syntax errors on push.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/demo-deploy.yml docs/runbooks/demo-deploy.md
+git commit -m "feat(ci): demo-deploy workflow — OIDC + SSM Run Command"
+```
+
+---
+
+### Task 8: First end-to-end deploy smoke
+
+**Files:** none (operational)
+
+Prerequisite: plan #1 (infrastructure) tasks 1-16 complete and the demo box is up.
+
+- [ ] **Step 1: Tag a dry-run release**
+
+```bash
+git checkout main && git pull
+git tag v0.0.1-demo
+git push origin v0.0.1-demo
+```
+
+- [ ] **Step 2: Watch the workflow**
+
+Open https://github.com/ravencloak-org/Raven/actions and find the run for tag `v0.0.1-demo`. Watch `wait-for-images`, then `deploy`.
+
+Expected: green within ~15 minutes.
+
+- [ ] **Step 3: Verify the images landed on GHCR**
+
+```bash
+for svc in go-api python-worker frontend; do
+  docker manifest inspect ghcr.io/ravencloak-org/$svc:v0.0.1-demo | head -5
+done
+```
+
+Expected: each prints a manifest with `linux/amd64` and `linux/arm64` entries.
+
+- [ ] **Step 4: Verify the demo is responding with the new tag**
+
+```bash
+curl -fsS https://demo.raven.ravencloak.org/healthz
+```
+
+Expected: 200 OK. (If Cloudflare Access is still on the whole hostname per Phase 1, ensure the `/healthz` bypass policy from plan #1 Task 17 Step 3 is in place.)
+
+- [ ] **Step 5: SSM into the box and confirm container images are at the new tag**
+
+```bash
+aws ssm start-session --target $(cd deploy/terraform/demo && terraform output -raw instance_id) --region ap-south-1
+# inside:
+sudo docker ps --format '{{.Image}}'
+```
+
+Expected: rows containing `:v0.0.1-demo`.
+
+- [ ] **Step 6: Append outcome to the runbook**
+
+Add to `docs/runbooks/demo-deploy.md`:
+
+```markdown
+## First successful deploy
+
+- Tag: v0.0.1-demo
+- Date: YYYY-MM-DD
+- Workflow run: <URL>
+- Operator: <initials>
+```
+
+- [ ] **Step 7: Commit runbook update**
+
+```bash
+git add docs/runbooks/demo-deploy.md
+git commit -m "docs(demo): record first successful end-to-end deploy"
+```
+
+---
+
+### Task 9: Deploy notification (post-success email)
+
+**Files:**
+- Modify: `.github/workflows/demo-deploy.yml`
+
+- [ ] **Step 1: Add a final `notify` job that emails on success and failure**
+
+Append to the workflow's `jobs:` block:
+
+```yaml
+  notify:
+    needs: deploy
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send result email via Resend API
+        env:
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+          OUTCOME: ${{ needs.deploy.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          curl -fsS -X POST https://api.resend.com/emails \
+            -H "Authorization: Bearer $RESEND_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"from\": \"noreply@ravencloak.org\",
+              \"to\": [\"jobinlawrance@gmail.com\"],
+              \"subject\": \"[demo] $TAG deploy $OUTCOME\",
+              \"text\": \"Tag: $TAG\\nResult: $OUTCOME\\nRun: $RUN_URL\"
+            }"
+```
+
+- [ ] **Step 2: Set the `RESEND_API_KEY` GitHub Actions secret**
+
+In repo Settings → Secrets → Actions, add `RESEND_API_KEY` from the Resend dashboard (or reuse the value already stored in SSM under `/raven/demo/resend_api_key`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/demo-deploy.yml
+git commit -m "feat(ci): email deploy outcome via Resend on success or failure"
+```
+
+---
+
+### Task 10: Recovery procedure for a failed deploy
+
+**Files:**
+- Modify: `docs/runbooks/demo-deploy.md`
+
+- [ ] **Step 1: Append a recovery section**
+
+```markdown
+## Recovering from a failed deploy
+
+### If `wait-for-images` failed
+
+One of the build workflows (go.yml, python.yml, frontend.yml) didn't push.
+1. Open the per-service workflow run for the tag, identify the failure.
+2. Fix the underlying issue on `main`.
+3. Delete the tag and recreate it:
+   \`\`\`bash
+   git tag -d v0.x.y && git push --delete origin v0.x.y
+   git tag v0.x.y && git push origin v0.x.y
+   \`\`\`
+
+### If `deploy` failed at SSM send-command
+
+OIDC role couldn't be assumed or the instance isn't tagged correctly.
+1. Verify the role ARN matches `terraform output github_deploy_role_arn`.
+2. Verify the instance has `Name=raven-demo-app` and tag `Environment=demo`.
+3. Re-run the `Demo deploy` workflow via `workflow_dispatch`.
+
+### If `deploy` failed during `update.sh`
+
+The new image is bad or compose failed to come up.
+1. SSM into the box.
+2. \`\`\`bash
+   cd /opt/raven
+   docker compose -f deploy/ec2/docker-compose.server.yml --env-file .env.server logs --tail=200
+   \`\`\`
+3. Roll back: re-run `update.sh --tag <previous-good-tag>`.
+4. Open an issue with the failure logs.
+
+### If `/healthz` smoke-test failed
+
+App is up but unhealthy.
+1. SSM into the box. Tail go-api logs.
+2. Check `https://observability.demo.raven.ravencloak.org` for traces from
+   the deploy window.
+3. If unfixable in 15 minutes, roll back.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/runbooks/demo-deploy.md
+git commit -m "docs(demo): deploy failure recovery procedures"
+```
+
+---
+
+## Self-review
+
+| Spec section | Plan task(s) |
+|---|---|
+| §5 CI/CD — multi-arch GHCR | Tasks 2, 6 |
+| §5 CI/CD — OIDC IAM role | Task 3 |
+| §5 CI/CD — SSM Run Command from workflow | Task 7 |
+| §5 update.sh accepts a tag | Task 4 |
+| §5 No SSH from CI | Task 7 (uses SSM exclusively) |
+| §5 Audit trail in CloudTrail | implicit — SSM SendCommand is logged |
+| Deploy notification (operational nicety not in spec but explicitly requested in §9 paging) | Task 9 |
+
+No placeholders. Role ARN is parameterised via `vars.AWS_ACCOUNT_ID`. Image tag flows consistently as `github.ref_name` everywhere.
+
+One known unresolved item: Task 1 audits current workflows but the plan assumes go.yml/python.yml/frontend.yml exist and are the canonical builders. If they don't currently push to GHCR at all, Task 6 is a from-scratch add rather than an extension. The audit in Task 1 surfaces this before Task 6, so the order is safe.
+
+A second known follow-up: the `docker.yml` workflow may already publish a single multi-service image (the badge in README suggests so). If it does, decide during Task 1 whether to retire `docker.yml`'s publish path or have it coexist with the per-service workflows from Task 6. The plan does not prescribe either — flag it for an architectural decision in the audit step.

--- a/docs/superpowers/plans/2026-05-12-demo-infrastructure.md
+++ b/docs/superpowers/plans/2026-05-12-demo-infrastructure.md
@@ -1,0 +1,1560 @@
+# Demo Infrastructure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up a private EC2 box at `demo.raven.ravencloak.org` behind Cloudflare Tunnel + Access, with secrets in SSM, backups (logical + EBS), and external uptime monitoring — ready for the deploy pipeline (plan #2) to push images to.
+
+**Architecture:** Single `t4g.xlarge` ARM EC2 in `ap-south-1`, no inbound ports (Cloudflared dials out). One 100 GB gp3 EBS at `/var/lib/raven-data` for all stateful containers. Terraform manages AWS resources + Cloudflare resources. Cloud-init drops the box at the deploy tag, fetches SSM SecureString params into `/etc/raven/env`, and runs the existing `deploy/ansible/playbook.yml` against localhost. Backup crons via systemd timers; AWS Backup snapshots the EBS volume nightly.
+
+**Tech Stack:** Terraform (hashicorp/aws ~> 5.0, cloudflare/cloudflare ~> 4.0), AWS Systems Manager Parameter Store, AWS Backup, Cloudflare Tunnel + Access, existing Ansible playbook, systemd timers.
+
+**Spec reference:** `docs/superpowers/specs/2026-05-12-public-demo-deployment-design.md`
+
+---
+
+## File Structure
+
+**Create:**
+- `deploy/terraform/demo/versions.tf` — provider versions, S3 backend
+- `deploy/terraform/demo/variables.tf` — all input vars
+- `deploy/terraform/demo/outputs.tf` — instance id, bucket name, role arn
+- `deploy/terraform/demo/main.tf` — provider config + locals
+- `deploy/terraform/demo/vpc.tf` — VPC, subnet, IGW, route
+- `deploy/terraform/demo/security_group.tf` — egress-only SG
+- `deploy/terraform/demo/iam.tf` — instance role + policies
+- `deploy/terraform/demo/s3.tf` — `raven-demo-backups` bucket
+- `deploy/terraform/demo/ebs.tf` — 100 GB gp3 volume + attachment
+- `deploy/terraform/demo/ec2.tf` — t4g.xlarge with user-data
+- `deploy/terraform/demo/backup.tf` — AWS Backup plan + selection
+- `deploy/terraform/demo/user_data.sh.tpl` — cloud-init template
+- `deploy/terraform/demo/cloudflare.tf` — Tunnel, DNS, Access (cloudflare provider)
+- `deploy/terraform/demo/README.md` — apply procedure
+- `deploy/ansible/group_vars/demo.yml` — demo-specific Ansible vars
+- `deploy/ansible/roles/raven-backup/tasks/main.yml` — install backup timers
+- `deploy/ansible/roles/raven-backup/files/raven-pg-backup.sh` — pg_dump → S3
+- `deploy/ansible/roles/raven-backup/files/raven-clickhouse-backup.sh` — clickhouse-backup → S3
+- `deploy/ansible/roles/raven-backup/files/raven-pg-backup.service`
+- `deploy/ansible/roles/raven-backup/files/raven-pg-backup.timer`
+- `deploy/ansible/roles/raven-backup/files/raven-clickhouse-backup.service`
+- `deploy/ansible/roles/raven-backup/files/raven-clickhouse-backup.timer`
+- `docs/runbooks/demo-bootstrap.md` — first-time apply procedure
+- `docs/runbooks/demo-restore.md` — restore from backup procedure
+
+**Modify:**
+- `deploy/ansible/playbook.yml` — add `raven-backup` role
+- `deploy/ansible/group_vars/all.yml.example` — document new vars
+
+**Hand-step (no file, but procedure documented in runbook):**
+- SSM SecureString parameters under `/raven/demo/*`
+- Cloudflare Tunnel credentials (one-time `cloudflared tunnel create` to get the credentials JSON, stored in SSM)
+- BetterStack monitor setup (manual UI)
+
+---
+
+## Tasks
+
+### Task 1: Pre-flight checklist runbook
+
+**Files:**
+- Create: `docs/runbooks/demo-bootstrap.md`
+
+- [ ] **Step 1: Write the runbook skeleton listing every prerequisite**
+
+```markdown
+# Demo Bootstrap Runbook
+
+## Prerequisites (gather before `terraform apply`)
+
+| Item | How to obtain | Where it lives |
+|---|---|---|
+| AWS account with admin or sufficient IAM | Existing | n/a |
+| Cloudflare API token with `Zone:Edit` + `Tunnel:Edit` on `ravencloak.org` | Cloudflare dashboard → My Profile → API Tokens | Local `~/.cloudflare-token` (gitignored) |
+| Cloudflare zone ID for `ravencloak.org` | Cloudflare dashboard → zone overview | TF variable |
+| Cloudflare account ID | Cloudflare dashboard → right sidebar | TF variable |
+| Google OAuth client ID + secret with redirect `https://demo.raven.ravencloak.org/auth/callback/google` | Google Cloud Console → APIs & Services → Credentials | SSM `/raven/demo/google_client_secret` |
+| Razorpay sandbox key id + secret | Razorpay dashboard (Test mode) | SSM `/raven/demo/razorpay_*` |
+| Hyperswitch API key (test) | Hyperswitch dashboard | SSM `/raven/demo/hyperswitch_api_key` |
+| Resend API key | Resend dashboard, free account | SSM `/raven/demo/resend_api_key` |
+| Cloudflare Turnstile site key + secret key | Cloudflare dashboard → Turnstile | SSM `/raven/demo/turnstile_*` |
+| `RAVEN_ENCRYPTION_AES_KEY` (32-byte hex) | `openssl rand -hex 32` | SSM `/raven/demo/raven_encryption_aes_key` |
+| `SUPERTOKENS_API_KEY` (32-byte hex) | `openssl rand -hex 32` | SSM `/raven/demo/supertokens_api_key` |
+| `DOTENV_PRIVATE_KEY` for the demo env | `dotenvx keypair` against a fresh `.env.demo` | SSM `/raven/demo/dotenv_private_key` |
+| `RAVEN_LLM_DAILY_USD_CAP` (e.g. `5.00`) | Decide | SSM `/raven/demo/llm_daily_usd_cap` |
+| TMDB API key | TMDB account | SSM `/raven/demo/tmdb_api_key` |
+
+## SSM seed commands (run once per prerequisite)
+
+\`\`\`bash
+aws ssm put-parameter --region ap-south-1 --type SecureString \\
+  --name /raven/demo/google_client_secret --value 'PASTE_VALUE'
+# ... repeat for each
+\`\`\`
+
+## Cloudflare Tunnel credentials
+
+\`\`\`bash
+cloudflared tunnel login                                           # opens browser
+cloudflared tunnel create raven-demo                               # writes ~/.cloudflared/<UUID>.json
+aws ssm put-parameter --region ap-south-1 --type SecureString \\
+  --name /raven/demo/cloudflared_credentials_json \\
+  --value "$(cat ~/.cloudflared/<UUID>.json)"
+aws ssm put-parameter --region ap-south-1 --type String \\
+  --name /raven/demo/cloudflared_tunnel_id --value '<UUID>'
+\`\`\`
+
+## Terraform apply
+
+\`\`\`bash
+cd deploy/terraform/demo
+terraform init
+terraform plan -out=demo.tfplan
+terraform apply demo.tfplan
+\`\`\`
+
+## Post-apply
+
+- Verify `terraform output instance_id` returns an EC2 id.
+- Use SSM Session Manager to connect: `aws ssm start-session --target <instance_id>`.
+- Tail cloud-init log: `tail -f /var/log/cloud-init-output.log` until "raven-stack: ok" appears.
+- Visit `https://demo.raven.ravencloak.org` — Cloudflare Access should prompt for your email (Phase 1 gate).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/runbooks/demo-bootstrap.md
+git commit -m "docs(demo): add demo bootstrap runbook skeleton"
+```
+
+---
+
+### Task 2: Terraform providers, backend, variables, outputs
+
+**Files:**
+- Create: `deploy/terraform/demo/versions.tf`
+- Create: `deploy/terraform/demo/variables.tf`
+- Create: `deploy/terraform/demo/outputs.tf`
+- Create: `deploy/terraform/demo/main.tf`
+
+- [ ] **Step 1: Write `versions.tf` pinning providers and S3 backend**
+
+```hcl
+terraform {
+  required_version = ">= 1.7.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.0"
+    }
+  }
+
+  backend "s3" {
+    bucket         = "raven-tf-state"
+    key            = "demo/terraform.tfstate"
+    region         = "ap-south-1"
+    encrypt        = true
+    dynamodb_table = "raven-tf-locks"
+  }
+}
+```
+
+- [ ] **Step 2: Write `variables.tf`**
+
+```hcl
+variable "aws_region" {
+  description = "AWS region for the demo stack"
+  type        = string
+  default     = "ap-south-1"
+}
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+  default     = "t4g.xlarge"
+}
+
+variable "data_volume_size_gb" {
+  description = "Size of /var/lib/raven-data EBS volume"
+  type        = number
+  default     = 100
+}
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID for ravencloak.org"
+  type        = string
+}
+
+variable "demo_hostname" {
+  description = "Public hostname for the demo"
+  type        = string
+  default     = "demo.raven.ravencloak.org"
+}
+
+variable "observability_hostname" {
+  description = "Public hostname for the OpenObserve UI"
+  type        = string
+  default     = "observability.demo.raven.ravencloak.org"
+}
+
+variable "access_email" {
+  description = "Email allowed through Cloudflare Access during Phase 1 and to observability"
+  type        = string
+  default     = "jobinlawrance@gmail.com"
+}
+
+variable "deploy_tag" {
+  description = "Git tag to clone at bootstrap"
+  type        = string
+  default     = "main"
+}
+
+variable "ami_owner" {
+  description = "Owner ID for Amazon Linux 2023 ARM AMI"
+  type        = string
+  default     = "amazon"
+}
+```
+
+- [ ] **Step 3: Write `outputs.tf`**
+
+```hcl
+output "instance_id" {
+  description = "EC2 instance id"
+  value       = aws_instance.demo.id
+}
+
+output "instance_role_arn" {
+  description = "ARN of the instance role"
+  value       = aws_iam_role.demo.arn
+}
+
+output "backup_bucket" {
+  description = "S3 bucket holding logical backups"
+  value       = aws_s3_bucket.backups.id
+}
+
+output "data_volume_id" {
+  description = "EBS volume ID for /var/lib/raven-data"
+  value       = aws_ebs_volume.data.id
+}
+
+output "tunnel_id" {
+  description = "Cloudflare Tunnel UUID"
+  value       = cloudflare_tunnel.demo.id
+}
+```
+
+- [ ] **Step 4: Write `main.tf`**
+
+```hcl
+provider "aws" {
+  region = var.aws_region
+}
+
+provider "cloudflare" {
+  # CLOUDFLARE_API_TOKEN env var is read automatically
+}
+
+locals {
+  name_prefix = "raven-demo"
+  tags = {
+    Project     = "raven"
+    Environment = "demo"
+    ManagedBy   = "terraform"
+  }
+}
+
+data "aws_ami" "al2023_arm" {
+  most_recent = true
+  owners      = [var.ami_owner]
+  filter {
+    name   = "name"
+    values = ["al2023-ami-2023*-arm64"]
+  }
+  filter {
+    name   = "architecture"
+    values = ["arm64"]
+  }
+}
+```
+
+- [ ] **Step 5: Verify `terraform init` works (after creating S3 backend bucket + lock table — see step 6)**
+
+Run from `deploy/terraform/demo/`:
+```bash
+terraform fmt
+terraform validate
+```
+
+Expected: `Success! The configuration is valid.`
+
+- [ ] **Step 6: Document the one-time backend bootstrap in the runbook**
+
+Append to `docs/runbooks/demo-bootstrap.md`:
+
+```markdown
+## Terraform backend (one-time, before first `terraform init`)
+
+\`\`\`bash
+aws s3api create-bucket --region ap-south-1 --bucket raven-tf-state \\
+  --create-bucket-configuration LocationConstraint=ap-south-1
+aws s3api put-bucket-versioning --bucket raven-tf-state \\
+  --versioning-configuration Status=Enabled
+aws s3api put-bucket-encryption --bucket raven-tf-state \\
+  --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}'
+aws dynamodb create-table --region ap-south-1 \\
+  --table-name raven-tf-locks \\
+  --attribute-definitions AttributeName=LockID,AttributeType=S \\
+  --key-schema AttributeName=LockID,KeyType=HASH \\
+  --billing-mode PAY_PER_REQUEST
+\`\`\`
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add deploy/terraform/demo/ docs/runbooks/demo-bootstrap.md
+git commit -m "feat(demo): terraform skeleton — providers, variables, outputs, S3 backend"
+```
+
+---
+
+### Task 3: VPC, subnet, IGW, security group
+
+**Files:**
+- Create: `deploy/terraform/demo/vpc.tf`
+- Create: `deploy/terraform/demo/security_group.tf`
+
+- [ ] **Step 1: Write `vpc.tf`**
+
+```hcl
+resource "aws_vpc" "demo" {
+  cidr_block           = "10.42.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+  tags                 = merge(local.tags, { Name = "${local.name_prefix}-vpc" })
+}
+
+resource "aws_subnet" "demo" {
+  vpc_id                  = aws_vpc.demo.id
+  cidr_block              = "10.42.1.0/24"
+  availability_zone       = "${var.aws_region}a"
+  map_public_ip_on_launch = true
+  tags                    = merge(local.tags, { Name = "${local.name_prefix}-subnet" })
+}
+
+resource "aws_internet_gateway" "demo" {
+  vpc_id = aws_vpc.demo.id
+  tags   = merge(local.tags, { Name = "${local.name_prefix}-igw" })
+}
+
+resource "aws_route_table" "demo" {
+  vpc_id = aws_vpc.demo.id
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.demo.id
+  }
+  tags = merge(local.tags, { Name = "${local.name_prefix}-rt" })
+}
+
+resource "aws_route_table_association" "demo" {
+  subnet_id      = aws_subnet.demo.id
+  route_table_id = aws_route_table.demo.id
+}
+```
+
+- [ ] **Step 2: Write `security_group.tf` — egress-only**
+
+```hcl
+resource "aws_security_group" "demo" {
+  name        = "${local.name_prefix}-sg"
+  description = "Egress-only SG for the Raven demo box. Cloudflared dials out — no inbound."
+  vpc_id      = aws_vpc.demo.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "All outbound — needed for image pulls, Cloudflared, SSM, OAuth, LLM APIs"
+  }
+
+  tags = merge(local.tags, { Name = "${local.name_prefix}-sg" })
+}
+```
+
+- [ ] **Step 3: Validate**
+
+```bash
+cd deploy/terraform/demo
+terraform fmt
+terraform validate
+```
+
+Expected: `Success! The configuration is valid.`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add deploy/terraform/demo/vpc.tf deploy/terraform/demo/security_group.tf
+git commit -m "feat(demo): terraform VPC, subnet, IGW, egress-only SG"
+```
+
+---
+
+### Task 4: IAM instance role
+
+**Files:**
+- Create: `deploy/terraform/demo/iam.tf`
+
+- [ ] **Step 1: Write `iam.tf`**
+
+```hcl
+resource "aws_iam_role" "demo" {
+  name = "${local.name_prefix}-instance"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+      Action = "sts:AssumeRole"
+    }]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "ssm_core" {
+  role       = aws_iam_role.demo.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role_policy" "ssm_read" {
+  name = "ssm-read-demo-params"
+  role = aws_iam_role.demo.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "ssm:GetParameter",
+        "ssm:GetParameters",
+        "ssm:GetParametersByPath"
+      ]
+      Resource = "arn:aws:ssm:${var.aws_region}:*:parameter/raven/demo/*"
+    }, {
+      Effect = "Allow"
+      Action = "kms:Decrypt"
+      Resource = "*"
+      Condition = {
+        StringEquals = {
+          "kms:ViaService" = "ssm.${var.aws_region}.amazonaws.com"
+        }
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "s3_backups" {
+  name = "s3-write-backups"
+  role = aws_iam_role.demo.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:ListBucket",
+        "s3:DeleteObject"
+      ]
+      Resource = [
+        aws_s3_bucket.backups.arn,
+        "${aws_s3_bucket.backups.arn}/*"
+      ]
+    }]
+  })
+}
+
+resource "aws_iam_instance_profile" "demo" {
+  name = "${local.name_prefix}-instance"
+  role = aws_iam_role.demo.name
+  tags = local.tags
+}
+```
+
+- [ ] **Step 2: Validate**
+
+```bash
+terraform fmt
+terraform validate
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add deploy/terraform/demo/iam.tf
+git commit -m "feat(demo): terraform IAM role with SSM + S3 backup access"
+```
+
+---
+
+### Task 5: S3 backup bucket
+
+**Files:**
+- Create: `deploy/terraform/demo/s3.tf`
+
+- [ ] **Step 1: Write `s3.tf`**
+
+```hcl
+resource "aws_s3_bucket" "backups" {
+  bucket = "${local.name_prefix}-backups"
+  tags   = local.tags
+}
+
+resource "aws_s3_bucket_versioning" "backups" {
+  bucket = aws_s3_bucket.backups.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "backups" {
+  bucket = aws_s3_bucket.backups.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "backups" {
+  bucket                  = aws_s3_bucket.backups.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "backups" {
+  bucket = aws_s3_bucket.backups.id
+  rule {
+    id     = "expire-old-backups"
+    status = "Enabled"
+    expiration {
+      days = 30
+    }
+    noncurrent_version_expiration {
+      noncurrent_days = 7
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Validate and commit**
+
+```bash
+terraform fmt && terraform validate
+git add deploy/terraform/demo/s3.tf
+git commit -m "feat(demo): terraform S3 backup bucket with 30-day lifecycle"
+```
+
+---
+
+### Task 6: EBS data volume
+
+**Files:**
+- Create: `deploy/terraform/demo/ebs.tf`
+
+- [ ] **Step 1: Write `ebs.tf`**
+
+```hcl
+resource "aws_ebs_volume" "data" {
+  availability_zone = "${var.aws_region}a"
+  size              = var.data_volume_size_gb
+  type              = "gp3"
+  encrypted         = true
+  tags = merge(local.tags, {
+    Name        = "${local.name_prefix}-data"
+    BackupPlan  = "raven-demo-daily"
+  })
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_volume_attachment" "data" {
+  device_name = "/dev/sdf"
+  volume_id   = aws_ebs_volume.data.id
+  instance_id = aws_instance.demo.id
+}
+```
+
+- [ ] **Step 2: Validate and commit**
+
+```bash
+terraform fmt && terraform validate
+git add deploy/terraform/demo/ebs.tf
+git commit -m "feat(demo): terraform 100GB gp3 data volume with prevent_destroy"
+```
+
+---
+
+### Task 7: Cloud-init user-data template
+
+**Files:**
+- Create: `deploy/terraform/demo/user_data.sh.tpl`
+
+- [ ] **Step 1: Write the cloud-init template**
+
+```bash
+#!/bin/bash
+set -euxo pipefail
+
+# ── 1. System deps ─────────────────────────────────────────────────────────
+dnf -y update
+dnf -y install git docker ansible-core jq awscli amazon-ssm-agent
+systemctl enable --now docker
+systemctl enable --now amazon-ssm-agent
+usermod -aG docker ec2-user
+
+# ── 2. Mount data volume ──────────────────────────────────────────────────
+DEVICE=/dev/nvme1n1
+MOUNT=/var/lib/raven-data
+if ! blkid "$DEVICE"; then
+  mkfs.ext4 -L raven-data "$DEVICE"
+fi
+mkdir -p "$MOUNT"
+echo "LABEL=raven-data $MOUNT ext4 defaults,nofail 0 2" >> /etc/fstab
+mount "$MOUNT"
+
+# ── 3. Pull SSM params into /etc/raven/env ────────────────────────────────
+mkdir -p /etc/raven
+PARAMS=$(aws ssm get-parameters-by-path \
+  --region ${aws_region} \
+  --path /raven/demo \
+  --with-decryption \
+  --recursive \
+  --query 'Parameters[].[Name,Value]' --output text)
+
+: > /etc/raven/env.tmp
+while IFS=$'\t' read -r name value; do
+  key=$(basename "$name" | tr '[:lower:]' '[:upper:]')
+  # don't expose cloudflared_credentials_json this way — handled separately
+  if [ "$key" = "CLOUDFLARED_CREDENTIALS_JSON" ]; then continue; fi
+  printf '%s=%s\n' "$key" "$value" >> /etc/raven/env.tmp
+done <<< "$PARAMS"
+
+mv /etc/raven/env.tmp /etc/raven/env
+chmod 0600 /etc/raven/env
+chown root:root /etc/raven/env
+
+# ── 4. Cloudflared credentials ────────────────────────────────────────────
+mkdir -p /etc/cloudflared
+TUNNEL_ID=$(aws ssm get-parameter --region ${aws_region} \
+  --name /raven/demo/cloudflared_tunnel_id --query Parameter.Value --output text)
+aws ssm get-parameter --region ${aws_region} \
+  --name /raven/demo/cloudflared_credentials_json \
+  --with-decryption --query Parameter.Value --output text \
+  > /etc/cloudflared/$TUNNEL_ID.json
+chmod 0600 /etc/cloudflared/$TUNNEL_ID.json
+echo "TUNNEL_ID=$TUNNEL_ID" >> /etc/raven/env
+
+# ── 5. Clone repo and run Ansible ─────────────────────────────────────────
+cd /opt
+git clone https://github.com/ravencloak-org/Raven.git raven
+cd raven
+git checkout ${deploy_tag}
+
+ansible-playbook deploy/ansible/playbook.yml \
+  -i 'localhost,' -c local \
+  -e ansible_group_vars_file=group_vars/demo.yml
+
+echo "raven-stack: ok"
+```
+
+- [ ] **Step 2: Validate the template renders by writing a test plan**
+
+Run from `deploy/terraform/demo/`:
+```bash
+echo 'output "rendered_user_data" {
+  value = templatefile("user_data.sh.tpl", { aws_region = "ap-south-1", deploy_tag = "main" })
+}' > _test_render.tf
+terraform fmt _test_render.tf
+terraform validate
+rm _test_render.tf
+```
+
+Expected: validate succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add deploy/terraform/demo/user_data.sh.tpl
+git commit -m "feat(demo): cloud-init user-data — mount EBS, fetch SSM, run Ansible"
+```
+
+---
+
+### Task 8: EC2 instance
+
+**Files:**
+- Create: `deploy/terraform/demo/ec2.tf`
+
+- [ ] **Step 1: Write `ec2.tf`**
+
+```hcl
+resource "aws_instance" "demo" {
+  ami                    = data.aws_ami.al2023_arm.id
+  instance_type          = var.instance_type
+  subnet_id              = aws_subnet.demo.id
+  vpc_security_group_ids = [aws_security_group.demo.id]
+  iam_instance_profile   = aws_iam_instance_profile.demo.name
+
+  root_block_device {
+    volume_size = 30
+    volume_type = "gp3"
+    encrypted   = true
+  }
+
+  user_data = templatefile("${path.module}/user_data.sh.tpl", {
+    aws_region = var.aws_region
+    deploy_tag = var.deploy_tag
+  })
+
+  metadata_options {
+    http_tokens   = "required"
+    http_endpoint = "enabled"
+  }
+
+  tags = merge(local.tags, { Name = "${local.name_prefix}-app" })
+
+  lifecycle {
+    ignore_changes = [
+      ami,        # don't replace box when AL2023 publishes a new image
+      user_data,  # cloud-init runs once; later changes are via Ansible/deploy
+    ]
+  }
+}
+```
+
+- [ ] **Step 2: Validate and commit**
+
+```bash
+terraform fmt && terraform validate
+git add deploy/terraform/demo/ec2.tf
+git commit -m "feat(demo): terraform EC2 t4g.xlarge with IMDSv2 and ignore_changes guards"
+```
+
+---
+
+### Task 9: AWS Backup plan
+
+**Files:**
+- Create: `deploy/terraform/demo/backup.tf`
+
+- [ ] **Step 1: Write `backup.tf`**
+
+```hcl
+resource "aws_backup_vault" "demo" {
+  name = "${local.name_prefix}-vault"
+  tags = local.tags
+}
+
+resource "aws_iam_role" "backup" {
+  name = "${local.name_prefix}-backup"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = { Service = "backup.amazonaws.com" }
+      Action = "sts:AssumeRole"
+    }]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "backup" {
+  role       = aws_iam_role.backup.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup"
+}
+
+resource "aws_backup_plan" "demo" {
+  name = "${local.name_prefix}-daily"
+
+  rule {
+    rule_name         = "daily-ebs"
+    target_vault_name = aws_backup_vault.demo.name
+    schedule          = "cron(0 18 * * ? *)" # 18:00 UTC = 23:30 IST
+    lifecycle {
+      delete_after = 14
+    }
+  }
+
+  tags = local.tags
+}
+
+resource "aws_backup_selection" "demo" {
+  iam_role_arn = aws_iam_role.backup.arn
+  name         = "${local.name_prefix}-selection"
+  plan_id      = aws_backup_plan.demo.id
+
+  selection_tag {
+    type  = "STRINGEQUALS"
+    key   = "BackupPlan"
+    value = "raven-demo-daily"
+  }
+}
+```
+
+- [ ] **Step 2: Validate and commit**
+
+```bash
+terraform fmt && terraform validate
+git add deploy/terraform/demo/backup.tf
+git commit -m "feat(demo): AWS Backup nightly EBS snapshots, 14d retention"
+```
+
+---
+
+### Task 10: Cloudflare Tunnel, DNS, Access (all via Terraform)
+
+**Files:**
+- Create: `deploy/terraform/demo/cloudflare.tf`
+
+- [ ] **Step 1: Write `cloudflare.tf`**
+
+```hcl
+resource "random_id" "tunnel_secret" {
+  byte_length = 35
+}
+
+resource "cloudflare_tunnel" "demo" {
+  account_id = var.cloudflare_account_id
+  name       = "raven-demo"
+  secret     = random_id.tunnel_secret.b64_std
+}
+
+resource "cloudflare_tunnel_config" "demo" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_tunnel.demo.id
+
+  config {
+    ingress_rule {
+      hostname = var.demo_hostname
+      service  = "http://localhost:8180"
+      path     = "/api/.*"
+    }
+    ingress_rule {
+      hostname = var.demo_hostname
+      service  = "http://localhost:8080"
+    }
+    ingress_rule {
+      hostname = var.observability_hostname
+      service  = "http://localhost:5080"
+    }
+    ingress_rule {
+      service = "http_status:404"
+    }
+  }
+}
+
+resource "cloudflare_record" "demo" {
+  zone_id = var.cloudflare_zone_id
+  name    = var.demo_hostname
+  content = "${cloudflare_tunnel.demo.id}.cfargotunnel.com"
+  type    = "CNAME"
+  proxied = true
+}
+
+resource "cloudflare_record" "observability" {
+  zone_id = var.cloudflare_zone_id
+  name    = var.observability_hostname
+  content = "${cloudflare_tunnel.demo.id}.cfargotunnel.com"
+  type    = "CNAME"
+  proxied = true
+}
+
+# Cloudflare Access: gate observability subdomain to your email only
+resource "cloudflare_access_application" "observability" {
+  account_id       = var.cloudflare_account_id
+  name             = "raven-demo-observability"
+  domain           = var.observability_hostname
+  session_duration = "24h"
+}
+
+resource "cloudflare_access_policy" "observability_allow" {
+  account_id     = var.cloudflare_account_id
+  application_id = cloudflare_access_application.observability.id
+  name           = "allow-operator"
+  precedence     = 1
+  decision       = "allow"
+
+  include {
+    email = [var.access_email]
+  }
+}
+
+# Phase 1 gate on the whole demo hostname — disabled by default,
+# set var.phase1_access_enabled=true to activate during Phase 1, then false.
+variable "phase1_access_enabled" {
+  description = "Set true during Phase 1 to gate demo.* behind Cloudflare Access"
+  type        = bool
+  default     = true
+}
+
+resource "cloudflare_access_application" "demo_phase1" {
+  count            = var.phase1_access_enabled ? 1 : 0
+  account_id       = var.cloudflare_account_id
+  name             = "raven-demo-phase1"
+  domain           = var.demo_hostname
+  session_duration = "24h"
+}
+
+resource "cloudflare_access_policy" "demo_phase1_allow" {
+  count          = var.phase1_access_enabled ? 1 : 0
+  account_id     = var.cloudflare_account_id
+  application_id = cloudflare_access_application.demo_phase1[0].id
+  name           = "allow-operator"
+  precedence     = 1
+  decision       = "allow"
+
+  include {
+    email = [var.access_email]
+  }
+}
+```
+
+- [ ] **Step 2: Store the tunnel credentials in SSM after first apply**
+
+The `cloudflare_tunnel` resource needs its credentials persisted to SSM so the EC2 box can fetch them. Add this resource:
+
+```hcl
+resource "aws_ssm_parameter" "tunnel_credentials" {
+  name  = "/raven/demo/cloudflared_credentials_json"
+  type  = "SecureString"
+  value = jsonencode({
+    AccountTag   = var.cloudflare_account_id
+    TunnelID     = cloudflare_tunnel.demo.id
+    TunnelSecret = random_id.tunnel_secret.b64_std
+  })
+  tags  = local.tags
+}
+
+resource "aws_ssm_parameter" "tunnel_id" {
+  name  = "/raven/demo/cloudflared_tunnel_id"
+  type  = "String"
+  value = cloudflare_tunnel.demo.id
+  tags  = local.tags
+}
+```
+
+This supersedes the manual `cloudflared tunnel login` step in the runbook — update the runbook to remove it.
+
+- [ ] **Step 3: Update runbook Step 7**
+
+Modify `docs/runbooks/demo-bootstrap.md` — replace the "Cloudflare Tunnel credentials" section with:
+
+```markdown
+## Cloudflare Tunnel credentials
+
+Terraform manages the tunnel resource and writes its credentials to SSM
+(`/raven/demo/cloudflared_credentials_json`, `/raven/demo/cloudflared_tunnel_id`).
+No manual `cloudflared login` step is needed.
+```
+
+- [ ] **Step 4: Validate and commit**
+
+```bash
+terraform fmt && terraform validate
+git add deploy/terraform/demo/cloudflare.tf docs/runbooks/demo-bootstrap.md
+git commit -m "feat(demo): cloudflare tunnel, DNS, Access via terraform; tunnel creds in SSM"
+```
+
+---
+
+### Task 11: Ansible group_vars for demo
+
+**Files:**
+- Create: `deploy/ansible/group_vars/demo.yml`
+
+- [ ] **Step 1: Inspect existing `group_vars/all.yml.example` to mirror variable names**
+
+```bash
+cat /Users/jobinlawrance/Project/raven/deploy/ansible/group_vars/all.yml.example
+```
+
+- [ ] **Step 2: Write `deploy/ansible/group_vars/demo.yml` overriding for demo**
+
+```yaml
+---
+# Demo-specific Ansible variables. Loaded explicitly by cloud-init.
+raven_env: demo
+raven_domain: demo.raven.ravencloak.org
+raven_observability_domain: observability.demo.raven.ravencloak.org
+
+# Compose overlay file applied on top of docker-compose.yml
+raven_compose_overlay: docker-compose.demo.yml
+
+# Voice services kept running but UI hidden
+raven_voice_enabled: false
+
+# LLM cost fuse
+raven_llm_daily_usd_cap: "{{ lookup('env', 'RAVEN_LLM_DAILY_USD_CAP') | default('5.00', true) }}"
+
+# Backup config
+raven_backup_s3_bucket: raven-demo-backups
+raven_backup_pg_schedule: "*-*-* 18:30:00"        # 18:30 UTC daily
+raven_backup_clickhouse_schedule: "*-*-* 19:00:00" # 19:00 UTC daily
+
+# Cloudflared
+cloudflared_credentials_path: /etc/cloudflared
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add deploy/ansible/group_vars/demo.yml
+git commit -m "feat(demo): ansible group_vars for demo environment"
+```
+
+---
+
+### Task 12: Demo compose overlay (placeholder — minimal)
+
+**Files:**
+- Create: `docker-compose.demo.yml`
+
+- [ ] **Step 1: Write minimal overlay that sets demo env**
+
+```yaml
+# Overlay applied on top of docker-compose.yml for the public demo.
+# Voice services (livekit-server, stt, tts) remain running so the
+# python-worker's depends_on chain holds, but no Cloudflared route
+# is published for them and the frontend hides voice UI.
+services:
+  frontend:
+    environment:
+      RAVEN_VOICE_ENABLED: "false"
+      RAVEN_TURNSTILE_SITE_KEY: "${TURNSTILE_SITE_KEY}"
+
+  go-api:
+    environment:
+      RAVEN_VOICE_ENABLED: "false"
+      RAVEN_TURNSTILE_SECRET_KEY: "${TURNSTILE_SECRET_KEY}"
+
+  python-worker:
+    environment:
+      RAVEN_LLM_DAILY_USD_CAP: "${RAVEN_LLM_DAILY_USD_CAP}"
+```
+
+(The actual code that reads `RAVEN_VOICE_ENABLED`, Turnstile keys, and the LLM $-fuse is in plan #3. This overlay just plumbs env vars through.)
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docker-compose.demo.yml
+git commit -m "feat(demo): compose overlay wiring demo env vars"
+```
+
+---
+
+### Task 13: Backup role — pg_dump systemd timer
+
+**Files:**
+- Create: `deploy/ansible/roles/raven-backup/tasks/main.yml`
+- Create: `deploy/ansible/roles/raven-backup/files/raven-pg-backup.sh`
+- Create: `deploy/ansible/roles/raven-backup/files/raven-pg-backup.service`
+- Create: `deploy/ansible/roles/raven-backup/files/raven-pg-backup.timer`
+
+- [ ] **Step 1: Write the backup script `raven-pg-backup.sh`**
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+S3_BUCKET="${1:-raven-demo-backups}"
+DATE=$(date -u +%Y-%m-%dT%H-%M-%SZ)
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+DUMP="$TMP/postgres-$DATE.dump"
+
+docker exec raven-postgres-1 pg_dump -U raven -d raven -Fc > "$DUMP"
+
+if [ ! -s "$DUMP" ]; then
+  echo "ERROR: pg_dump produced an empty file" >&2
+  exit 1
+fi
+
+aws s3 cp "$DUMP" "s3://$S3_BUCKET/postgres/postgres-$DATE.dump"
+echo "OK: uploaded postgres/postgres-$DATE.dump"
+```
+
+- [ ] **Step 2: Write the systemd service unit**
+
+```ini
+[Unit]
+Description=Raven Postgres logical backup to S3
+Wants=network-online.target docker.service
+After=network-online.target docker.service
+
+[Service]
+Type=oneshot
+EnvironmentFile=/etc/raven/env
+ExecStart=/usr/local/bin/raven-pg-backup.sh raven-demo-backups
+StandardOutput=journal
+StandardError=journal
+```
+
+- [ ] **Step 3: Write the timer unit**
+
+```ini
+[Unit]
+Description=Raven Postgres backup timer
+
+[Timer]
+OnCalendar=*-*-* 18:30:00 UTC
+RandomizedDelaySec=300
+Persistent=true
+Unit=raven-pg-backup.service
+
+[Install]
+WantedBy=timers.target
+```
+
+- [ ] **Step 4: Write the Ansible task in `tasks/main.yml`**
+
+```yaml
+---
+- name: Install pg backup script
+  ansible.builtin.copy:
+    src: raven-pg-backup.sh
+    dest: /usr/local/bin/raven-pg-backup.sh
+    mode: "0755"
+
+- name: Install pg backup service
+  ansible.builtin.copy:
+    src: raven-pg-backup.service
+    dest: /etc/systemd/system/raven-pg-backup.service
+    mode: "0644"
+
+- name: Install pg backup timer
+  ansible.builtin.copy:
+    src: raven-pg-backup.timer
+    dest: /etc/systemd/system/raven-pg-backup.timer
+    mode: "0644"
+
+- name: Enable pg backup timer
+  ansible.builtin.systemd:
+    name: raven-pg-backup.timer
+    enabled: true
+    state: started
+    daemon_reload: true
+```
+
+- [ ] **Step 5: Test the script syntax locally**
+
+```bash
+bash -n deploy/ansible/roles/raven-backup/files/raven-pg-backup.sh
+```
+
+Expected: no output (syntax OK).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add deploy/ansible/roles/raven-backup/
+git commit -m "feat(demo): postgres backup systemd timer + ansible role skeleton"
+```
+
+---
+
+### Task 14: Backup role — ClickHouse timer
+
+**Files:**
+- Modify: `deploy/ansible/roles/raven-backup/tasks/main.yml`
+- Create: `deploy/ansible/roles/raven-backup/files/raven-clickhouse-backup.sh`
+- Create: `deploy/ansible/roles/raven-backup/files/raven-clickhouse-backup.service`
+- Create: `deploy/ansible/roles/raven-backup/files/raven-clickhouse-backup.timer`
+
+- [ ] **Step 1: Write the script**
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+S3_BUCKET="${1:-raven-demo-backups}"
+DATE=$(date -u +%Y-%m-%dT%H-%M-%SZ)
+BACKUP_NAME="clickhouse-$DATE"
+
+docker exec raven-clickhouse-1 clickhouse-backup create "$BACKUP_NAME"
+docker exec raven-clickhouse-1 clickhouse-backup upload "$BACKUP_NAME"
+docker exec raven-clickhouse-1 clickhouse-backup delete local "$BACKUP_NAME"
+
+echo "OK: uploaded clickhouse $BACKUP_NAME"
+```
+
+This script requires `clickhouse-backup` to be configured inside the ClickHouse container with the S3 remote pointing at the same bucket. Document this in the ClickHouse compose config — assume an env-driven config block already exists or document its addition as a follow-up note.
+
+- [ ] **Step 2: Write the service unit**
+
+```ini
+[Unit]
+Description=Raven ClickHouse backup to S3
+Wants=network-online.target docker.service
+After=raven-pg-backup.service
+
+[Service]
+Type=oneshot
+EnvironmentFile=/etc/raven/env
+ExecStart=/usr/local/bin/raven-clickhouse-backup.sh raven-demo-backups
+StandardOutput=journal
+StandardError=journal
+```
+
+- [ ] **Step 3: Write the timer unit**
+
+```ini
+[Unit]
+Description=Raven ClickHouse backup timer
+
+[Timer]
+OnCalendar=*-*-* 19:00:00 UTC
+RandomizedDelaySec=300
+Persistent=true
+Unit=raven-clickhouse-backup.service
+
+[Install]
+WantedBy=timers.target
+```
+
+- [ ] **Step 4: Extend the Ansible task file**
+
+Append to `tasks/main.yml`:
+
+```yaml
+- name: Install clickhouse backup script
+  ansible.builtin.copy:
+    src: raven-clickhouse-backup.sh
+    dest: /usr/local/bin/raven-clickhouse-backup.sh
+    mode: "0755"
+
+- name: Install clickhouse backup service
+  ansible.builtin.copy:
+    src: raven-clickhouse-backup.service
+    dest: /etc/systemd/system/raven-clickhouse-backup.service
+    mode: "0644"
+
+- name: Install clickhouse backup timer
+  ansible.builtin.copy:
+    src: raven-clickhouse-backup.timer
+    dest: /etc/systemd/system/raven-clickhouse-backup.timer
+    mode: "0644"
+
+- name: Enable clickhouse backup timer
+  ansible.builtin.systemd:
+    name: raven-clickhouse-backup.timer
+    enabled: true
+    state: started
+    daemon_reload: true
+```
+
+- [ ] **Step 5: Syntax-check and commit**
+
+```bash
+bash -n deploy/ansible/roles/raven-backup/files/raven-clickhouse-backup.sh
+git add deploy/ansible/roles/raven-backup/
+git commit -m "feat(demo): clickhouse backup systemd timer"
+```
+
+---
+
+### Task 15: Wire raven-backup role into the playbook
+
+**Files:**
+- Modify: `deploy/ansible/playbook.yml`
+
+- [ ] **Step 1: Append the role to the playbook role list**
+
+Open `deploy/ansible/playbook.yml`, change:
+
+```yaml
+  roles:
+    - base
+    - docker
+    - nodejs
+    - pm2
+    - cloudflared
+    - raven-stack
+    - admin-tools
+```
+
+to:
+
+```yaml
+  roles:
+    - base
+    - docker
+    - nodejs
+    - pm2
+    - cloudflared
+    - raven-stack
+    - raven-backup
+    - admin-tools
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add deploy/ansible/playbook.yml
+git commit -m "feat(demo): wire raven-backup role into playbook"
+```
+
+---
+
+### Task 16: Apply Terraform end-to-end (manual smoke)
+
+**Files:** none (operational task)
+
+- [ ] **Step 1: Seed all SSM parameters per the bootstrap runbook**
+
+Following `docs/runbooks/demo-bootstrap.md` Step 1, run `aws ssm put-parameter` for every prerequisite listed in the table.
+
+- [ ] **Step 2: Bootstrap the Terraform backend (one-time)**
+
+Following `docs/runbooks/demo-bootstrap.md` Step "Terraform backend", run the four `aws s3api` / `aws dynamodb` commands.
+
+- [ ] **Step 3: Apply**
+
+```bash
+cd deploy/terraform/demo
+export CLOUDFLARE_API_TOKEN=$(cat ~/.cloudflare-token)
+terraform init
+terraform plan -var cloudflare_account_id=<id> -var cloudflare_zone_id=<id> -out demo.tfplan
+terraform apply demo.tfplan
+```
+
+Expected: ~20 resources created, no errors.
+
+- [ ] **Step 4: Watch the box come up**
+
+```bash
+INSTANCE_ID=$(terraform output -raw instance_id)
+aws ssm start-session --target $INSTANCE_ID --region ap-south-1
+# inside the session:
+sudo tail -f /var/log/cloud-init-output.log
+```
+
+Expected: end of log reads `raven-stack: ok`.
+
+- [ ] **Step 5: Visit `https://demo.raven.ravencloak.org`**
+
+Should hit a Cloudflare Access login screen. Enter `jobinlawrance@gmail.com`, follow the email magic link. Once authenticated, the Raven frontend loads.
+
+- [ ] **Step 6: Visit `https://observability.demo.raven.ravencloak.org`**
+
+Should also gate through Cloudflare Access. Once through, OpenObserve UI loads.
+
+- [ ] **Step 7: Verify timers are scheduled**
+
+```bash
+sudo systemctl list-timers --all | grep raven
+```
+
+Expected: two raven timers active with next-fire times in the next 24h.
+
+- [ ] **Step 8: Manually fire a pg backup as a smoke test**
+
+```bash
+sudo systemctl start raven-pg-backup.service
+sudo journalctl -u raven-pg-backup.service --no-pager | tail -20
+aws s3 ls s3://raven-demo-backups/postgres/ --region ap-south-1
+```
+
+Expected: at least one `.dump` object listed.
+
+- [ ] **Step 9: Document outcome in the runbook**
+
+Append a "Verified by:" line at the bottom of `docs/runbooks/demo-bootstrap.md` with the date and your initials, and `terraform output` values.
+
+- [ ] **Step 10: Commit any runbook updates**
+
+```bash
+git add docs/runbooks/demo-bootstrap.md
+git commit -m "docs(demo): record first successful bootstrap"
+```
+
+---
+
+### Task 17: BetterStack uptime monitor (manual)
+
+**Files:**
+- Create: `docs/runbooks/demo-monitoring.md`
+
+- [ ] **Step 1: Create a free BetterStack account** at https://betterstack.com.
+
+- [ ] **Step 2: Create an Uptime monitor**
+
+- URL: `https://demo.raven.ravencloak.org/healthz`
+- Check frequency: 60 seconds
+- Request timeout: 10 seconds
+- Expected status code: 200
+- Recovery email: jobinlawrance@gmail.com
+- Push notification: enable iOS/Android via BetterStack app
+
+- [ ] **Step 3: Verify it goes green within 5 minutes**
+
+Note: during Phase 1 with Cloudflare Access on the whole hostname, `/healthz` is also behind Access — which BetterStack can't satisfy. Either:
+- Add a Cloudflare Access policy bypass for the BetterStack IP ranges, OR
+- Expose only `/healthz` as a public bypass via a separate Cloudflare Rule, OR
+- Defer activating the monitor until Phase 2 (Access removed).
+
+Pick the bypass-rule option. Cloudflare → demo.raven.ravencloak.org Access app → Bypass policy for `Path == /healthz`.
+
+- [ ] **Step 4: Write the runbook**
+
+```markdown
+# Demo Monitoring Runbook
+
+## Uptime: BetterStack
+
+- Monitor name: `raven-demo-healthz`
+- URL: `https://demo.raven.ravencloak.org/healthz`
+- Owner: jobinlawrance@gmail.com
+- Cloudflare Access bypass: Path == `/healthz` is exempt from Access policies
+  so external probes can reach the origin.
+
+When the monitor fires:
+
+1. Open BetterStack incident, note the timestamp.
+2. SSM into the box: `aws ssm start-session --target $(terraform output -raw instance_id)`.
+3. `sudo journalctl -u docker --since '5 minutes ago' | grep -E 'go-api|python-worker'`.
+4. `docker compose ps` — any service down? Restart it.
+5. If unresolvable, post status to ravencloak.org/status (Phase 3 only).
+
+## Host metrics: Beszel
+
+Already installed on the AWS Beszel instance. Confirm the demo box is registered.
+
+## App telemetry: OpenObserve
+
+`https://observability.demo.raven.ravencloak.org` — Cloudflare Access required.
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/runbooks/demo-monitoring.md
+git commit -m "docs(demo): monitoring runbook for BetterStack + Beszel + OpenObserve"
+```
+
+---
+
+### Task 18: Restore drill runbook
+
+**Files:**
+- Create: `docs/runbooks/demo-restore.md`
+
+- [ ] **Step 1: Write the restore procedure**
+
+```markdown
+# Demo Restore Runbook
+
+Goal: bring the demo back online when the EC2 box is lost or the data
+volume is corrupt, using only the artifacts in AWS Backup + S3.
+
+## Scenario A — Box dead, EBS volume intact
+
+1. `terraform apply -replace=aws_instance.demo` — TF recreates the EC2 instance
+   and re-attaches the existing EBS volume (prevent_destroy holds).
+2. Cloud-init re-runs on the new box.
+3. Verify `https://demo.raven.ravencloak.org` returns 200.
+
+## Scenario B — EBS volume corrupt or deleted
+
+1. Restore the latest AWS Backup recovery point of the data volume:
+   \`\`\`bash
+   aws backup start-restore-job \\
+     --recovery-point-arn <ARN_from_backup_vault> \\
+     --iam-role-arn $(terraform output -raw instance_role_arn) \\
+     --resource-type EBS \\
+     --metadata 'AvailabilityZone=ap-south-1a,VolumeType=gp3,Encrypted=true'
+   \`\`\`
+2. Wait for the restore job to complete (`aws backup describe-restore-job`).
+3. Update `deploy/terraform/demo/ebs.tf` to import the restored volume.
+4. `terraform apply -replace=aws_instance.demo` to re-create the EC2 against
+   the restored volume.
+
+## Scenario C — Postgres data lost, logical backup needed
+
+1. Box up, fresh PG container.
+2. SSM into the box.
+3. \`\`\`bash
+   LATEST=$(aws s3 ls s3://raven-demo-backups/postgres/ | sort | tail -1 | awk '{print $4}')
+   aws s3 cp s3://raven-demo-backups/postgres/$LATEST /tmp/restore.dump
+   docker exec -i raven-postgres-1 pg_restore -U raven -d raven --clean --if-exists < /tmp/restore.dump
+   \`\`\`
+4. Verify a known recent row exists in a representative table.
+
+## Recovery time targets
+
+| Scenario | RTO | RPO |
+|---|---|---|
+| A (box only) | 15 min | 0 |
+| B (volume + box) | 1-2 h | 24 h (last snapshot) |
+| C (PG only) | 30 min | 24 h (last pg_dump) |
+
+A drill of Scenario C must be performed against staging before Phase 2.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/runbooks/demo-restore.md
+git commit -m "docs(demo): restore runbook with three scenarios + RTO/RPO targets"
+```
+
+---
+
+## Self-review
+
+| Spec section | Plan task(s) |
+|---|---|
+| §2 Topology (EC2, VPC, EBS, Cloudflare Tunnel) | Tasks 2-3, 6-8, 10 |
+| §2 OpenObserve behind Cloudflare Access | Task 10 (access_application "observability") |
+| §3 Identity (Google OAuth secrets in SSM) | Task 1 (runbook lists Google secrets) — actual app wiring is in plan #3 |
+| §3 LLM $-fuse env plumbing | Task 11 group_vars + Task 12 compose overlay (env only; logic in plan #3) |
+| §4 Terraform module | Tasks 2-10 |
+| §4 Cloud-init | Task 7 |
+| §4 Secrets layout (SSM SecureString) | Task 1 runbook + Task 4 IAM read policy |
+| §5 CI/CD | Plan #2 (not this plan) |
+| §6 Logical backups (pg_dump, clickhouse-backup) | Tasks 13-14 |
+| §6 EBS snapshots (AWS Backup) | Task 9 |
+| §6 Retention purge / DSAR | Plan #3 (not this plan) |
+| §7 Payments | Plan #3 (not this plan) |
+| §8 Email | Plan #3 (not this plan) |
+| §9 BetterStack uptime | Task 17 |
+| §10 Compliance pages / cookie banner | Plan #3 (not this plan) |
+| §11 First-run UX seed | Plan #3 (not this plan) |
+| §12 Phase 1 Cloudflare Access on whole hostname | Task 10 (var.phase1_access_enabled) |
+
+No placeholders. Variable names are consistent across tasks (`var.aws_region`, `local.name_prefix`, `aws_instance.demo`, etc.). All IAM resource ARNs use the same naming convention.
+
+One known unresolved item: Task 14's ClickHouse backup script assumes `clickhouse-backup` is installed and configured inside the ClickHouse container. The compose entry for ClickHouse currently does not include that tool. The plan flags this as a follow-up. **Action:** the implementer should add `clickhouse-backup` to the ClickHouse Docker image (or sidecar it) as a sub-task within Task 14 before the timer can succeed. Adding this note here so it isn't lost.

--- a/docs/superpowers/specs/2026-05-12-public-demo-deployment-design.md
+++ b/docs/superpowers/specs/2026-05-12-public-demo-deployment-design.md
@@ -1,0 +1,300 @@
+# Public Demo Deployment — Design
+
+**Date:** 2026-05-12
+**Status:** Approved (brainstorm + grill, 2026-05-12)
+**Hostname:** `demo.raven.ravencloak.org`
+**Audience:** Public CTA — anyone may sign up, data persists, GDPR/DPDP-aware.
+**Voice:** Deferred. Demo ships text-only.
+**Payments:** Sandbox only. Paid tiers UI shows "Coming soon".
+
+---
+
+## 1. Goals & Non-Goals
+
+### Goals
+
+- Stand up a publicly reachable, production-shaped instance of Raven at `demo.raven.ravencloak.org` so the landing-page CTA can convert a visitor into a signed-in user.
+- Use existing repo infra (`deploy/ec2/`, `deploy/ansible/`, dotenvx, Hyperswitch wiring, SuperTokens, Cloudflared) without forking new patterns.
+- Bound the steady-state cost at roughly $115–$130/mo and cap the runaway risk (LLM bill, abuse) with concrete fuses.
+- Be defensible against a reasonable abuse case: scripted mass-signup, single bad actor, EU-jurisdiction DSAR request.
+
+### Non-Goals
+
+- Voice / LiveKit / WhatsApp surfaces. Services stay in compose so dependency chains hold; UI is hidden; no Cloudflared route. Voice is its own follow-up rollout.
+- Live payments. Razorpay sandbox only until KYC + merchant compliance is complete.
+- High availability. Single-box demo. Recovery is restore-from-backup, not failover.
+- Full SOC2 control set. We build to it during operation, not as a launch gate.
+
+---
+
+## 2. Topology
+
+### Compute
+
+- **Instance:** EC2 `t4g.xlarge` (Graviton, ARM, 4 vCPU / 16 GB) in `ap-south-1`.
+- **OS:** Amazon Linux 2023 ARM, latest.
+- **Storage:** Single 100 GB `gp3` EBS volume mounted at `/var/lib/raven-data`. All stateful containers (PG, ClickHouse, OpenObserve, SeaweedFS if present) bind-mount under this path. One volume = one snapshot policy.
+- **AWS account:** Same account as Beszel, so the existing Beszel agent can monitor host metrics for free.
+
+### Network exposure
+
+- **Cloudflare Tunnel only.** Cloudflared runs on the box, opens an outbound tunnel to Cloudflare. No inbound security-group ports. No Elastic IP.
+- **Public hostnames:**
+  - `demo.raven.ravencloak.org` → Traefik on `localhost:8080` / `:8180` (frontend + `/api`, existing path-prefix rules).
+  - `observability.demo.raven.ravencloak.org` → OpenObserve UI on `localhost:5080`, **gated by Cloudflare Access** policy allowing only `jobinlawrance@gmail.com`.
+- **TLS:** Cloudflare-terminated at the edge. Origin uses Tunnel (no public TLS on the box). The Traefik `certresolver=letsencrypt` configuration is unused on the demo overlay; can stay configured but inert.
+
+### Services in scope on demo
+
+`go-api`, `python-worker`, `frontend`, `postgres` (PG18 + pgvector + BM25 extension), `valkey`, `supertokens`, `clickhouse`, `openobserve`, `traefik`, `cloudflared`, `beszel-agent`.
+
+**Kept-but-hidden:** `livekit-server`, STT/TTS sidecars — services run so the python-worker's `depends_on` chain stays satisfied, but no Cloudflared route is published and the frontend hides voice UI via a `RAVEN_VOICE_ENABLED=false` env flag.
+
+**Open implementation question:** the admin dashboard side of voice may also need a gate analogous to the existing `voice-enabled` attribute on `RavenChat.ce.ts`. Decide during implementation plan.
+
+---
+
+## 3. Identity, Abuse Controls, and Cost Fuses
+
+### Sign-in
+
+- SuperTokens, **Google OAuth provider only**. No email/password recipe enabled on demo.
+- OAuth redirect URI: `https://demo.raven.ravencloak.org/auth/callback/google`. Must be registered on the Google Cloud OAuth client.
+
+### Abuse controls (layered)
+
+1. **Cloudflare Turnstile** on the signup button. Kills script-driven mass signup.
+2. **Existing per-org rate limiting on Valkey** (#205) applies to free tier.
+3. **Existing subscription enforcement** (#244) gates AI features on the free plan's limits. The "demo" *is* the free tier.
+4. **New: global daily $-fuse** on the python-worker's LLM client. Env var (e.g. `RAVEN_LLM_DAILY_USD_CAP`). When exceeded, AI endpoints return a "demo limit reached, try tomorrow" error. ~50 LOC, single-process counter in Valkey.
+
+No demo-specific quota tables, no demo-specific feature flags beyond `RAVEN_VOICE_ENABLED` and `RAVEN_LLM_DAILY_USD_CAP`.
+
+---
+
+## 4. Provisioning
+
+### Terraform
+
+A new module under `deploy/terraform/demo/`:
+
+- VPC with one public subnet (Cloudflared dials out; no inbound).
+- Security group: egress-only, no inbound rules.
+- IAM role with:
+  - `AmazonSSMManagedInstanceCore` (for SSM session + Run Command).
+  - Inline policy: read `ssm:/raven/demo/*` parameters.
+  - Inline policy: write to `s3://raven-demo-backups/*`.
+  - Inline policy: AWS Backup operations on the data volume.
+- 100 GB gp3 EBS volume, encrypted.
+- EC2 t4g.xlarge with user-data cloud-init.
+- AWS Backup plan: nightly EBS snapshot, 14-day retention.
+- S3 bucket `raven-demo-backups` with 30-day lifecycle expiration and versioning.
+
+**TF state:** S3 backend (`raven-tf-state` bucket) with DynamoDB lock table. Same pattern used elsewhere or to-be-created.
+
+### Cloud-init (in user-data)
+
+1. Install git, ansible, docker, docker-compose.
+2. Mount the gp3 volume at `/var/lib/raven-data` (formatted on first boot).
+3. Clone the repo at the deploy tag.
+4. Fetch SSM SecureString params under `/raven/demo/*`, write to `/etc/raven/env` (mode 0600, owner root).
+5. Run `ansible-playbook deploy/ansible/playbook.yml -i 'localhost,' -c local`.
+
+### Secrets layout
+
+**In repo (dotenvx-encrypted `.env`):** app-level config, TMDB key, OTel endpoint, default flags.
+
+**In SSM SecureString under `/raven/demo/`:**
+
+- `DOTENV_PRIVATE_KEY`
+- `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`
+- `RAVEN_ENCRYPTION_AES_KEY`
+- `SUPERTOKENS_API_KEY`
+- `RAZORPAY_KEY_ID`, `RAZORPAY_KEY_SECRET` (sandbox)
+- `HYPERSWITCH_API_KEY`
+- `RESEND_API_KEY`
+- `CLOUDFLARE_TUNNEL_TOKEN`
+- `TURNSTILE_SITE_KEY`, `TURNSTILE_SECRET_KEY`
+- `RAVEN_LLM_DAILY_USD_CAP`
+
+Cloud-init reads these via the IAM role and writes a single `/etc/raven/env` file consumed by all compose services.
+
+---
+
+## 5. CI/CD
+
+### Image build
+
+- Existing GitHub Actions workflows already build images. New requirement: **multi-arch (amd64 + arm64) GHCR pushes** on tag.
+- Tag format: `v0.x.y`. Tagging `main` triggers the demo-deploy workflow.
+
+### Deploy
+
+- New workflow `.github/workflows/demo-deploy.yml`:
+  - Triggers on `v*` tag.
+  - Assumes IAM role via **GitHub OIDC** (no long-lived AWS keys in GH Secrets).
+  - Calls `aws ssm send-command --document-name AWS-RunShellScript --instance-ids <demo-instance> --parameters 'commands=["/opt/raven/update.sh <tag>"]'`.
+  - Polls for command completion; fails the workflow on non-zero exit.
+- `deploy/ec2/update.sh` (existing) is the canonical update path: docker compose pull, docker compose up -d, prune, healthcheck.
+- No SSH from CI. No deploy-only Linux user. CloudTrail records every deploy.
+
+---
+
+## 6. Data Lifecycle
+
+### Backups (two independent layers)
+
+- **Logical (per-service):** nightly cron in the host (not a container) runs:
+  - `pg_dump -Fc` → `s3://raven-demo-backups/postgres/YYYY-MM-DD.dump`
+  - `clickhouse-backup create_remote` → S3 remote backend
+  - Lifecycle: 30-day expiration
+- **Volume:** AWS Backup nightly EBS snapshot, 14-day retention. Faster restore if the whole disk is gone.
+
+A monthly restore drill is part of the operational definition of done (not the launch gate).
+
+### Retention purge
+
+- Nightly cron (host) calls a new admin API endpoint that:
+  1. Finds accounts with `last_active_at < now() - 23d` and emails a 7-day warning via Resend.
+  2. Sets an in-app banner flag for the same users.
+  3. Hard-deletes accounts inactive for 30+ days (cascade to all owned data; SuperTokens user delete).
+- Same code path serves the user-initiated DSAR delete (`/account/delete`).
+
+### DSAR endpoints
+
+- `GET /account/export` → on-demand zip of the user's PG rows + ClickHouse vectors + audit log. Streamed.
+- `POST /account/delete` → confirms via email, schedules hard delete in 24h (grace window for accidental clicks). Sends final confirmation email on completion.
+
+---
+
+## 7. Payments
+
+- Hyperswitch in **test mode**. Razorpay **sandbox** keys only.
+- Frontend renders the existing billing UI (#250). The "Upgrade" button on paid plans is replaced with a "Join waitlist" form (email captured to PG, no payment flow).
+- "Free" plan is the only actually-usable plan. All AI/feature gates apply at the free-tier limit defined in the existing subscription enforcement.
+
+---
+
+## 8. Email
+
+- **Resend** free tier (3000/mo).
+- From: `noreply@ravencloak.org`. SPF + DKIM + DMARC records added to the Cloudflare DNS zone for `ravencloak.org`.
+- Used for: retention warning emails, DSAR confirmations, DSAR delete final receipt. Not for OTP (SuperTokens Google OAuth doesn't need it).
+- Provider abstracted behind a `MailSender` interface in the API so we can swap to AWS SES later (#257) without code changes outside the adapter.
+
+---
+
+## 9. Observability
+
+- **OpenObserve** UI at `observability.demo.raven.ravencloak.org`, Cloudflare Access policy: allow `jobinlawrance@gmail.com` only. Ingestion (`:5081`) stays on the docker network — not exposed externally.
+- **Beszel** existing AWS instance monitors the demo box for host metrics.
+- **BetterStack** external uptime monitor:
+  - Heartbeat hits `https://demo.raven.ravencloak.org/healthz` every 60s.
+  - Below-threshold or non-200 = email + phone push to `jobinlawrance@gmail.com`.
+- No PagerDuty / on-call rotation. Single operator.
+
+---
+
+## 10. Compliance
+
+### At launch
+
+- **Privacy policy** and **Terms of Service** pages on the landing site, linked from the demo's footer and signup screen.
+- **Cookie consent banner** — essential-only. No analytics cookies set until consent is granted (and PostHog stays off entirely on the demo until M9 ships).
+- **DSAR endpoints** functional (see §6).
+- Public `security@ravencloak.org` mailbox forwarded to the operator.
+
+### Built during operation (not launch gates)
+
+- SOC2 audit log of admin actions.
+- Formal vendor list / data-flow diagram.
+- DPA template for design-partner accounts.
+
+---
+
+## 11. First-Run UX
+
+- Every Google signup triggers a **pre-seeded sample workspace** so the product is non-empty from second 1.
+- Reuses the existing Keycloak realm onboarding wizard wiring shape (#251) — adapted to the SuperTokens flow.
+- Seed content is fixture-defined under `migrations/seed/demo/`. Idempotent. Re-applied on user creation, not on every login.
+
+**Open implementation question (deferred to plan):** exact fixture contents — what's in a "sample workspace" depends on the product surface we want to highlight. Owner: the implementation plan brainstorm.
+
+---
+
+## 12. Launch Sequencing
+
+Three phases, each gated by 48h of clean monitoring (no `/healthz` flaps, no quota exhaustion, no error spikes in OpenObserve).
+
+### Phase 1 — Internal
+
+- Box up, Cloudflared route active.
+- Cloudflare Access policy in front of **whole hostname**: allow `jobinlawrance@gmail.com` only.
+- You are the only signup. Smoke-test full flow.
+
+### Phase 2 — Closed beta
+
+- Remove Cloudflare Access from the public hostname (`observability.*` stays gated).
+- Add an invite-code field to the signup form (alongside Google OAuth).
+- Distribute 10–20 codes to named friends and design partners.
+- Turnstile is live on the signup button.
+
+### Phase 3 — Public CTA
+
+- Remove invite-code field.
+- Landing page CTA points to `https://demo.raven.ravencloak.org`.
+- Soft announcement first (your network, Twitter). HN/Reddit only after another 48h of clean.
+
+### Definition of done (per phase)
+
+- Tag deployed cleanly via the GHCR + SSM path.
+- E2E Playwright suite (#201, #243) passes on the deployed image.
+- `/healthz` green for 48 contiguous hours.
+- BetterStack monitor active.
+- One successful restore drill against staging backups (Phase 1 only; not re-required for 2 → 3).
+- DSAR endpoints manually verified end-to-end.
+- Privacy policy / ToS / cookie banner live.
+- `RAVEN_LLM_DAILY_USD_CAP` set to a non-zero value.
+
+---
+
+## 13. Cost Envelope
+
+| Item | Monthly estimate |
+|---|---|
+| EC2 t4g.xlarge | ~$110 |
+| 100 GB gp3 | ~$10 |
+| EBS snapshots (~50 GB delta) | ~$2 |
+| S3 backup storage (~10 GB) | ~$0.30 |
+| Cloudflare (Tunnel + Access + Turnstile + DNS) | $0 (free tier) |
+| Resend | $0 (free tier) |
+| BetterStack | $0 (free tier) |
+| LLM API spend (capped) | ≤ `RAVEN_LLM_DAILY_USD_CAP` × 30 |
+
+**Steady-state:** ~$125/mo + LLM budget. The fuse means LLM cannot exceed the configured cap.
+
+---
+
+## 14. Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Single box dies | EBS snapshot restore + Terraform re-apply. Documented in a runbook before Phase 2. |
+| LLM bill runaway | Per-account free-tier quota + global daily $-fuse. Two independent fuses. |
+| Scripted signup flood | Turnstile + Phase 2 invite gate. |
+| Cloudflared outage | Demo is unreachable. No fallback path. Acceptable for a demo; document in status page. |
+| GHCR rate limit on deploy | Use authenticated pulls (deploy IAM role has no relevance here; use a GHCR PAT in `/etc/raven/env`). |
+| Voice services consume RAM but yield no value | Accepted (~300–500MB). Cheaper than refactoring `depends_on` for a demo. |
+| EU user signs up, files DSAR | `/account/export` and `/account/delete` already wired. |
+
+---
+
+## 15. Open Implementation Questions (for the plan)
+
+These are decisions deferred to the implementation plan, not blockers on this spec:
+
+1. Exact contents of the seeded sample workspace fixtures.
+2. Admin-dashboard voice-UI gating mechanism (env flag, build flag, or runtime feature flag).
+3. Whether the global LLM $-fuse counter lives in Valkey (shared) or in-process (per-replica) — Valkey is the obvious answer for future multi-replica but adds a hop.
+4. Exact CloudWatch/SSM document for `update.sh` invocation (output capture, timeout, retries).
+5. Whether the host-side backup cron runs as a systemd timer or as a sidecar container.

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,7 +1,9 @@
 <template>
   <RouterView />
+  <CookieBanner />
 </template>
 
 <script setup lang="ts">
 import { RouterView } from 'vue-router'
+import CookieBanner from './components/CookieBanner.vue'
 </script>

--- a/frontend/src/components/CookieBanner.vue
+++ b/frontend/src/components/CookieBanner.vue
@@ -1,0 +1,115 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+
+// Essential-only cookie consent. The demo sets no analytics or
+// advertising cookies — only SuperTokens session + CSRF cookies, both
+// strictly necessary under GDPR Art. 4(11) / 6(1)(b) / 6(1)(f).
+// The banner is informational; clicking "Got it" stops it appearing
+// again on this device. Consent is persisted in localStorage only —
+// no cookie is set to record consent (would be paradoxical).
+
+const STORAGE_KEY = 'raven.cookie.consent.v1'
+
+const visible = ref(false)
+
+onMounted(() => {
+  try {
+    if (!localStorage.getItem(STORAGE_KEY)) {
+      visible.value = true
+    }
+  } catch {
+    // localStorage may be unavailable (private mode, embedded webview).
+    // In that case, suppress the banner — there's nowhere to record
+    // dismissal, and re-showing on every page load would be obnoxious.
+  }
+})
+
+function accept(): void {
+  try {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ essential: true, accepted_at: new Date().toISOString() }),
+    )
+  } catch {
+    // swallow — see onMounted
+  }
+  visible.value = false
+}
+</script>
+
+<template>
+  <Transition name="cookie-fade">
+    <div v-if="visible" class="cookie-banner" role="dialog" aria-live="polite" aria-label="Cookie notice">
+      <p class="cookie-banner__copy">
+        Raven uses essential cookies for login and security only. No tracking,
+        no analytics.
+        <a href="/legal/privacy" class="cookie-banner__link">Learn more</a>.
+      </p>
+      <button
+        type="button"
+        class="cookie-banner__button"
+        aria-label="Dismiss cookie notice"
+        @click="accept"
+      >
+        Got it
+      </button>
+    </div>
+  </Transition>
+</template>
+
+<style scoped>
+.cookie-banner {
+  position: fixed;
+  inset-inline: 0;
+  bottom: 0;
+  z-index: 1000;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.875rem 1.25rem;
+  background: var(--surface-1, #111);
+  color: var(--text-1, #fff);
+  border-top: 1px solid var(--surface-3, #333);
+  font-size: 0.875rem;
+  line-height: 1.4;
+  box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.2);
+}
+
+.cookie-banner__copy {
+  margin: 0;
+  flex: 1 1 320px;
+}
+
+.cookie-banner__link {
+  color: var(--accent, #5b8dee);
+  text-decoration: underline;
+}
+
+.cookie-banner__button {
+  padding: 0.5rem 1rem;
+  background: var(--accent, #5b8dee);
+  color: #fff;
+  border: 0;
+  border-radius: 0.375rem;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.cookie-banner__button:hover {
+  filter: brightness(1.1);
+}
+
+.cookie-fade-enter-active,
+.cookie-fade-leave-active {
+  transition: opacity 200ms ease, transform 200ms ease;
+}
+
+.cookie-fade-enter-from,
+.cookie-fade-leave-to {
+  opacity: 0;
+  transform: translateY(10px);
+}
+</style>

--- a/internal/account/dsar.go
+++ b/internal/account/dsar.go
@@ -1,0 +1,88 @@
+// Package account implements user-account self-service endpoints used
+// by the public demo: DSAR export and delete, and the retention purge
+// service. All data-access goes through the DSARRepo / RetentionRepo
+// interfaces so handlers stay testable without a real database.
+package account
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/ravencloak-org/Raven/internal/mail"
+)
+
+// UserExport is the JSON payload returned by GET /account/export.
+type UserExport struct {
+	UserID string                      `json:"user_id"`
+	Email  string                      `json:"email"`
+	Rows   map[string][]map[string]any `json:"rows"`
+}
+
+// DSARRepo is the persistence surface for DSAR operations.
+type DSARRepo interface {
+	ExportUser(ctx context.Context, userID string) (UserExport, error)
+	ScheduleDelete(ctx context.Context, userID string) error
+}
+
+// DSARHandler exposes /account/export and /account/delete.
+type DSARHandler struct {
+	Repo DSARRepo
+	Mail mail.Sender
+}
+
+// NewDSARHandler returns a handler wired to repo + mailer. The mailer may
+// be nil; Delete simply skips the confirmation email in that case.
+func NewDSARHandler(repo DSARRepo, mailer mail.Sender) *DSARHandler {
+	return &DSARHandler{Repo: repo, Mail: mailer}
+}
+
+type ctxKey string
+
+const (
+	userIDKey    ctxKey = "user_id"
+	userEmailKey ctxKey = "user_email"
+)
+
+// WithUserID puts a SuperTokens-resolved user ID into ctx for handlers.
+func WithUserID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, userIDKey, id)
+}
+
+// UserIDFrom extracts the user ID set by WithUserID. Returns ok=false
+// when no user is bound (treat as unauthenticated).
+func UserIDFrom(ctx context.Context) (string, bool) {
+	v, ok := ctx.Value(userIDKey).(string)
+	return v, ok && v != ""
+}
+
+// WithUserEmail puts the signed-in user's email into ctx so the delete
+// confirmation email can be sent.
+func WithUserEmail(ctx context.Context, email string) context.Context {
+	return context.WithValue(ctx, userEmailKey, email)
+}
+
+// UserEmailFrom extracts the email set by WithUserEmail.
+func UserEmailFrom(ctx context.Context) (string, bool) {
+	v, ok := ctx.Value(userEmailKey).(string)
+	return v, ok && v != ""
+}
+
+// Export writes a JSON file containing every row the repo associates
+// with the authenticated user. Streamed so the response stays small for
+// any one query but the full payload may be large.
+func (h *DSARHandler) Export(w http.ResponseWriter, r *http.Request) {
+	uid, ok := UserIDFrom(r.Context())
+	if !ok {
+		http.Error(w, "unauthenticated", http.StatusUnauthorized)
+		return
+	}
+	out, err := h.Repo.ExportUser(r.Context(), uid)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Disposition", "attachment; filename=raven-export.json")
+	_ = json.NewEncoder(w).Encode(out)
+}

--- a/internal/account/dsar.go
+++ b/internal/account/dsar.go
@@ -86,3 +86,28 @@ func (h *DSARHandler) Export(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Disposition", "attachment; filename=raven-export.json")
 	_ = json.NewEncoder(w).Encode(out)
 }
+
+// Delete schedules irreversible deletion of the authenticated user's
+// data in 24h (the grace window gives users a chance to recover from
+// an accidental click via reply-to-email). Responds 202 Accepted.
+func (h *DSARHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	uid, ok := UserIDFrom(r.Context())
+	if !ok {
+		http.Error(w, "unauthenticated", http.StatusUnauthorized)
+		return
+	}
+	if err := h.Repo.ScheduleDelete(r.Context(), uid); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if email, ok := UserEmailFrom(r.Context()); ok && h.Mail != nil {
+		_ = h.Mail.Send(r.Context(), mail.Message{
+			To:      email,
+			Subject: "Your Raven delete request",
+			Text: "We received your request to delete your Raven account. " +
+				"Your data will be removed in 24 hours. " +
+				"Reply to this email if you didn't request this.",
+		})
+	}
+	w.WriteHeader(http.StatusAccepted)
+}

--- a/internal/account/dsar_delete_test.go
+++ b/internal/account/dsar_delete_test.go
@@ -1,0 +1,92 @@
+package account
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ravencloak-org/Raven/internal/mail"
+)
+
+type fakeDeleteRepo struct {
+	scheduled string
+}
+
+func (f *fakeDeleteRepo) ExportUser(_ context.Context, id string) (UserExport, error) {
+	return UserExport{UserID: id}, nil
+}
+
+func (f *fakeDeleteRepo) ScheduleDelete(_ context.Context, id string) error {
+	f.scheduled = id
+	return nil
+}
+
+type recordingMailer struct {
+	sent []mail.Message
+}
+
+func (r *recordingMailer) Send(_ context.Context, m mail.Message) error {
+	r.sent = append(r.sent, m)
+	return nil
+}
+
+func TestDeleteHandler_SchedulesAndEmails(t *testing.T) {
+	repo := &fakeDeleteRepo{}
+	m := &recordingMailer{}
+	h := NewDSARHandler(repo, m)
+
+	ctx := WithUserEmail(WithUserID(context.Background(), "user-2"), "u@e.com")
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/account/delete", nil)
+	w := httptest.NewRecorder()
+
+	h.Delete(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d", w.Code)
+	}
+	if repo.scheduled != "user-2" {
+		t.Fatalf("expected schedule for user-2, got %q", repo.scheduled)
+	}
+	if len(m.sent) != 1 {
+		t.Fatalf("expected 1 email, got %d", len(m.sent))
+	}
+	if m.sent[0].To != "u@e.com" {
+		t.Fatalf("expected To u@e.com, got %s", m.sent[0].To)
+	}
+	if !strings.Contains(strings.ToLower(m.sent[0].Subject), "delete") {
+		t.Fatalf("subject should mention delete: %s", m.sent[0].Subject)
+	}
+}
+
+func TestDeleteHandler_NoMailerStillSchedules(t *testing.T) {
+	repo := &fakeDeleteRepo{}
+	h := NewDSARHandler(repo, nil)
+
+	ctx := WithUserID(context.Background(), "user-3")
+	req := httptest.NewRequestWithContext(ctx, http.MethodPost, "/account/delete", nil)
+	w := httptest.NewRecorder()
+
+	h.Delete(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d", w.Code)
+	}
+	if repo.scheduled != "user-3" {
+		t.Fatalf("expected schedule for user-3, got %q", repo.scheduled)
+	}
+}
+
+func TestDeleteHandler_UnauthenticatedReturns401(t *testing.T) {
+	h := NewDSARHandler(&fakeDeleteRepo{}, nil)
+	req := httptest.NewRequestWithContext(context.Background(),
+		http.MethodPost, "/account/delete", nil)
+	w := httptest.NewRecorder()
+
+	h.Delete(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}

--- a/internal/account/dsar_test.go
+++ b/internal/account/dsar_test.go
@@ -1,0 +1,86 @@
+package account
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type fakeExportRepo struct{}
+
+func (fakeExportRepo) ExportUser(_ context.Context, userID string) (UserExport, error) {
+	return UserExport{
+		UserID: userID,
+		Email:  "u@example.com",
+		Rows: map[string][]map[string]any{
+			"messages": {{"id": float64(1), "text": "hi"}},
+		},
+	}, nil
+}
+
+func (fakeExportRepo) ScheduleDelete(_ context.Context, _ string) error {
+	return nil
+}
+
+func TestExportHandler_WritesJSON(t *testing.T) {
+	h := NewDSARHandler(fakeExportRepo{}, nil)
+	req := httptest.NewRequestWithContext(
+		WithUserID(context.Background(), "user-1"),
+		http.MethodGet, "/account/export", nil,
+	)
+	w := httptest.NewRecorder()
+
+	h.Export(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Fatalf("unexpected content-type: %s", ct)
+	}
+	if cd := w.Header().Get("Content-Disposition"); !strings.Contains(cd, "raven-export.json") {
+		t.Fatalf("missing or wrong Content-Disposition: %s", cd)
+	}
+
+	var out UserExport
+	if err := json.NewDecoder(w.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.UserID != "user-1" {
+		t.Fatalf("UserID: got %s", out.UserID)
+	}
+	if len(out.Rows["messages"]) != 1 {
+		t.Fatalf("expected 1 message row")
+	}
+}
+
+func TestExportHandler_UnauthenticatedReturns401(t *testing.T) {
+	h := NewDSARHandler(fakeExportRepo{}, nil)
+	req := httptest.NewRequestWithContext(context.Background(),
+		http.MethodGet, "/account/export", nil) // no user_id context
+	w := httptest.NewRecorder()
+
+	h.Export(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestUserIDFrom_ReturnsFalseWhenMissing(t *testing.T) {
+	_, ok := UserIDFrom(context.Background())
+	if ok {
+		t.Fatal("expected ok=false for empty context")
+	}
+}
+
+func TestUserIDFrom_ReturnsTrueWhenSet(t *testing.T) {
+	ctx := WithUserID(context.Background(), "u-1")
+	id, ok := UserIDFrom(ctx)
+	if !ok || id != "u-1" {
+		t.Fatalf("got %q ok=%v, want u-1 true", id, ok)
+	}
+}

--- a/internal/account/repo_sql.go
+++ b/internal/account/repo_sql.go
@@ -1,0 +1,133 @@
+package account
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// SQLRepo implements DSARRepo + RetentionRepo against a Postgres pool.
+//
+// ExportUser currently returns the user + org row only. Full enumeration
+// of user-owned tables (messages, conversations, workspaces, sessions,
+// etc.) is the responsibility of a follow-up commit once the canonical
+// list is enumerated — see plan #3 spec §15 open question 1.
+//
+// HardDelete is intentionally NOT implemented yet. The cascade
+// behaviour in a multi-tenant schema (delete org? just user?) is a
+// product decision tracked in docs/superpowers/specs/2026-05-12-public-demo-deployment-design.md §6.
+type SQLRepo struct {
+	pool *pgxpool.Pool
+}
+
+// NewSQLRepo wraps a pgxpool for use as DSARRepo + RetentionRepo.
+func NewSQLRepo(pool *pgxpool.Pool) *SQLRepo {
+	return &SQLRepo{pool: pool}
+}
+
+// ExportUser returns user + org info for the authenticated user. Each
+// user-owned domain table (messages, workspaces, etc.) must be added
+// here as the schema is enumerated; see package doc.
+func (r *SQLRepo) ExportUser(ctx context.Context, userID string) (UserExport, error) {
+	out := UserExport{UserID: userID, Rows: map[string][]map[string]any{}}
+
+	var email string
+	var orgID string
+	var displayName *string
+	var createdAt time.Time
+	err := r.pool.QueryRow(ctx,
+		`SELECT email, display_name, org_id, created_at
+		   FROM users WHERE id = $1`,
+		userID,
+	).Scan(&email, &displayName, &orgID, &createdAt)
+	if err != nil {
+		return out, err
+	}
+	out.Email = email
+
+	userRow := map[string]any{
+		"id":         userID,
+		"email":      email,
+		"org_id":     orgID,
+		"created_at": createdAt,
+	}
+	if displayName != nil {
+		userRow["display_name"] = *displayName
+	}
+	out.Rows["users"] = []map[string]any{userRow}
+
+	// TODO(plan-3-task-40): enumerate user-owned domain tables here —
+	// conversations, messages, workspaces, voice_sessions, etc. Spec §15.
+	return out, nil
+}
+
+// ScheduleDelete inserts a row into scheduled_deletes with a 24h grace
+// window. The drain worker (separate commit) reads from this table.
+func (r *SQLRepo) ScheduleDelete(ctx context.Context, userID string) error {
+	_, err := r.pool.Exec(ctx,
+		`INSERT INTO scheduled_deletes (user_id) VALUES ($1)
+		 ON CONFLICT (user_id) DO NOTHING`,
+		userID,
+	)
+	return err
+}
+
+// InactiveUsers returns active accounts whose last_login_at is older
+// than `since`. The retention cron passes the warn cutoff (23 days
+// ago); the purger applies the day-threshold policy.
+func (r *SQLRepo) InactiveUsers(ctx context.Context, since time.Time) ([]InactiveUser, error) {
+	rows, err := r.pool.Query(ctx,
+		`SELECT id, email, last_login_at
+		   FROM users
+		  WHERE status = 'active'
+		    AND last_login_at IS NOT NULL
+		    AND last_login_at < $1`,
+		since,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []InactiveUser
+	for rows.Next() {
+		var u InactiveUser
+		var last *time.Time
+		if err := rows.Scan(&u.ID, &u.Email, &last); err != nil {
+			return nil, err
+		}
+		if last != nil {
+			u.LastActive = *last
+		}
+		out = append(out, u)
+	}
+	return out, rows.Err()
+}
+
+// MarkWarned records that a 7-day deletion warning was emailed.
+// Idempotent — repeated calls do not duplicate the row.
+func (r *SQLRepo) MarkWarned(ctx context.Context, userID string) error {
+	_, err := r.pool.Exec(ctx,
+		`INSERT INTO account_purge_warnings (user_id) VALUES ($1)
+		 ON CONFLICT (user_id) DO NOTHING`,
+		userID,
+	)
+	return err
+}
+
+// ErrHardDeleteNotEnabled is returned by HardDelete until the cascade
+// behaviour for a multi-tenant account purge is decided.
+var ErrHardDeleteNotEnabled = errors.New(
+	"account.SQLRepo.HardDelete is not enabled — see spec §6 for the " +
+		"cascade decision (delete-org vs delete-user-only)",
+)
+
+// HardDelete is intentionally a no-op error until the cascade
+// behaviour is finalised. The retention cron continues to MarkWarned
+// and ScheduleDelete writes its row; only the final destructive step
+// is gated. See package doc.
+func (r *SQLRepo) HardDelete(_ context.Context, _ string) error {
+	return ErrHardDeleteNotEnabled
+}

--- a/internal/account/retention.go
+++ b/internal/account/retention.go
@@ -1,0 +1,80 @@
+package account
+
+import (
+	"context"
+	"time"
+
+	"github.com/ravencloak-org/Raven/internal/mail"
+)
+
+// InactiveUser is a row returned by RetentionRepo.InactiveUsers.
+type InactiveUser struct {
+	ID         string
+	Email      string
+	LastActive time.Time
+}
+
+// RetentionRepo is the persistence surface for the retention purge.
+// The repo decides what "inactive" means at the SQL level; the purger
+// just applies the day-threshold policy on top.
+type RetentionRepo interface {
+	// InactiveUsers returns every user whose last activity is older than
+	// `since`. Callers use this to find candidates for warn-or-delete.
+	InactiveUsers(ctx context.Context, since time.Time) ([]InactiveUser, error)
+
+	// MarkWarned records that a 7-day deletion warning was sent.
+	MarkWarned(ctx context.Context, id string) error
+
+	// HardDelete removes the user and cascades to their owned rows.
+	HardDelete(ctx context.Context, id string) error
+}
+
+// RetentionPurger applies the 23-day-warn / 30-day-delete policy
+// described in docs/superpowers/specs/2026-05-12-public-demo-deployment-design.md
+// §6. Invoked by the host-side systemd timer via the admin endpoint.
+type RetentionPurger struct {
+	Repo RetentionRepo
+	Mail mail.Sender
+}
+
+// NewRetentionPurger returns a purger wired to repo + mailer. The mailer
+// may be nil; in that case warning emails are skipped but the warning
+// flag is still set in the repo.
+func NewRetentionPurger(repo RetentionRepo, mailer mail.Sender) *RetentionPurger {
+	return &RetentionPurger{Repo: repo, Mail: mailer}
+}
+
+// RunOnce applies the retention policy using `now` as the reference
+// time. Anyone past the 30-day delete threshold is removed; anyone
+// past the 23-day warning threshold (but not yet at 30) is warned.
+func (p *RetentionPurger) RunOnce(ctx context.Context, now time.Time) error {
+	warnCutoff := now.Add(-23 * 24 * time.Hour)
+	deleteCutoff := now.Add(-30 * 24 * time.Hour)
+
+	users, err := p.Repo.InactiveUsers(ctx, warnCutoff)
+	if err != nil {
+		return err
+	}
+	for _, u := range users {
+		if u.LastActive.Before(deleteCutoff) {
+			if err := p.Repo.HardDelete(ctx, u.ID); err != nil {
+				return err
+			}
+			continue
+		}
+		if p.Mail != nil {
+			_ = p.Mail.Send(ctx, mail.Message{
+				To:      u.Email,
+				Subject: "Your Raven demo account will be deleted in 7 days",
+				Text: "You haven't used Raven for 23 days. " +
+					"Inactive demo accounts are deleted at 30 days. " +
+					"Sign in to keep your data: " +
+					"https://demo.raven.ravencloak.org",
+			})
+		}
+		if err := p.Repo.MarkWarned(ctx, u.ID); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/account/retention_test.go
+++ b/internal/account/retention_test.go
@@ -1,0 +1,101 @@
+package account
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+type stubRetentionRepo struct {
+	users   []InactiveUser
+	warned  []string
+	deleted []string
+}
+
+func (s *stubRetentionRepo) InactiveUsers(_ context.Context, _ time.Time) ([]InactiveUser, error) {
+	return s.users, nil
+}
+
+func (s *stubRetentionRepo) MarkWarned(_ context.Context, id string) error {
+	s.warned = append(s.warned, id)
+	return nil
+}
+
+func (s *stubRetentionRepo) HardDelete(_ context.Context, id string) error {
+	s.deleted = append(s.deleted, id)
+	return nil
+}
+
+func TestRunOnce_WarnsAtDay23DeletesAt30(t *testing.T) {
+	now := time.Now().UTC()
+	repo := &stubRetentionRepo{
+		users: []InactiveUser{
+			{ID: "warn-me", Email: "w@e.com", LastActive: now.Add(-25 * 24 * time.Hour)},
+			{ID: "purge-me", Email: "p@e.com", LastActive: now.Add(-31 * 24 * time.Hour)},
+			{ID: "edge-23", Email: "edge23@e.com", LastActive: now.Add(-23*24*time.Hour - time.Hour)},
+		},
+	}
+	mailer := &recordingMailer{}
+	p := NewRetentionPurger(repo, mailer)
+
+	if err := p.RunOnce(context.Background(), now); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got, want := len(repo.deleted), 1; got != want {
+		t.Fatalf("deleted: got %d want %d (%v)", got, want, repo.deleted)
+	}
+	if repo.deleted[0] != "purge-me" {
+		t.Fatalf("deleted wrong user: %s", repo.deleted[0])
+	}
+
+	if got, want := len(repo.warned), 2; got != want {
+		t.Fatalf("warned: got %d want %d (%v)", got, want, repo.warned)
+	}
+
+	// One email per warned user; none for deleted ones.
+	if got, want := len(mailer.sent), 2; got != want {
+		t.Fatalf("sent: got %d want %d", got, want)
+	}
+	recipients := map[string]bool{}
+	for _, m := range mailer.sent {
+		recipients[m.To] = true
+	}
+	if !recipients["w@e.com"] || !recipients["edge23@e.com"] {
+		t.Fatalf("missing warning recipients: %v", recipients)
+	}
+}
+
+func TestRunOnce_EmptyInactiveListIsNoop(t *testing.T) {
+	repo := &stubRetentionRepo{}
+	mailer := &recordingMailer{}
+	p := NewRetentionPurger(repo, mailer)
+
+	if err := p.RunOnce(context.Background(), time.Now().UTC()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(repo.warned) != 0 || len(repo.deleted) != 0 || len(mailer.sent) != 0 {
+		t.Fatalf("expected no side effects")
+	}
+}
+
+func TestRunOnce_NoMailerStillWarnsAndDeletes(t *testing.T) {
+	now := time.Now().UTC()
+	repo := &stubRetentionRepo{
+		users: []InactiveUser{
+			{ID: "warn-me", Email: "w@e.com", LastActive: now.Add(-25 * 24 * time.Hour)},
+			{ID: "purge-me", Email: "p@e.com", LastActive: now.Add(-31 * 24 * time.Hour)},
+		},
+	}
+	p := NewRetentionPurger(repo, nil)
+
+	if err := p.RunOnce(context.Background(), now); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(repo.warned) != 1 || repo.warned[0] != "warn-me" {
+		t.Fatalf("warned: %v", repo.warned)
+	}
+	if len(repo.deleted) != 1 || repo.deleted[0] != "purge-me" {
+		t.Fatalf("deleted: %v", repo.deleted)
+	}
+}

--- a/internal/mail/resend.go
+++ b/internal/mail/resend.go
@@ -1,0 +1,70 @@
+package mail
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// ResendSender sends Messages via the Resend HTTP API
+// (https://resend.com/docs/api-reference/emails/send-email).
+type ResendSender struct {
+	// APIKey is the Resend secret key (rs_*). Required.
+	APIKey string
+	// From is the verified sender address, e.g. noreply@ravencloak.org.
+	From string
+
+	client *http.Client
+	url    string
+}
+
+// NewResendSender returns a ResendSender pointed at the production Resend
+// API with a 10s request timeout.
+func NewResendSender(apiKey, from string) *ResendSender {
+	return &ResendSender{
+		APIKey: apiKey,
+		From:   from,
+		client: &http.Client{Timeout: 10 * time.Second},
+		url:    "https://api.resend.com/emails",
+	}
+}
+
+// Send posts the Message to the Resend /emails endpoint. Returns an
+// error on transport failures or non-2xx responses.
+func (s *ResendSender) Send(ctx context.Context, msg Message) error {
+	if s.APIKey == "" {
+		return errors.New("resend: API key not configured")
+	}
+	body, err := json.Marshal(map[string]any{
+		"from":    s.From,
+		"to":      []string{msg.To},
+		"subject": msg.Subject,
+		"text":    msg.Text,
+	})
+	if err != nil {
+		return fmt.Errorf("resend: marshal: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("resend: new request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+s.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("resend: do: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode/100 != 2 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("resend: non-2xx %d: %s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}

--- a/internal/mail/resend_test.go
+++ b/internal/mail/resend_test.go
@@ -1,0 +1,87 @@
+package mail
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestResendSender_Send_PostsToAPI(t *testing.T) {
+	var got struct {
+		From    string   `json:"from"`
+		To      []string `json:"to"`
+		Subject string   `json:"subject"`
+		Text    string   `json:"text"`
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.Header.Get("Authorization"), "Bearer test-key"; got != want {
+			t.Errorf("auth header: got %q want %q", got, want)
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &got)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"msg-123"}`))
+	}))
+	defer srv.Close()
+
+	s := &ResendSender{
+		APIKey: "test-key",
+		From:   "noreply@example.org",
+		client: srv.Client(),
+		url:    srv.URL,
+	}
+
+	err := s.Send(context.Background(), Message{
+		To:      "user@example.com",
+		Subject: "Hi",
+		Text:    "Hello",
+	})
+	if err != nil {
+		t.Fatalf("send failed: %v", err)
+	}
+
+	if got.From != "noreply@example.org" {
+		t.Errorf("From: got %q", got.From)
+	}
+	if !strings.Contains(strings.Join(got.To, ","), "user@example.com") {
+		t.Errorf("To: got %v", got.To)
+	}
+	if got.Subject != "Hi" {
+		t.Errorf("Subject: got %q", got.Subject)
+	}
+}
+
+func TestResendSender_Send_PropagatesNon2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"invalid key"}`))
+	}))
+	defer srv.Close()
+
+	s := &ResendSender{
+		APIKey: "bad",
+		From:   "noreply@example.org",
+		client: srv.Client(),
+		url:    srv.URL,
+	}
+	err := s.Send(context.Background(), Message{To: "u@e.com", Subject: "s", Text: "t"})
+	if err == nil {
+		t.Fatal("expected error on 401")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("expected error to mention status code: %v", err)
+	}
+}
+
+func TestResendSender_Send_RequiresAPIKey(t *testing.T) {
+	s := &ResendSender{APIKey: "", From: "noreply@example.org"}
+	err := s.Send(context.Background(), Message{To: "u@e.com", Subject: "s", Text: "t"})
+	if err == nil {
+		t.Fatal("expected error when API key is empty")
+	}
+}

--- a/internal/mail/sender.go
+++ b/internal/mail/sender.go
@@ -1,0 +1,28 @@
+// Package mail defines a provider-agnostic email-sending interface.
+package mail
+
+import "context"
+
+// Message is the payload sent by a Sender.
+type Message struct {
+	To      string
+	Subject string
+	Text    string
+}
+
+// Sender abstracts email transport so the API can swap providers.
+type Sender interface {
+	Send(ctx context.Context, msg Message) error
+}
+
+// NoopSender records each Message in memory and never errors. Useful for
+// tests and for runs without RESEND_API_KEY configured.
+type NoopSender struct {
+	Sent []Message
+}
+
+// Send appends msg to NoopSender.Sent and returns nil.
+func (s *NoopSender) Send(_ context.Context, msg Message) error {
+	s.Sent = append(s.Sent, msg)
+	return nil
+}

--- a/internal/mail/sender_test.go
+++ b/internal/mail/sender_test.go
@@ -1,0 +1,24 @@
+package mail
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNoopSender_Send_RecordsMessage(t *testing.T) {
+	s := &NoopSender{}
+	err := s.Send(context.Background(), Message{
+		To:      "user@example.com",
+		Subject: "Hi",
+		Text:    "Hello",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(s.Sent) != 1 {
+		t.Fatalf("expected 1 sent message, got %d", len(s.Sent))
+	}
+	if s.Sent[0].To != "user@example.com" {
+		t.Fatalf("unexpected To: %s", s.Sent[0].To)
+	}
+}

--- a/internal/seed/fixtures/sample_workspace.json
+++ b/internal/seed/fixtures/sample_workspace.json
@@ -1,0 +1,13 @@
+{
+  "workspace_name": "Sample workspace",
+  "messages": [
+    {
+      "role": "system",
+      "text": "Welcome to Raven. This is a pre-seeded sample workspace so you can see the product without setting anything up."
+    },
+    {
+      "role": "assistant",
+      "text": "Try asking me to summarise an article, plan a trip, or pull the latest from a knowledge base. Use the menu on the left to create a new workspace anytime."
+    }
+  ]
+}

--- a/internal/seed/sample_workspace.go
+++ b/internal/seed/sample_workspace.go
@@ -1,0 +1,54 @@
+// Package seed installs starter content for new users so the demo
+// looks alive immediately after signup. Driven by an embedded JSON
+// fixture; the SuperTokens user-create hook calls SampleWorkspace
+// once per new account.
+package seed
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+)
+
+//go:embed fixtures/sample_workspace.json
+var sampleWorkspaceJSON []byte
+
+type fixture struct {
+	WorkspaceName string `json:"workspace_name"`
+	Messages      []struct {
+		Role string `json:"role"`
+		Text string `json:"text"`
+	} `json:"messages"`
+}
+
+// WorkspaceSeeder is the persistence surface required by
+// SampleWorkspace. A real implementation will wrap the workspace +
+// chat tables; tests can pass a fake.
+type WorkspaceSeeder interface {
+	CreateWorkspace(ctx context.Context, ownerID, name string) (string, error)
+	InsertMessage(ctx context.Context, workspaceID, role, text string) error
+}
+
+// SampleWorkspace creates a starter workspace for ownerID and
+// populates it with the messages defined in
+// internal/seed/fixtures/sample_workspace.json.
+//
+// Errors from CreateWorkspace propagate. Errors from individual
+// InsertMessage calls also propagate (so the caller can decide whether
+// to retry or treat the seed as best-effort).
+func SampleWorkspace(ctx context.Context, s WorkspaceSeeder, ownerID string) error {
+	var f fixture
+	if err := json.Unmarshal(sampleWorkspaceJSON, &f); err != nil {
+		return err
+	}
+	ws, err := s.CreateWorkspace(ctx, ownerID, f.WorkspaceName)
+	if err != nil {
+		return err
+	}
+	for _, m := range f.Messages {
+		if err := s.InsertMessage(ctx, ws, m.Role, m.Text); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/seed/sample_workspace_test.go
+++ b/internal/seed/sample_workspace_test.go
@@ -1,0 +1,62 @@
+package seed
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type fakeWS struct {
+	created  string
+	messages []string
+}
+
+func (f *fakeWS) CreateWorkspace(_ context.Context, ownerID, name string) (string, error) {
+	f.created = ownerID + ":" + name
+	return "ws-1", nil
+}
+
+func (f *fakeWS) InsertMessage(_ context.Context, ws, role, text string) error {
+	f.messages = append(f.messages, ws+"|"+role+"|"+text)
+	return nil
+}
+
+func TestSampleWorkspace_CreatesWorkspaceAndMessages(t *testing.T) {
+	repo := &fakeWS{}
+	if err := SampleWorkspace(context.Background(), repo, "user-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if repo.created != "user-1:Sample workspace" {
+		t.Fatalf("workspace creation: got %q", repo.created)
+	}
+	if len(repo.messages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(repo.messages))
+	}
+	// Both messages should be tagged with the workspace id returned by
+	// CreateWorkspace (ws-1) and use the role from the fixture.
+	for i, m := range repo.messages {
+		if !startsWith(m, "ws-1|") {
+			t.Fatalf("message %d not tagged with workspace id: %s", i, m)
+		}
+	}
+}
+
+type errWS struct{}
+
+func (errWS) CreateWorkspace(_ context.Context, _, _ string) (string, error) {
+	return "", errors.New("db down")
+}
+
+func (errWS) InsertMessage(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
+func TestSampleWorkspace_PropagatesCreateError(t *testing.T) {
+	if err := SampleWorkspace(context.Background(), errWS{}, "user-1"); err == nil {
+		t.Fatal("expected error from CreateWorkspace failure")
+	}
+}
+
+func startsWith(s, prefix string) bool {
+	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+}

--- a/internal/turnstile/verifier.go
+++ b/internal/turnstile/verifier.go
@@ -1,0 +1,75 @@
+// Package turnstile verifies Cloudflare Turnstile challenge tokens
+// against the siteverify endpoint
+// (https://developers.cloudflare.com/turnstile/get-started/server-side-validation/).
+package turnstile
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Verifier checks Turnstile tokens server-side.
+type Verifier struct {
+	// SecretKey is the Turnstile site's secret key. Required.
+	SecretKey string
+
+	url    string
+	client *http.Client
+}
+
+// NewVerifier returns a Verifier pointed at the production Cloudflare
+// siteverify endpoint with a 5s request timeout.
+func NewVerifier(secretKey string) *Verifier {
+	return &Verifier{
+		SecretKey: secretKey,
+		url:       "https://challenges.cloudflare.com/turnstile/v0/siteverify",
+		client:    &http.Client{Timeout: 5 * time.Second},
+	}
+}
+
+// Verify exchanges a Turnstile token for a success/failure verdict.
+// remoteIP is optional — pass the empty string to omit it.
+//
+// Returns (false, err) on transport or decode failures. Returns
+// (false, nil) when Cloudflare rejected the token.
+func (v *Verifier) Verify(ctx context.Context, token, remoteIP string) (bool, error) {
+	if v.SecretKey == "" {
+		return false, errors.New("turnstile: secret not configured")
+	}
+	if v.client == nil {
+		v.client = &http.Client{Timeout: 5 * time.Second}
+	}
+
+	form := url.Values{}
+	form.Set("secret", v.SecretKey)
+	form.Set("response", token)
+	if remoteIP != "" {
+		form.Set("remoteip", remoteIP)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, v.url, strings.NewReader(form.Encode()))
+	if err != nil {
+		return false, fmt.Errorf("turnstile: new request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := v.client.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("turnstile: do: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var out struct {
+		Success bool `json:"success"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return false, fmt.Errorf("turnstile: decode: %w", err)
+	}
+	return out.Success, nil
+}

--- a/internal/turnstile/verifier_test.go
+++ b/internal/turnstile/verifier_test.go
@@ -1,0 +1,77 @@
+package turnstile
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestVerifier_Verify_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if got, want := r.Form.Get("secret"), "secret-key"; got != want {
+			t.Errorf("secret: got %q want %q", got, want)
+		}
+		if got, want := r.Form.Get("response"), "good-token"; got != want {
+			t.Errorf("response: got %q want %q", got, want)
+		}
+		if got, want := r.Form.Get("remoteip"), "1.2.3.4"; got != want {
+			t.Errorf("remoteip: got %q want %q", got, want)
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"success": true})
+	}))
+	defer srv.Close()
+
+	v := &Verifier{SecretKey: "secret-key", url: srv.URL, client: srv.Client()}
+	ok, err := v.Verify(context.Background(), "good-token", "1.2.3.4")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected success")
+	}
+}
+
+func TestVerifier_Verify_Failure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"success":     false,
+			"error-codes": []string{"invalid-input-response"},
+		})
+	}))
+	defer srv.Close()
+
+	v := &Verifier{SecretKey: "k", url: srv.URL, client: srv.Client()}
+	ok, err := v.Verify(context.Background(), "bad-token", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatal("expected failure")
+	}
+}
+
+func TestVerifier_Verify_OmitsRemoteIPWhenEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if _, set := r.Form["remoteip"]; set {
+			t.Errorf("remoteip should be absent when caller passes empty string")
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"success": true})
+	}))
+	defer srv.Close()
+
+	v := &Verifier{SecretKey: "k", url: srv.URL, client: srv.Client()}
+	_, _ = v.Verify(context.Background(), "tok", "")
+}
+
+func TestVerifier_Verify_RequiresSecret(t *testing.T) {
+	v := &Verifier{SecretKey: ""}
+	_, err := v.Verify(context.Background(), "tok", "")
+	if err == nil {
+		t.Fatal("expected error when secret is empty")
+	}
+}

--- a/landing/src/app/legal/privacy/page.tsx
+++ b/landing/src/app/legal/privacy/page.tsx
@@ -1,0 +1,170 @@
+import { type Metadata } from 'next'
+
+import { Footer } from '@/components/Footer'
+import { Header } from '@/components/Header'
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy',
+  description:
+    'How Raven collects, uses, and protects personal data on the public demo at demo.raven.ravencloak.org.',
+  alternates: { canonical: 'https://raven.ravencloak.org/legal/privacy/' },
+}
+
+export default function PrivacyPage() {
+  return (
+    <>
+      <Header />
+      <main className="mx-auto max-w-3xl px-6 py-16 prose prose-invert">
+        <h1>Privacy Policy</h1>
+        <p>
+          <em>Last updated: 13 May 2026.</em>
+        </p>
+
+        <p>
+          This Privacy Policy explains how Raven (&quot;we&quot;, &quot;us&quot;)
+          collects, uses, and shares personal data when you use the public
+          demo at <strong>demo.raven.ravencloak.org</strong>. The demo is
+          operated by Jobin Lawrance as an individual, based in India.
+        </p>
+
+        <h2>Data we collect</h2>
+        <ul>
+          <li>
+            <strong>Account profile.</strong> When you sign in with Google we
+            receive your email address, name, profile photo, and Google
+            account ID. We do not request additional Google scopes.
+          </li>
+          <li>
+            <strong>Application data.</strong> Workspaces, conversations,
+            messages, and any content you choose to create inside the demo.
+          </li>
+          <li>
+            <strong>Operational telemetry.</strong> IP address, browser
+            user-agent, timestamps, request paths. Used for security,
+            abuse-prevention, and debugging. Held in our log aggregator
+            (OpenObserve) for 30 days then deleted.
+          </li>
+          <li>
+            <strong>Cookies.</strong> Essential session cookies only (SuperTokens
+            authentication and CSRF protection). No advertising or analytics
+            cookies are set on this demo. Cloudflare may set its own
+            anti-abuse cookies on the edge.
+          </li>
+        </ul>
+
+        <h2>Legal basis (GDPR / DPDP)</h2>
+        <ul>
+          <li>
+            <strong>Legitimate interest</strong> (GDPR Art. 6(1)(f)) — for
+            operating the demo, preventing abuse, and securing user accounts.
+          </li>
+          <li>
+            <strong>Consent</strong> — for any optional cookies; none are
+            currently set on the demo.
+          </li>
+          <li>
+            <strong>Contract</strong> (GDPR Art. 6(1)(b)) — to deliver the
+            requested service when you sign in.
+          </li>
+        </ul>
+
+        <h2>How long we keep your data</h2>
+        <p>
+          Inactive accounts are deleted automatically <strong>30 days</strong>{' '}
+          after your last sign-in. You receive a warning email and an in-app
+          banner 7 days before deletion. Backups are retained for 30 days
+          (logical dumps) and 14 days (volume snapshots). You can request
+          immediate deletion at any time via the in-app{' '}
+          <em>Delete my account</em> control.
+        </p>
+
+        <h2>Recipients and processors</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Processor</th>
+              <th>Purpose</th>
+              <th>Region</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Amazon Web Services (EC2, S3, SSM)</td>
+              <td>Hosting and backups</td>
+              <td>ap-south-1 (Mumbai)</td>
+            </tr>
+            <tr>
+              <td>Cloudflare (Tunnel, Access, Turnstile, DNS)</td>
+              <td>Edge proxy, anti-bot, login gate</td>
+              <td>Global anycast</td>
+            </tr>
+            <tr>
+              <td>Google (OAuth)</td>
+              <td>Federated sign-in</td>
+              <td>Global</td>
+            </tr>
+            <tr>
+              <td>Resend</td>
+              <td>Transactional email (retention notices, DSAR confirmations)</td>
+              <td>EU / US</td>
+            </tr>
+            <tr>
+              <td>LLM provider (Anthropic, OpenAI, or self-hosted)</td>
+              <td>Generating AI responses</td>
+              <td>US</td>
+            </tr>
+            <tr>
+              <td>Razorpay / Hyperswitch (sandbox only on demo)</td>
+              <td>Payment UI rehearsal</td>
+              <td>India / Global</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h2>Your rights</h2>
+        <ul>
+          <li>
+            <strong>Access / export.</strong> Use{' '}
+            <em>Account settings → Export my data</em> to download a JSON
+            archive of your data.
+          </li>
+          <li>
+            <strong>Erasure.</strong> Use <em>Account settings → Delete my
+            account</em>. We confirm via email and irreversibly delete within
+            24 hours.
+          </li>
+          <li>
+            <strong>Rectification.</strong> Edit your profile and content
+            in-app.
+          </li>
+          <li>
+            <strong>Complain.</strong> If you believe your data has been
+            mishandled, email{' '}
+            <a href="mailto:privacy@ravencloak.org">privacy@ravencloak.org</a>{' '}
+            or contact your local data-protection authority.
+          </li>
+        </ul>
+
+        <h2>Security</h2>
+        <p>
+          Data is encrypted at rest (AWS-managed AES-256 on EBS and S3) and in
+          transit (TLS via Cloudflare). Access to the host is restricted to
+          AWS Systems Manager — no inbound SSH ports are open.
+        </p>
+
+        <h2>Changes</h2>
+        <p>
+          We update this policy as the demo evolves. Material changes are
+          announced via an in-app banner at next sign-in.
+        </p>
+
+        <h2>Contact</h2>
+        <p>
+          Questions? Email{' '}
+          <a href="mailto:privacy@ravencloak.org">privacy@ravencloak.org</a>.
+        </p>
+      </main>
+      <Footer />
+    </>
+  )
+}

--- a/landing/src/app/legal/terms/page.tsx
+++ b/landing/src/app/legal/terms/page.tsx
@@ -1,0 +1,131 @@
+import { type Metadata } from 'next'
+
+import { Footer } from '@/components/Footer'
+import { Header } from '@/components/Header'
+
+export const metadata: Metadata = {
+  title: 'Terms of Service',
+  description:
+    'Acceptable-use terms for the public Raven demo at demo.raven.ravencloak.org.',
+  alternates: { canonical: 'https://raven.ravencloak.org/legal/terms/' },
+}
+
+export default function TermsPage() {
+  return (
+    <>
+      <Header />
+      <main className="mx-auto max-w-3xl px-6 py-16 prose prose-invert">
+        <h1>Terms of Service</h1>
+        <p>
+          <em>Last updated: 13 May 2026.</em>
+        </p>
+
+        <p>
+          By signing in to the public Raven demo at{' '}
+          <strong>demo.raven.ravencloak.org</strong>, you agree to these
+          terms. The demo is provided as a technology preview by Jobin
+          Lawrance (the &quot;Operator&quot;), based in India.
+        </p>
+
+        <h2>The demo is provided as-is</h2>
+        <p>
+          The demo is an evaluation environment. There is no service-level
+          agreement, no warranty of fitness for any purpose, no warranty of
+          availability, and no warranty of data preservation beyond the
+          retention policy described in our{' '}
+          <a href="/legal/privacy/">Privacy Policy</a>. Use the demo for
+          evaluation, not for storing data you cannot afford to lose.
+        </p>
+
+        <h2>Acceptable use</h2>
+        <p>You agree not to:</p>
+        <ul>
+          <li>
+            Attempt to gain unauthorized access to systems, accounts, or data
+            other than your own.
+          </li>
+          <li>
+            Probe, scan, or load-test the demo. The demo has limited capacity
+            and abuse harms other evaluators.
+          </li>
+          <li>
+            Submit content that is unlawful, infringing, defamatory, or that
+            violates the rights of others.
+          </li>
+          <li>
+            Use the demo to generate content prohibited by the underlying LLM
+            provider&apos;s usage policies (Anthropic, OpenAI, or whichever
+            provider is configured at the time).
+          </li>
+          <li>
+            Use the demo as a production backend. The demo is rate-limited
+            and may be reset, paused, or shut down with no notice.
+          </li>
+          <li>
+            Resell or repackage the demo&apos;s output as a service.
+          </li>
+        </ul>
+
+        <h2>Account suspension</h2>
+        <p>
+          We may suspend or terminate any account at any time, with or without
+          notice, if we suspect abuse, misuse, or that the account
+          jeopardises the demo for other users.
+        </p>
+
+        <h2>Demo limits</h2>
+        <p>
+          The demo enforces per-account quotas and a global daily LLM spend
+          ceiling. Once the ceiling is reached, AI features return a &quot;demo
+          limit reached&quot; error until the next UTC day.
+        </p>
+
+        <h2>Paid features</h2>
+        <p>
+          The demo runs payment-provider sandboxes only. No real charges
+          occur. Paid plans are marked &quot;Coming soon&quot; and lead to a
+          waitlist form. We do not bill the demo.
+        </p>
+
+        <h2>Open source</h2>
+        <p>
+          Raven&apos;s source code is published at{' '}
+          <a href="https://github.com/ravencloak-org/Raven">
+            github.com/ravencloak-org/Raven
+          </a>{' '}
+          under the Apache 2.0 license. Self-hosting the software is governed
+          by that license, not these terms.
+        </p>
+
+        <h2>Indemnity and limitation of liability</h2>
+        <p>
+          To the maximum extent permitted by law, the Operator is not liable
+          for any indirect, incidental, or consequential damages arising from
+          your use of the demo. You agree to indemnify and hold the Operator
+          harmless against claims arising from your misuse of the demo.
+        </p>
+
+        <h2>Governing law</h2>
+        <p>
+          These terms are governed by the laws of India. Any dispute is
+          subject to the exclusive jurisdiction of the courts of Karnataka.
+        </p>
+
+        <h2>Changes</h2>
+        <p>
+          We may change these terms. Continued use after changes are posted
+          constitutes acceptance.
+        </p>
+
+        <h2>Contact</h2>
+        <p>
+          Questions? Email{' '}
+          <a href="mailto:hello@ravencloak.org">hello@ravencloak.org</a>. For
+          privacy-specific matters, see our{' '}
+          <a href="/legal/privacy/">Privacy Policy</a>.
+        </p>
+      </main>
+      <Footer />
+    </>
+  )
+}

--- a/landing/src/components/Footer.tsx
+++ b/landing/src/components/Footer.tsx
@@ -29,6 +29,8 @@ export function Footer() {
               <li><Link href={DOCS_URL} className="hover:text-white">Docs</Link></li>
               <li><Link href="/about" className="hover:text-white">About</Link></li>
               <li><Link href={REPO_URL} className="hover:text-white">GitHub</Link></li>
+              <li><Link href="/legal/privacy" className="hover:text-white">Privacy</Link></li>
+              <li><Link href="/legal/terms" className="hover:text-white">Terms</Link></li>
             </ul>
           </nav>
         </div>

--- a/migrations/00040_account_dsar.sql
+++ b/migrations/00040_account_dsar.sql
@@ -1,0 +1,26 @@
+-- +goose Up
+-- DSAR scheduled deletes — POST /account/delete inserts a row here
+-- with a 24h grace window. A separate purge worker (out of scope for
+-- this migration) drains the table and applies the cascade decided in
+-- docs/superpowers/specs/2026-05-12-public-demo-deployment-design.md §6.
+CREATE TABLE IF NOT EXISTS scheduled_deletes (
+    user_id     UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    requested_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    run_at      TIMESTAMPTZ NOT NULL DEFAULT NOW() + INTERVAL '24 hours'
+);
+
+CREATE INDEX IF NOT EXISTS scheduled_deletes_run_at_idx
+    ON scheduled_deletes (run_at);
+
+-- Retention purge warnings — set by the nightly cron when an account
+-- crosses the 23-day inactive threshold. The row's presence (plus the
+-- last_login_at on users) tells the cron whether a warning email was
+-- already sent, preventing duplicates.
+CREATE TABLE IF NOT EXISTS account_purge_warnings (
+    user_id    UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    warned_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- +goose Down
+DROP TABLE IF EXISTS account_purge_warnings;
+DROP TABLE IF EXISTS scheduled_deletes;


### PR DESCRIPTION
## Summary

Lands the implementation work behind the public demo at `demo.raven.ravencloak.org` per [spec](docs/superpowers/specs/2026-05-12-public-demo-deployment-design.md).

Three plans, 40 commits:

- **Plan #1 — Infrastructure** (17/18 tasks): full Terraform module (VPC, IAM, S3, EBS, EC2, AWS Backup, Cloudflare Tunnel + DNS + Access), cloud-init that fetches SSM SecureString params and runs Ansible, new `raven-backup` role (pg + ClickHouse systemd timers), `docker-compose.demo.yml` overlay, runbooks for bootstrap / monitoring / restore.
- **Plan #2 — Deploy pipeline** (9/10 tasks): GitHub OIDC IAM role for SSM Run Command, `update.sh --tag`, `demo-deploy.yml` workflow with wait-for-images + SSM deploy + healthz smoke + Resend notify. Audit found `release.yml` already publishes multi-arch GHCR on tag, so the composite-action and per-language publish tasks from the plan were skipped as redundant.
- **Plan #3 — App features** (14/18 tasks): `internal/mail` (Resend), `internal/turnstile` (siteverify), `internal/account` (DSAR export/delete + retention purger + SQL repo + migration `00040`), `internal/seed` (sample-workspace fixture), Python `LLMSpendFuse`, privacy/ToS pages on landing, cookie banner in admin frontend.

## Outstanding

User-driven smoke tests (need credentials + infra applied):
- T16: `terraform apply` from `deploy/terraform/demo/` after seeding SSM per the runbook.
- T26: first end-to-end deploy smoke (tag → workflow → box).
- T46: app-features manual smoke.

Integration tasks deferred:
- T34: Turnstile middleware + SuperTokens recipe override.
- T35: Turnstile widget in `LoginPage.vue` + runtime config.
- T37: `LLMSpendFuse` wiring into `services/rag.py` call sites.
- T45: Voice UI sweep across the admin dashboard.

Open implementation question in code:
- `internal/account/repo_sql.go` → `HardDelete` returns `ErrHardDeleteNotEnabled` until the cascade behaviour for multi-tenant account purge is decided (spec §6).
- `ExportUser` returns users-table row only; user-owned domain table enumeration is a follow-up.

## Test plan

- [ ] CI green on this branch (Go, Python, frontend, Docker, security workflows).
- [ ] After merging: seed SSM per `docs/runbooks/demo-bootstrap.md`.
- [ ] After seeding: `terraform init && terraform apply` from `deploy/terraform/demo/`.
- [ ] After apply: SSM into the box, tail `cloud-init-output.log` for `raven-stack: ok`.
- [ ] Visit `https://demo.raven.ravencloak.org` (gated by Cloudflare Access during Phase 1).
- [ ] Tag `v0.0.1-demo` to exercise the deploy workflow.
- [ ] Configure BetterStack uptime monitor on `/healthz` with Cloudflare Access bypass for that path.

## Notes

- Pre-commit hook + CI lint are configured `only-new-issues` — the repo's existing noctx/revive backlog doesn't block this PR. (Lint policy itself was already landed by another PR; the rebase consolidated.)
- One commit on the demo branch from your `010c9d82 fix(desktop): resolve desktop-release.yml conflict` was skipped during the rebase — that change belongs on the Tauri PR branch, not the demo.