### PR TITLE
fix(auth): switch SuperTokens to header-based session transfer

### DIFF
--- a/frontend/src/plugins/supertokens.ts
+++ b/frontend/src/plugins/supertokens.ts
@@ -42,7 +42,14 @@ export function initSuperTokens() {
       apiBasePath: import.meta.env.VITE_AUTH_BASE_PATH || "/auth",
     },
     recipeList: [
-      Session.init(),
+      // Header-based auth: SDK stores access/refresh tokens in localStorage
+      // and sends them via `Authorization: Bearer` + `st-refresh-token`
+      // headers instead of cookies. Removes the SameSite / Secure /
+      // cross-domain cookie issues that plagued the path-prefixed demo
+      // deploy. Matches SuperTokens' recommended SPA configuration.
+      Session.init({
+        tokenTransferMethod: 'header',
+      }),
       ThirdParty.init({
         preAPIHook: async (context) => attachTurnstileTokenOnSignup(context),
       }),


### PR DESCRIPTION
Hard-reload logout + mid-session logout on the path-prefixed demo both came down to cookie failure modes that I couldn't fully reproduce server-side. Header-based auth sidesteps the entire class — tokens in localStorage + Authorization header. SuperTokens recommends header for SPAs; backend supports both modes via the per-request st-auth-mode header so no backend change needed.