### PR TITLE
feat(auth): honor RAVEN_PATH_PREFIX in SuperTokens APIBasePath

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -201,6 +201,7 @@ func main() {
 			APIKey:        cfg.SuperTokens.APIKey,
 			APIDomain:     cfg.SuperTokens.APIDomain,
 			WebsiteDomain: cfg.SuperTokens.WebsiteDomain,
+			PathPrefix:    cfg.Server.PathPrefix,
 		}); err != nil {
 			log.Fatalf("failed to initialize SuperTokens: %v", err)
 		}

--- a/internal/auth/supertokens_init.go
+++ b/internal/auth/supertokens_init.go
@@ -16,14 +16,19 @@ type SuperTokensInitConfig struct {
 	APIKey        string
 	APIDomain     string // e.g. https://api.ravencloak.org
 	WebsiteDomain string // e.g. https://app.ravencloak.org
+	// PathPrefix prepends to apiBasePath + websiteBasePath so the SuperTokens
+	// SDK matches incoming requests at the same path the Go API actually
+	// mounts auth routes under. The demo runs under /raven; SaaS at root.
+	// Empty string = no prefix.
+	PathPrefix string
 }
 
 // InitSuperTokens initialises the SuperTokens Go SDK with the ThirdParty and
 // Session recipes. The SDK must be initialised once, before any route
-// registration, so that supertokens.Middleware can intercept /auth/* paths.
+// registration, so that supertokens.Middleware can intercept the auth paths.
 func InitSuperTokens(cfg SuperTokensInitConfig) error {
-	apiBasePath := "/auth"
-	websiteBasePath := "/auth"
+	apiBasePath := cfg.PathPrefix + "/auth"
+	websiteBasePath := cfg.PathPrefix + "/auth"
 
 	// Cookie domain for cross-subdomain session sharing.
 	// api.ravencloak.org sets cookies, app.ravencloak.org reads them.


### PR DESCRIPTION
## Summary

`internal/auth/supertokens_init.go` hardcoded `apiBasePath` / `websiteBasePath` to `/auth`. With path-prefix routing (#625/#626), the Go API mounts auth routes at `/raven/auth/*` on the demo — but SuperTokens still thought they were at `/auth/*`. Two consequences:

- SuperTokens middleware wouldn't match incoming requests (path comparison failed).
- OAuth callback URLs sent to Google/etc. pointed at `https://<APIDomain>/auth/callback/<id>` — a 404 on the demo.

Fix: `SuperTokensInitConfig` now takes a `PathPrefix` field that gets prepended to both base paths. `cmd/api/main.go` threads `cfg.Server.PathPrefix` through. SaaS (`PathPrefix=""`) keeps the original `/auth` behaviour.

## Verification

- [x] `go build` / `go vet` / `golangci-lint --new-from-rev=origin/main` — all clean
- [x] Existing `TestNoRouterRouteRegistrationsAfterRootGroup` AST guard still passes
- [ ] After this image redeploys on Vultr: Google OAuth callback URL `https://demo.ravencloak.org/raven/auth/callback/google` resolves and completes login

## Related

Builds on #625 (path prefix), #626 (route mount fix), #631 (frontend nginx reverse-proxies `/raven/auth/*` to go-api). Unblocks Google OAuth on the demo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authentication routes now respect a configurable path prefix setting, allowing flexible deployment of authentication endpoints under custom paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ravencloak-org/Raven/pull/636?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->