### PR TITLE
ci(infra-lint): guard against src-tauri/target/ regression in workflow YAML

### DIFF
--- a/.github/workflows/lint-infra.yml
+++ b/.github/workflows/lint-infra.yml
@@ -68,3 +68,39 @@ jobs:
         with:
           reporter: github-pr-check
           fail_level: warning
+
+  # Catches a class of regression that desktop-release.yml's tag-only
+  # trigger makes invisible at PR time. The Tauri desktop crate lives in
+  # a Cargo workspace at desktop/ — cargo writes build artefacts to
+  # desktop/target/, NOT desktop/src-tauri/target/. PR #502 fixed this in
+  # April; PR #542 (auto-update channel) re-introduced the wrong path,
+  # and no one noticed until the next tag push because desktop-release.yml
+  # never runs on PRs. PR #600 had to clean up after the fact.
+  #
+  # Asserting at PR time that no workflow YAML references the wrong path
+  # would have caught #542 before merge.
+  forbidden-workflow-paths:
+    name: Forbidden workflow paths
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Reject src-tauri/target/ in workflows
+        run: |
+          set -euo pipefail
+          # Exclude this file (it documents the forbidden pattern in
+          # comments + error messages) and use grep -F for a literal
+          # match — the forbidden token is just a fixed string.
+          if matches=$(grep -rFn --exclude='lint-infra.yml' 'src-tauri/target' .github/workflows/ 2>/dev/null); then
+            echo "::error::Workflow YAML references the forbidden path token."
+            echo "::error::The Tauri desktop crate is part of the Cargo workspace at desktop/, so artefacts land at desktop/target/ (workspace root), not under the crate subdirectory."
+            echo "::error::See PR #502 (original fix) and #600 (regression cleanup) for history."
+            echo ""
+            echo "$matches"
+            exit 1
+          fi
+          echo "OK - no forbidden target-path references in .github/workflows/"


### PR DESCRIPTION
## Post-mortem

**Timeline:**

- **PR #502** (April) moved Tauri bundler output paths from `desktop/src-tauri/target/` → `desktop/target/`. The desktop Tauri crate is a member of a Cargo workspace at `desktop/`, so Cargo writes artefacts to the workspace root, not the crate subdirectory.
- **PR #542** (May 15, auto-update channel) silently reverted all 7 of those paths back to `desktop/src-tauri/target/` while adding `.sig_glob` lines for the updater.
- The regression was **invisible at PR time** because `desktop-release.yml` only runs on `push: tags` — PR CI never exercises it.
- **Tag-push v0.1.6** (May 15) failed across macOS, Windows, and Linux with `Could not find subject at path desktop/src-tauri/target/…` from `actions/attest-build-provenance`. Three more retries failed the same way before the cause was diagnosed.
- **PR #600** cleaned up the paths after the fact, ~24h later.

**Root cause:** No PR-time guard for a path that's only validated by a tag-only workflow.

## Fix

Add a `forbidden-workflow-paths` job to `Infra Lint` that fails any PR touching `.github/workflows/*.yml` if those files reference `src-tauri/target/`. The lint workflow already runs on PRs that touch workflow files, so the guard is free.

Local verification:

```
$ grep -rFn --exclude='lint-infra.yml' 'src-tauri/target' .github/workflows/
$ echo $?
1
$ # (Nothing found on current main — guard passes.)

$ # If reintroduced in any workflow:
$ grep -rFn --exclude='lint-infra.yml' 'src-tauri/target' .github/workflows/
.github/workflows/desktop-release.yml:35:  artifact_glob: 'desktop/src-tauri/target/…'
$ # guard fails with a clear error message
```

## Test plan

- [x] Guard passes on current main (no references)
- [x] Guard fails when forbidden token is reintroduced in any workflow YAML
- [x] `actionlint` clean