### PR TITLE
fix(ci): unbreak release + demo-deploy pipelines after v0.4.0 cutover

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -28,17 +28,22 @@ jobs:
           TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
           set -euo pipefail
+          # release.yml publishes image tags via docker/metadata-action's
+          # {{version}} pattern, which strips the leading `v` from the
+          # SemVer tag. The git ref still carries `v` (e.g. v0.4.1) so we
+          # normalise to the published image-tag form here.
+          IMG_TAG="${TAG#v}"
           for svc in go-api python-worker frontend; do
             for i in {1..30}; do
-              if docker manifest inspect ghcr.io/ravencloak-org/$svc:$TAG > /dev/null 2>&1; then
-                echo "Found $svc:$TAG"
+              if docker manifest inspect "ghcr.io/ravencloak-org/$svc:$IMG_TAG" > /dev/null 2>&1; then
+                echo "Found $svc:$IMG_TAG"
                 break
               fi
               if [ "$i" = "30" ]; then
-                echo "Timed out waiting for $svc:$TAG"
+                echo "Timed out waiting for $svc:$IMG_TAG"
                 exit 1
               fi
-              echo "Waiting for $svc:$TAG (attempt $i/30)..."
+              echo "Waiting for $svc:$IMG_TAG (attempt $i/30)..."
               sleep 30
             done
           done
@@ -75,11 +80,21 @@ jobs:
           INSTANCE_ID: ${{ steps.instance.outputs.instance_id }}
         run: |
           set -euo pipefail
+          # git checkout uses the v-prefixed git tag; update.sh `--tag`
+          # takes the SemVer string (no v) because that's how release.yml
+          # publishes to GHCR. See wait-for-images for the same reasoning.
+          IMG_TAG="${TAG#v}"
+          # After update.sh pulls the standard frontend image (built with
+          # VITE_BASE_PATH=/), swap to the path-prefixed variant for demo
+          # so the SPA's asset URLs resolve under /raven/. The variant
+          # tag is produced by a follow-up CI matrix (Task #9); until
+          # then we use the one-off :raven-prefixed tag.
+          FRONTEND_DEMO_IMAGE="ghcr.io/ravencloak-org/frontend:raven-prefixed"
           CMD_ID=$(aws ssm send-command \
             --instance-ids "$INSTANCE_ID" \
             --document-name AWS-RunShellScript \
             --comment "demo deploy $TAG" \
-            --parameters "commands=[\"cd /opt/raven && git fetch --tags && git checkout $TAG && bash deploy/ec2/update.sh --tag $TAG\"]" \
+            --parameters "commands=[\"cd /opt/raven && git fetch --tags && git checkout $TAG && bash deploy/ec2/update.sh --tag $IMG_TAG && sed -i 's|^FRONTEND_IMAGE=.*|FRONTEND_IMAGE=$FRONTEND_DEMO_IMAGE|' .env.server && DOCKER_HOST=unix:///run/raven/docker.sock docker compose -f deploy/ec2/docker-compose.server.yml --env-file .env.server pull frontend && DOCKER_HOST=unix:///run/raven/docker.sock docker compose -f deploy/ec2/docker-compose.server.yml --env-file .env.server up -d --remove-orphans frontend\"]" \
             --timeout-seconds 1800 \
             --query 'Command.CommandId' --output text)
           echo "command_id=$CMD_ID" >> "$GITHUB_OUTPUT"
@@ -109,15 +124,20 @@ jobs:
           echo "Timed out waiting for SSM command"
           exit 1
 
-      - name: Smoke-test /healthz
+      - name: Smoke-test demo /raven/api/v1/config
         run: |
-          for i in {1..20}; do
-            if curl -fsS https://demo.raven.ravencloak.org/healthz; then
+          # Hits the path-prefixed public-config endpoint via cloudflared.
+          # demo.raven.ravencloak.org is offline since the DNS cutover;
+          # /raven/api/v1/config is publicly reachable, returns JSON, and
+          # exercises both the tunnel ingress rule and the Go API's
+          # PathPrefix-mounted route group (verifies the fix from #626).
+          for _ in {1..20}; do
+            if curl -fsS https://demo.ravencloak.org/raven/api/v1/config | grep -q single_user; then
               echo "OK"; exit 0
             fi
             sleep 15
           done
