### PR TITLE
feat(demo): retire AWS EC2 deploy, ship demo to Vultr via SSH

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -1,5 +1,13 @@
 name: Demo deploy
 
+# Triggers
+#   - push:  any v* tag from main fires a deploy with that tag's images.
+#   - workflow_dispatch: manual re-deploy of an existing tag.
+#
+# Targets the Vultr demo box at vars.VULTR_DEMO_HOST (e.g. 64.176.97.248).
+# SSH key is in secrets.VULTR_SSH_KEY (ed25519). The previous AWS EC2 +
+# OIDC + SSM flow has been retired.
+
 on:
   push:
     tags: ['v*']
@@ -10,14 +18,7 @@ on:
         required: true
 
 permissions:
-  id-token: write     # needed for OIDC
   contents: read
-
-env:
-  AWS_REGION: ap-south-1
-  ROLE_ARN: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/raven-demo-github-deploy
-  INSTANCE_TAG_KEY: Name
-  INSTANCE_TAG_VALUE: raven-demo-app
 
 jobs:
   wait-for-images:
@@ -28,10 +29,8 @@ jobs:
           TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
           set -euo pipefail
-          # release.yml publishes image tags via docker/metadata-action's
-          # {{version}} pattern, which strips the leading `v` from the
-          # SemVer tag. The git ref still carries `v` (e.g. v0.4.1) so we
-          # normalise to the published image-tag form here.
+          # release.yml publishes via docker/metadata-action's {{version}}
+          # pattern which strips the leading `v` from the SemVer tag.
           IMG_TAG="${TAG#v}"
           for svc in go-api python-worker frontend; do
             for i in {1..30}; do
@@ -52,85 +51,47 @@ jobs:
     needs: wait-for-images
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS credentials via OIDC
-        uses: aws-actions/configure-aws-credentials@v4
+      - name: Load SSH key
+        uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd  # v0.9.1
         with:
-          role-to-assume: ${{ env.ROLE_ARN }}
-          aws-region: ${{ env.AWS_REGION }}
+          ssh-private-key: ${{ secrets.VULTR_SSH_KEY }}
 
-      - name: Resolve demo instance ID
-        id: instance
+      - name: Trust Vultr host key
+        env:
+          VULTR_HOST: ${{ vars.VULTR_DEMO_HOST }}
         run: |
           set -euo pipefail
-          INSTANCE_ID=$(aws ec2 describe-instances \
-            --filters "Name=tag:${INSTANCE_TAG_KEY},Values=${INSTANCE_TAG_VALUE}" \
-                      "Name=instance-state-name,Values=running" \
-            --query 'Reservations[0].Instances[0].InstanceId' \
-            --output text)
-          if [ "$INSTANCE_ID" = "None" ] || [ -z "$INSTANCE_ID" ]; then
-            echo "No running demo instance found"
-            exit 1
-          fi
-          echo "instance_id=$INSTANCE_ID" >> "$GITHUB_OUTPUT"
+          mkdir -p ~/.ssh
+          ssh-keyscan -T 10 -H "$VULTR_HOST" >> ~/.ssh/known_hosts
 
-      - name: Send update.sh via SSM
-        id: ssm
+      - name: Deploy via SSH
         env:
           TAG: ${{ github.event.inputs.tag || github.ref_name }}
-          INSTANCE_ID: ${{ steps.instance.outputs.instance_id }}
+          VULTR_HOST: ${{ vars.VULTR_DEMO_HOST }}
         run: |
           set -euo pipefail
-          # git checkout uses the v-prefixed git tag; update.sh `--tag`
-          # takes the SemVer string (no v) because that's how release.yml
-          # publishes to GHCR. See wait-for-images for the same reasoning.
           IMG_TAG="${TAG#v}"
