### PR TITLE
feat(demo): build frontend-raven variant in CI, fix nginx + Dockerfile build args

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -86,6 +86,23 @@ jobs:
             platform: linux/arm64
             arch: arm64
             runner: ubuntu-24.04-arm
+          # Path-prefixed variant of the frontend, baked with
+          # VITE_BASE_PATH=/raven/. Used by the public demo so the SPA's
+          # assets + same-origin API calls resolve under /raven/. Same
+          # Dockerfile + context as `frontend`; only the build-args differ
+          # (handled in the build-push step via matrix.image).
+          - image: frontend-raven
+            context: frontend
+            dockerfile: frontend/Dockerfile
+            platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+          - image: frontend-raven
+            context: frontend
+            dockerfile: frontend/Dockerfile
+            platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -116,6 +133,10 @@ jobs:
             ${{ matrix.image == 'frontend' && format('VITE_API_URL={0}', vars.VITE_API_URL || 'https://api.ravencloak.org') || '' }}
             ${{ matrix.image == 'frontend' && format('VITE_API_BASE_URL={0}', vars.VITE_API_BASE_URL || 'https://api.ravencloak.org/api/v1') || '' }}
             ${{ matrix.image == 'frontend' && format('VITE_LIVEKIT_URL={0}', vars.VITE_LIVEKIT_URL || '') || '' }}
+            ${{ matrix.image == 'frontend-raven' && 'VITE_BASE_PATH=/raven/' || '' }}
+            ${{ matrix.image == 'frontend-raven' && format('VITE_API_URL={0}/raven', vars.RAVEN_DEMO_BASE_URL || 'https://demo.ravencloak.org') || '' }}
+            ${{ matrix.image == 'frontend-raven' && format('VITE_API_BASE_URL={0}/raven/api/v1', vars.RAVEN_DEMO_BASE_URL || 'https://demo.ravencloak.org') || '' }}
+            ${{ matrix.image == 'frontend-raven' && format('VITE_API_DOMAIN={0}', vars.RAVEN_DEMO_BASE_URL || 'https://demo.ravencloak.org') || '' }}
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
 
@@ -143,6 +164,9 @@ jobs:
             context: ai-worker
             dockerfile: ai-worker/Dockerfile
           - image: frontend
+            context: frontend
+            dockerfile: frontend/Dockerfile
+          - image: frontend-raven
             context: frontend
             dockerfile: frontend/Dockerfile
     steps:
@@ -184,6 +208,10 @@ jobs:
             ${{ matrix.image == 'frontend' && format('VITE_API_URL={0}', vars.VITE_API_URL || 'https://api.ravencloak.org') || '' }}
             ${{ matrix.image == 'frontend' && format('VITE_API_BASE_URL={0}', vars.VITE_API_BASE_URL || 'https://api.ravencloak.org/api/v1') || '' }}
             ${{ matrix.image == 'frontend' && format('VITE_LIVEKIT_URL={0}', vars.VITE_LIVEKIT_URL || '') || '' }}
+            ${{ matrix.image == 'frontend-raven' && 'VITE_BASE_PATH=/raven/' || '' }}
+            ${{ matrix.image == 'frontend-raven' && format('VITE_API_URL={0}/raven', vars.RAVEN_DEMO_BASE_URL || 'https://demo.ravencloak.org') || '' }}
+            ${{ matrix.image == 'frontend-raven' && format('VITE_API_BASE_URL={0}/raven/api/v1', vars.RAVEN_DEMO_BASE_URL || 'https://demo.ravencloak.org') || '' }}
+            ${{ matrix.image == 'frontend-raven' && format('VITE_API_DOMAIN={0}', vars.RAVEN_DEMO_BASE_URL || 'https://demo.ravencloak.org') || '' }}
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
           provenance: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,6 +196,21 @@ jobs:
             platform: linux/arm64
             arch: arm64
             runner: ubuntu-24.04-arm
