### PR TITLE
docs(runbook): demo.ravencloak.org cutover AWS → Vultr

### DIFF
--- a/docs/runbooks/demo-cutover.md
+++ b/docs/runbooks/demo-cutover.md
@@ -1,0 +1,167 @@
+# Runbook: cut `demo.ravencloak.org` over from AWS to Vultr
+
+**Status**: pending (operational steps below have not been executed yet)
+**Estimated time**: ~15 min hands-on + ~5 min DNS propagation
+**Reversibility**: full, ~5 min via DNS flip-back
+**Risk**: low — both stacks remain runnable during cutover; the only
+shared resource is Cloudflare DNS
+
+## Background
+
+`demo.ravencloak.org` currently routes to a cloudflared connector on an
+**AWS EC2** instance (`raven-demo-app`, public IP `65.0.104.188`, in
+`ap-south-1`). That stack runs pre-#625 code — broken behind the new
+`/raven/*` path-prefixed ingress rules.
+
+A parallel **Vultr** stack (`64.176.97.248`) has been provisioned and
+proven via the public-IP URL `http://64.176.97.248:13080/raven/` (see
+#628 for provisioning, #631 for the path-prefixed CI image). Its
+cloudflared connector is already running, but bound to a **different**
+tunnel (`ac5bd284-c908-4c7d-8666-f6e8e824c693`) than the one DNS
+currently points at (`9bae2af2-f8e8-45ed-aa61-e1eb29182c3c`).
+
+Cutover means: route `demo.ravencloak.org` through the Vultr tunnel
+instead of the AWS one, then decommission AWS in a follow-up.
+
+## Tunnel topology — before / after
+
+| | Before | After |
+|---|---|---|
+| `demo.ravencloak.org` CNAME → | `9bae2af2-….cfargotunnel.com` (terraform-managed) | `ac5bd284-….cfargotunnel.com` (created out-of-band) |
+| Connector for that tunnel | cloudflared on AWS EC2 | cloudflared on Vultr |
+| Ingress rules on tunnel | terraform: `/raven/api/.*` → `localhost:8081`, `/raven/.*` → `localhost:3080` (AWS box) | dashboard: same two rules, on the Vultr tunnel |
+| Old tunnel (`9bae2af2`) | active, terraform-managed | dormant; decommission with AWS |
+
+## Pre-flight checks (do not skip)
+
+Run all of these on your laptop. If any fails, fix before proceeding.
+
+```bash
+# 1. Vultr stack is healthy end-to-end via the public IP. Replace
+#    asset hash with whatever index-*.js the current build emits.
+curl -sf http://64.176.97.248:13080/raven/api/v1/config \
+  | grep -q single_user && echo "✓ API responds with JSON"
+
+curl -sf -o /dev/null -w "asset HTTP %{http_code}\n" \
+  "http://64.176.97.248:13080$(curl -s http://64.176.97.248:13080/raven/ \
+    | grep -oE '/raven/assets/index-[^"]+\.js' | head -1)"
+
+# 2. Vultr cloudflared is connected to the tunnel.
+ssh root@64.176.97.248 'systemctl is-active cloudflared && \
+  journalctl -u cloudflared -n 10 --no-pager | grep -c "Registered tunnel connection"'
+# expect: active, plus a non-zero "Registered tunnel connection" count
+
+# 3. AWS demo is still up (so we have a rollback target).
+curl -sI https://demo.ravencloak.org/raven/api/v1/config \
+  | head -1   # any 200/404 from Go's gin (with `x-trace-id` header) is fine — proves AWS is reachable
+```
+
+## Cutover steps
+
+### Step 1 — add Public Hostnames on the Vultr tunnel (Cloudflare dashboard)
+
+Zero Trust → Networks → Tunnels → click into tunnel `ac5bd284-c908-4c7d-8666-f6e8e824c693` → **Public Hostnames** tab → **Add a public hostname**.
+
+Add **two** entries in this order (more specific first):
+
+| Subdomain | Domain | Path | Service |
+|----|----|----|----|
+| `demo` | `ravencloak.org` | `raven/api/.*` | `http://localhost:8081` |
+| `demo` | `ravencloak.org` | `raven/.*`     | `http://localhost:3080` |
+
+Click **Additional application settings** → leave defaults.
+Save each entry.
+
+When prompted to create/overwrite the DNS record, **decline** — we'll handle DNS explicitly in Step 2 so we can verify+roll back independently.
+
+### Step 2 — verify ingress is published before touching DNS
+
+Cloudflare propagates ingress rules to connectors within ~5s. Confirm:
+
+```bash
+ssh root@64.176.97.248 'journalctl -u cloudflared -n 20 --no-pager' \
+  | grep -i 'ingress\|configuration update\|reload' | tail -5
+```
+
+You should see a recent log line about a config update. If nothing appears within a minute, retry the Cloudflare save.
+
+### Step 3 — flip the DNS CNAME
+
+Cloudflare dashboard → `ravencloak.org` zone → **DNS** → **Records** → click the `demo` row → edit:
+
+| Field | Before | After |
+|----|----|----|
+| Target | `9bae2af2-….cfargotunnel.com` | `ac5bd284-c908-4c7d-8666-f6e8e824c693.cfargotunnel.com` |
+| Proxy status | Proxied (orange) | unchanged |
+| TTL | Auto | unchanged |
+
+Save. Cloudflare's edge picks up the new CNAME within ~30s.
+
+### Step 4 — smoke test
+
+```bash
+# Within ~30s after the DNS save:
+for _ in {1..6}; do
+  curl -sS -o /tmp/resp -D /tmp/headers -w "HTTP %{http_code}\n" \
+    https://demo.ravencloak.org/raven/api/v1/config
+  if grep -q 'single_user' /tmp/resp; then
+    echo "✓ JSON received from new Vultr stack"
+    break
+  fi
+  sleep 5
+done
+
+# Confirm response came from the right origin:
+# - go-api's middleware adds x-trace-id; AWS path was getting Go's 404 page
+# - bundle digest should match the frontend-raven image you just published
+grep -i 'x-trace-id' /tmp/headers   # presence proves Vultr go-api responded
+curl -s https://demo.ravencloak.org/raven/ \
+  | grep -oE '/raven/assets/index-[^"]+\.js' | head -1
+```
+
+If any of those fail, go to **Rollback** below.
+
+### Step 5 — stop the AWS cloudflared connector
+
+We **don't terraform-destroy AWS yet** — keeping it as a warm rollback target for ~24h after cutover. Just stop the cloudflared service so it stops trying to serve the now-orphaned tunnel:
+
+```bash
+# Via AWS SSM (preferred — keeps SSH closed):
+aws ssm send-command --region ap-south-1 \
+  --instance-ids $(aws ec2 describe-instances --region ap-south-1 \
+    --filters 'Name=tag:Name,Values=raven-demo-app' \
+              'Name=instance-state-name,Values=running' \
+    --query 'Reservations[0].Instances[0].InstanceId' --output text) \
+  --document-name AWS-RunShellScript \
+  --comment 'stop cloudflared post-cutover' \
+  --parameters 'commands=["systemctl stop cloudflared && systemctl disable cloudflared"]'
+```
+
+After this, tunnel `9bae2af2` has zero connectors. Cloudflare keeps the
+tunnel registered (it's a billing/free-tier resource that stays in your
+account) but it serves no traffic.
+
+## Rollback (executable in ~2 min)
+
+If Step 4 fails:
+
+1. Cloudflare DNS → `demo` row → flip Target back to `9bae2af2-….cfargotunnel.com`. Save.
+2. The AWS cloudflared is still running (Step 5 hasn't happened yet), so traffic resumes via AWS within ~30s.
+3. Investigate the Vultr-side failure (cloudflared logs on Vultr, Public Hostname config on `ac5bd284`).
+4. Fix, retry from Step 4.
+
+If Step 5 already ran (AWS cloudflared stopped) and you need to roll back: re-enable + start AWS cloudflared via the same SSM pattern (`systemctl enable --now cloudflared`), then flip DNS back.
+
+## Post-cutover follow-ups (separate PRs)
+
+- **Terraform import** of the now-canonical tunnel `ac5bd284` and replace `cloudflare_tunnel.demo` + `cloudflare_tunnel_config.demo` references. Drop the orphaned `9bae2af2` resource. Touches `deploy/terraform/demo/cloudflare.tf` + `terraform import` blocks.
+- **AWS decommission**: `terraform destroy` of `aws_instance.demo` + IAM + S3 backup bucket + SSM parameters. Tracked as Task #11.
+- **Vultr lockdown**: now that the demo serves through cloudflared, the public-IP ports `13080` + `18081` are no longer needed. Either add a Vultr cloud-firewall rule restricting them to SSH-only, OR rebind compose ports back to `127.0.0.1:` in `docker-compose.override.yml` on the box.
+- **Frontend image cleanup**: retire the one-off `ghcr.io/ravencloak-org/frontend:raven-prefixed` tag I hand-built — every release tag now produces `frontend-raven:<version>` via CI (#631).
+
+## What success looks like
+
+- `curl https://demo.ravencloak.org/raven/api/v1/config` → `{"single_user":false}` with `x-trace-id` header
+- `curl https://demo.ravencloak.org/raven/` → SPA HTML referencing `/raven/assets/index-….js`
+- Browser load of `https://demo.ravencloak.org/raven/` → boots the Vue app, can hit the login page (SuperTokens calls via same-origin nginx proxy)
+- Vultr `journalctl -u cloudflared` shows connection events; AWS box shows the same when re-enabled


### PR DESCRIPTION
## Summary

Operational runbook for moving `demo.ravencloak.org` from the AWS cloudflared connector to the Vultr one. Docs-only — no code changes; the actual cutover happens by following the steps in the doc.

## Why a runbook PR (vs just doing the cutover ad-hoc)

Three reasons it's worth checking in:

1. **Reversibility deadline** — Step 5 (stop AWS cloudflared) is the point of no warm-rollback. Documenting that boundary explicitly makes it harder to skip.
2. **Pre-flight discipline** — without a checklist it's easy to skip "is AWS still reachable as rollback?" and find out the hard way.
3. **Post-cutover follow-ups don't get forgotten** — terraform state migration, AWS decommission, Vultr port lockdown, and the one-off `:raven-prefixed` tag retirement are all enumerated at the bottom.

## Cutover shape

| | Before | After |
|---|---|---|
| `demo.ravencloak.org` CNAME → | `9bae2af2-….cfargotunnel.com` (terraform-managed) | `ac5bd284-….cfargotunnel.com` (created out-of-band, already serving Vultr) |
| Connector | AWS EC2 | Vultr |
| Code on box | pre-#625 (broken behind `/raven/*`) | post-#631 (working) |

Single DNS CNAME flip in the Cloudflare dashboard. Cloudflare proxied records propagate ~30s. Rollback = flip CNAME back. AWS box stays running for ~24h after cutover as rollback target.

## What this PR does NOT do

- ❌ Doesn't execute the cutover — manual, follows the doc
- ❌ Doesn't terraform-migrate state — separate PR after cutover succeeds (the `ac5bd284` tunnel needs `terraform import` before the existing `cloudflare_tunnel.demo` resource can be retargeted)
- ❌ Doesn't terraform-destroy AWS — Task #11, days after cutover when we're confident there's no rollback need

## Verification

- [x] Markdown renders correctly in GitHub preview
- [ ] After merge: run the runbook
- [ ] Document outcome by linking the PR + the runbook from a follow-up issue (or this PR's comments)

## Related

- Builds on #625 (path prefix), #626 (route mount fix), #627 (release pipeline fixes), #628 (Vultr deploy workflow), #631 (path-prefixed CI image)
- Unblocks: terraform import PR (next), AWS decommission (Task #11), Vultr lockdown