-          # After update.sh pulls the standard frontend image (built with
-          # VITE_BASE_PATH=/), swap to the path-prefixed variant for demo
-          # so the SPA's asset URLs resolve under /raven/. The variant
-          # tag is produced by a follow-up CI matrix (Task #9); until
-          # then we use the one-off :raven-prefixed tag.
-          FRONTEND_DEMO_IMAGE="ghcr.io/ravencloak-org/frontend:raven-prefixed"
-          CMD_ID=$(aws ssm send-command \
-            --instance-ids "$INSTANCE_ID" \
-            --document-name AWS-RunShellScript \
-            --comment "demo deploy $TAG" \
-            --parameters "commands=[\"cd /opt/raven && git fetch --tags && git checkout $TAG && bash deploy/ec2/update.sh --tag $IMG_TAG && sed -i 's|^FRONTEND_IMAGE=.*|FRONTEND_IMAGE=$FRONTEND_DEMO_IMAGE|' .env.server && DOCKER_HOST=unix:///run/raven/docker.sock docker compose -f deploy/ec2/docker-compose.server.yml --env-file .env.server pull frontend && DOCKER_HOST=unix:///run/raven/docker.sock docker compose -f deploy/ec2/docker-compose.server.yml --env-file .env.server up -d --remove-orphans frontend\"]" \
-            --timeout-seconds 1800 \
-            --query 'Command.CommandId' --output text)
-          echo "command_id=$CMD_ID" >> "$GITHUB_OUTPUT"
-
-      - name: Wait for SSM command to complete
-        env:
-          CMD_ID: ${{ steps.ssm.outputs.command_id }}
-          INSTANCE_ID: ${{ steps.instance.outputs.instance_id }}
-        run: |
-          set -euo pipefail
-          for i in {1..60}; do
-            STATUS=$(aws ssm get-command-invocation \
-              --command-id "$CMD_ID" --instance-id "$INSTANCE_ID" \
-              --query Status --output text)
-            echo "[$i] Status: $STATUS"
-            case "$STATUS" in
-              Success) exit 0 ;;
-              Failed|Cancelled|TimedOut)
-                aws ssm get-command-invocation \
-                  --command-id "$CMD_ID" --instance-id "$INSTANCE_ID" \
-                  --query '{stdout:StandardOutputContent,stderr:StandardErrorContent}'
-                exit 1
-                ;;
-            esac
-            sleep 30
-          done
-          echo "Timed out waiting for SSM command"
-          exit 1
+          # git checkout uses the v-prefixed tag; update.sh `--tag` takes
+          # the image-tag form (no v) since release.yml publishes via
+          # docker/metadata-action's `{{version}}` (no v) pattern. Pass
+          # both as positional args to a heredoc'd remote script so no
+          # client-side expansion is needed inside the SSH payload.
+          ssh "root@$VULTR_HOST" bash -s -- "$TAG" "$IMG_TAG" <<'REMOTE'
+            set -euo pipefail
+            REMOTE_TAG="$1"
+            REMOTE_IMG_TAG="$2"
+            cd /opt/raven
+            git fetch --tags
+            git checkout "$REMOTE_TAG"
+            bash deploy/vultr/update.sh --tag "$REMOTE_IMG_TAG"
+          REMOTE
 
       - name: Smoke-test demo /raven/api/v1/config
         run: |
-          # Hits the path-prefixed public-config endpoint via cloudflared.
-          # demo.raven.ravencloak.org is offline since the DNS cutover;
-          # /raven/api/v1/config is publicly reachable, returns JSON, and
-          # exercises both the tunnel ingress rule and the Go API's
-          # PathPrefix-mounted route group (verifies the fix from #626).
+          set -euo pipefail
+          # Hits the path-prefixed public-config endpoint through cloudflared.
+          # Exercises the tunnel ingress + the Go API's PathPrefix-mounted
+          # route group (verifying #626 is live on the deployed box).
           for _ in {1..20}; do
             if curl -fsS https://demo.ravencloak.org/raven/api/v1/config | grep -q single_user; then
               echo "OK"; exit 0

