### PR TITLE
chore(terraform): import Vultr-side cloudflare tunnel into demo state

### DIFF
--- a/deploy/terraform/demo/cloudflare.tf
+++ b/deploy/terraform/demo/cloudflare.tf
@@ -1,3 +1,43 @@
+####
+# `cloudflare_tunnel.demo` was originally created by `terraform apply` from
+# this file (tunnel id `9bae2af2-f8e8-45ed-aa61-e1eb29182c3c`, connected
+# from an AWS EC2 box). On 2026-05-18 the demo was cut over to Vultr per
+# `docs/runbooks/demo-cutover.md` — a SECOND tunnel
+# (`ac5bd284-c908-4c7d-8666-f6e8e824c693`) was created out-of-band in the
+# Cloudflare dashboard with the same two `/raven/...` ingress rules, the
+# Vultr cloudflared registered against it, and `demo.ravencloak.org`'s
+# CNAME was flipped to the new tunnel. The old `9bae2af2` tunnel is now
+# dormant and will be deleted alongside the AWS decommission.
+#
+# The `import` blocks below adopt the new (Vultr) tunnel + its config
+# into the same `cloudflare_tunnel.demo` / `cloudflare_tunnel_config.demo`
+# addresses so Terraform converges on reality. The dashboard-configured
+# ingress rules are identical to those declared in `cloudflare_tunnel_config.demo`
+# below, so the post-import plan should be a clean no-op refresh.
+#
+# `secret` is kept (provider schema makes it required) but wrapped in
+# `lifecycle { ignore_changes }` so Terraform does NOT rotate the
+# dashboard-issued secret on first apply — rotating it would invalidate
+# the token the Vultr cloudflared connector is bootstrapped from. The
+# `random_id.tunnel_secret` + `aws_ssm_parameter.*` resources below are
+# AWS-only and will be removed by the parallel AWS-decommission PR.
+#
+# REVIEWER NOTE: state currently has `cloudflare_tunnel.demo` +
+# `cloudflare_tunnel_config.demo` bound to the OLD tunnel
+# (`9bae2af2-…`). Before `terraform plan`, run:
+#   terraform state rm cloudflare_tunnel.demo cloudflare_tunnel_config.demo
+# so the `import` blocks have a clean slot to re-populate.
+####
+import {
+  to = cloudflare_tunnel.demo
+  id = "${var.cloudflare_account_id}/${var.demo_tunnel_id}"
+}
+
+import {
+  to = cloudflare_tunnel_config.demo
+  id = "${var.cloudflare_account_id}/${var.demo_tunnel_id}"
+}
+
 resource "random_id" "tunnel_secret" {
   byte_length = 35
 }
