### PR TITLE
ci(docker): broaden path filter to source dirs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,23 +5,55 @@ on:
     branches: [main]
     # Tag builds are handled by release.yml (with cosign signing). This
     # workflow is for main-branch CI + PR-gate builds only.
+    #
+    # The path filter must cover everything Docker COPYs into a layer the
+    # source actually changes — Dockerfile alone isn't enough. Previously
+    # frontend/src/** and ai-worker/raven_worker/** edits silently skipped
+    # the build, leaving :main + :raven-self-contained stale relative to
+    # source. Same hole existed for cmd/** and internal/** (Go).
     paths:
       - 'Dockerfile'
+      - 'cmd/**'
+      - 'internal/**'
+      - 'pkg/**'
+      - 'go.mod'
+      - 'go.sum'
       - 'ai-worker/Dockerfile'
+      - 'ai-worker/raven_worker/**'
       - 'ai-worker/requirements.txt'
       - 'ai-worker/requirements-dev.txt'
       - 'frontend/Dockerfile'
       - 'frontend/nginx.conf'
+      - 'frontend/src/**'
+      - 'frontend/public/**'
+      - 'frontend/index.html'
+      - 'frontend/package.json'
+      - 'frontend/package-lock.json'
+      - 'frontend/vite.config.ts'
+      - 'frontend/tsconfig*.json'
       - 'docker-compose.yml'
   pull_request:
     branches: [main]
     paths:
       - 'Dockerfile'
+      - 'cmd/**'
+      - 'internal/**'
+      - 'pkg/**'
+      - 'go.mod'
+      - 'go.sum'
       - 'ai-worker/Dockerfile'
+      - 'ai-worker/raven_worker/**'
       - 'ai-worker/requirements.txt'
       - 'ai-worker/requirements-dev.txt'
       - 'frontend/Dockerfile'
       - 'frontend/nginx.conf'
+      - 'frontend/src/**'
+      - 'frontend/public/**'
+      - 'frontend/index.html'
+      - 'frontend/package.json'
+      - 'frontend/package-lock.json'
+      - 'frontend/vite.config.ts'
+      - 'frontend/tsconfig*.json'
       - 'docker-compose.yml'
       # NOTE: `.github/workflows/docker.yml` is intentionally NOT a path
       # filter trigger. Internal edits to this workflow (Dependabot SHA


### PR DESCRIPTION
## Summary
- The previous `paths:` filter on `docker.yml` only fired for `Dockerfile` / `nginx.conf` / `docker-compose.yml` edits.
- Source-only PRs (frontend/src/**, ai-worker python, Go under cmd/internal/pkg) silently skipped the image build, leaving `:main` and `:raven-self-contained` stale relative to source.
- Discovered after **PR #670** (header-based SuperTokens session transfer) merged to main but its bundle never reached the demo box because `docker.yml` didn't fire on the merge commit (`ebf76654`).

Adds these paths to both `push` and `pull_request` triggers:

- `cmd/**`, `internal/**`, `pkg/**`, `go.mod`, `go.sum` (Go source)
- `ai-worker/raven_worker/**` (Python source)
- `frontend/src/**`, `frontend/public/**`, `frontend/index.html`, `frontend/package.json`, `frontend/package-lock.json`, `frontend/vite.config.ts`, `frontend/tsconfig*.json` (Vite build inputs)

## Test plan
- [ ] CI Required passes (lint+test+build of every matrix variant runs on this PR — that itself proves the filter expansion works)
- [ ] Trigger this workflow on push to main with a frontend-src-only change in a follow-up; observe a fresh `:main` image is published