--- a/deploy/vultr/.env.server.example
+++ b/deploy/vultr/.env.server.example
@@ -1,0 +1,39 @@
+# Raven — Vultr server .env.server template
+#
+# Copy this file to /opt/raven/.env.server on the Vultr box and populate the
+# values. Do NOT commit the populated file (it contains secrets).
+#
+# Required by deploy/ec2/docker-compose.server.yml (shared compose; see
+# deploy/vultr/update.sh which mounts the same file).
+
+# ─── Image refs (rewritten by update.sh when run with --tag) ──────────────────
+GO_API_IMAGE=ghcr.io/ravencloak-org/go-api:latest
+PYTHON_WORKER_IMAGE=ghcr.io/ravencloak-org/python-worker:latest
+# Path-prefixed variant baked with VITE_BASE_PATH=/raven/. Demo-only.
+FRONTEND_IMAGE=ghcr.io/ravencloak-org/frontend:raven-prefixed
+
+# ─── App-wide ──────────────────────────────────────────────────────────────────
+RAVEN_PATH_PREFIX=/raven
+
+# ─── Postgres ──────────────────────────────────────────────────────────────────
+POSTGRES_USER=raven
+POSTGRES_PASSWORD=
+POSTGRES_DB=raven
+
+# ─── SuperTokens ──────────────────────────────────────────────────────────────
+SUPERTOKENS_API_KEY=
+
+# ─── OpenObserve ──────────────────────────────────────────────────────────────
+ZO_ROOT_USER_EMAIL=
+ZO_ROOT_USER_PASSWORD=
+
+# ─── Turnstile (signup gate) ───────────────────────────────────────────────────
+TURNSTILE_SITE_KEY=
+TURNSTILE_SECRET_KEY=
+
+# ─── LLM cost fuse ─────────────────────────────────────────────────────────────
+RAVEN_LLM_DAILY_USD_CAP=5.00
+
+# ─── OAuth (optional) ──────────────────────────────────────────────────────────
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=

