### PR TITLE
chore(desktop): bump version to 0.1.7

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Raven AI",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "identifier": "io.ravencloak.ai",
   "build": {
     "beforeDevCommand": "",


### PR DESCRIPTION
## Summary

- Bumps `tauri.conf.json` version from `0.1.6` → `0.1.7` for the next clean release cut
- Previous `0.1.6` tag was moved multiple times during CI debugging; using a fresh tag avoids GitHub's tag-move workflow trigger issues

## Test plan

- [ ] Merge and push tag `raven-ai-v0.1.7` — desktop-release workflow should trigger cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)