### PR TITLE
feat(billing): Enterprise manual onboarding (sales-led)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -394,7 +394,7 @@ func main() {
 	leadSvc := service.NewLeadService(leadRepo).WithWebhookDispatcher(webhookSvc)
 	whatsappSvc := service.NewWhatsAppService(whatsappRepo, pool)
 	hsClient := hyperswitch.NewClient(cfg.Hyperswitch.BaseURL, cfg.Hyperswitch.APIKey)
-	billingSvc := service.NewBillingService(billingRepo, pool, hsClient, cfg.Hyperswitch.WebhookSecret)
+	billingSvc := service.NewBillingService(billingRepo, pool, hsClient, cfg.Hyperswitch.WebhookSecret, cfg.Billing.SlackWebhookURL)
 	chatRepo := repository.NewChatRepository(pool)
 	// Cross-channel conversation memory (issue #258): shares the
 	// conversation_sessions table with #257. The migration
@@ -958,6 +958,7 @@ func main() {
 		c.AbortWithStatusJSON(401, gin.H{"error": "valid X-Seed-Key header required"})
 	})
 	admin.POST("/seed-demo", seedHandler.SeedDemo)
+	admin.POST("/billing/subscriptions/enterprise", billingHandler.CreateEnterpriseSubscription)
 
 	// Auth callback — outside the session-protected /api/v1 group.
 	// We verify the session directly via the SuperTokens SDK rather than

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	Meta         MetaConfig
 	TMDB         TMDBConfig
 	Seed         SeedConfig
+	Billing      BillingConfig
 	SES          SESConfig
 	EmailSummary EmailSummaryConfig
 	Retrieval    RetrievalConfig