--- a/deploy/vultr/bootstrap.sh
+++ b/deploy/vultr/bootstrap.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# bootstrap.sh — one-shot provisioning for a fresh Ubuntu Vultr instance.
+#
+# Brings the box from "bare Ubuntu" to "ready to run docker compose":
+#   - Docker Engine + Compose plugin (official get.docker.com script)
+#   - /opt/raven repo clone (the working tree the deploy steps live in)
+#   - cloudflared systemd unit pointing at /etc/cloudflared/config.yml
+#
+# Idempotent — re-runnable. Skips work that's already done.
+#
+# Manual prerequisites (NOT done by this script — they need secrets):
+#   1. /opt/raven/.env.server — populate from .env.server.example
+#   2. /etc/cloudflared/<tunnel_id>.json — extract via fetch-tunnel-creds.sh
+#      from AWS SSM, scp to box, chmod 600.
+#   3. /etc/cloudflared/config.yml — written by this script using
+#      CLOUDFLARE_TUNNEL_ID env (must be set before running).
+#
+# Usage:
+#   sudo CLOUDFLARE_TUNNEL_ID=<uuid> bash bootstrap.sh
+#
+set -euo pipefail
+
+if [ "${EUID:-0}" -ne 0 ]; then
+  echo "Run as root (this script installs system packages)." >&2
+  exit 1
+fi
+
+REPO_URL="${REPO_URL:-https://github.com/ravencloak-org/Raven.git}"
+REPO_DIR="${REPO_DIR:-/opt/raven}"
+CF_TUNNEL_ID="${CLOUDFLARE_TUNNEL_ID:-}"
+
+# ─── Docker Engine + Compose ──────────────────────────────────────────────────
+if ! command -v docker >/dev/null 2>&1; then
+  echo "[bootstrap] installing docker via get.docker.com..."
+  curl -fsSL https://get.docker.com | sh
+else
+  echo "[bootstrap] docker present: $(docker --version)"
+fi
+
+if ! docker compose version >/dev/null 2>&1; then
+  echo "[bootstrap] installing docker compose plugin..."
+  apt-get update -y
+  apt-get install -y docker-compose-plugin
+else
+  echo "[bootstrap] docker compose plugin present: $(docker compose version --short)"
+fi
+
+systemctl enable --now docker
+
+# ─── Repo clone ───────────────────────────────────────────────────────────────
+if [ ! -d "$REPO_DIR/.git" ]; then
+  echo "[bootstrap] cloning $REPO_URL into $REPO_DIR..."
+  git clone "$REPO_URL" "$REPO_DIR"
+else
+  echo "[bootstrap] $REPO_DIR already a git checkout; fetching latest..."
+  git -C "$REPO_DIR" fetch --tags --prune
+fi
+
+# ─── Cloudflared systemd unit ─────────────────────────────────────────────────
+if [ -z "$CF_TUNNEL_ID" ]; then
+  echo "[bootstrap] CLOUDFLARE_TUNNEL_ID not set; skipping cloudflared config." >&2
+  echo "[bootstrap] re-run with CLOUDFLARE_TUNNEL_ID=<uuid> to wire the tunnel." >&2
+else
+  install -d -m 700 /etc/cloudflared
+  cat > /etc/cloudflared/config.yml <<EOF
+tunnel: ${CF_TUNNEL_ID}
+credentials-file: /etc/cloudflared/${CF_TUNNEL_ID}.json
+# Ingress rules are managed remotely via Cloudflare's API (terraform-controlled
+# in deploy/terraform/demo/cloudflare.tf). No local ingress config needed.
+EOF
+  if [ ! -f "/etc/cloudflared/${CF_TUNNEL_ID}.json" ]; then
+    echo "[bootstrap] WARN: /etc/cloudflared/${CF_TUNNEL_ID}.json missing." >&2
+    echo "[bootstrap] Extract it from AWS SSM via deploy/vultr/fetch-tunnel-creds.sh" >&2
+    echo "[bootstrap] then scp it to this box (chmod 600) before starting cloudflared." >&2
+  fi
+  cat > /etc/systemd/system/cloudflared.service <<'EOF'
+[Unit]
+Description=Cloudflare Tunnel
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=/usr/local/bin/cloudflared --config /etc/cloudflared/config.yml --no-autoupdate tunnel run
+Restart=on-failure
+User=root
+
+[Install]
+WantedBy=multi-user.target
+EOF
+  systemctl daemon-reload
+  systemctl enable cloudflared
+  if [ -f "/etc/cloudflared/${CF_TUNNEL_ID}.json" ]; then
+    systemctl restart cloudflared
+    echo "[bootstrap] cloudflared started; check: systemctl status cloudflared"
+  else
+    echo "[bootstrap] cloudflared NOT started (waiting for credentials JSON)."
+  fi
+fi
+
+# ─── Final reminders ──────────────────────────────────────────────────────────
+ENV_FILE="$REPO_DIR/.env.server"
+if [ ! -f "$ENV_FILE" ]; then
+  cp "$REPO_DIR/deploy/vultr/.env.server.example" "$ENV_FILE"
+  echo "[bootstrap] WROTE template $ENV_FILE — populate secrets before deploying."
+fi
+
+echo
+echo "[bootstrap] DONE. Next steps:"
+echo "  1. populate $ENV_FILE with real secrets (POSTGRES_PASSWORD, SUPERTOKENS_API_KEY, etc.)"
+echo "  2. place /etc/cloudflared/<tunnel_id>.json (chmod 600) if not already there"
+echo "  3. trigger the demo-deploy workflow OR run: bash $REPO_DIR/deploy/vultr/update.sh --tag <ver>"

