### PR TITLE
fix(landing): add gap between GitHub icon and 'Star on GitHub' label

### DIFF
--- a/landing/src/components/Hero.tsx
+++ b/landing/src/components/Hero.tsx
@@ -33,7 +33,7 @@ export function Hero() {
         <Button href={REPO_URL} variant="outline" color="ink">
           <svg
             aria-hidden="true"
-            className="-mr-1 h-5 w-5 flex-none"
+            className="mr-2 h-5 w-5 flex-none"
             viewBox="0 0 24 24"
             fill="currentColor"
           >


### PR DESCRIPTION
## Summary

The hero CTA button in landing/src/components/Hero.tsx:36 used `-mr-1` (a negative right margin) on the GitHub icon, which pulled the 'Star on GitHub' text flush against the mark. Replace with `mr-2` so the icon sits 8 px to the left of the label.

## Test plan

- [ ] After deploy: visit raven.ravencloak.org, verify visible gap between GitHub mark and label in the 'Star on GitHub' button

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted spacing of the GitHub button icon for improved visual alignment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ravencloak-org/Raven/pull/622?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->