@@ -5,7 +45,16 @@ resource "random_id" "tunnel_secret" {
 resource "cloudflare_tunnel" "demo" {
   account_id = var.cloudflare_account_id
   name       = "raven-demo"
-  secret     = random_id.tunnel_secret.b64_std
+  # `secret` is required by the provider schema, but the imported (Vultr)
+  # tunnel was created in the dashboard with its own server-generated
+  # secret; the live Vultr cloudflared connector was bootstrapped from
+  # that secret's token and would disconnect if Terraform rotated it.
+  # We seed the argument from `random_id.tunnel_secret` to satisfy the
+  # schema and `ignore_changes` to prevent any rotation post-import.
+  secret = random_id.tunnel_secret.b64_std
+  lifecycle {
+    ignore_changes = [secret]
+  }
 }
 
 resource "cloudflare_tunnel_config" "demo" {

--- a/deploy/terraform/demo/variables.tf
+++ b/deploy/terraform/demo/variables.tf
@@ -26,6 +26,12 @@ variable "cloudflare_zone_id" {
   type        = string
 }
 
+variable "demo_tunnel_id" {
+  description = "ID of the Cloudflare tunnel that fronts demo.ravencloak.org. After the AWS→Vultr cutover (see docs/runbooks/demo-cutover.md) this points at the Vultr-side tunnel created out-of-band in the dashboard."
+  type        = string
+  default     = "ac5bd284-c908-4c7d-8666-f6e8e824c693"
+}
+
 variable "demo_hostname" {
   description = "Public hostname for the demo"
   type        = string


### PR DESCRIPTION
## Summary

Following the AWS→Vultr cutover documented in `docs/runbooks/demo-cutover.md` (merged in #632), `demo.ravencloak.org` now CNAMEs to a Cloudflare tunnel (`ac5bd284-c908-4c7d-8666-f6e8e824c693`) that was created out-of-band in the dashboard. This PR brings terraform state in line with that reality.

**Code-only, do not auto-merge.** The `terraform apply` happens manually after a reviewer verifies the plan.

## Changes

- `deploy/terraform/demo/cloudflare.tf`:
  - Added two Terraform 1.5+ `import` blocks (one for `cloudflare_tunnel.demo`, one for `cloudflare_tunnel_config.demo`) retargeting from the old AWS tunnel `9bae2af2-…` to the Vultr tunnel `ac5bd284-…`.
  - Wrapped `cloudflare_tunnel.demo.secret` in `lifecycle { ignore_changes = [secret] }` so the dashboard-issued secret is not rotated post-import (rotation would invalidate the token the live Vultr cloudflared bootstrapped from).
  - Added a header comment explaining the cutover history and reviewer prep step.
- `deploy/terraform/demo/variables.tf`:
  - New `demo_tunnel_id` variable (default `ac5bd284-c908-4c7d-8666-f6e8e824c693`) so the tunnel ID is referenced symbolically rather than scattered as literals.

`cloudflare_tunnel_config.demo` body is unchanged — same path-prefix routing under `${var.demo_path_prefix}` (`/raven` by default).

Out of scope: the AWS resource files (`ec2.tf`, `s3.tf`, `iam.tf`, `backup.tf`, `oidc.tf`, `security_group.tf`, `vpc.tf`, `user_data.sh.tpl`) and the `random_id.tunnel_secret` / `aws_ssm_parameter.*` resources still in `cloudflare.tf` — these all retire in the parallel AWS-decommission PR (Task #11).

## How to verify locally

```bash
cd deploy/terraform/demo

# 1. Drop the OLD tunnel + its config from local state so the import
#    blocks have a clean slot to re-populate. (State currently has both
#    bound to 9bae2af2-...)
terraform state rm cloudflare_tunnel.demo cloudflare_tunnel_config.demo

# 2. Plan. Requires CLOUDFLARE_API_TOKEN with Account:Cloudflare Tunnel:Edit
#    and Zone:DNS:Edit scopes for ravencloak.org.
export CLOUDFLARE_API_TOKEN=...   # from 1Password
terraform plan

# Expected: two "Plan to import" entries (one tunnel, one tunnel_config)
# plus an effective no-op on the rest. The ingress rules in the imported
# tunnel_config already match the HCL because the Vultr tunnel was
# configured in the dashboard with the same two /raven/... rules.
```

If the plan shows anything beyond import + no-op (e.g. the imported tunnel has a different `name` than `raven-demo`, or the dashboard ingress rules drifted from the HCL), do NOT apply — flag in PR review.

## Test plan

- [ ] `terraform fmt -check` clean in `deploy/terraform/demo/` (already verified locally)
- [ ] `terraform validate` clean in `deploy/terraform/demo/` (already verified locally; only pre-existing deprecation warnings remain)
- [ ] Reviewer runs the `terraform plan` flow above and confirms plan is import + no-op
- [ ] After approval, operator runs `terraform apply` (NOT done by this PR)
- [ ] Post-apply, `demo.ravencloak.org/raven/api/v1/config` still returns `{"single_user":false}` via the Vultr connector

## Related

- Cutover runbook: `docs/runbooks/demo-cutover.md` (#632)
- Parallel: AWS demo decommission (Task #11) — strips `ec2.tf`, IAM, S3, SSM params, `random_id.tunnel_secret`