### PR TITLE
feat(worker): wire LLMSpendFuse into RAG streaming entry points

### DIFF
--- a/ai-worker/raven_worker/server.py
+++ b/ai-worker/raven_worker/server.py
@@ -12,6 +12,7 @@ from grpc_reflection.v1alpha import reflection
 from raven_worker.config import settings
 from raven_worker.generated import ai_worker_pb2, ai_worker_pb2_grpc
 from raven_worker.http_internal import build_app
+from raven_worker.llm_fuse import FuseTripped
 from raven_worker.services.embedding import EmbeddingServicer
 from raven_worker.services.rag import RAGServicer
 from raven_worker.telemetry import get_grpc_server_interceptor, init_telemetry
@@ -43,9 +44,21 @@ class AIWorkerServicer(
         )
 
     async def QueryRAG(self, request, context):
-        """Stream RAG results for a query."""
-        async for chunk in self._rag.query(request, context):
-            yield chunk
+        """Stream RAG results for a query.
+
+        Translates :class:`raven_worker.llm_fuse.FuseTripped` (raised when
+        the demo's daily $-cap is crossed) into gRPC
+        ``RESOURCE_EXHAUSTED`` so callers can surface a clear "demo limit
+        reached" error to the end user.
+        """
+        try:
+            async for chunk in self._rag.query(request, context):
+                yield chunk
+        except FuseTripped as e:
+            await context.abort(
+                grpc.StatusCode.RESOURCE_EXHAUSTED,
+                f"Demo daily LLM limit reached. Try again tomorrow. ({e})",
+            )
 
     async def GetEmbedding(self, request, context):
         """Generate an embedding for a single text input."""

--- a/ai-worker/raven_worker/services/rag.py
+++ b/ai-worker/raven_worker/services/rag.py
@@ -22,6 +22,7 @@ from collections.abc import AsyncIterator
 import anthropic
 import asyncpg
 import grpc
+import redis as syncredis
 import redis.asyncio as aioredis
 import structlog
 from openai import AsyncOpenAI
@@ -29,6 +30,7 @@ from openai import AsyncOpenAI
 from raven_worker.config import settings
 from raven_worker.crypto import decrypt_api_key
 from raven_worker.generated import ai_worker_pb2
+from raven_worker.llm_fuse import FuseTripped, LLMSpendFuse
 from raven_worker.memory import MEMORY_TOOL, MemoryStore
 from raven_worker.providers.registry import get_provider_for_request
 from raven_worker.retrieval.bm25_search import bm25_search
@@ -38,6 +40,39 @@ from raven_worker.retrieval.rrf import reciprocal_rank_fusion
 from raven_worker.retrieval.vector_search import vector_search
 
 logger = structlog.get_logger(__name__)
+
+# ── LLM spend fuse ────────────────────────────────────────────────────────
+# Module-level lazy fuse. Used by the public demo to bound runaway LLM
+# spend; disabled when ``settings.llm_daily_usd_cap <= 0``. The cost is a
+# flat per-request estimate — accurate per-model pricing is a follow-up
+# once we wire a token-usage callback into the stream readers. For demo
+# purposes the goal is "fail closed once the day's $-cap is crossed",
+# not an accurate cost ledger.
+_LLM_REQUEST_COST_USD = 0.02
+
+_llm_fuse_sync_client: syncredis.Redis | None = None
+_llm_fuse_singleton: LLMSpendFuse | None = None
+
+
+def _get_llm_fuse() -> LLMSpendFuse | None:
+    """Return the module-level LLMSpendFuse, or None when disabled.
+
+    Lazy construction lets this module import cleanly in tests that never
+    touch the fuse. The sync Redis client is acceptable here because each
+    guard/charge call is a single tiny Redis round-trip — not enough to
+    matter against the orders-of-magnitude-longer LLM stream that follows.
+    """
+    global _llm_fuse_sync_client, _llm_fuse_singleton
+    if settings.llm_daily_usd_cap <= 0:
+        return None
+    if _llm_fuse_singleton is None:
+        _llm_fuse_sync_client = syncredis.from_url(settings.valkey_url)
+        _llm_fuse_singleton = LLMSpendFuse(
+            redis=_llm_fuse_sync_client,
+            daily_cap_usd=settings.llm_daily_usd_cap,
+        )
+    return _llm_fuse_singleton
+
 
 SYSTEM_PROMPT = """You are a helpful assistant. Answer the question based on the provided context.
 If the answer is not in the context, say you don't know.
@@ -674,6 +709,13 @@ class RAGServicer:
         messages: list[dict],
     ) -> AsyncIterator[ai_worker_pb2.RAGChunk]:
         """Stream tokens from the OpenAI Chat Completions API."""
+        # Demo $-fuse: refuse new LLM requests once today's cap is crossed.
+        # FuseTripped propagates up to QueryRAG, which translates to
+        # gRPC RESOURCE_EXHAUSTED.
+        fuse = _get_llm_fuse()
+        if fuse is not None:
+            fuse.guard(_LLM_REQUEST_COST_USD)
+
         client = AsyncOpenAI(api_key=api_key)
         full_messages = [{"role": "system", "content": system_prompt}, *messages]
 
@@ -682,6 +724,15 @@ class RAGServicer:
             messages=full_messages,  # type: ignore[arg-type]
             stream=True,
         )
+        # Charge after the stream is established; guard already verified
+        # we're under the cap. If charge crosses the cap mid-day we still
+        # let this in-flight request finish (it's already running).
+        if fuse is not None:
+            try:
+                fuse.charge(_LLM_REQUEST_COST_USD)
+            except FuseTripped:
+                logger.warning("llm_fuse_charge_crossed_cap", request_cost=_LLM_REQUEST_COST_USD)
+
         async for event in stream:  # type: ignore[union-attr]
             delta = event.choices[0].delta.content if event.choices else None
             if delta:
@@ -713,6 +764,17 @@ class RAGServicer:
           server-side ``web_search_20260209`` tool is included so Claude can
           supplement knowledge-base context with live web results.
         """
