### PR TITLE
fix(api): mount every route under PathPrefix group

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -566,7 +566,7 @@ func main() {
 
 	// Frontend config endpoint — public, unauthenticated. Returns feature flags
 	// that the frontend reads on boot to decide behaviour (e.g. single-user mode).
-	router.GET("/api/v1/config", func(c *gin.Context) {
+	root.GET("/api/v1/config", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{
 			"single_user": cfg.Server.SingleUser,
 		})
@@ -575,11 +575,11 @@ func main() {
 	// One-click unsubscribe — public, authenticated via a signed token embedded
 	// in the link (RFC 8058). Placed outside /api/v1 so email clients can hit
 	// it without triggering CORS/auth middleware.
-	router.GET("/api/v1/notifications/unsubscribe", middleware.Deadline(10*time.Second), notifPrefsHandler.Unsubscribe)
-	router.POST("/api/v1/notifications/unsubscribe", middleware.Deadline(10*time.Second), notifPrefsHandler.UnsubscribePost)
+	root.GET("/api/v1/notifications/unsubscribe", middleware.Deadline(10*time.Second), notifPrefsHandler.Unsubscribe)
+	root.POST("/api/v1/notifications/unsubscribe", middleware.Deadline(10*time.Second), notifPrefsHandler.UnsubscribePost)
 
 	// Swagger UI — served at /api/docs (unauthenticated; disable in prod via env).
-	router.GET("/api/docs/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
+	root.GET("/api/docs/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 
 	// SuperTokens SDK routes — catch-all for /auth/* so the SDK middleware
 	// can intercept signinup, session/refresh, callback, etc.
@@ -591,7 +591,7 @@ func main() {
 		// when TURNSTILE_SECRET_KEY is empty (dev / non-demo).
 		turnstileVerifier := turnstile.NewVerifier(os.Getenv("TURNSTILE_SECRET_KEY"))
 		turnstileBypass := os.Getenv("TURNSTILE_BYPASS_SECRET") // CI / E2E only
-		router.Any("/auth/*path",
+		root.Any("/auth/*path",
 			turnstile.SignupOnly(turnstileVerifier, turnstileBypass),
 			handler.SuperTokensMiddleware(),
 		)
@@ -607,7 +607,7 @@ func main() {
 	// (chat, voice, upload) for tighter budgets than the 60s http.Server
 	// WriteTimeout. Endpoints without their own Deadline are bounded by
 	// WriteTimeout — acceptable for default-CRUD route groups.
-	api := router.Group("/api/v1")
+	api := root.Group("/api/v1")
 
 	// Single-user mode: inject synthetic local session without SuperTokens.
 	// Multi-user mode: verify session via SuperTokens and resolve DB user.
@@ -931,7 +931,7 @@ func main() {
 	}
 
 	// Public chat routes — API key authentication (for embeddable chat widget).
-	chatAPI := router.Group("/api/v1/chat")
+	chatAPI := root.Group("/api/v1/chat")
 	// 30s budget for streaming completions (not under api, so full 30s is effective).
 	chatAPI.Use(middleware.Deadline(30 * time.Second))
 	chatAPI.Use(middleware.APIKeyAuth(&apiKeyLookupAdapter{repo: apiKeyRepo}))
@@ -956,15 +956,15 @@ func main() {
 	}
 
 	// --- Hyperswitch Billing Webhook (public, no JWT — uses HMAC signature verification) ---
-	router.POST("/api/v1/billing/webhook", middleware.Deadline(10*time.Second), billingHandler.Webhook)
+	root.POST("/api/v1/billing/webhook", middleware.Deadline(10*time.Second), billingHandler.Webhook)
 
 	// --- Meta Graph API Webhook (public, no JWT — Meta sends to a single URL) ---
 	metaWebhookHandler := handler.NewMetaWebhookHandler(cfg.Meta.AppSecret, cfg.Meta.WebhookToken, nil)
-	router.GET("/webhooks/meta", middleware.Deadline(10*time.Second), metaWebhookHandler.VerifyWebhook)
-	router.POST("/webhooks/meta", middleware.Deadline(10*time.Second), metaWebhookHandler.HandleEvent)
+	root.GET("/webhooks/meta", middleware.Deadline(10*time.Second), metaWebhookHandler.VerifyWebhook)
+	root.POST("/webhooks/meta", middleware.Deadline(10*time.Second), metaWebhookHandler.HandleEvent)
 
 	// --- Admin routes (seed key auth required) ---
-	admin := router.Group("/api/v1/admin")
+	admin := root.Group("/api/v1/admin")
 	admin.Use(middleware.Deadline(10 * time.Second))
 	admin.Use(func(c *gin.Context) {
 		seedKey := c.GetHeader("X-Seed-Key")
@@ -984,7 +984,7 @@ func main() {
 	demoJoiner := service.NewDemoOrgJoiner(orgSvc, wsSvc)
 	authHandler := handler.NewAuthHandler(userSvc, demoJoiner)
 	if !cfg.Server.SingleUser {
-		router.GET("/api/v1/auth/callback", middleware.Deadline(10*time.Second), func(c *gin.Context) {
+		root.GET("/api/v1/auth/callback", middleware.Deadline(10*time.Second), func(c *gin.Context) {
 			info, err := authProvider.VerifySession(c.Request)
 			if err != nil || info == nil {
 				c.AbortWithStatusJSON(401, gin.H{"error": "invalid_session"})

--- a/cmd/api/path_prefix_test.go
+++ b/cmd/api/path_prefix_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+// TestNoRouterRouteRegistrationsAfterRootGroup parses main.go and asserts
+// that no route registrations are made directly on `router` after
+// `root := router.Group(cfg.Server.PathPrefix)` is declared. Every
+// route-registration call (router.GET, router.POST, router.Group, ...)
+// must be on `root` so RAVEN_PATH_PREFIX is honoured. router.Use(...)
+// middleware calls are exempt — they apply to all groups by design.
+//
+// Catches the class of regression where a single route is registered on
+// the bare router and 404s silently in path-prefixed deployments such
+// as https://demo.ravencloak.org/raven/.
+func TestNoRouterRouteRegistrationsAfterRootGroup(t *testing.T) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "main.go", nil, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parse main.go: %v", err)
+	}
+
+	var rootLine int
+	ast.Inspect(f, func(n ast.Node) bool {
+		as, ok := n.(*ast.AssignStmt)
+		if !ok || as.Tok != token.DEFINE {
+			return true
+		}
+		for _, lhs := range as.Lhs {
+			if id, ok := lhs.(*ast.Ident); ok && id.Name == "root" {
+				rootLine = fset.Position(as.Pos()).Line
+				return false
+			}
+		}
+		return true
+	})
+	if rootLine == 0 {
+		t.Fatal("could not locate `root := ...` declaration in main.go")
+	}
+
+	var bad []string
+	ast.Inspect(f, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		x, ok := sel.X.(*ast.Ident)
+		if !ok || x.Name != "router" {
+			return true
+		}
+		line := fset.Position(call.Pos()).Line
+		if line <= rootLine {
+			return true
+		}
+		switch sel.Sel.Name {
+		case "GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "Any", "Group":
+			bad = append(bad, fmt.Sprintf("L%d: router.%s(...) — should be root.%s(...)", line, sel.Sel.Name, sel.Sel.Name))
+		}
+		return true
+	})
+
+	if len(bad) > 0 {
+		t.Errorf("route registrations on bare `router` after `root :=` declaration:\n  %s", strings.Join(bad, "\n  "))
+	}
+}


### PR DESCRIPTION
## Summary

Hotfix for #625. That PR introduced `root := router.Group(cfg.Server.PathPrefix)` to support running the API behind a URL prefix (`RAVEN_PATH_PREFIX`), but only moved `/healthz` under the new group. Every other route — `/api/v1/*` (the whole versioned API), `/auth/*`, `/api/docs/*`, `/api/v1/chat/*`, `/api/v1/admin/*`, `/api/v1/billing/webhook`, `/webhooks/meta`, `/api/v1/auth/callback` — was left on the bare `router`.

In prod this means every request to `https://demo.ravencloak.org/raven/api/v1/*` reaches the Go API via cloudflared (which forwards the full prefixed path), the router looks up `/api/v1/*` (no prefix), and returns `404 page not found` for everything except `/raven/healthz`.

This commit moves every route-registration call (`router.GET/POST/Any/Group`) to `root`. The `router.Use(...)` middleware stays on the engine so it still applies to every sub-group.

## Test

Added `TestNoRouterRouteRegistrationsAfterRootGroup` — parses `cmd/api/main.go` with `go/ast` and fails if any `router.GET/POST/PUT/DELETE/PATCH/HEAD/OPTIONS/Any/Group(...)` call appears after `root :=` is declared. Verified locally that the test:

- Passes on the fixed code
- Fails with a clear message identifying the regressing line when a single registration is moved back to `router`

## Verification

- [x] `go build ./cmd/api/... ./internal/config/...`
- [x] `go vet ./cmd/api/...`
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] `go test ./cmd/api/... ./internal/config/...` — pass
- [ ] After merge + redeploy + new frontend image with `VITE_BASE_PATH=/raven/`: `curl https://demo.ravencloak.org/raven/api/v1/config` returns the config JSON, SPA boots and authenticates

## Related

- Bug 2 from the demo cutover (frontend SPA image still built with `VITE_BASE_PATH=/`) is being addressed separately — rebuilding `ghcr.io/ravencloak-org/frontend` with the prefix baked in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated verification to ensure routes respect configured path prefix settings.

* **Refactor**
  * Improved consistency in how API endpoints are organized under the configured path prefix.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ravencloak-org/Raven/pull/626?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->