### PR TITLE
fix(onboarding): make model picker react to precheck + repair Tauri 2 e2e bridge

### DIFF
--- a/frontend/e2e/raven-ai-onboarding.spec.ts
+++ b/frontend/e2e/raven-ai-onboarding.spec.ts
@@ -61,33 +61,84 @@ async function installTauriBridge(
 
   await page.addInitScript(
     ({ precheck, pullFrames }: { precheck: PrecheckResult; pullFrames: PullProgressEvent[] }) => {
-      type Listener = (e: { payload: unknown }) => void
-      const listeners: Record<string, Set<Listener>> = {}
+      // Map of event-name → callbackIds returned by transformCallback. The
+      // real Tauri 2 `listen()` calls invoke('plugin:event|listen', …) under
+      // the hood and Rust delivers events by calling window[`_${id}`](…) —
+      // so we need to mimic that machinery, not the older __TAURI_EVENT__
+      // direct bus.
+      const eventToCallbacks: Record<string, Set<number>> = {}
+      let nextCallbackId = 1
 
-      // Surface helpers the test can call from page.evaluate to drive events
-      // and check call history.
-      ;(window as unknown as { __ravenTestBridge: unknown }).__ravenTestBridge = {
-        invokes: [] as Array<{ cmd: string; args: unknown }>,
-        emit(event: string, payload: unknown) {
-          listeners[event]?.forEach((cb) => cb({ payload }))
-        },
-        listenerCount(event: string): number {
-          return listeners[event]?.size ?? 0
-        },
+      function deliver(event: string, payload: unknown): void {
+        eventToCallbacks[event]?.forEach((id) => {
+          const cb = (window as unknown as Record<string, unknown>)[`_${id}`] as
+            | ((e: { event: string; payload: unknown; id: number }) => void)
+            | undefined
+          cb?.({ event, payload, id })
+        })
       }
 
-      // Tauri 2 invoke dispatcher.
+      // Sticky-event store: events emitted by the Rust shell on boot can
+      // race ahead of the frontend listener registration. Mirror that
+      // timing-tolerant behaviour by storing the latest payload per event
+      // and replaying it whenever a new listener subscribes.
+      const sticky: Record<string, unknown> = {
+        'precheck:result': precheck,
+      }
+
+      // Tauri 2 INTERNALS shim — implements the bits @tauri-apps/api/core
+      // and @tauri-apps/api/event actually reach for.
       ;(window as unknown as { __TAURI_INTERNALS__: unknown }).__TAURI_INTERNALS__ = {
+        // Registers a global callback under window[`_${id}`] and returns the
+        // id, matching Tauri's runtime contract used by `listen()`.
+        transformCallback: (callback: (arg: unknown) => void, once?: boolean) => {
+          const id = nextCallbackId++
+          ;(window as unknown as Record<string, unknown>)[`_${id}`] = (
+            result: unknown,
+          ) => {
+            if (once) {
+              delete (window as unknown as Record<string, unknown>)[`_${id}`]
+            }
+            callback(result)
+          }
+          return id
+        },
         invoke: async (cmd: string, args: unknown) => {
           ;(
             window as unknown as { __ravenTestBridge: { invokes: unknown[] } }
           ).__ravenTestBridge.invokes.push({ cmd, args })
 
+          if (cmd === 'plugin:event|listen') {
+            const { event, handler } = args as { event: string; handler: number }
+            if (!eventToCallbacks[event]) eventToCallbacks[event] = new Set()
+            eventToCallbacks[event].add(handler)
+            // Replay sticky payload on a microtask so the handler isn't
+            // invoked inside listen() itself.
+            if (event in sticky) {
+              const payload = sticky[event]
+              void Promise.resolve().then(() => {
+                const cb = (window as unknown as Record<string, unknown>)[
+                  `_${handler}`
+                ] as
+                  | ((e: { event: string; payload: unknown; id: number }) => void)
+                  | undefined
+                cb?.({ event, payload, id: handler })
+              })
+            }
+            // Tauri's listen() expects the resolved value to be an eventId
+            // (number) it can later pass to plugin:event|unlisten.
+            return handler
+          }
+          if (cmd === 'plugin:event|unlisten') {
+            const { event, eventId } = args as { event: string; eventId: number }
+            eventToCallbacks[event]?.delete(eventId)
+            return null
+          }
           if (cmd === 'ollama_pull_model') {
             // Stream the recorded progress frames, then resolve.
             for (const frame of pullFrames) {
               await new Promise((r) => setTimeout(r, 20))
-              listeners['ollama:pull-progress']?.forEach((cb) => cb({ payload: frame }))
+              deliver('ollama:pull-progress', frame)
             }
             return null
           }
@@ -98,15 +149,17 @@ async function installTauriBridge(
         },
       }
 
-      // Tauri 2 event bus shim.
-      ;(window as unknown as { __TAURI_EVENT__: unknown }).__TAURI_EVENT__ = {
-        listen: async (event: string, handler: Listener) => {
-          if (!listeners[event]) listeners[event] = new Set()
-          listeners[event].add(handler)
-          return () => listeners[event].delete(handler)
+      // Surface helpers the test can call from page.evaluate to drive
+      // events and inspect invoke history. Both backed by the real
+      // Tauri-2 callback table above so they behave like the runtime.
+      ;(window as unknown as { __ravenTestBridge: unknown }).__ravenTestBridge = {
+        invokes: [] as Array<{ cmd: string; args: unknown }>,
+        emit(event: string, payload: unknown) {
+          deliver(event, payload)
         },
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        emit: async (_event: string, _payload: unknown) => {},
+        listenerCount(event: string): number {
+          return eventToCallbacks[event]?.size ?? 0
+        },
       }
 
       // Patch window.fetch BEFORE the app boots so /api/v1/config and the
@@ -139,11 +192,8 @@ async function installTauriBridge(
         return originalFetch(input, init)
       }
 
-      // Replay the initial precheck:result so the model picker has a
-      // RAM tier ready immediately after subscribe.
-      setTimeout(() => {
-        listeners['precheck:result']?.forEach((cb) => cb({ payload: precheck }))
-      }, 0)
+      // The sticky-event store above handles replay; no extra setTimeout
+      // emit is needed.
     },
     { precheck, pullFrames },
   )

--- a/frontend/src/pages/onboarding/ModelPickerStep.vue
+++ b/frontend/src/pages/onboarding/ModelPickerStep.vue
@@ -41,7 +41,19 @@ const visibleModels = computed(() => {
   return allModels.filter((m) => tierRank[m.minTier] <= tierRank[tier])
 })
 
-const selectedModel = ref<string>(tierToDefault[precheck.tier] ?? 'llama3.2:3b')
+// The precheck result arrives asynchronously from the Rust shell (via the
+// `precheck:result` event), so `precheck.tier` can flip from 'unknown' →
+// 'low/mid/high' after this component has mounted. A plain ref captured at
+// setup time would freeze the default to whatever tier was known on first
+// render. Track an explicit user override so the default follows the tier
+// until the user picks a radio.
+const userSelected = ref<string | null>(null)
+const selectedModel = computed<string>({
+  get: () => userSelected.value ?? tierToDefault[precheck.tier] ?? 'llama3.2:3b',
+  set: (v) => {
+    userSelected.value = v
+  },
+})
 
 const pullState = ref<'idle' | 'pulling' | 'done' | 'error'>('idle')
 const percent = ref(0)

--- a/frontend/src/stores/precheck.spec.ts
+++ b/frontend/src/stores/precheck.spec.ts
@@ -3,12 +3,13 @@ import { setActivePinia, createPinia } from 'pinia'
 import { usePrecheckStore, ramTier } from './precheck'
 
 describe('ramTier', () => {
-  it('classifies under 8 GB as floor', () => {
+  it('classifies up to 8 GB as floor', () => {
     expect(ramTier(4)).toBe('floor')
     expect(ramTier(7)).toBe('floor')
+    expect(ramTier(8)).toBe('floor')
   })
-  it('classifies 8-11 as low', () => {
-    expect(ramTier(8)).toBe('low')
+  it('classifies 9-11 as low', () => {
+    expect(ramTier(9)).toBe('low')
     expect(ramTier(11)).toBe('low')
   })
   it('classifies 12-15 as mid', () => {

--- a/frontend/src/stores/precheck.ts
+++ b/frontend/src/stores/precheck.ts
@@ -12,14 +12,15 @@ export interface PrecheckResult {
 }
 
 /**
- * Returns the RAM tier band for the host. Bands match the model-picker spec:
- *   <8 GB  → 'floor' (only the smallest model fits)
- *   8-11   → 'low'   (default 8b model is OK but tight)
- *   12-15  → 'mid'   (default 8b model is comfortable)
- *   16+    → 'high'  (13b also offered)
+ * Returns the RAM tier band for the host. Bands match the model-picker spec
+ * and the per-model "fits X GB hosts" descriptions in ModelPickerStep.vue:
+ *   ≤ 8 GB   → 'floor' (only llama3.2:3b — "fits 8 GB hosts")
+ *   9-11 GB  → 'low'   (default 8b model is OK but tight)
+ *   12-15 GB → 'mid'   (default 8b model is comfortable)
+ *   16+ GB   → 'high'  (13b also offered)
  */
 export function ramTier(ramGb: number): RamTier {
-  if (ramGb < 8) return 'floor'
+  if (ramGb < 9) return 'floor'
   if (ramGb < 12) return 'low'
   if (ramGb < 16) return 'mid'
   return 'high'


### PR DESCRIPTION
## Summary

Three interlocking bugs that made the onboarding e2e tests pass only by accident — the precheck event was being dropped, tier stayed `'unknown'` (which defaults to the smallest model), and the tests that asserted the smallest model happened to be right for the wrong reason.

### 1. `ModelPickerStep.vue` — reactivity bug

`selectedModel` was a plain `ref(tierToDefault[tier])` captured at setup time. Because `precheck.tier` arrives asynchronously via a Tauri event, the default would freeze to `'unknown'` → `'llama3.2:3b'` even after the precheck landed. Replaced with a computed-with-setter backed by a `userSelected` override, so the default tracks the latest tier until the user explicitly picks a radio.

### 2. `ramTier` — 8 GB boundary

`<8 → floor` contradicted the user-facing model card text "llama3.2:3b — fits 8 GB hosts". An 8 GB host should be the floor tier. Bump the threshold to `<9`. Unit test updated to match.

### 3. `raven-ai-onboarding.spec.ts` — Tauri 2 bridge was non-functional

The bridge tried to deliver events via a hand-rolled `__TAURI_EVENT__` shim, but real `listen()` in Tauri 2 goes through `invoke('plugin:event|listen', …)` + `transformCallback` + `window[_${id}]`. The bridge's listeners were never wired to the app, so the precheck event was silently dropped on every test run. Implemented the actual runtime contract (`transformCallback`, `plugin:event|listen`, `plugin:event|unlisten`) and added a sticky-event replay so a listener registered after the initial emit still receives the payload — the same timing tolerance the real Rust shell needs.

## Result

All four onboarding e2e tests pass for the right reasons:

- high-tier (16 GB) → pre-selects `llama3.1:8b` and completes the wizard ✓
- floor-tier (8 GB) → pre-selects `llama3.2:3b`, hides 13b ✓
- skip-model path → reaches dashboard ✓
- `ollama_pull_model` invoked with `{ model: 'llama3.1:8b' }` ✓

## Test plan

- [x] `bun run test:unit` — 134/134 passing
- [x] `CI=1 bun run test:e2e --project=chromium` — 8 passed, 54 skipped (mobile/auth, intentional)
- [x] `bun run lint` — clean for changed lines (1 pre-existing v-model attribute-order warning, not from this PR)

Closes #535 properly (the existing close was via #579, but the fix only renamed the test, not the root cause).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Model selection during onboarding now remains responsive to system recommendations, automatically updating suggested options until you manually choose a preferred model
  * Revised system RAM detection and classification boundaries; devices with 8–9 GB of memory now use updated tier criteria for more accurate device capability assessment

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ravencloak-org/Raven/pull/598?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->