### PR TITLE
fix(auth): make frontend SuperTokens apiBasePath env-driven

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -137,6 +137,7 @@ jobs:
             ${{ matrix.image == 'frontend-raven' && format('VITE_API_URL={0}/raven', vars.RAVEN_DEMO_BASE_URL || 'https://demo.ravencloak.org') || '' }}
             ${{ matrix.image == 'frontend-raven' && format('VITE_API_BASE_URL={0}/raven/api/v1', vars.RAVEN_DEMO_BASE_URL || 'https://demo.ravencloak.org') || '' }}
             ${{ matrix.image == 'frontend-raven' && format('VITE_API_DOMAIN={0}', vars.RAVEN_DEMO_BASE_URL || 'https://demo.ravencloak.org') || '' }}
+            ${{ matrix.image == 'frontend-raven' && 'VITE_AUTH_BASE_PATH=/raven/auth' || '' }}
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
 
@@ -212,6 +213,7 @@ jobs:
             ${{ matrix.image == 'frontend-raven' && format('VITE_API_URL={0}/raven', vars.RAVEN_DEMO_BASE_URL || 'https://demo.ravencloak.org') || '' }}
             ${{ matrix.image == 'frontend-raven' && format('VITE_API_BASE_URL={0}/raven/api/v1', vars.RAVEN_DEMO_BASE_URL || 'https://demo.ravencloak.org') || '' }}
             ${{ matrix.image == 'frontend-raven' && format('VITE_API_DOMAIN={0}', vars.RAVEN_DEMO_BASE_URL || 'https://demo.ravencloak.org') || '' }}
+            ${{ matrix.image == 'frontend-raven' && 'VITE_AUTH_BASE_PATH=/raven/auth' || '' }}
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
           provenance: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,6 +252,7 @@ jobs:
             ${{ matrix.component == 'frontend-raven' && format('VITE_API_URL={0}/raven', vars.RAVEN_DEMO_BASE_URL || 'https://demo.ravencloak.org') || '' }}
             ${{ matrix.component == 'frontend-raven' && format('VITE_API_BASE_URL={0}/raven/api/v1', vars.RAVEN_DEMO_BASE_URL || 'https://demo.ravencloak.org') || '' }}
             ${{ matrix.component == 'frontend-raven' && format('VITE_API_DOMAIN={0}', vars.RAVEN_DEMO_BASE_URL || 'https://demo.ravencloak.org') || '' }}
+            ${{ matrix.component == 'frontend-raven' && 'VITE_AUTH_BASE_PATH=/raven/auth' || '' }}
           provenance: false
           sbom: false
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -201,6 +201,7 @@ func main() {
 			APIKey:        cfg.SuperTokens.APIKey,
 			APIDomain:     cfg.SuperTokens.APIDomain,
 			WebsiteDomain: cfg.SuperTokens.WebsiteDomain,
+			PathPrefix:    cfg.Server.PathPrefix,
 		}); err != nil {
 			log.Fatalf("failed to initialize SuperTokens: %v", err)
 		}

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -15,13 +15,17 @@ ARG VITE_LIVEKIT_URL=
 # Vite base path. Override at build time (e.g. --build-arg VITE_BASE_PATH=/raven/)
 # when serving under a path prefix. Must include trailing slash. Default: root.
 ARG VITE_BASE_PATH=/
+# SuperTokens apiBasePath for the supertokens-web-js SDK. Must match the
+# Go API's apiBasePath (internal/auth/supertokens_init.go). For prefixed
+# deployments set to e.g. /raven/auth; root deployments use /auth.
+ARG VITE_AUTH_BASE_PATH=/auth
 
 # Vite reads env vars from `.env.production.local` ahead of `.env.production`
 # in production builds, so writing them here is the most reliable way to feed
 # ARG values into the build (process env from ARGs isn't propagated by default).
 # Whatever's already in .env.production stays as the fallback if no ARG is set.
