### PR TITLE
feat(demo): serve demo behind /raven path prefix

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -554,9 +554,15 @@ func main() {
 	router.Use(middleware.CORSMiddleware(&cfg.CORS, &apiKeyLookupAdapter{repo: apiKeyRepo}))
 	router.Use(apierror.ErrorHandler())
 
+	// All routes mount under cfg.Server.PathPrefix. Empty string (default) keeps
+	// behaviour unchanged for local/dev/desktop. The public demo sets this to
+	// "/raven" so a request to https://demo.ravencloak.org/raven/api/v1/... is
+	// matched by the same handlers as a local request to /api/v1/...
+	root := router.Group(cfg.Server.PathPrefix)
+
 	// Infrastructure endpoint — intentionally outside the versioned group.
 	// Excluded from rate limiting.
-	router.GET("/healthz", middleware.Deadline(1*time.Second), handler.HealthCheck)
+	root.GET("/healthz", middleware.Deadline(1*time.Second), handler.HealthCheck)
 
 	// Frontend config endpoint — public, unauthenticated. Returns feature flags
 	// that the frontend reads on boot to decide behaviour (e.g. single-user mode).

--- a/deploy/ansible/group_vars/demo.yml
+++ b/deploy/ansible/group_vars/demo.yml
@@ -1,8 +1,13 @@
 ---
 # Demo-specific Ansible variables. Loaded explicitly by cloud-init.
 raven_env: demo
-raven_domain: demo.raven.ravencloak.org
-raven_observability_domain: observability.demo.raven.ravencloak.org
+raven_domain: demo.ravencloak.org
+raven_observability_domain: observability.ravencloak.org
+
+# Path prefix the demo is served under (e.g. https://demo.ravencloak.org/raven/).
+# Empty string = served at root. Wired into both the Go API (RAVEN_PATH_PREFIX)
+# and the frontend image (VITE_BASE_PATH build arg, must include trailing slash).
+raven_path_prefix: /raven
 
 # Compose overlay file applied on top of docker-compose.yml
 raven_compose_overlay: docker-compose.demo.yml

--- a/deploy/ansible/roles/raven-stack/templates/env.server.j2
+++ b/deploy/ansible/roles/raven-stack/templates/env.server.j2
@@ -17,6 +17,8 @@ KC_HOSTNAME={{ keycloak_hostname }}
 
 # ─── Raven API ────────────────────────────────────────────────────────────────
 RAVEN_SERVER_PORT=8080
+# Empty string = serve at root. Set per-env in group_vars (e.g. demo: /raven).
+RAVEN_PATH_PREFIX={{ raven_path_prefix | default('') }}
 RAVEN_DATABASE_URL=${DATABASE_URL}
 RAVEN_VALKEY_URL=${VALKEY_URL}
 RAVEN_GRPC_WORKER_ADDR=python-worker:50051

--- a/deploy/terraform/demo/.terraform.lock.hcl
+++ b/deploy/terraform/demo/.terraform.lock.hcl
@@ -46,3 +46,23 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.9.0"
+  hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/deploy/terraform/demo/cloudflare.tf
+++ b/deploy/terraform/demo/cloudflare.tf
@@ -13,14 +13,20 @@ resource "cloudflare_tunnel_config" "demo" {
   tunnel_id  = cloudflare_tunnel.demo.id
 
   config {
+    # API requests at <demo_hostname><prefix>/api/* → Go API on 8081.
+    # cloudflared forwards the full path (including the prefix); the Go API
+    # router mounts everything under cfg.Server.PathPrefix so paths line up.
     ingress_rule {
       hostname = var.demo_hostname
-      service  = "http://localhost:8180"
-      path     = "/api/.*"
+      service  = "http://localhost:8081"
+      path     = "${var.demo_path_prefix}/api/.*"
     }
+    # Everything else under the prefix → Vue SPA on 3080 (Vite built with
+    # base=<prefix>/ so asset URLs resolve correctly).
     ingress_rule {
       hostname = var.demo_hostname
-      service  = "http://localhost:8080"
+      service  = "http://localhost:3080"
+      path     = "${var.demo_path_prefix}/.*"
     }
     ingress_rule {
       hostname = var.observability_hostname

--- a/deploy/terraform/demo/variables.tf
+++ b/deploy/terraform/demo/variables.tf
@@ -29,13 +29,19 @@ variable "cloudflare_zone_id" {
 variable "demo_hostname" {
   description = "Public hostname for the demo"
   type        = string
-  default     = "demo.raven.ravencloak.org"
+  default     = "demo.ravencloak.org"
+}
+
+variable "demo_path_prefix" {
+  description = "URL path prefix the demo app is served under (e.g. /raven). No trailing slash."
+  type        = string
+  default     = "/raven"
 }
 
 variable "observability_hostname" {
   description = "Public hostname for the OpenObserve UI"
   type        = string
-  default     = "observability.demo.raven.ravencloak.org"
+  default     = "observability.ravencloak.org"
 }
 
 variable "access_email" {

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -12,6 +12,9 @@ services:
     environment:
       RAVEN_VOICE_ENABLED: "false"
       RAVEN_TURNSTILE_SECRET_KEY: "${TURNSTILE_SECRET_KEY}"
+      # Demo is served behind /raven/ on demo.ravencloak.org. The Go API mounts
+      # all routes under this prefix so cloudflared can forward the full path.
+      RAVEN_PATH_PREFIX: "${RAVEN_PATH_PREFIX:-/raven}"
 
   python-worker:
     environment:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,6 +12,10 @@ ARG VITE_API_URL=https://api.ravencloak.org
 ARG VITE_API_BASE_URL=https://api.ravencloak.org/api/v1
 ARG VITE_API_DOMAIN=https://api.ravencloak.org
 ARG VITE_LIVEKIT_URL=
+# Vite base path. Override at build time (e.g. --build-arg VITE_BASE_PATH=/raven/)
+# when serving under a path prefix. Must include trailing slash. Default: root.
+ARG VITE_BASE_PATH=/
+ENV VITE_BASE_PATH=$VITE_BASE_PATH
 
 RUN npm run build
 

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -8,13 +8,16 @@ server {
     gzip_types text/plain text/css application/javascript application/json image/svg+xml;
     gzip_min_length 1024;
 
-    # Cache static assets aggressively (Vite hashes filenames)
-    location /assets/ {
+    # Cache static assets aggressively (Vite hashes filenames). Matches both
+    # root (/assets/) and path-prefixed deployments (e.g. /raven/assets/).
+    location ~ ^(?:/[^/]+)?/assets/ {
         expires 1y;
         add_header Cache-Control "public, immutable";
     }
 
-    # SPA fallback — all unmatched routes serve index.html
+    # SPA fallback — all unmatched routes serve index.html. With Vite's `base`
+    # set, the bundled index.html already references assets under the prefix,
+    # so try_files works the same way for / and /raven/ deployments.
     location / {
         try_files $uri $uri/ /index.html;
     }

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -5,7 +5,7 @@ import { useServerConfigStore } from '../stores/server-config'
 import { useOnboardingStore } from '../stores/onboarding'
 
 const router = createRouter({
-  history: createWebHistory(),
+  history: createWebHistory(import.meta.env.BASE_URL),
   routes: [
     {
       path: '/',

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,7 +2,12 @@ import { defineConfig } from 'vitest/config'
 import vue from '@vitejs/plugin-vue'
 import tailwindcss from '@tailwindcss/vite'
 
+// VITE_BASE_PATH lets the build target a path-prefixed deployment (e.g. the
+// public demo at https://demo.ravencloak.org/raven/). Default is root.
+const basePath = process.env.VITE_BASE_PATH ?? '/'
+
 export default defineConfig({
+  base: basePath,
   plugins: [vue(), tailwindcss()],
   server: {
     port: 3000,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -308,6 +308,11 @@ type ServerConfig struct {
 	// org_id=local without contacting SuperTokens. The /auth/* routes are not
 	// registered. Default false (standard multi-user mode).
 	SingleUser bool `mapstructure:"single_user"`
+
+	// PathPrefix mounts every route under this prefix (e.g. "/raven" for the
+	// public demo at https://demo.ravencloak.org/raven/...). Empty string =
+	// served at root, which is the default and matches local/dev/desktop.
+	PathPrefix string `mapstructure:"path_prefix"`
 }
 
 // DatabaseConfig holds database connection settings.
@@ -346,6 +351,7 @@ func Load() (*Config, error) {
 	// Set defaults
 	v.SetDefault("server.port", 8081)
 	v.SetDefault("server.mode", "debug")
+	v.SetDefault("server.path_prefix", "")
 	v.SetDefault("server.read_header_timeout", "5s")
 	v.SetDefault("server.read_timeout", "30s")
 	v.SetDefault("server.write_timeout", "60s")
@@ -495,6 +501,7 @@ func Load() (*Config, error) {
 	_ = v.BindEnv("googleoauth.client_secret", "GOOGLE_CLIENT_SECRET")
 	_ = v.BindEnv("server.port", "RAVEN_SERVER_PORT")
 	_ = v.BindEnv("server.mode", "RAVEN_SERVER_MODE")
+	_ = v.BindEnv("server.path_prefix", "RAVEN_PATH_PREFIX")
 	_ = v.BindEnv("server.read_header_timeout", "RAVEN_HTTP_READ_HEADER_TIMEOUT")
 	_ = v.BindEnv("server.read_timeout", "RAVEN_HTTP_READ_TIMEOUT")
 	_ = v.BindEnv("server.write_timeout", "RAVEN_HTTP_WRITE_TIMEOUT")


### PR DESCRIPTION
## Summary

Wire a configurable URL path prefix through every layer so the public demo can live at `https://demo.ravencloak.org/raven/` while local/dev/desktop continue serving at root.

- **Go API**: new `server.path_prefix` config (env `RAVEN_PATH_PREFIX`, empty default). `cmd/api/main` mounts every route — including `/healthz` — under `cfg.Server.PathPrefix`.
- **Frontend**: `vite.config` reads `VITE_BASE_PATH` into Vite's `base`; `Dockerfile` forwards the build arg; `router/index` uses `import.meta.env.BASE_URL` so vue-router matches the prefix; `nginx.conf` `/assets/` cache rule now matches both root and prefixed paths.
- **Cloudflare tunnel**: `terraform/demo/cloudflare.tf` routes `<hostname><prefix>/api/.*` to `localhost:8081` and `<hostname><prefix>/.*` to `localhost:3080` (matches existing compose ports — previous `8180`/`8080` routes were stale).
- **Hostname cutover**: `demo.raven.ravencloak.org` → `demo.ravencloak.org` and `observability.demo.raven.ravencloak.org` → `observability.ravencloak.org` (terraform variables + ansible `group_vars/demo.yml`).
- **Ansible**: `raven_path_prefix: /raven` in `group_vars/demo.yml`; `env.server.j2` renders `RAVEN_PATH_PREFIX` from that (empty default preserves non-demo envs).
- **Demo compose**: pin `RAVEN_PATH_PREFIX` on `go-api`.

## Follow-ups (not in this PR)

- `.github/workflows/docker.yml` must build a frontend image with `VITE_BASE_PATH=/raven/` baked in (e.g. a `frontend:latest-raven` tag). The published `frontend:latest` is root-based and will 404 behind `/raven`.
- `.github/workflows/demo-deploy.yml` currently deploys to AWS EC2 via SSM; the new demo box needs an SSH/ansible-based deploy path.

## Test plan

- [x] `go build`, `go vet`, `golangci-lint run --new-from-rev=HEAD~1` — clean
- [x] `go test ./internal/config/...` — pass
- [x] `terraform fmt -check` + `terraform validate` (deploy/terraform/demo) — clean (warnings pre-existing)
- [x] `npm run build` with `VITE_BASE_PATH=/` — pass
- [x] `npm run build` with `VITE_BASE_PATH=/raven/` — pass, `dist/index.html` references `/raven/assets`
- [x] `npm run test:unit` — 134/134 pass
- [x] Playwright at `/` — 8 passed, 54 skipped (API creds absent locally), 0 failed
- [ ] Playwright at `/raven/` — 8 tests use hardcoded root-relative `page.goto('/foo')` and don't honor a baseURL prefix; updating the suite is out of scope for this PR
- [ ] Manual smoke after deploy: `https://demo.ravencloak.org/raven/` loads SPA, `/raven/api/v1/healthz` returns 200, asset URLs resolve under `/raven/assets/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for deploying the application under a configurable path prefix, enabling flexible hosting arrangements.

* **Chores**
  * Updated demo environment to use new hostnames (`demo.ravencloak.org`, `observability.ravencloak.org`).
  * Enhanced API routing infrastructure for path-prefixed request handling.
  * Updated frontend asset serving and routing configuration for prefix-aware deployments.
  * Modified containerization and infrastructure-as-code configuration to support path prefix settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ravencloak-org/Raven/pull/625?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->