### PR TITLE
chore(demo): drop remote TF backend, use local state for solo operator

### DIFF
--- a/deploy/terraform/demo/versions.tf
+++ b/deploy/terraform/demo/versions.tf
@@ -12,11 +12,11 @@ terraform {
     }
   }
 
-  backend "s3" {
-    bucket         = "raven-tf-state"
-    key            = "demo/terraform.tfstate"
-    region         = "ap-south-1"
-    encrypt        = true
-    dynamodb_table = "raven-tf-locks"
-  }
+  # Local state — solo-operator demo, no team concurrency to protect
+  # against. The state file lives at deploy/terraform/demo/terraform.tfstate
+  # on the operator's machine (gitignored). If the machine is lost, the
+  # demo can be re-created from scratch by re-running `terraform apply`;
+  # the EBS data volume has prevent_destroy so re-import after re-create
+  # is straightforward. Switch to a remote backend if/when more than one
+  # operator ever needs to drive this stack.
 }

--- a/docs/runbooks/demo-bootstrap.md
+++ b/docs/runbooks/demo-bootstrap.md
@@ -49,18 +49,21 @@ terraform apply demo.tfplan
 - Tail cloud-init log: `tail -f /var/log/cloud-init-output.log` until "raven-stack: ok" appears.
 - Visit `https://demo.raven.ravencloak.org` — Cloudflare Access should prompt for your email (Phase 1 gate).
 
-## Terraform backend (one-time, before first `terraform init`)
+## Terraform state
 
-```bash
-aws s3api create-bucket --region ap-south-1 --bucket raven-tf-state \
-  --create-bucket-configuration LocationConstraint=ap-south-1
-aws s3api put-bucket-versioning --bucket raven-tf-state \
-  --versioning-configuration Status=Enabled
-aws s3api put-bucket-encryption --bucket raven-tf-state \
-  --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}'
-aws dynamodb create-table --region ap-south-1 \
-  --table-name raven-tf-locks \
-  --attribute-definitions AttributeName=LockID,AttributeType=S \
-  --key-schema AttributeName=LockID,KeyType=HASH \
-  --billing-mode PAY_PER_REQUEST
-```
+Local state — no remote backend, no S3 bucket for state, no DynamoDB
+lock table. The state file lives at `deploy/terraform/demo/terraform.tfstate`
+on the operator's machine and is gitignored. This is a deliberate
+solo-operator choice: nothing to bootstrap, nothing to pay for, no
+backend contention.
+
+If the operator's machine is lost and the state file is gone with it,
+re-create the stack with `terraform apply` and re-import the EBS data
+volume (which has `prevent_destroy = true` and therefore survives even
+when its TF reference is forgotten). The `docs/runbooks/demo-restore.md`
+runbook covers this path.
+
+The `raven-demo-backups` S3 bucket (for `pg_dump` + `clickhouse-backup`
+uploads) is **not** the state bucket — it's a separate resource that
+Terraform itself creates via `deploy/terraform/demo/s3.tf`. No manual
+`aws s3api` step is required.


### PR DESCRIPTION
## Summary

Solo-operator demo has no concurrent-`apply` problem to solve. The S3 + DynamoDB pair in `versions.tf` was boilerplate inherited from team-shared-TF muscle memory; it added two AWS resources whose only job was to host one `tfstate` file and one lock entry.

Switches to the default local state. The state file lives at `deploy/terraform/demo/terraform.tfstate` on the operator's machine and is gitignored.

## Changes

- `deploy/terraform/demo/versions.tf` — removed the `backend "s3"` block (and the `dynamodb_table` reference inside it). Inline comment documents the choice.
- `docs/runbooks/demo-bootstrap.md` — replaced the "create `raven-tf-state` bucket + `raven-tf-locks` DynamoDB table" section with a short note about local state and how to recover when the operator's machine is lost (re-apply + re-import the EBS data volume, which has `prevent_destroy = true`).

## Not affected

The `raven-demo-backups` S3 bucket (for `pg_dump` + `clickhouse-backup` nightly uploads) is a **separate resource** created by Terraform itself in `deploy/terraform/demo/s3.tf`. It still exists and is unchanged.

## Test plan

- [ ] `terraform -chdir=deploy/terraform/demo fmt -recursive` is clean.
- [ ] `terraform -chdir=deploy/terraform/demo init -backend=false` succeeds (verified locally).
- [ ] After this lands, the demo bootstrap runbook no longer prescribes any `aws s3api` / `aws dynamodb` step before `terraform init`.

## Why now

Came up while reviewing the demo PR (#587). DynamoDB locking is a team-concurrency control that gives a solo operator zero value. The cleaner topology lands one PR earlier than a "team-ready" topology that nobody on the team would have used.