### PR TITLE
fix(auth): build Google OAuth redirectURI from Vite BASE_URL

### DIFF
--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -36,9 +36,14 @@ export const useAuthStore = defineStore('auth', () => {
   }
 
   async function loginWithGoogle() {
+    // BASE_URL (from Vite's `base`) is "/" for root deployments and
+    // "/raven/" for the path-prefixed demo. Without it, prefixed
+    // deployments send Google a redirect_uri of `<origin>/callback`
+    // which (a) doesn't match Google Console's authorised URIs and
+    // (b) bypasses Vue Router's base-path mapping for /callback.
     const authUrl = await getAuthorisationURLWithQueryParamsAndSetState({
       thirdPartyId: 'google',
-      frontendRedirectURI: `${window.location.origin}/callback`,
+      frontendRedirectURI: `${window.location.origin}${import.meta.env.BASE_URL}callback`,
     })
     window.location.assign(authUrl)
   }


### PR DESCRIPTION
## Summary

Companion to #636 (Go-side path prefix) and #666 (frontend SDK apiBasePath). The remaining mismatch: `loginWithGoogle` built `frontendRedirectURI` as `\${origin}/callback`, sending Google `https://demo.ravencloak.org/callback`. Google rejected with `redirect_uri_mismatch` because:

1. The OAuth Client's authorised redirect URI list doesn't contain that
2. Vue Router has BASE_URL `/raven/`, so `/callback` doesn't map to the CallbackPage anyway

Fix: prepend `import.meta.env.BASE_URL` (Vite injects the `base` config). For the demo: `https://demo.ravencloak.org/raven/callback`. For root deployments unchanged.

## Operator action required

The Google OAuth Client's Authorised redirect URIs needs to contain `https://demo.ravencloak.org/raven/callback` — the SuperTokens-default `/raven/auth/callback/google` URL wasn't actually used by this SPA's flow (custom CallbackPage handles it).

## Verification

- [x] Local build with `VITE_BASE_PATH=/raven/`: bundle contains the string `\`/raven/callback\`` (verified with grep on minified output)
- [ ] After redeploy + Google Console update: Sign in with Google → no redirect_uri_mismatch → lands on the demo's CallbackPage → session established