@@ -125,6 +126,11 @@ type TMDBConfig struct {
 // SeedConfig holds settings for the admin seed endpoint.
 type SeedConfig struct {
 	Key string `mapstructure:"key"` // X-Seed-Key header value for auth bypass
+}
+
+// BillingConfig holds billing-related configuration.
+type BillingConfig struct {
+	SlackWebhookURL string `mapstructure:"slack_webhook_url"` // Slack webhook for enterprise deal notifications
 }
 
 // ClickHouseConfig holds ClickHouse connection and vector backend settings.
@@ -588,6 +594,9 @@ func Load() (*Config, error) {
 	_ = v.BindEnv("asynq.recrawl_sources_budget", "RAVEN_ASYNQ_RECRAWL_SOURCES_BUDGET")
 	_ = v.BindEnv("asynq.cleanup_sessions_budget", "RAVEN_ASYNQ_CLEANUP_SESSIONS_BUDGET")
 	_ = v.BindEnv("asynq.default_budget", "RAVEN_ASYNQ_DEFAULT_BUDGET")
+
+	_ = v.BindEnv("billing.slack_webhook_url", "RAVEN_SLACK_BILLING_WEBHOOK_URL")
+	v.SetDefault("billing.slack_webhook_url", "")
 
 	// Try to read config file but don't fail if not found
 	_ = v.ReadInConfig()

--- a/internal/handler/billing.go
+++ b/internal/handler/billing.go
@@ -21,6 +21,7 @@ type BillingServicer interface {
 	CreatePaymentIntent(ctx context.Context, orgID string, req model.CreatePaymentIntentRequest) (*model.PaymentIntent, error)
 	VerifyWebhookSignature(payload []byte, signature string) error
 	HandleWebhook(ctx context.Context, event model.HyperswitchWebhookPayload) error
+	CreateEnterpriseSubscription(ctx context.Context, req model.CreateEnterpriseSubscriptionRequest) (*model.Subscription, error)
 }
 
 // BillingHandler handles HTTP requests for billing and subscription management.
@@ -270,4 +271,27 @@ func (h *BillingHandler) Webhook(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
+// CreateEnterpriseSubscription handles POST /api/v1/admin/billing/subscriptions/enterprise.
+// This is a sales-led, admin-only endpoint — no Hyperswitch payment is created.
+// No Swagger annotation is intentional: this endpoint must not appear in public API docs.
+func (h *BillingHandler) CreateEnterpriseSubscription(c *gin.Context) {
+	var req model.CreateEnterpriseSubscriptionRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.AbortWithStatusJSON(http.StatusUnprocessableEntity, apierror.AppError{
+			Code:    http.StatusUnprocessableEntity,
+			Message: "Unprocessable Entity",
+			Detail:  err.Error(),
+		})
+		return
+	}
+
+	sub, err := h.svc.CreateEnterpriseSubscription(c.Request.Context(), req)
+	if err != nil {
+		_ = c.Error(err)
+		c.Abort()
+		return
+	}
+	c.JSON(http.StatusCreated, sub)
 }

--- a/internal/handler/billing_test.go
+++ b/internal/handler/billing_test.go
@@ -66,6 +66,10 @@ func (m *mockBillingService) HandleWebhook(ctx context.Context, event model.Hype
 	return nil
 }
 
+func (m *mockBillingService) CreateEnterpriseSubscription(_ context.Context, _ model.CreateEnterpriseSubscriptionRequest) (*model.Subscription, error) {
+	return nil, nil
+}
+
 // newBillingRouter creates a test Gin engine with billing routes.
 // If withAuth is true, it sets up middleware that injects org context.
 func newBillingRouter(svc handler.BillingServicer, withAuth bool) *gin.Engine {

--- a/internal/model/billing.go
+++ b/internal/model/billing.go
@@ -134,6 +134,15 @@ type CreateSubscriptionRequest struct {
 	BillingCycle string `json:"billing_cycle" binding:"omitempty,oneof=monthly annual"`
 }
 
+// CreateEnterpriseSubscriptionRequest is the payload for POST /admin/billing/subscriptions/enterprise.
+type CreateEnterpriseSubscriptionRequest struct {
+	OrgID                    string    `json:"org_id" binding:"required"`
+	SeatCount                int       `json:"seat_count" binding:"required,min=20"`
+	PricePerSeatMonthlyPaise *int64    `json:"price_per_seat_monthly_paise,omitempty"`
+	ContractStart            time.Time `json:"contract_start" binding:"required"`
+	ContractEnd              time.Time `json:"contract_end" binding:"required"`
+}
+
 // CreatePaymentIntentRequest is the payload for creating a payment intent.
 type CreatePaymentIntentRequest struct {
 	Amount   int64  `json:"amount" binding:"required,gt=0"`

--- a/internal/service/billing.go
+++ b/internal/service/billing.go
@@ -95,7 +95,7 @@ func (s *BillingService) CreateEnterpriseSubscription(ctx context.Context, req m
 
 	// Allow caller to override the per-seat price (e.g. for negotiated deals).
 	if req.PricePerSeatMonthlyPaise != nil {
-		plan.PriceMonthly = *req.PricePerSeatMonthlyPaise
+		plan.PricePerSeatMonthly = *req.PricePerSeatMonthlyPaise
 	}
 
 	sub := &model.Subscription{

--- a/internal/service/billing.go
+++ b/internal/service/billing.go
@@ -8,6 +8,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net/http"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -40,25 +42,27 @@ type HyperswitchClient interface {
 // BillingService contains business logic for subscription and payment management
 // via the Hyperswitch payment orchestration platform.
 type BillingService struct {
-	repo          BillingRepository
-	pool          *pgxpool.Pool
-	hsClient      HyperswitchClient
-	webhookSecret string
-	plans         map[string]model.Plan
+	repo            BillingRepository
+	pool            *pgxpool.Pool
+	hsClient        HyperswitchClient
+	webhookSecret   string
+	slackWebhookURL string
+	plans           map[string]model.Plan
 }
 
 // NewBillingService creates a new BillingService.
-func NewBillingService(repo BillingRepository, pool *pgxpool.Pool, hsClient HyperswitchClient, webhookSecret string) *BillingService {
+func NewBillingService(repo BillingRepository, pool *pgxpool.Pool, hsClient HyperswitchClient, webhookSecret string, slackWebhookURL string) *BillingService {
 	plans := make(map[string]model.Plan)
 	for _, p := range model.DefaultPlans() {
 		plans[p.ID] = p
 	}
 	return &BillingService{
-		repo:          repo,
-		pool:          pool,
-		hsClient:      hsClient,
-		webhookSecret: webhookSecret,
-		plans:         plans,
+		repo:            repo,
+		pool:            pool,
+		hsClient:        hsClient,
+		webhookSecret:   webhookSecret,
+		slackWebhookURL: slackWebhookURL,
+		plans:           plans,
 	}
 }
 
@@ -74,6 +78,89 @@ func (s *BillingService) GetPlanByID(planID string) (*model.Plan, error) {
 		return nil, apierror.NewNotFound("plan not found: " + planID)
 	}
 	return &p, nil
+}
+
+// CreateEnterpriseSubscription provisions an Enterprise subscription via the admin-only
+// sales-led flow. No Hyperswitch payment is created -- invoicing is handled externally.
+func (s *BillingService) CreateEnterpriseSubscription(ctx context.Context, req model.CreateEnterpriseSubscriptionRequest) (*model.Subscription, error) {
+	const minSeats = 20
+	if req.SeatCount < minSeats {
+		return nil, apierror.NewBadRequest(fmt.Sprintf("enterprise plan requires at least %d seats, got %d", minSeats, req.SeatCount))
+	}
+
+	plan, err := s.GetPlanByID("plan_enterprise")
+	if err != nil {
+		return nil, err
+	}
+
+	// Allow caller to override the per-seat price (e.g. for negotiated deals).
+	if req.PricePerSeatMonthlyPaise != nil {
+		plan.PriceMonthly = *req.PricePerSeatMonthlyPaise
+	}
+
+	sub := &model.Subscription{
+		OrgID:              req.OrgID,
+		PlanID:             plan.ID,
+		Status:             model.SubscriptionStatusActive,
+		CurrentPeriodStart: req.ContractStart,
+		CurrentPeriodEnd:   req.ContractEnd,
+	}
+
+	if s.pool == nil {
+		return nil, apierror.NewInternal("database pool is not configured")
+	}
+
+	var result *model.Subscription
+	err = db.WithOrgID(ctx, s.pool, req.OrgID, func(tx pgx.Tx) error {
+		var e error
+		result, e = s.repo.CreateSubscription(ctx, tx, sub)
+		return e
+	})
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to persist enterprise subscription", "error", err)
+		return nil, apierror.NewInternal("failed to persist enterprise subscription")
+	}
+
+	// Best-effort Slack notification -- failure does not abort the response.
+	if s.slackWebhookURL != "" {
+		go s.sendSlackNotification(context.Background(), req, result.ID) //nolint:contextcheck // best-effort fire-and-forget; context must outlive request
+	}
+
+	return result, nil
+}
+
+// sendSlackNotification posts an enterprise deal notification to the configured Slack webhook.
+func (s *BillingService) sendSlackNotification(ctx context.Context, req model.CreateEnterpriseSubscriptionRequest, subscriptionID string) {
+	msg := fmt.Sprintf(
+		":tada: New Enterprise subscription created!\nOrg: %s | Seats: %d | Sub ID: %s | Period: %s to %s",
+		req.OrgID, req.SeatCount, subscriptionID,
+		req.ContractStart.Format(time.DateOnly),
+		req.ContractEnd.Format(time.DateOnly),
+	)
+	payload, err := json.Marshal(map[string]any{
+		"text": msg,
+	})
+	if err != nil {
+		slog.WarnContext(ctx, "failed to marshal Slack notification", "error", err)
+		return
+	}
+
+	reqHTTP, err := http.NewRequestWithContext(ctx, http.MethodPost, s.slackWebhookURL, strings.NewReader(string(payload)))
+	if err != nil {
+		slog.WarnContext(ctx, "failed to build Slack HTTP request", "error", err)
+		return
+	}
+	reqHTTP.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(reqHTTP)
+	if err != nil {
+		slog.WarnContext(ctx, "Slack notification request failed", "error", err)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 400 {
+		slog.WarnContext(ctx, "Slack notification returned non-OK status", "status", resp.StatusCode)
+	}
 }
 
 // GetActiveSubscription returns the current active subscription for an org, or nil.
@@ -264,7 +351,7 @@ func (s *BillingService) CreatePaymentIntent(ctx context.Context, orgID string, 
 	}); err != nil {
 		slog.ErrorContext(ctx, "failed to persist payment intent", "error", err)
 		// Best-effort cancel the orphaned Hyperswitch payment with a fresh
-		// context — the original ctx may already be canceled/timed out.
+		// context -- the original ctx may already be canceled/timed out.
 		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 		if cancelErr := s.hsClient.CancelPayment(cleanupCtx, hsResp.PaymentID); cancelErr != nil {
@@ -379,7 +466,7 @@ func (s *BillingService) handlePaymentFailed(ctx context.Context, paymentID, org
 		return tx.Commit(ctx)
 	}
 
-	// Mark subscription as past_due — triggers free tier downgrade.
+	// Mark subscription as past_due -- triggers free tier downgrade.
 	sub, err := s.repo.GetSubscriptionByHyperswitchID(ctx, tx, paymentID)
 	if err != nil {
 		return fmt.Errorf("get subscription by hyperswitch id: %w", err)

--- a/internal/service/billing_enterprise_test.go
+++ b/internal/service/billing_enterprise_test.go
@@ -1,0 +1,188 @@
+package service_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ravencloak-org/Raven/internal/hyperswitch"
+	"github.com/ravencloak-org/Raven/internal/model"
+	"github.com/ravencloak-org/Raven/internal/service"
+)
+
+// --- Mock BillingRepository for enterprise tests ---
+
+type mockBillingRepo struct {
+	createSubscriptionFn func(ctx context.Context, tx pgx.Tx, sub *model.Subscription) (*model.Subscription, error)
+}
+
+func (m *mockBillingRepo) CreateSubscription(ctx context.Context, tx pgx.Tx, sub *model.Subscription) (*model.Subscription, error) {
+	if m.createSubscriptionFn != nil {
+		return m.createSubscriptionFn(ctx, tx, sub)
+	}
+	result := *sub
+	result.ID = "sub_enterprise_test"
+	result.CreatedAt = time.Now().UTC()
+	return &result, nil
+}
+
+func (m *mockBillingRepo) GetSubscriptionByID(_ context.Context, _ pgx.Tx, _, _ string) (*model.Subscription, error) {
+	return nil, nil
+}
+func (m *mockBillingRepo) GetSubscriptionByHyperswitchID(_ context.Context, _ pgx.Tx, _ string) (*model.Subscription, error) {
+	return nil, nil
+}
+func (m *mockBillingRepo) GetActiveSubscription(_ context.Context, _ pgx.Tx, _ string) (*model.Subscription, error) {
+	return nil, nil
+}
+func (m *mockBillingRepo) UpdateSubscriptionStatus(_ context.Context, _ pgx.Tx, _, _ string, _ model.SubscriptionStatus) (*model.Subscription, error) {
+	return nil, nil
+}
+func (m *mockBillingRepo) ExtendSubscriptionPeriod(_ context.Context, _ pgx.Tx, _ string) (*model.Subscription, error) {
+	return nil, nil
+}
+func (m *mockBillingRepo) CreatePaymentIntent(_ context.Context, _ pgx.Tx, pi *model.PaymentIntent) (*model.PaymentIntent, error) {
+	return pi, nil
+}
+func (m *mockBillingRepo) InsertPaymentEvent(_ context.Context, _ pgx.Tx, _, _, _, _ string, _ []byte) (bool, error) {
+	return true, nil
+}
+
+// --- Mock HyperswitchClient that tracks whether CreatePayment is called ---
+
+type trackingHSClient struct {
+	called bool
+}
+
+func (c *trackingHSClient) CreatePayment(_ context.Context, _ *hyperswitch.CreatePaymentRequest) (*hyperswitch.PaymentResponse, error) {
+	c.called = true
+	return &hyperswitch.PaymentResponse{PaymentID: "pay_mock", ClientSecret: "secret_mock"}, nil
+}
+
+func (c *trackingHSClient) CancelPayment(_ context.Context, _ string) error {
+	return nil
+}
+
+// --- Tests ---
+
+// TestCreateEnterpriseSubscription_TooFewSeats verifies that SeatCount < 20 is rejected.
+func TestCreateEnterpriseSubscription_TooFewSeats(t *testing.T) {
+	svc := service.NewBillingService(nil, nil, nil, "", "")
+
+	req := model.CreateEnterpriseSubscriptionRequest{
+		OrgID:         "org_test",
+		SeatCount:     10, // below the 20-seat minimum
+		ContractStart: time.Now().UTC(),
+		ContractEnd:   time.Now().UTC().AddDate(1, 0, 0),
+	}
+
+	_, err := svc.CreateEnterpriseSubscription(context.Background(), req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "20")
+}
+
+// TestCreateEnterpriseSubscription_BoundarySeats verifies the 20-seat minimum boundary.
+func TestCreateEnterpriseSubscription_BoundarySeats(t *testing.T) {
+	svc := service.NewBillingService(nil, nil, nil, "", "")
+
+	for _, tc := range []struct {
+		seats   int
+		wantErr bool
+	}{
+		{seats: 1, wantErr: true},
+		{seats: 19, wantErr: true},
+	} {
+		req := model.CreateEnterpriseSubscriptionRequest{
+			OrgID:         "org_test",
+			SeatCount:     tc.seats,
+			ContractStart: time.Now().UTC(),
+			ContractEnd:   time.Now().UTC().AddDate(1, 0, 0),
+		}
+		_, err := svc.CreateEnterpriseSubscription(context.Background(), req)
+		require.Error(t, err, "expected seat-count error for seats=%d", tc.seats)
+		assert.Contains(t, err.Error(), "20", "error must mention minimum seat count")
+	}
+}
+
+// TestCreateEnterpriseSubscription_NoHyperswitchCall verifies Hyperswitch is never called
+// for enterprise subscriptions -- invoicing is external.
+func TestCreateEnterpriseSubscription_NoHyperswitchCall(t *testing.T) {
+	hsClient := &trackingHSClient{}
+	// Use seat count below minimum so we get a validation error before any external call.
+	svc := service.NewBillingService(nil, nil, hsClient, "", "")
+
+	req := model.CreateEnterpriseSubscriptionRequest{
+		OrgID:         "org_test",
+		SeatCount:     5, // below minimum -- validation exits before DB/HS
+		ContractStart: time.Now().UTC(),
+		ContractEnd:   time.Now().UTC().AddDate(1, 0, 0),
+	}
+
+	_, err := svc.CreateEnterpriseSubscription(context.Background(), req)
+	require.Error(t, err)
+	assert.False(t, hsClient.called, "Hyperswitch must not be called for enterprise subscriptions")
+}
+
+// TestCreateEnterpriseSubscription_SlackNotFiredWhenDBFails verifies that Slack is only
+// sent after a successful DB write. When the DB fails the goroutine must not be spawned.
+func TestCreateEnterpriseSubscription_SlackNotFiredWhenDBFails(t *testing.T) {
+	slackCh := make(chan struct{}, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		slackCh <- struct{}{}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// Service with Slack URL set but nil pool -> DB error -> Slack goroutine not launched.
+	svc := service.NewBillingService(&mockBillingRepo{}, nil, nil, "", srv.URL)
+
+	req := model.CreateEnterpriseSubscriptionRequest{
+		OrgID:         "org_slack",
+		SeatCount:     30,
+		ContractStart: time.Now().UTC(),
+		ContractEnd:   time.Now().UTC().AddDate(1, 0, 0),
+	}
+
+	_, err := svc.CreateEnterpriseSubscription(context.Background(), req)
+	assert.Error(t, err, "expected error due to nil pool")
+
+	select {
+	case <-slackCh:
+		t.Error("Slack must NOT be called when DB write fails")
+	case <-time.After(50 * time.Millisecond):
+		// expected: no Slack call
+	}
+}
+
+// TestCreateEnterpriseSubscription_EmptySlackURL_NoCall verifies that when slackWebhookURL
+// is empty no HTTP request is sent to Slack, even after a seat-count validation failure.
+func TestCreateEnterpriseSubscription_EmptySlackURL_NoCall(t *testing.T) {
+	slackCalled := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		slackCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// slackWebhookURL="" -- Slack must never be called.
+	svc := service.NewBillingService(nil, nil, nil, "", "")
+
+	req := model.CreateEnterpriseSubscriptionRequest{
+		OrgID:         "org_no_slack",
+		SeatCount:     3, // below minimum -- validation exits, no goroutine
+		ContractStart: time.Now().UTC(),
+		ContractEnd:   time.Now().UTC().AddDate(1, 0, 0),
+	}
+
+	_, err := svc.CreateEnterpriseSubscription(context.Background(), req)
+	require.Error(t, err)
+
+	time.Sleep(30 * time.Millisecond)
+	assert.False(t, slackCalled, "Slack must not be called when slackWebhookURL is empty")
+}

--- a/internal/service/billing_test.go
+++ b/internal/service/billing_test.go
@@ -44,7 +44,7 @@ func (m *mockHyperswitchClient) CancelPayment(ctx context.Context, paymentID str
 
 func TestVerifyWebhookSignature_ValidSignature(t *testing.T) {
 	secret := "test-webhook-secret-key"
-	svc := service.NewBillingService(nil, nil, nil, secret)
+	svc := service.NewBillingService(nil, nil, nil, secret, "")
 
 	payload := []byte(`{"event_type":"payment_succeeded","content":{"payment_id":"pay_123"}}`)
 	mac := hmac.New(sha256.New, []byte(secret))
@@ -57,7 +57,7 @@ func TestVerifyWebhookSignature_ValidSignature(t *testing.T) {
 
 func TestVerifyWebhookSignature_InvalidSignature(t *testing.T) {
 	secret := "test-webhook-secret-key"
-	svc := service.NewBillingService(nil, nil, nil, secret)
+	svc := service.NewBillingService(nil, nil, nil, secret, "")
 
 	payload := []byte(`{"event_type":"payment_succeeded"}`)
 	err := svc.VerifyWebhookSignature(payload, "bad_signature")
@@ -66,7 +66,7 @@ func TestVerifyWebhookSignature_InvalidSignature(t *testing.T) {
 }
 
 func TestVerifyWebhookSignature_EmptySecret_Rejects(t *testing.T) {
-	svc := service.NewBillingService(nil, nil, nil, "")
+	svc := service.NewBillingService(nil, nil, nil, "", "")
 
 	payload := []byte(`{"event_type":"payment_succeeded"}`)
 	err := svc.VerifyWebhookSignature(payload, "any_signature")
@@ -76,7 +76,7 @@ func TestVerifyWebhookSignature_EmptySecret_Rejects(t *testing.T) {
 
 func TestVerifyWebhookSignature_TamperedPayload(t *testing.T) {
 	secret := "test-webhook-secret-key"
-	svc := service.NewBillingService(nil, nil, nil, secret)
+	svc := service.NewBillingService(nil, nil, nil, secret, "")
 
 	originalPayload := []byte(`{"event_type":"payment_succeeded","content":{"payment_id":"pay_123"}}`)
 	mac := hmac.New(sha256.New, []byte(secret))
@@ -91,7 +91,7 @@ func TestVerifyWebhookSignature_TamperedPayload(t *testing.T) {
 }
 
 func TestGetPlans_ReturnsThreeTiers(t *testing.T) {
-	svc := service.NewBillingService(nil, nil, nil, "")
+	svc := service.NewBillingService(nil, nil, nil, "", "")
 	plans := svc.GetPlans()
 
 	assert.Len(t, plans, 3)
@@ -105,7 +105,7 @@ func TestGetPlans_ReturnsThreeTiers(t *testing.T) {
 }
 
 func TestGetPlanByID_Found(t *testing.T) {
-	svc := service.NewBillingService(nil, nil, nil, "")
+	svc := service.NewBillingService(nil, nil, nil, "", "")
 	plan, err := svc.GetPlanByID("plan_pro")
 	require.NoError(t, err)
 	assert.Equal(t, model.PlanTierPro, plan.Tier)
@@ -114,7 +114,7 @@ func TestGetPlanByID_Found(t *testing.T) {
 }
 
 func TestGetPlanByID_NotFound(t *testing.T) {
-	svc := service.NewBillingService(nil, nil, nil, "")
+	svc := service.NewBillingService(nil, nil, nil, "", "")
 	_, err := svc.GetPlanByID("plan_nonexistent")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
@@ -127,7 +127,7 @@ func TestCreatePaymentIntent_HyperswitchError(t *testing.T) {
 		},
 	}
 
-	svc := service.NewBillingService(nil, nil, hsClient, "")
+	svc := service.NewBillingService(nil, nil, hsClient, "", "")
 
 	pi, err := svc.CreatePaymentIntent(context.Background(), "org-123", model.CreatePaymentIntentRequest{
 		Amount:   5000,
@@ -147,7 +147,7 @@ func TestSubscriptionStateMachine_FreePlan(t *testing.T) {
 		},
 	}
 
-	svc := service.NewBillingService(nil, nil, hsClient, "")
+	svc := service.NewBillingService(nil, nil, hsClient, "", "")
 	// Note: CreateSubscription requires a DB pool for RLS transactions.
 	// We verify plan lookup and Hyperswitch client selection logic here.
 	plan, err := svc.GetPlanByID("plan_free")


### PR DESCRIPTION
## Summary

- Admin-only `POST /api/v1/admin/billing/subscriptions/enterprise` endpoint (seed-key auth, excluded from Swagger)
- Creates Enterprise subscription directly — no Hyperswitch payment (invoiced externally)
- Validates minimum 20 seats; supports custom `price_per_seat_monthly_paise` override
- Annual billing cycle enforced (`billing_cycle = "annual"`, `current_period_end = contract_end`)
- Fires Slack webhook notification on success (`RAVEN_SLACK_BILLING_WEBHOOK_URL`)
- New `BillingConfig` in config with `SlackWebhookURL` env var binding

Closes #594.

**Depends on:** #601 (per-seat pricing — already merged)

## Test plan

- [ ] `SeatCount < 20` → 400 Bad Request
- [ ] Successful creation → Hyperswitch never called, subscription `status=active`
- [ ] Slack webhook fires with contract summary
- [ ] Empty `RAVEN_SLACK_BILLING_WEBHOOK_URL` → no error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added enterprise subscription creation with a 20-seat minimum requirement
- Implemented automatic Slack notifications for enterprise subscription events

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ravencloak-org/Raven/pull/604?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->