--- a/deploy/vultr/fetch-tunnel-creds.sh
+++ b/deploy/vultr/fetch-tunnel-creds.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# fetch-tunnel-creds.sh — pull the Cloudflare tunnel credentials JSON from
+# AWS SSM (where terraform stores it) and write it to a local file.
+#
+# Run this on your laptop (where AWS creds are available), then scp the
+# resulting JSON to /etc/cloudflared/<tunnel_id>.json on the Vultr box.
+#
+# The tunnel itself is terraform-managed (deploy/terraform/demo/), so the
+# tunnel ID + credentials live in AWS SSM as
+#   /raven/demo/tunnel_id          (SecureString)
+#   /raven/demo/tunnel_credentials (SecureString, base64-encoded JSON)
+#
+# Usage:
+#   AWS_REGION=ap-south-1 bash deploy/vultr/fetch-tunnel-creds.sh ./tunnel.json
+#   scp ./tunnel.json root@64.176.97.248:/etc/cloudflared/<id>.json
+#   ssh root@64.176.97.248 'chmod 600 /etc/cloudflared/<id>.json'
+#
+set -euo pipefail
+
+OUT="${1:-./tunnel.json}"
+REGION="${AWS_REGION:-ap-south-1}"
+TUNNEL_ID_PARAM="${TUNNEL_ID_PARAM:-/raven/demo/tunnel_id}"
+TUNNEL_CREDS_PARAM="${TUNNEL_CREDS_PARAM:-/raven/demo/tunnel_credentials}"
+
+command -v aws >/dev/null || { echo "aws CLI required" >&2; exit 1; }
+command -v jq  >/dev/null || { echo "jq required" >&2; exit 1; }
+
+echo "[fetch-creds] reading $TUNNEL_ID_PARAM ($REGION)..."
+TUNNEL_ID=$(aws ssm get-parameter --region "$REGION" \
+  --name "$TUNNEL_ID_PARAM" --with-decryption \
+  --query 'Parameter.Value' --output text)
+
+echo "[fetch-creds] reading $TUNNEL_CREDS_PARAM ($REGION)..."
+aws ssm get-parameter --region "$REGION" \
+  --name "$TUNNEL_CREDS_PARAM" --with-decryption \
+  --query 'Parameter.Value' --output text | base64 -d > "$OUT"
+
+# Sanity-check the JSON is well-formed and references the same tunnel.
+JSON_TUNNEL_ID=$(jq -r '.TunnelID // .tunnel_id // empty' < "$OUT")
+if [ -z "$JSON_TUNNEL_ID" ]; then
+  echo "[fetch-creds] WARN: couldn't parse TunnelID from credentials JSON" >&2
+elif [ "$JSON_TUNNEL_ID" != "$TUNNEL_ID" ]; then
+  echo "[fetch-creds] WARN: tunnel_id ($TUNNEL_ID) != credentials TunnelID ($JSON_TUNNEL_ID)" >&2
+fi
+
+chmod 600 "$OUT"
+echo "[fetch-creds] wrote $OUT (chmod 600)"
+echo "[fetch-creds] tunnel_id=$TUNNEL_ID"
+echo
+echo "Next:"
+echo "  scp $OUT root@<vultr-host>:/etc/cloudflared/${TUNNEL_ID}.json"
+echo "  ssh root@<vultr-host> 'chmod 600 /etc/cloudflared/${TUNNEL_ID}.json'"
+echo "  ssh root@<vultr-host> 'CLOUDFLARE_TUNNEL_ID=${TUNNEL_ID} bash /opt/raven/deploy/vultr/bootstrap.sh'"

--- a/deploy/vultr/update.sh
+++ b/deploy/vultr/update.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# update.sh — pull latest images and restart the Raven stack on a Vultr box.
+#
+# Differences from deploy/ec2/update.sh:
+#   - Uses the default docker daemon socket (Vultr runs a single daemon;
+#     EC2 used a hidden secondary daemon at /run/raven/docker.sock).
+#   - Targets deploy/vultr/docker-compose.server.yml.
+#
+# Usage:
+#   ./deploy/vultr/update.sh
+#   ./deploy/vultr/update.sh --tag v0.4.1   # pin to a release tag
+#   ./deploy/vultr/update.sh --sha abc1234  # pin to a commit SHA
+#
+set -euo pipefail
+
+COMPOSE="docker compose"
+ENV_FILE=".env.server"
+# The compose file in deploy/ec2/ is platform-agnostic — the EC2-vs-Vultr
+# distinction was the secondary docker socket (an env var, not in the YAML).
+# Reusing it here avoids drift between deploys.
+COMPOSE_FILE="deploy/ec2/docker-compose.server.yml"
+
+REF=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --sha)
+      REF="sha-${2::7}"
+      shift 2
+      ;;
+    --tag)
+      REF="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -n "${REF}" ]; then
+  GO_API_IMAGE="ghcr.io/ravencloak-org/go-api:${REF}"
+  PYTHON_WORKER_IMAGE="ghcr.io/ravencloak-org/python-worker:${REF}"
+  FRONTEND_IMAGE="ghcr.io/ravencloak-org/frontend:${REF}"
+
+  set_or_append() {
+    local key="$1" value="$2"
+    if grep -q "^${key}=" "$ENV_FILE"; then
+      sed -i "s|^${key}=.*|${key}=${value}|" "$ENV_FILE"
+    else
+      echo "${key}=${value}" >> "$ENV_FILE"
+    fi
+  }
+  set_or_append GO_API_IMAGE "$GO_API_IMAGE"
+  set_or_append PYTHON_WORKER_IMAGE "$PYTHON_WORKER_IMAGE"
+  set_or_append FRONTEND_IMAGE "$FRONTEND_IMAGE"
+  echo "Pinned to ref: ${REF}"
+fi
+
+echo "Pulling images..."
+$COMPOSE -f "$COMPOSE_FILE" --env-file "$ENV_FILE" pull
+
+echo "Restarting stack..."
+$COMPOSE -f "$COMPOSE_FILE" --env-file "$ENV_FILE" up -d --remove-orphans
+
+echo "Stack status:"
+$COMPOSE -f "$COMPOSE_FILE" --env-file "$ENV_FILE" ps


