### PR TITLE
fix(auth): pin SuperTokens backend to header-only token transfer

### DIFF
--- a/internal/auth/supertokens_init.go
+++ b/internal/auth/supertokens_init.go
@@ -1,6 +1,8 @@
 package auth
 
 import (
+	"net/http"
+
 	"github.com/supertokens/supertokens-golang/recipe/session"
 	"github.com/supertokens/supertokens-golang/recipe/session/sessmodels"
 	"github.com/supertokens/supertokens-golang/recipe/thirdparty"
@@ -44,6 +46,17 @@ func InitSuperTokens(cfg SuperTokensInitConfig) error {
 		session.Init(&sessmodels.TypeInput{
 			CookieDomain:  &cookieDomain,
 			CookieSameSite: strPtr("none"),
+			// Pin tokens to the Authorization header / response-header path so
+			// the supertokens-web-js SDK (configured with
+			// tokenTransferMethod: 'header' in frontend/src/plugins/supertokens.ts)
+			// receives tokens it can store in localStorage. Without this, the
+			// backend's default ("any") chose cookies on the OAuth callback
+			// response, leaving localStorage empty — Session.doesSessionExist()
+			// then returned false on the next page-load and the SPA bounced the
+			// user to /login (the long-running "logout on navigation" bug).
+			GetTokenTransferMethod: func(_ *http.Request, _ bool, _ supertokens.UserContext) sessmodels.TokenTransferMethod {
+				return sessmodels.HeaderTransferMethod
+			},
 		}),
 	}
 


### PR DESCRIPTION
## Summary
Pins `session.Init()` to `HeaderTransferMethod` so the OAuth callback's response carries tokens in headers, matching the SPA's `tokenTransferMethod: 'header'` config from #670.

## Root cause of "logout on navigation"
- SPA sends `st-auth-mode: header` on its SDK-intercepted requests, but the **OAuth callback path** (the actual session-creation point) doesn't carry that header.
- supertokens-golang's default `GetTokenTransferMethod` returns `"any"`, which falls back to **cookies** when no `st-auth-mode` is present.
- So Google sign-in → `Set-Cookie` for `st-access-token` / `st-refresh-token` / `sFrontToken` → SPA in header-mode reads localStorage (empty) → `Session.doesSessionExist()` returns false → /login redirect on the next navigation.

Pinning `HeaderTransferMethod` makes the backend always respond with tokens in headers (no `Set-Cookie`). The SDK reads them via its fetch interceptor and writes to localStorage — `doesSessionExist()` then returns true and the SPA stays signed in.

## Behavior note
- Existing cookie-based sessions stop working at deploy time. Users sign in once more after this lands. Acceptable for the demo.

## Test plan
- [ ] CI: green build + lint
- [ ] Deploy to demo box (64.176.97.248)
- [ ] Sign in via Google → confirm localStorage has `st-access-token`, `st-refresh-token`, `st-front-token` and `document.cookie` is empty of those names
- [ ] Navigate between routes (`/settings`, `/knowledge-bases`, dashboard) — session persists
- [ ] Hard reload — session persists

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where authentication tokens could be lost on subsequent page loads. Session tokens are now consistently maintained across page navigation, ensuring uninterrupted authenticated user sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ravencloak-org/Raven/pull/672?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->