### PR TITLE
fix(desktop): replace raven_local_lib with raven_ai_lib in main.rs

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -70,9 +70,18 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: desktop -> desktop/target
+          cache-on-failure: true
+
+      - name: Cache Tauri CLI binary
+        id: cache-tauri-cli
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.cargo/bin/cargo-tauri
+          key: tauri-cli-2.11.1-${{ runner.os }}-${{ runner.arch }}
 
       - name: Install Tauri CLI
-        run: cargo install tauri-cli --version '^2.0' --locked
+        if: steps.cache-tauri-cli.outputs.cache-hit != 'true'
+        run: cargo install tauri-cli --version '=2.11.1' --locked
 
       # ── macOS signing + notarization ──────────────────────────────────────
       # Requires these secrets in the repo (Settings → Secrets → Actions):

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -3,10 +3,10 @@
 
 use std::path::{Path, PathBuf};
 
-use raven_local_lib::compose::{ComposeManager, StatusEvent};
-use raven_local_lib::precheck::{run_precheck, skip_requested, RealSystemInfo};
-use raven_local_lib::tray::{self, TrayStatus};
-use raven_local_lib::updater;
+use raven_ai_lib::compose::{ComposeManager, StatusEvent};
+use raven_ai_lib::precheck::{run_precheck, skip_requested, RealSystemInfo};
+use raven_ai_lib::tray::{self, TrayStatus};
+use raven_ai_lib::updater;
 use tauri::{Emitter, Listener, Manager};
 
 const COMPOSE_FILE: &str = "docker-compose.local.yml";
@@ -42,10 +42,10 @@ fn main() {
             app.listen("compose:status", move |event| {
                 if let Ok(payload) = serde_json::from_str::<StatusEvent>(event.payload()) {
                     let status = match payload.status {
-                        raven_local_lib::compose::ComposeStatus::Starting => TrayStatus::Starting,
-                        raven_local_lib::compose::ComposeStatus::Ready => TrayStatus::Ready,
-                        raven_local_lib::compose::ComposeStatus::Stopped => TrayStatus::Stopped,
-                        raven_local_lib::compose::ComposeStatus::Error => TrayStatus::Error,
+                        raven_ai_lib::compose::ComposeStatus::Starting => TrayStatus::Starting,
+                        raven_ai_lib::compose::ComposeStatus::Ready => TrayStatus::Ready,
+                        raven_ai_lib::compose::ComposeStatus::Stopped => TrayStatus::Stopped,
+                        raven_ai_lib::compose::ComposeStatus::Error => TrayStatus::Error,
                     };
                     tray::apply_status(&tray_handle, status);
                 }
@@ -152,9 +152,9 @@ fn main() {
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
-            raven_local_lib::ollama::ollama_pull_model,
-            raven_local_lib::ollama::ollama_list_models,
-            raven_local_lib::updater::updater_install_and_restart
+            raven_ai_lib::ollama::ollama_pull_model,
+            raven_ai_lib::ollama::ollama_list_models,
+            raven_ai_lib::updater::updater_install_and_restart
         ])
         .build(tauri::generate_context!())
         .expect("error while building Raven AI")


### PR DESCRIPTION
## Summary

`main.rs` was still importing from `raven_local_lib` but the crate was renamed to `raven_ai_lib` (as `[lib] name` in `Cargo.toml`) as part of the Raven Local → Raven AI rebrand. This caused all three platform builds to fail with `cannot find module or crate 'raven_local_lib' in this scope`.

Replaces all 11 occurrences of `raven_local_lib` → `raven_ai_lib` in `main.rs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build pipeline with improved dependency caching
  * Updated internal library dependencies

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ravencloak-org/Raven/pull/588?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->