### PR TITLE
fix(ci): repair desktop-release pipeline (binaries, cask trigger, sig noise)

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -26,6 +26,11 @@ jobs:
     env:
       HAVE_APPLE_CERT: ${{ secrets.APPLE_CERTIFICATE != '' }}
       HAVE_WINDOWS_PFX: ${{ secrets.WINDOWS_PFX_BASE64 != '' }}
+      # Used to skip Tauri-updater .sig handling (upload + manifest read)
+      # when no signing key is configured. Without the key Tauri emits no
+      # .sig files, so the upload/download steps would only generate
+      # confusing "artifact not found" warnings.
+      HAVE_TAURI_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY != '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -341,9 +346,16 @@ jobs:
           subject-path: ${{ matrix.artifact_glob }}
 
       # ── Upload artifacts + per-platform .sig files ────────────────────────
+      # Pinned to v2.0.9 (same as the manifest step's final upload). v3.0.0
+      # had a regression where supplying tag_name for a tag the worker
+      # could not yet see produced an "untagged-XXX" orphan release per
+      # matrix job, so none of the binaries landed on the real
+      # raven-ai-v0.1.6 release (which only carried latest.json). v2.0.9
+      # reliably reuses the existing draft, and the manifest job's final
+      # v2.0.9 upload then flips that same draft to published.
       - name: Upload to draft release
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/raven-ai-v')
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        uses: softprops/action-gh-release@e7a8f85e1c67a31e6ed99a94b41bd0b71bbee6b8 # v2.0.9
         with:
           draft: true
           files: |
@@ -355,8 +367,13 @@ jobs:
 
       # Stash .sig files as GitHub Actions artifacts so the manifest job can
       # assemble latest.json without downloading from the release directly.
+      # Skipped when no Tauri signing key is configured — there are no
+      # .sig files to upload, so the step would only produce noise.
       - name: Upload sig artifacts
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/raven-ai-v')
+        if: |
+          github.event_name == 'push' &&
+          startsWith(github.ref, 'refs/tags/raven-ai-v') &&
+          env.HAVE_TAURI_KEY == 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: sig-${{ matrix.os }}
@@ -375,10 +392,14 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/raven-ai-v')
     permissions:
       contents: write
+      actions: write   # for `gh workflow run update-cask.yml` at the end
+    env:
+      HAVE_TAURI_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY != '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Download macOS sig
+        if: env.HAVE_TAURI_KEY == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
         with:
           name: sig-macos-latest
@@ -386,6 +407,7 @@ jobs:
         continue-on-error: true
 
       - name: Download Windows sig
+        if: env.HAVE_TAURI_KEY == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
         with:
           name: sig-windows-latest
@@ -393,6 +415,7 @@ jobs:
         continue-on-error: true
 
       - name: Download Linux sig
+        if: env.HAVE_TAURI_KEY == 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
         with:
           name: sig-ubuntu-latest
@@ -457,11 +480,9 @@ jobs:
           echo "latest.json written:"
           cat latest.json
 
-      # Final step: publish the release. All per-platform artefacts are
-      # already uploaded by the `build` matrix (each into the same draft).
-      # Setting draft: false here flips it to "published", which fires
-      # `release: published` and triggers `update-cask.yml` to open the
-      # Homebrew tap bump PR.
+      # Publish the release. All per-platform artefacts are already
+      # uploaded by the `build` matrix (each into the same draft). Setting
+      # draft: false flips it to "published".
       - name: Upload latest.json and publish release
         uses: softprops/action-gh-release@e7a8f85e1c67a31e6ed99a94b41bd0b71bbee6b8 # v2.0.9
         with:
