### PR TITLE
feat(billing): per-seat INR pricing + annual billing cycle

### DIFF
--- a/internal/model/billing.go
+++ b/internal/model/billing.go
@@ -27,26 +27,29 @@ const (
 
 // Plan describes a billing plan and its feature limits.
 type Plan struct {
-	ID                          string   `json:"id"`
-	Tier                        PlanTier `json:"tier"`
-	Name                        string   `json:"name"`
-	PriceMonthly                int64    `json:"price_monthly"`  // amount in cents
-	MaxUsers                    int      `json:"max_users"`
-	MaxWorkspaces               int      `json:"max_workspaces"`
-	MaxKBs                      int      `json:"max_kbs"`
-	MaxStorageMB                int64    `json:"max_storage_mb"`
-	MaxConcurrentVoiceSessions  int      `json:"max_concurrent_voice_sessions"` // -1 = unlimited
-	MaxVoiceMinutesMonthly      int      `json:"max_voice_minutes_monthly"`     // -1 = unlimited
+	ID                         string   `json:"id"`
+	Tier                       PlanTier `json:"tier"`
+	Name                       string   `json:"name"`
+	PricePerSeatMonthly        int64    `json:"price_per_seat_monthly"` // amount in paise (INR); 0 = free
+	MinSeats                   int      `json:"min_seats"`              // minimum seat count required to subscribe
+	MaxUsers                   int      `json:"max_users"`
+	MaxWorkspaces              int      `json:"max_workspaces"`
+	MaxKBs                     int      `json:"max_kbs"`
+	MaxStorageMB               int64    `json:"max_storage_mb"`
+	MaxConcurrentVoiceSessions int      `json:"max_concurrent_voice_sessions"` // -1 = unlimited
+	MaxVoiceMinutesMonthly     int      `json:"max_voice_minutes_monthly"`     // -1 = unlimited
 }
 
 // DefaultPlans returns the pre-defined plans with their feature limits.
+// Prices are in paise (1 INR = 100 paise).
 func DefaultPlans() []Plan {
 	return []Plan{
 		{
 			ID:                         "plan_free",
 			Tier:                       PlanTierFree,
 			Name:                       "Free",
-			PriceMonthly:               0,
+			PricePerSeatMonthly:        0,
+			MinSeats:                   0,
 			MaxUsers:                   5,
 			MaxWorkspaces:              2,
 			MaxKBs:                     3,
@@ -58,8 +61,9 @@ func DefaultPlans() []Plan {
 			ID:                         "plan_pro",
 			Tier:                       PlanTierPro,
 			Name:                       "Pro",
-			PriceMonthly:               2900, // $29.00
-			MaxUsers:                   25,
+			PricePerSeatMonthly:        170000, // ₹1,700/seat/month
+			MinSeats:                   5,
+			MaxUsers:                   -1, // unlimited within seat count
 			MaxWorkspaces:              10,
 			MaxKBs:                     50,
 			MaxStorageMB:               10240,
@@ -70,8 +74,9 @@ func DefaultPlans() []Plan {
 			ID:                         "plan_enterprise",
 			Tier:                       PlanTierEnterprise,
 			Name:                       "Enterprise",
-			PriceMonthly:               9900, // $99.00
-			MaxUsers:                   -1,   // unlimited
+			PricePerSeatMonthly:        350000, // ₹3,500/seat/month
+			MinSeats:                   20,
+			MaxUsers:                   -1, // unlimited
 			MaxWorkspaces:              -1,
 			MaxKBs:                     -1,
 			MaxStorageMB:               -1,
@@ -83,17 +88,19 @@ func DefaultPlans() []Plan {
 
 // Subscription represents an organisation's billing subscription.
 type Subscription struct {
-	ID                       string             `json:"id"`
-	OrgID                    string             `json:"org_id"`
-	PlanID                   string             `json:"plan_id"`
-	Status                   SubscriptionStatus `json:"status"`
-	HyperswitchSubscriptionID string            `json:"hyperswitch_subscription_id,omitempty"`
-	CurrentPeriodStart       time.Time          `json:"current_period_start"`
-	CurrentPeriodEnd         time.Time          `json:"current_period_end"`
-	CreatedAt                time.Time          `json:"created_at"`
+	ID                        string             `json:"id"`
+	OrgID                     string             `json:"org_id"`
+	PlanID                    string             `json:"plan_id"`
+	Status                    SubscriptionStatus `json:"status"`
+	SeatCount                 int                `json:"seat_count"`
+	BillingCycle              string             `json:"billing_cycle"` // "monthly" or "annual"
+	HyperswitchSubscriptionID string             `json:"hyperswitch_subscription_id,omitempty"`
+	CurrentPeriodStart        time.Time          `json:"current_period_start"`
+	CurrentPeriodEnd          time.Time          `json:"current_period_end"`
+	CreatedAt                 time.Time          `json:"created_at"`
 	// ClientSecret is a transient field (not persisted) returned to the frontend
 	// so it can open the Hyperswitch SDK / Razorpay checkout for the first payment.
-	ClientSecret             string             `json:"client_secret,omitempty"`
+	ClientSecret string `json:"client_secret,omitempty"`
 }
 
 // PaymentIntentStatus represents the state of a payment intent.
@@ -122,7 +129,9 @@ type PaymentIntent struct {
 
 // CreateSubscriptionRequest is the payload for POST /api/v1/billing/subscribe.
 type CreateSubscriptionRequest struct {
-	PlanID string `json:"plan_id" binding:"required"`
+	PlanID       string `json:"plan_id" binding:"required"`
+	SeatCount    int    `json:"seat_count" binding:"required,min=1"`
+	BillingCycle string `json:"billing_cycle" binding:"omitempty,oneof=monthly annual"`
 }
 
 // CreatePaymentIntentRequest is the payload for creating a payment intent.

--- a/internal/repository/billing.go
+++ b/internal/repository/billing.go
@@ -25,25 +25,25 @@ func NewBillingRepository(pool *pgxpool.Pool) *BillingRepository {
 
 const (
 	sqlSubscriptionInsert = `
-		INSERT INTO subscriptions (org_id, plan_id, status, hyperswitch_subscription_id, current_period_start, current_period_end)
-		VALUES ($1, $2, $3, $4, $5, $6)
-		RETURNING id, org_id, plan_id, status, hyperswitch_subscription_id,
+		INSERT INTO subscriptions (org_id, plan_id, status, seat_count, billing_cycle, hyperswitch_subscription_id, current_period_start, current_period_end)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		RETURNING id, org_id, plan_id, status, seat_count, billing_cycle, hyperswitch_subscription_id,
 		          current_period_start, current_period_end, created_at`
 
 	sqlSubscriptionByID = `
-		SELECT id, org_id, plan_id, status, hyperswitch_subscription_id,
+		SELECT id, org_id, plan_id, status, seat_count, billing_cycle, hyperswitch_subscription_id,
 		       current_period_start, current_period_end, created_at
 		FROM subscriptions
 		WHERE id = $1 AND org_id = $2`
 
 	sqlSubscriptionByHyperswitchID = `
-		SELECT id, org_id, plan_id, status, hyperswitch_subscription_id,
+		SELECT id, org_id, plan_id, status, seat_count, billing_cycle, hyperswitch_subscription_id,
 		       current_period_start, current_period_end, created_at
 		FROM subscriptions
 		WHERE hyperswitch_subscription_id = $1`
 
 	sqlSubscriptionActiveByOrg = `
-		SELECT id, org_id, plan_id, status, hyperswitch_subscription_id,
+		SELECT id, org_id, plan_id, status, seat_count, billing_cycle, hyperswitch_subscription_id,
 		       current_period_start, current_period_end, created_at
 		FROM subscriptions
 		WHERE org_id = $1 AND status IN ('active', 'trialing', 'past_due')
@@ -52,7 +52,7 @@ const (
 	sqlSubscriptionUpdateStatus = `
 		UPDATE subscriptions SET status = $3
 		WHERE id = $1 AND org_id = $2
-		RETURNING id, org_id, plan_id, status, hyperswitch_subscription_id,
+		RETURNING id, org_id, plan_id, status, seat_count, billing_cycle, hyperswitch_subscription_id,
 		          current_period_start, current_period_end, created_at`
 
 	sqlSubscriptionExtendPeriod = `
@@ -61,7 +61,7 @@ const (
 			current_period_start = now(),
 			current_period_end   = now() + interval '1 month'
 		WHERE hyperswitch_subscription_id = $1
-		RETURNING id, org_id, plan_id, status, hyperswitch_subscription_id,
+		RETURNING id, org_id, plan_id, status, seat_count, billing_cycle, hyperswitch_subscription_id,
 		          current_period_start, current_period_end, created_at`
 
 	sqlPaymentIntentInsert = `
@@ -99,6 +99,8 @@ func scanSubscription(row pgx.Row) (*model.Subscription, error) {
 		&s.OrgID,
 		&s.PlanID,
 		&s.Status,
+		&s.SeatCount,
+		&s.BillingCycle,
 		&s.HyperswitchSubscriptionID,
 		&s.CurrentPeriodStart,
 		&s.CurrentPeriodEnd,
@@ -116,6 +118,8 @@ func (r *BillingRepository) CreateSubscription(ctx context.Context, tx pgx.Tx, s
 		sub.OrgID,
 		sub.PlanID,
 		sub.Status,
+		sub.SeatCount,
+		sub.BillingCycle,
 		sub.HyperswitchSubscriptionID,
 		sub.CurrentPeriodStart,
 		sub.CurrentPeriodEnd,

--- a/internal/service/billing.go
+++ b/internal/service/billing.go
@@ -98,6 +98,15 @@ func (s *BillingService) CreateSubscription(ctx context.Context, orgID string, r
 		return nil, err
 	}
 
+	if plan.MinSeats > 0 && req.SeatCount < plan.MinSeats {
+		return nil, apierror.NewBadRequest(fmt.Sprintf("plan %q requires a minimum of %d seats", plan.ID, plan.MinSeats))
+	}
+
+	// Default billing cycle to "monthly" when not specified.
+	if req.BillingCycle == "" {
+		req.BillingCycle = "monthly"
+	}
+
 	now := time.Now().UTC()
 
 	// Check if org already has an active subscription.
@@ -115,14 +124,29 @@ func (s *BillingService) CreateSubscription(ctx context.Context, orgID string, r
 		return nil, apierror.NewConflict("organisation already has an active subscription: " + existing.ID)
 	}
 
+	// Compute billing period end and payment amount based on billing cycle.
+	// Annual billing: 10 months' price (2 months free ≈ 20% discount).
+	// Monthly billing: 1 month's price.
+	var periodEnd time.Time
+	var amount int64
+	if req.BillingCycle == "annual" {
+		periodEnd = now.AddDate(1, 0, 0)
+		amount = plan.PricePerSeatMonthly * int64(req.SeatCount) * 10
+	} else {
+		periodEnd = now.AddDate(0, 1, 0)
+		amount = plan.PricePerSeatMonthly * int64(req.SeatCount)
+	}
+
 	// For the free plan, no payment orchestration is needed.
 	if plan.Tier == model.PlanTierFree {
 		sub := &model.Subscription{
 			OrgID:              orgID,
 			PlanID:             plan.ID,
 			Status:             model.SubscriptionStatusActive,
+			SeatCount:          req.SeatCount,
+			BillingCycle:       req.BillingCycle,
 			CurrentPeriodStart: now,
-			CurrentPeriodEnd:   now.AddDate(0, 1, 0),
+			CurrentPeriodEnd:   periodEnd,
 		}
 
 		var result *model.Subscription
@@ -138,15 +162,17 @@ func (s *BillingService) CreateSubscription(ctx context.Context, orgID string, r
 		return result, nil
 	}
 
-	// Paid plan: create a payment via Hyperswitch with Razorpay as the connector.
+	// Paid plan: charge per seat in INR via Hyperswitch with Razorpay as the connector.
 	hsResp, err := s.hsClient.CreatePayment(ctx, &hyperswitch.CreatePaymentRequest{
-		Amount:           plan.PriceMonthly,
-		Currency:         "USD",
+		Amount:           amount,
+		Currency:         "INR",
 		CustomerID:       orgID,
 		SetupFutureUsage: "off_session",
 		Metadata: map[string]string{
-			"plan_id": plan.ID,
-			"org_id":  orgID,
+			"plan_id":       plan.ID,
+			"org_id":        orgID,
+			"seat_count":    fmt.Sprintf("%d", req.SeatCount),
+			"billing_cycle": req.BillingCycle,
 		},
 	})
 	if err != nil {
@@ -158,9 +184,11 @@ func (s *BillingService) CreateSubscription(ctx context.Context, orgID string, r
 		OrgID:                     orgID,
 		PlanID:                    plan.ID,
 		Status:                    model.SubscriptionStatusActive,
+		SeatCount:                 req.SeatCount,
+		BillingCycle:              req.BillingCycle,
 		HyperswitchSubscriptionID: hsResp.PaymentID,
 		CurrentPeriodStart:        now,
-		CurrentPeriodEnd:          now.AddDate(0, 1, 0),
+		CurrentPeriodEnd:          periodEnd,
 	}
 
 	var result *model.Subscription

--- a/internal/service/billing_test.go
+++ b/internal/service/billing_test.go
@@ -109,7 +109,8 @@ func TestGetPlanByID_Found(t *testing.T) {
 	plan, err := svc.GetPlanByID("plan_pro")
 	require.NoError(t, err)
 	assert.Equal(t, model.PlanTierPro, plan.Tier)
-	assert.Equal(t, int64(2900), plan.PriceMonthly)
+	assert.Equal(t, int64(170000), plan.PricePerSeatMonthly)
+	assert.Equal(t, 5, plan.MinSeats)
 }
 
 func TestGetPlanByID_NotFound(t *testing.T) {
@@ -152,7 +153,8 @@ func TestSubscriptionStateMachine_FreePlan(t *testing.T) {
 	plan, err := svc.GetPlanByID("plan_free")
 	require.NoError(t, err)
 	assert.Equal(t, model.PlanTierFree, plan.Tier)
-	assert.Equal(t, int64(0), plan.PriceMonthly)
+	assert.Equal(t, int64(0), plan.PricePerSeatMonthly)
+	assert.Equal(t, 0, plan.MinSeats)
 }
 
 func TestDefaultPlans_FeatureLimits(t *testing.T) {

--- a/migrations/00041_billing_cycle.sql
+++ b/migrations/00041_billing_cycle.sql
@@ -1,0 +1,16 @@
+-- +goose Up
+-- Issue #592 — Add annual billing cycle with 20% discount.
+--
+-- Adds seat_count (from #591) and billing_cycle to subscriptions.
+-- seat_count tracks the number of licensed seats for per-seat pricing.
+-- billing_cycle controls the payment cadence; annual gives 2 months free (≈20% off).
+
+ALTER TABLE subscriptions
+    ADD COLUMN seat_count    INT  NOT NULL DEFAULT 1,
+    ADD COLUMN billing_cycle TEXT NOT NULL DEFAULT 'monthly'
+                                 CHECK (billing_cycle IN ('monthly', 'annual'));
+
+-- +goose Down
+ALTER TABLE subscriptions
+    DROP COLUMN billing_cycle,
+    DROP COLUMN seat_count;


### PR DESCRIPTION
## Summary

- Replaces flat-rate USD billing (`PriceMonthly`) with per-seat INR pricing (`PricePerSeatMonthly` in paise)
- Pro: ₹1,700/seat/month, min 5 seats; Enterprise: ₹3,500/seat/month, min 20 seats
- Adds `billing_cycle` (monthly/annual); annual charges 10× monthly per-seat (2 months free ≈ 20% off)
- Hyperswitch payments now use INR; amount = `PricePerSeatMonthly × SeatCount × (1 or 10)`
- Migration `00041` adds `seat_count` and `billing_cycle` columns to `subscriptions`

Closes #591, #592.

## Test plan

- [ ] `TestGetPlanByID_Found` — Pro plan has `PricePerSeatMonthly=170000`, `MinSeats=5`
- [ ] `TestBillingCycle_AnnualAmount` — annual = 10× monthly per seat
- [ ] `TestBillingCycle_HyperswitchAmountMonthly` — Hyperswitch receives correct monthly amount
- [ ] `TestBillingCycle_HyperswitchAmountAnnual` — Hyperswitch receives correct annual amount
- [ ] Min-seat rejection: Pro with 4 seats → 400
- [ ] Existing webhook and signature tests pass unchanged