### PR TITLE
fix(desktop): macOS updater sig + manifest publish race

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -42,8 +42,10 @@ jobs:
           - os: macos-latest
             tauri_target: universal-apple-darwin
             rustup_targets: 'aarch64-apple-darwin,x86_64-apple-darwin'
-            artifact_glob: 'desktop/target/universal-apple-darwin/release/bundle/dmg/*.dmg'
-            sig_glob: 'desktop/target/universal-apple-darwin/release/bundle/dmg/*.dmg.sig'
+            artifact_glob: |
+              desktop/target/universal-apple-darwin/release/bundle/dmg/*.dmg
+              desktop/target/universal-apple-darwin/release/bundle/macos/*.app.tar.gz
+            sig_glob: 'desktop/target/universal-apple-darwin/release/bundle/macos/*.app.tar.gz.sig'
           - os: windows-latest
             tauri_target: x86_64-pc-windows-msvc
             rustup_targets: 'x86_64-pc-windows-msvc'
@@ -445,11 +447,12 @@ jobs:
             if [ -n "$file" ] && [ -f "$file" ]; then cat "$file"; else echo ""; fi
           }
 
-          DMG_SIG="$(read_sig sigs/macos)"
+          APP_SIG="$(read_sig sigs/macos)"
           MSI_SIG="$(read_sig sigs/windows)"
           APPIMAGE_SIG="$(read_sig sigs/linux)"
 
           DMG_URL="${BASE_URL}/Raven.AI_${VERSION}_universal.dmg"
+          APP_TARBALL_URL="${BASE_URL}/Raven.AI_${VERSION}_universal.app.tar.gz"
           MSI_URL="${BASE_URL}/Raven.AI_${VERSION}_x64_en-US.msi"
           APPIMAGE_URL="${BASE_URL}/Raven.AI_${VERSION}_amd64.AppImage"
           NOTES="See the full changelog at https://github.com/ravencloak-org/Raven/releases/tag/raven-ai-v${VERSION}"
@@ -462,7 +465,8 @@ jobs:
             --arg notes      "$NOTES" \
             --arg pub_date   "$PUB_DATE" \
             --arg dmg_url    "$DMG_URL" \
-            --arg dmg_sig    "$DMG_SIG" \
+            --arg app_url    "$APP_TARBALL_URL" \
+            --arg dmg_sig    "$APP_SIG" \
             --arg msi_url    "$MSI_URL" \
             --arg msi_sig    "$MSI_SIG" \
             --arg appimg_url "$APPIMAGE_URL" \
@@ -472,7 +476,7 @@ jobs:
               notes: $notes,
               pub_date: $pub_date,
               platforms: {
-                "darwin-universal": { url: $dmg_url, signature: $dmg_sig },
+                "darwin-universal": { url: $app_url, signature: $dmg_sig },
                 "windows-x86_64":   { url: $msi_url, signature: $msi_sig },
                 "linux-x86_64":     { url: $appimg_url, signature: $appimg_sig }
               }
@@ -484,13 +488,15 @@ jobs:
       # uploaded by the `build` matrix (each into the same draft). Setting
       # draft: false flips it to "published".
       - name: Upload latest.json and publish release
-        uses: softprops/action-gh-release@e7a8f85e1c67a31e6ed99a94b41bd0b71bbee6b8 # v2.0.9
-        with:
-          draft: false
-          files: latest.json
-          tag_name: ${{ github.ref_name }}
+        # Use gh CLI to add latest.json to the existing draft release (created by the
+        # build matrix) and flip it to published. Using softprops/action-gh-release
+        # here created a second, conflicting published release.
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_TAG: ${{ github.ref_name }}
+        run: |
+          gh release upload "$GIT_TAG" latest.json --clobber
+          gh release edit "$GIT_TAG" --draft=false
 
       # `release: published` events emitted by github-actions[bot] using
       # GITHUB_TOKEN do NOT trigger other workflows — GHA's anti-loop

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Raven AI",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "identifier": "io.ravencloak.ai",
   "build": {
     "beforeDevCommand": "",
@@ -27,6 +27,7 @@
     "active": true,
     "targets": [
       "dmg",
+      "app",
       "msi",
       "appimage",
       "deb"


### PR DESCRIPTION
## Summary

- **macOS .app target**: Added `\"app\"` to `bundle.targets` in `tauri.conf.json`. The `dmg` target is not updater-enabled; the bundler silently skipped sig generation with a warning. The `.app` target generates `.app.tar.gz` + `.app.tar.gz.sig` which is what the Tauri updater downloads on macOS.
- **macOS globs**: `sig_glob` updated from `*.dmg.sig` → `*.app.tar.gz.sig`; `artifact_glob` extended to also upload the `.app.tar.gz` bundle. Manifest builder's `darwin-universal.url` now points at the `.app.tar.gz`.
- **Duplicate release bug**: Replaced `softprops/action-gh-release@v2` in the manifest job with `gh release upload` + `gh release edit`. The v2 action was creating a second published release with only `latest.json` instead of updating the draft that the build matrix already populated with installers.
- **Version**: bumped to `0.1.8` for next clean release cut.

## Test plan

- [ ] After merge: push tag `raven-ai-v0.1.8` → verify macOS build produces `*.app.tar.gz.sig`, release has all installers + sigs + `latest.json` in a single published release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.1.8
  * Updated macOS build artifacts and release configuration
  * Enhanced desktop release publishing workflow with improved signature handling and updated distribution manifest

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ravencloak-org/Raven/pull/610?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->