@@ -470,3 +491,14 @@ jobs:
           tag_name: ${{ github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # `release: published` events emitted by github-actions[bot] using
+      # GITHUB_TOKEN do NOT trigger other workflows — GHA's anti-loop
+      # protection. So `update-cask.yml` won't fire on its own when we
+      # publish above. Explicitly dispatch it instead. The action must
+      # come from main (not the tag ref) since update-cask.yml lives
+      # there and reads the freshly-published release by tag name.
+      - name: Trigger Homebrew Cask bump
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run update-cask.yml --ref main

--- a/.github/workflows/update-cask.yml
+++ b/.github/workflows/update-cask.yml
@@ -6,8 +6,19 @@ name: Update Homebrew Cask after release
 # ravencloak-org/Raven/raven-ai` they get the new bits.
 
 on:
+  # The release-publish path is kept as the natural trigger when a human
+  # cuts a release manually. desktop-release.yml's manifest job uses
+  # workflow_dispatch instead, because GHA does NOT fire `release:
+  # published` for releases authored by github-actions[bot] using the
+  # default GITHUB_TOKEN (anti-loop protection).
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to bump (e.g. raven-ai-v0.1.6). Leave blank to pick the latest published raven-ai-v* release.'
+        required: false
+        default: ''
 
 permissions:
   contents: write
@@ -15,15 +26,39 @@ permissions:
 
 jobs:
   bump-cask:
-    if: startsWith(github.event.release.tag_name, 'raven-ai-v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Resolve target tag
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          if [ -n "$INPUT_TAG" ]; then
+            TAG="$INPUT_TAG"
+          elif [ -n "$RELEASE_TAG" ]; then
+            TAG="$RELEASE_TAG"
+          else
+            # workflow_dispatch with no input - pick the most recent
+            # raven-ai-v* release that isn't a draft.
+            TAG=$(gh release list --limit 30 --json tagName,isDraft \
+              --jq '[.[] | select(.tagName | startswith("raven-ai-v")) | select(.isDraft | not) | .tagName][0] // empty')
+          fi
+          if [ -z "$TAG" ] || ! echo "$TAG" | grep -qE '^raven-ai-v[0-9]+\.[0-9]+\.[0-9]+'; then
+            echo "ERROR: could not resolve a raven-ai-v* tag to bump (got: '$TAG')" >&2
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Resolved tag: $TAG"
+
       - name: Compute new version + sha256
         id: dmg
         env:
-          TAG: ${{ github.event.release.tag_name }}
+          TAG: ${{ steps.resolve.outputs.tag }}
         run: |
           set -euo pipefail
           VERSION="${TAG#raven-ai-v}"
@@ -67,7 +102,7 @@ jobs:
           body: |
             Auto-bump from the release pipeline.
 
-            - Tag: `${{ github.event.release.tag_name }}`
+            - Tag: `${{ steps.resolve.outputs.tag }}`
             - sha256: `${{ steps.dmg.outputs.sha }}`
 
             Once merged, users can `brew install --cask ravencloak-org/Raven/raven-ai`


### PR DESCRIPTION
## Summary

`raven-ai-v0.1.6` published with **only `latest.json`** — no DMG, MSI, AppImage, or deb. Brew cask never bumped either. This PR fixes the three independent bugs that caused it:

### 1. softprops v3.0.0 creates orphan "untagged" releases

The matrix's `Upload to draft release` step pinned `softprops/action-gh-release@v3.0.0`. v3 has a regression: when `tag_name` is supplied for a tag the worker can't yet observe locally, it creates an `untagged-XXX` draft release **per matrix job** instead of attaching to the named tag. The manifest job's later v2.0.9 step then sees no release for the tag and creates a fresh one — orphaning the binaries on those untagged drafts.

Net result for v0.1.6: 3 untagged-draft releases each holding one platform's bundle, plus the published `raven-ai-v0.1.6` release containing only `latest.json`.

**Fix:** pin the matrix step to v2.0.9 — same version the manifest uses, which reuses an existing tag-bound draft reliably.

### 2. `release: published` doesn't trigger update-cask.yml

GHA does NOT fire `release: published` for releases authored by `github-actions[bot]` using the default `GITHUB_TOKEN` — anti-loop protection. So even when the release publishes correctly, `update-cask.yml` never runs and no brew bump PR opens.

**Fix:** explicitly dispatch `update-cask.yml` from the manifest job's last step via `gh workflow run`. `update-cask.yml` now also accepts a `workflow_dispatch` input (or auto-picks the latest published `raven-ai-v*` release) so it remains runnable for manual reruns from the Actions UI.

### 3. Confusing "artifact not found" noise when signing is disabled

Without `TAURI_SIGNING_PRIVATE_KEY` configured, Tauri emits no `.sig` files for the bundles. But the matrix's `Upload sig artifacts` and the manifest's three `Download *sig` steps still ran — uploading nothing, then warning loudly about missing artifacts.

**Fix:** new `HAVE_TAURI_KEY` env var, all four steps gated on it.

## What about v0.1.6?

Binaries are still recoverable from the orphan `untagged-XXX` drafts (visible in the Releases UI). Either:

- Manually copy them onto `raven-ai-v0.1.6` so existing brew users can install it, or
- Cut `raven-ai-v0.1.7` after this merges and the next pipeline run publishes a complete release end-to-end.

## Test plan

- [x] `actionlint` clean on both workflow files
- [ ] Tag `raven-ai-v0.1.7` after merge — confirm:
  - [ ] All 4 platform binaries appear on the tag-bound release (not on `untagged-XXX`)
  - [ ] Release auto-publishes (no draft state)
  - [ ] `update-cask.yml` fires and opens a `cask/bump-0.1.7` PR
  - [ ] No "Download macOS/Windows/Linux sig" warnings in manifest job logs