+          # Path-prefixed variant for the demo (VITE_BASE_PATH=/raven/).
+          # Same Dockerfile + context; build-args differ via the
+          # `Build and push by digest` step's conditional below.
+          - component: frontend-raven
+            context: frontend
+            dockerfile: frontend/Dockerfile
+            platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+          - component: frontend-raven
+            context: frontend
+            dockerfile: frontend/Dockerfile
+            platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -229,6 +244,14 @@ jobs:
           cache-to:   type=gha,scope=${{ matrix.component }}-${{ matrix.arch }},mode=max
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=ghcr.io/${{ github.repository_owner }}/${{ matrix.component }},push-by-digest=true,name-canonical=true,push=true
+          build-args: |
+            ${{ matrix.component == 'frontend' && format('VITE_API_URL={0}', vars.VITE_API_URL || 'https://api.ravencloak.org') || '' }}
+            ${{ matrix.component == 'frontend' && format('VITE_API_BASE_URL={0}', vars.VITE_API_BASE_URL || 'https://api.ravencloak.org/api/v1') || '' }}
+            ${{ matrix.component == 'frontend' && format('VITE_LIVEKIT_URL={0}', vars.VITE_LIVEKIT_URL || '') || '' }}
+            ${{ matrix.component == 'frontend-raven' && 'VITE_BASE_PATH=/raven/' || '' }}
+            ${{ matrix.component == 'frontend-raven' && format('VITE_API_URL={0}/raven', vars.RAVEN_DEMO_BASE_URL || 'https://demo.ravencloak.org') || '' }}
+            ${{ matrix.component == 'frontend-raven' && format('VITE_API_BASE_URL={0}/raven/api/v1', vars.RAVEN_DEMO_BASE_URL || 'https://demo.ravencloak.org') || '' }}
+            ${{ matrix.component == 'frontend-raven' && format('VITE_API_DOMAIN={0}', vars.RAVEN_DEMO_BASE_URL || 'https://demo.ravencloak.org') || '' }}
           provenance: false
           sbom: false
 
@@ -264,7 +287,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        component: [go-api, python-worker, frontend]
+        component: [go-api, python-worker, frontend, frontend-raven]
     steps:
       - name: Download digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1

--- a/deploy/vultr/.env.server.example
+++ b/deploy/vultr/.env.server.example
@@ -10,7 +10,8 @@
 GO_API_IMAGE=ghcr.io/ravencloak-org/go-api:latest
 PYTHON_WORKER_IMAGE=ghcr.io/ravencloak-org/python-worker:latest
 # Path-prefixed variant baked with VITE_BASE_PATH=/raven/. Demo-only.
-FRONTEND_IMAGE=ghcr.io/ravencloak-org/frontend:raven-prefixed
+# Published by docker.yml/release.yml's `frontend-raven` matrix entry.
+FRONTEND_IMAGE=ghcr.io/ravencloak-org/frontend-raven:latest
 
 # ─── App-wide ──────────────────────────────────────────────────────────────────
 RAVEN_PATH_PREFIX=/raven

--- a/deploy/vultr/update.sh
+++ b/deploy/vultr/update.sh
@@ -41,7 +41,9 @@ done
 if [ -n "${REF}" ]; then
   GO_API_IMAGE="ghcr.io/ravencloak-org/go-api:${REF}"
   PYTHON_WORKER_IMAGE="ghcr.io/ravencloak-org/python-worker:${REF}"