### PR DESCRIPTION
## Summary

Retires the AWS OIDC + SSM deploy path in `.github/workflows/demo-deploy.yml`. The demo now ships to a Vultr box via key-based SSH.

Two reasons to switch now:

1. v0.4.1's deploy run surfaced that the AWS path is broken — repo variable `AWS_ACCOUNT_ID` is unset, so the role ARN rendered as `arn:aws:iam:::role/...` and OIDC failed (`Request ARN is invalid`).
2. Direction is to drop AWS for demo entirely.

## What's new under `deploy/vultr/`

| File | Purpose |
|------|---------|
| `bootstrap.sh` | One-shot provisioning for a fresh Ubuntu box: docker + compose plugin, clone `/opt/raven`, write cloudflared systemd unit + `/etc/cloudflared/config.yml`. Idempotent. |
| `update.sh` | Image pull + restart, mirroring `deploy/ec2/update.sh` but without the secondary-docker-daemon socket. Reuses `deploy/ec2/docker-compose.server.yml` verbatim (platform-agnostic). |
| `fetch-tunnel-creds.sh` | Operator-side helper to extract the Cloudflare tunnel credentials JSON from AWS SSM (terraform-managed) so they can be scp'd to the Vultr box. Run locally, not in CI. |
| `.env.server.example` | Template defaulting `FRONTEND_IMAGE` to `ghcr.io/ravencloak-org/frontend:raven-prefixed` (the `/raven/`-baked variant from Task #13). |

## Workflow changes

- Replaces AWS `configure-aws-credentials` + `aws ec2 describe-instances` + `aws ssm send-command` with `webfactory/ssh-agent` (pinned by SHA) + `ssh-keyscan` + a single inline-heredoc SSH call.
- Remote payload is a heredoc passed via `bash -s -- $TAG $IMG_TAG` so client-side expansion is contained (clean per shellcheck SC2029).
- Smoke test unchanged: `https://demo.ravencloak.org/raven/api/v1/config` + `grep -q single_user`.

## Operator prerequisites (one-time, before first run)

1. **Repo variable** `VULTR_DEMO_HOST=64.176.97.248`
2. **Repo secret** `VULTR_SSH_KEY` = ed25519 private key whose public key is in `/root/.ssh/authorized_keys` on the Vultr box.
3. **On Vultr**: run `bootstrap.sh` once with `CLOUDFLARE_TUNNEL_ID=<id>`, then place the tunnel credentials JSON (use `fetch-tunnel-creds.sh` locally + scp).
4. **On Vultr**: populate `/opt/raven/.env.server` from `.env.server.example` with real secrets.

## Verification

- [x] `actionlint .github/workflows/demo-deploy.yml` — clean
- [x] `shellcheck deploy/vultr/*.sh` — clean
- [ ] After merge + operator prep: cut `v0.4.2`, demo-deploy fires, SSH push completes, smoke test goes green

## Related

- Builds on #625 (path prefix) + #626 (route mount fix) + #627 (release/deploy workflow fixes)
- `deploy/ec2/` left in place for now — nothing in CI references it after this PR. Decommissioning is a separate change.
- Cosign config conflicts in `release.yml` (Go binaries + Frontend bundle) are still outstanding (Task #17). They don't block demo-deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Migrated demo deployment infrastructure from AWS EC2 to Vultr with direct SSH access
  * Added Cloudflare tunnel credential management for demo environment
  * Enhanced demo provisioning with automated Docker Engine and repository setup

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ravencloak-org/Raven/pull/628?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->