### PR TITLE
fix(frontend): pass source_type when creating a URL source

### DIFF
--- a/frontend/src/api/knowledge-bases.ts
+++ b/frontend/src/api/knowledge-bases.ts
@@ -189,9 +189,12 @@ export async function addSource(
   kbId: string,
   url: string,
 ): Promise<KBSource> {
+  // Backend requires `source_type` (one of: web_page | web_site | sitemap |
+  // rss_feed) alongside `url`. Default to web_page for the simple URL-source
+  // entry box; a future picker can let users choose web_site/sitemap.
   return authFetch<KBSource>(`${kbBasePath(orgId, wsId)}/${kbId}/sources`, {
     method: 'POST',
-    body: JSON.stringify({ url }),
+    body: JSON.stringify({ source_type: 'web_page', url }),
   })
 }
 

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -36,9 +36,14 @@ export const useAuthStore = defineStore('auth', () => {
   }
 
   async function loginWithGoogle() {
+    // BASE_URL (from Vite's `base`) is "/" for root deployments and
+    // "/raven/" for the path-prefixed demo. Without it, prefixed
+    // deployments send Google a redirect_uri of `<origin>/callback`
+    // which (a) doesn't match Google Console's authorised URIs and
+    // (b) bypasses Vue Router's base-path mapping for /callback.
     const authUrl = await getAuthorisationURLWithQueryParamsAndSetState({
       thirdPartyId: 'google',
-      frontendRedirectURI: `${window.location.origin}/callback`,
+      frontendRedirectURI: `${window.location.origin}${import.meta.env.BASE_URL}callback`,
     })
     window.location.assign(authUrl)
   }


### PR DESCRIPTION
Sends  instead of  to /sources, matching the backend's required validation. Closes the 422 trap from the Add Source button on KB detail page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

- Knowledge base sources now correctly specify source type during creation
- Google login redirect now functions properly across different deployment configurations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ravencloak-org/Raven/pull/668?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->