-  FRONTEND_IMAGE="ghcr.io/ravencloak-org/frontend:${REF}"
+  # Vultr always runs the path-prefixed variant (built with VITE_BASE_PATH=/raven/
+  # by the docker.yml/release.yml `frontend-raven` matrix entry).
+  FRONTEND_IMAGE="ghcr.io/ravencloak-org/frontend-raven:${REF}"
 
   set_or_append() {
     local key="$1" value="$2"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -15,9 +15,15 @@ ARG VITE_LIVEKIT_URL=
 # Vite base path. Override at build time (e.g. --build-arg VITE_BASE_PATH=/raven/)
 # when serving under a path prefix. Must include trailing slash. Default: root.
 ARG VITE_BASE_PATH=/
-ENV VITE_BASE_PATH=$VITE_BASE_PATH
 
-RUN npm run build
+# Vite reads env vars from `.env.production.local` ahead of `.env.production`
+# in production builds, so writing them here is the most reliable way to feed
+# ARG values into the build (process env from ARGs isn't propagated by default).
+# Whatever's already in .env.production stays as the fallback if no ARG is set.
+RUN printf 'VITE_BASE_PATH=%s\nVITE_API_URL=%s\nVITE_API_BASE_URL=%s\nVITE_API_DOMAIN=%s\nVITE_LIVEKIT_URL=%s\n' \
+      "$VITE_BASE_PATH" "$VITE_API_URL" "$VITE_API_BASE_URL" "$VITE_API_DOMAIN" "$VITE_LIVEKIT_URL" \
+      > .env.production.local \
+ && npm run build
 
 # ── Stage 2: serve ────────────────────────────────────────────────────────────
 FROM nginxinc/nginx-unprivileged:1.27-alpine@sha256:65e3e85dbaed8ba248841d9d58a899b6197106c23cb0ff1a132b7bfe0547e4c0

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,6 +1,26 @@
+# nginx config for the Raven frontend container.
+#
+# Handles two deployment shapes from one config:
+#
+#   1. Root deployment (VITE_BASE_PATH=/, e.g. SaaS self-hosted): the
+#      /raven/* locations below are inert because nothing in the SPA
+#      references /raven paths. Requests hit `location /` directly.
+#
+#   2. Path-prefixed deployment (VITE_BASE_PATH=/raven/, used by the
+#      public demo): the SPA emits HTML referencing /raven/assets/...
+#      and the JS makes API calls to /raven/api/v1/... — those land in
+#      the /raven/api/, /raven/auth/, /raven/webhooks/ proxy locations
+#      below (reverse-proxied to go-api), and other /raven/* paths fall
+#      through to the prefix-stripping rewrite + SPA fallback.
+#
+# In both shapes, /raven/api/ is matched BEFORE the catch-all /raven/
+# (longer prefix wins in nginx), and the prefix-stripping rewrite is
+# inside the /raven/ location (NOT at server level) so it doesn't pre-
+# empt the proxy blocks.
 server {
     listen 8080;
     server_name _;
+
     root /usr/share/nginx/html;
     index index.html;
 
@@ -8,21 +28,63 @@ server {
     gzip_types text/plain text/css application/javascript application/json image/svg+xml;
     gzip_min_length 1024;
 
-    # Cache static assets aggressively (Vite hashes filenames). Matches both
-    # root (/assets/) and path-prefixed deployments (e.g. /raven/assets/).
-    location ~ ^(?:/[^/]+)?/assets/ {
+    # ── Reverse-proxy app paths to go-api on the docker network.
+    # Preserve the full /raven prefix on the upstream because go-api
+    # mounts every route under RAVEN_PATH_PREFIX.
+    location /raven/api/ {
+        proxy_pass http://go-api:8081;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+        proxy_read_timeout 90s;
+    }
+    location /raven/auth/ {
+        proxy_pass http://go-api:8081;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    location /raven/webhooks/ {
+        proxy_pass http://go-api:8081;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # ── Static + SPA fallback under /raven/. The rewrite is inside the
+    # location (not at server level) so it fires AFTER location matching:
+    # the proxy locations above still win for their specific prefixes.
+    location /raven/ {
+        rewrite ^/raven/(.*)$ /$1 break;
+        try_files $uri $uri/ /index.html;
+    }
+    location = /raven {
+        return 301 /raven/;
+    }
+
+    # ── Aggressive cache for Vite-hashed assets. Matches both /assets/
+    # (root deployment) and the rewritten /raven/assets/* (prefixed
+    # deployment, after the rewrite above).
+    location /assets/ {
         expires 1y;
         add_header Cache-Control "public, immutable";
     }
 
-    # SPA fallback — all unmatched routes serve index.html. With Vite's `base`
-    # set, the bundled index.html already references assets under the prefix,
-    # so try_files works the same way for / and /raven/ deployments.
+    # ── Root SPA fallback (root deployment only). For prefixed
+    # deployments the SPA serves under /raven/ so this is rarely hit.
     location / {
         try_files $uri $uri/ /index.html;
     }
 
-    # Health check endpoint for cloudflared / monitoring
+    # ── Container-internal healthcheck used by docker compose. The
+    # compose healthcheck hits this path directly (not via the prefix).
     location /healthz {
         return 200 "ok";
         add_header Content-Type text/plain;

--- a/frontend/src/stores/server-config.ts
+++ b/frontend/src/stores/server-config.ts
@@ -31,9 +31,10 @@ export const useServerConfigStore = defineStore('serverConfig', () => {
   async function load() {
     if (loaded.value) return
     try {
-      const res = await fetch(
-        `${import.meta.env.VITE_API_BASE_URL}/api/v1/config`,
-      )
+      // VITE_API_BASE_URL already ends with /api/v1 (matches the
+      // convention used everywhere else in src/api/*) — appending it
+      // again here doubled the path on path-prefixed deployments.
+      const res = await fetch(`${import.meta.env.VITE_API_BASE_URL}/config`)
       if (res.ok) {
         const data: ServerConfig = await res.json()
         singleUser.value = data.single_user ?? false


### PR DESCRIPTION
## Summary

Closes the loop left by #625 (path-prefix feature) and #628 (Vultr cutover): the public demo needs a frontend built with `VITE_BASE_PATH=/raven/` and a CI matrix entry to produce that variant on every tag/main push.

Five fixes bundled (one PR because they all need to ship together for the demo image to actually work):

### 1. `frontend/nginx.conf` — broken since #625

```nginx
# What #625 shipped:
location ~ ^(?:/[^/]+)?/assets/ {   # adds cache headers
    expires 1y; ...
}                                    # …but no try_files/alias/rewrite,
                                     # so nginx tries to serve files
                                     # from filesystem /raven/assets/* → 404
```

The SPA never booted behind `/raven/` because every asset request 404'd. Replaced with explicit `proxy_pass` blocks for `/raven/{api,auth,webhooks}/*` (longer-prefix-wins so they match before the catch-all) + a `/raven/` prefix-strip rewrite **inside** the location (NOT at server level, so the proxy blocks still win). For root deployments (`VITE_BASE_PATH=/`) the `/raven/*` locations are inert.

### 2. `frontend/Dockerfile` — only `VITE_BASE_PATH` was reaching Vite

The other four ARGs (`VITE_API_URL`, `VITE_API_BASE_URL`, `VITE_API_DOMAIN`, `VITE_LIVEKIT_URL`) were declared but never promoted to env that Vite can read. `--build-arg` overrides were silently ignored — the build always picked up `frontend/.env.production`. Now writes all five to `.env.production.local` (Vite's highest-precedence file in production mode) immediately before `npm run build`.

### 3. New CI matrix: `frontend-raven`

Added to both `.github/workflows/docker.yml` (main + PR) and `.github/workflows/release.yml` (tag + multi-arch + cosign + SBOM). Variant builds with:

- `VITE_BASE_PATH=/raven/`
- `VITE_API_URL=${RAVEN_DEMO_BASE_URL}/raven`
- `VITE_API_BASE_URL=${RAVEN_DEMO_BASE_URL}/raven/api/v1`
- `VITE_API_DOMAIN=${RAVEN_DEMO_BASE_URL}`

Where `RAVEN_DEMO_BASE_URL` defaults to `https://demo.ravencloak.org` and can be overridden via repo var. Published as `ghcr.io/ravencloak-org/frontend-raven:<version>` (and `:latest` on main). The SaaS `frontend` tag is unchanged.

### 4. `deploy/vultr/update.sh` + `.env.server.example`

Default `FRONTEND_IMAGE` to `frontend-raven:<ref>` since the Vultr box is always the path-prefixed demo. `update.sh --tag` continues to overwrite this per-run.

### 5. `frontend/src/stores/server-config.ts` — existing /api/v1-doubling bug

```diff
- `${VITE_API_BASE_URL}/api/v1/config`
+ `${VITE_API_BASE_URL}/config`
```

Every other `src/api/*` file already treats `VITE_API_BASE_URL` as ending in `/api/v1` (e.g. `const base = import.meta.env.VITE_API_BASE_URL ?? '/api/v1'`). This one path appended `/api/v1` a second time, producing `/raven/api/v1/api/v1/config` on prefixed builds. Surfaced by the build I ran while writing this PR.

## Verification

- [x] `actionlint .github/workflows/{docker,release,demo-deploy}.yml` — clean
- [x] `python3 -c "yaml.safe_load(...)"` — all three workflows parse
- [x] `shellcheck deploy/vultr/*.sh` — clean
- [x] Local `docker buildx build --target builder` with overridden build-args produces `dist/` that contains the expected URLs (proven the args flow into Vite)
- [x] `npm run build` with `VITE_API_BASE_URL=https://example.com/raven/api/v1` no longer has the doubled `/api/v1` string in the output bundle (proven the server-config fix works)
- [ ] After merge: `docker.yml` fires on main push (paths include `frontend/Dockerfile` + `frontend/nginx.conf`), publishes `frontend:latest` + `frontend-raven:latest`. Next demo-deploy tag pulls `frontend-raven` automatically.

## Related

Builds on #625 (path-prefix feature), #626 (route mount fix), #627 (release/deploy pipeline fixes), #628 (Vultr cutover). Allows retiring the manual `:raven-prefixed` tag once a new release ships.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for path-prefixed deployment variant with dedicated routing and API configuration.

* **Improvements**
  * Enhanced Vite build-time configuration injection for more reliable builds.
  * Refined nginx routing to support both root and path-prefixed application deployments.
  * Updated API endpoint resolution for feature flag fetching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ravencloak-org/Raven/pull/631?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->