### PR TITLE
fix(desktop): add createUpdaterArtifacts to enable .sig generation

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -25,11 +25,16 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["dmg", "msi", "appimage", "deb"],
+    "targets": [
+      "dmg",
+      "msi",
+      "appimage",
+      "deb"
+    ],
     "category": "Productivity",
     "shortDescription": "Self-contained Raven for local use",
     "longDescription": "Privacy-first desktop edition of Raven that runs the entire stack locally with Ollama as a bundled LLM provider. No cloud, no telemetry by default.",
-    "copyright": "© 2026 Raven Contributors",
+    "copyright": "\u00a9 2026 Raven Contributors",
     "homepage": "https://github.com/ravencloak-org/Raven",
     "publisher": "Raven Contributors",
     "icon": [
@@ -40,7 +45,9 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
-    "resources": ["../docker-compose.local.yml"],
+    "resources": [
+      "../docker-compose.local.yml"
+    ],
     "macOS": {
       "signingIdentity": null,
       "providerShortName": null,
@@ -50,7 +57,8 @@
       "certificateThumbprint": null,
       "digestAlgorithm": "sha256",
       "timestampUrl": ""
-    }
+    },
+    "createUpdaterArtifacts": true
   },
   "plugins": {
     "updater": {


### PR DESCRIPTION
## Summary

- Tauri v2 requires `bundle.createUpdaterArtifacts: true` in `tauri.conf.json` to generate `.sig` files alongside installers
- Setting `TAURI_SIGNING_PRIVATE_KEY` alone is not enough — without the config flag the bundler produces `AppImage`/`dmg`/`msi` but no `*.sig` companions
- This caused the manifest job to download empty sig artifacts and produce a `latest.json` with blank signatures, making the auto-updater non-functional

## Test plan

- [ ] After merge: move `raven-ai-v0.1.6` tag to new HEAD, re-trigger release — verify `*.sig` files appear in the draft release alongside each installer

🤖 Generated with [Claude Code](https://claude.com/claude-code)