-RUN printf 'VITE_BASE_PATH=%s\nVITE_API_URL=%s\nVITE_API_BASE_URL=%s\nVITE_API_DOMAIN=%s\nVITE_LIVEKIT_URL=%s\n' \
-      "$VITE_BASE_PATH" "$VITE_API_URL" "$VITE_API_BASE_URL" "$VITE_API_DOMAIN" "$VITE_LIVEKIT_URL" \
+RUN printf 'VITE_BASE_PATH=%s\nVITE_API_URL=%s\nVITE_API_BASE_URL=%s\nVITE_API_DOMAIN=%s\nVITE_LIVEKIT_URL=%s\nVITE_AUTH_BASE_PATH=%s\n' \
+      "$VITE_BASE_PATH" "$VITE_API_URL" "$VITE_API_BASE_URL" "$VITE_API_DOMAIN" "$VITE_LIVEKIT_URL" "$VITE_AUTH_BASE_PATH" \
       > .env.production.local \
  && npm run build
 

--- a/frontend/src/plugins/supertokens.ts
+++ b/frontend/src/plugins/supertokens.ts
@@ -36,7 +36,10 @@ export function initSuperTokens() {
     appInfo: {
       appName: "Raven",
       apiDomain: import.meta.env.VITE_API_DOMAIN || "http://localhost:8081",
-      apiBasePath: "/auth",
+      // Must match the apiBasePath the Go API's SuperTokens SDK is initialised
+      // with (internal/auth/supertokens_init.go). The demo runs path-prefixed
+      // (/raven/auth); SaaS/dev defaults to /auth.
+      apiBasePath: import.meta.env.VITE_AUTH_BASE_PATH || "/auth",
     },
     recipeList: [
       Session.init(),

--- a/internal/auth/supertokens_init.go
+++ b/internal/auth/supertokens_init.go
@@ -16,14 +16,19 @@ type SuperTokensInitConfig struct {
 	APIKey        string
 	APIDomain     string // e.g. https://api.ravencloak.org
 	WebsiteDomain string // e.g. https://app.ravencloak.org
+	// PathPrefix prepends to apiBasePath + websiteBasePath so the SuperTokens
+	// SDK matches incoming requests at the same path the Go API actually
+	// mounts auth routes under. The demo runs under /raven; SaaS at root.
+	// Empty string = no prefix.
+	PathPrefix string
 }
 
 // InitSuperTokens initialises the SuperTokens Go SDK with the ThirdParty and
 // Session recipes. The SDK must be initialised once, before any route
-// registration, so that supertokens.Middleware can intercept /auth/* paths.
+// registration, so that supertokens.Middleware can intercept the auth paths.
 func InitSuperTokens(cfg SuperTokensInitConfig) error {
-	apiBasePath := "/auth"
-	websiteBasePath := "/auth"
+	apiBasePath := cfg.PathPrefix + "/auth"
+	websiteBasePath := cfg.PathPrefix + "/auth"
 
 	// Cookie domain for cross-subdomain session sharing.
 	// api.ravencloak.org sets cookies, app.ravencloak.org reads them.


### PR DESCRIPTION
## Summary

Companion to #636 (Go-side apiBasePath fix). The frontend SDK was still hardcoded `apiBasePath: "/auth"`. From the path-prefixed demo, the SPA's "Sign in with Google" fetched `https://demo.ravencloak.org/auth/authorisationurl` which doesn't exist — only `/raven/auth/*` is routed. SDK got nginx's 404 HTML, threw "Failed to fetch".

## Changes

- `frontend/src/plugins/supertokens.ts` — `apiBasePath` reads `VITE_AUTH_BASE_PATH`, defaults `/auth`
- `frontend/Dockerfile` — new `ARG VITE_AUTH_BASE_PATH=/auth`, written into `.env.production.local` like the other Vite envs
- `.github/workflows/docker.yml` + `release.yml` — for `frontend-raven` matrix entry, pass `VITE_AUTH_BASE_PATH=/raven/auth` as build-arg. Plain `frontend` tag unchanged.

## Verification

- [x] `actionlint` + `yaml.safe_load` on both workflows
- [ ] After this image redeploys on Vultr (or via the ad-hoc local push being done now): click "Sign in with Google" → redirects to Google → consent → returns to `/raven/auth/callback/google` → session cookie set → SPA authenticated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker workflows and build configurations to enable custom authentication service path routing across deployment environments.
  * Backend and frontend components now properly synchronize authentication base path configuration, supporting flexible multi-user or namespaced deployments with configurable auth paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ravencloak-org/Raven/pull/666?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->