-          echo "Health check never went green"
+          echo "Demo API never went green"
           exit 1
 
   notify:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -299,7 +299,13 @@ jobs:
           IMAGE: ghcr.io/${{ github.repository_owner }}/${{ matrix.component }}
         run: |
           tag_args=$(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
-          digest_args=$(printf '%s@sha256:%s ' "$IMAGE" *)
+          # Build one IMAGE@sha256:DIGEST source per digest file. The
+          # previous printf-with-two-%s form mis-cycled when more than
+          # one arch was present (printf consumes args in pairs).
+          digest_args=""
+          for d in *; do
+            digest_args="$digest_args $IMAGE@sha256:$d"
+          done
           # shellcheck disable=SC2086  # intentional word-splitting on tag_args + digest_args
           docker buildx imagetools create $tag_args $digest_args
 


### PR DESCRIPTION
## Summary

v0.4.0 release exposed three latent bugs in the release → demo-deploy chain. All four arch-specific images built fine; manifest assembly and deploy failed downstream.

**release.yml — multi-arch manifest assembly (the actual v0.4.0 failure)**

```bash
digest_args=$(printf '%s@sha256:%s ' "$IMAGE" *)
```

`printf` cycles args in pairs. With two arches (amd64+arm64) the second cycle mis-pairs: `(digest2, <empty>) → digest2@sha256:` — exactly the error from run 26090801782 (`failed to parse source "a1f7e88...@sha256:"`). v0.3.0 succeeded because it predates the multi-arch matrix. Replaced with a `for d in *` loop, one `$IMAGE@sha256:$d` per digest file.

**demo-deploy.yml — v-prefix mismatch**

`wait-for-images`, the SSM checkout, and `update.sh --tag` all used `github.ref_name` raw (`v0.4.0`). release.yml's `docker/metadata-action` `{{version}}` strips the `v`, so only `:0.4.0` appears on GHCR. Workflow waited forever for `:v0.4.0`. Split into GIT_TAG (with v, for `git checkout`) and IMG_TAG (without v, for image tags + `update.sh --tag`).

**demo-deploy.yml — smoke URL**

Smoke test pointed at `https://demo.raven.ravencloak.org/healthz`. That hostname has been offline since the DNS cutover (`demo.ravencloak.org/raven/*` is the new layout) and `/healthz` would route to nginx SPA fallback anyway. Switched to `https://demo.ravencloak.org/raven/api/v1/config` — exercises both the cloudflared ingress rule and the Go API's PathPrefix-mounted route group (verifies #626 landed correctly).

**demo-deploy.yml — frontend image override**

CI-built frontend has `VITE_BASE_PATH=/` baked in (Dockerfile default), so the SPA references `/assets/*` which 404 behind `/raven`. Until the proper CI matrix variant lands, the SSM commands now `sed` `FRONTEND_IMAGE` in `.env.server` to `ghcr.io/ravencloak-org/frontend:raven-prefixed` (manually-built variant with `/raven/` baked in) and re-pull+restart the frontend service.

## Verification

- [x] `actionlint .github/workflows/{release,demo-deploy}.yml` — clean
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — both YAML parse
- [ ] After merge, tag v0.4.1 from new main HEAD; release pipeline produces multi-arch images, demo-deploy waits for the v-stripped tag, smoke test hits the live URL, frontend gets the prefixed image

## Related

- Builds on #625 (path-prefix feature) and #626 (route mount fix)
- Frontend variant in CI matrix (proper, not via SSM override) is a follow-up — Task #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced demo deployment reliability with improved health verification and standardized image tag handling
  * Fixed release image building process to correctly assemble multi-architecture images with proper manifest creation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ravencloak-org/Raven/pull/627?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->