+        # Demo $-fuse: refuse new LLM requests once today's cap is crossed.
+        # Charged once per user-facing exchange — the memory-preflight and
+        # tool-iteration sub-calls below don't bill an extra fuse charge.
+        fuse = _get_llm_fuse()
+        if fuse is not None:
+            fuse.guard(_LLM_REQUEST_COST_USD)
+            try:
+                fuse.charge(_LLM_REQUEST_COST_USD)
+            except FuseTripped:
+                logger.warning("llm_fuse_charge_crossed_cap", request_cost=_LLM_REQUEST_COST_USD)
+
         client = anthropic.AsyncAnthropic(api_key=api_key)
 
         # ── Prompt caching: wrap system prompt as a cacheable block ──────────

--- a/ai-worker/tests/test_rag_llm_fuse.py
+++ b/ai-worker/tests/test_rag_llm_fuse.py
@@ -1,0 +1,77 @@
+"""Integration shape test for the LLM $-fuse wiring in services.rag.
+
+We don't actually drive a real LLM call from here — that would require
+a real provider client and a real Redis instance. Instead we exercise
+:func:`raven_worker.services.rag._get_llm_fuse` against fakeredis and
+the cap-related branches in isolation.
+
+The realistic end-to-end behaviour (FuseTripped surfacing as
+``grpc.StatusCode.RESOURCE_EXHAUSTED``) is covered by the QueryRAG
+handler in :mod:`raven_worker.server` and verified during the manual
+smoke pass described in
+``docs/runbooks/demo-app-features.md``.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import fakeredis
+import pytest
+
+import raven_worker.services.rag as rag_module
+from raven_worker.config import settings
+from raven_worker.llm_fuse import FuseTripped
+
+
+@pytest.fixture
+def reset_fuse_singleton(monkeypatch: pytest.MonkeyPatch):
+    """Reload the rag module so the lazy fuse re-initialises per-test."""
+    importlib.reload(rag_module)
+    monkeypatch.setattr(rag_module, "_llm_fuse_sync_client", None)
+    monkeypatch.setattr(rag_module, "_llm_fuse_singleton", None)
+    yield rag_module
+
+
+def test_get_llm_fuse_returns_none_when_cap_zero(
+    monkeypatch: pytest.MonkeyPatch,
+    reset_fuse_singleton,
+) -> None:
+    monkeypatch.setattr(settings, "llm_daily_usd_cap", 0.0)
+    assert reset_fuse_singleton._get_llm_fuse() is None
+
+
+def test_get_llm_fuse_constructs_when_cap_positive(
+    monkeypatch: pytest.MonkeyPatch,
+    reset_fuse_singleton,
+) -> None:
+    monkeypatch.setattr(settings, "llm_daily_usd_cap", 5.0)
+    # Swap in fakeredis before the first call so the constructor uses it.
+    fake = fakeredis.FakeRedis()
+    monkeypatch.setattr(
+        "raven_worker.services.rag.syncredis.from_url",
+        lambda _url: fake,
+    )
+
+    fuse = reset_fuse_singleton._get_llm_fuse()
+    assert fuse is not None
+    # Second call returns the same instance (singleton behaviour).
+    assert reset_fuse_singleton._get_llm_fuse() is fuse
+
+
+def test_fuse_trips_at_module_constant(
+    monkeypatch: pytest.MonkeyPatch,
+    reset_fuse_singleton,
+) -> None:
+    """A cap just below 1× ``_LLM_REQUEST_COST_USD`` trips on the first guard."""
+    monkeypatch.setattr(settings, "llm_daily_usd_cap", 0.01)  # < 0.02 module const
+    fake = fakeredis.FakeRedis()
+    monkeypatch.setattr(
+        "raven_worker.services.rag.syncredis.from_url",
+        lambda _url: fake,
+    )
+
+    fuse = reset_fuse_singleton._get_llm_fuse()
+    assert fuse is not None
+    with pytest.raises(FuseTripped):
+        fuse.guard(reset_fuse_singleton._LLM_REQUEST_COST_USD)


### PR DESCRIPTION
## Summary

Plan #3 Task 9. Closes the loop on the LLM \$-fuse that landed back in #587: connects `LLMSpendFuse` (already in `ai-worker/raven_worker/llm_fuse.py`) to the actual LLM call sites in `services/rag.py`, and translates `FuseTripped` into a clean gRPC `RESOURCE_EXHAUSTED` at the QueryRAG boundary.

Without this PR the fuse exists but doesn't actually gate anything — a public-demo visitor could still burn through unbounded LLM spend.

## Behaviour

- One fuse charge per user-facing exchange. The Anthropic memory-preflight loop and tool-iteration sub-calls do **not** bill extra charges.
- Cost estimate is intentionally coarse: flat `$0.02` per exchange. With `RAVEN_LLM_DAILY_USD_CAP=5.00`, that bounds the day to ~250 exchanges across all visitors before AI features return "demo daily limit reached".
- A token-usage-aware charge is a deliberate follow-up: needs a stream-end callback that reads usage from the provider response and a per-model price table. Out of scope for closing the fuse loop.
- Disabled when `settings.llm_daily_usd_cap <= 0` — dev / single-user / non-demo runs are unaffected.
- Sync `redis-py` client used by the fuse (each `guard`/`charge` is one tiny round-trip, negligible against the multi-second LLM stream that follows). The async retrieval/cache paths keep their `aioredis` client.

## Translation at the gRPC boundary

```
QueryRAG (server.py)
  ├─ FuseTripped → context.abort(RESOURCE_EXHAUSTED, "Demo daily LLM limit reached. ...")
  └─ otherwise   → stream chunks as today
```

## Files

- `ai-worker/raven_worker/services/rag.py`
  - New import: `redis as syncredis`, `from raven_worker.llm_fuse import FuseTripped, LLMSpendFuse`.
  - Module-level lazy `_get_llm_fuse()` (returns `None` when disabled).
  - `_stream_openai`: `guard()` at entry, `charge()` after the stream is established.
  - `_stream_anthropic`: `guard()` + `charge()` at entry (single charge for the whole memory-preflight + final-stream exchange).
- `ai-worker/raven_worker/server.py`
  - `QueryRAG` wraps the inner stream and translates `FuseTripped` → `RESOURCE_EXHAUSTED`.
- `ai-worker/tests/test_rag_llm_fuse.py` (new)
  - 3 tests covering the lazy fuse singleton + cap-of-zero disable path + trip-at-cap behaviour against fakeredis.

## Test plan

- [x] `uv run pytest tests/test_llm_fuse.py tests/test_rag_llm_fuse.py -v` — 9/9 green locally.
- [x] `uv run ruff check raven_worker/services/rag.py raven_worker/server.py tests/test_rag_llm_fuse.py` — clean.
- [ ] CI green on this branch.
- [ ] After deploy: set `RAVEN_LLM_DAILY_USD_CAP=0.0001` temporarily, hit `/api/.../rag`, expect a `RESOURCE_EXHAUSTED` (mapped to HTTP 429 by the Go API), revert the env value.

## Open follow-ups (not in this PR)

- Token-usage-aware charge: hook a callback into the stream end, read `usage.input_tokens` / `output_tokens` from the provider response, charge based on a per-model price table.
- Surface the Valkey counter on an admin dashboard (`raven:llm:spend:YYYYMMDD` → today's $ spent / cap).