### PR TITLE
fix(spa): use sFrontToken cookie as cold-boot session fallback

### DIFF
--- a/.bytebase/fixtures/bad/00001_dropped_table_no_label.sql
+++ b/.bytebase/fixtures/bad/00001_dropped_table_no_label.sql
@@ -1,0 +1,4 @@
+-- +goose Up
+-- Intentionally violates statement.disallow-rm-tbl-cascade.
+-- Used by .github/workflows/sql-review-selftest.yml to verify the policy fires.
+DROP TABLE IF EXISTS chunks CASCADE;

--- a/.bytebase/fixtures/bad/00002_pascal_case_column.sql
+++ b/.bytebase/fixtures/bad/00002_pascal_case_column.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+-- Intentionally violates naming.column (PascalCase).
+CREATE TABLE bad_naming (
+    id            uuid PRIMARY KEY,
+    UserEmail     text NOT NULL,
+    CreatedAt     timestamptz NOT NULL DEFAULT now()
+);

--- a/.bytebase/fixtures/bad/00003_truncate_in_migration.sql
+++ b/.bytebase/fixtures/bad/00003_truncate_in_migration.sql
@@ -1,0 +1,3 @@
+-- +goose Up
+-- Intentionally violates statement.disallow-truncate.
+TRUNCATE TABLE response_cache;

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -21,6 +21,16 @@ export const useAuthStore = defineStore('auth', () => {
    * are bad UX — the app would never mount and the user would see a
    * blank page. A 5s timeout + try/catch falls back to "no session" so
    * the router guard sends the user to /login as expected.
+   *
+   * Cold-boot race: on a hard page load (vs in-app navigation),
+   * Session.doesSessionExist() can return false EVEN when the
+   * sFrontToken cookie is present and unexpired — the SDK's internal
+   * state hasn't hydrated from cookies yet. Calling it again ~50ms later
+   * returns true. To avoid bouncing the user to /login on every page
+   * reload, fall back to parsing the sFrontToken cookie directly: if
+   * its session expiry (`up.exp`) is in the future, treat as a valid
+   * session. The SDK will catch up and subsequent calls behave
+   * normally.
    */
   async function init() {
     try {
@@ -33,6 +43,34 @@ export const useAuthStore = defineStore('auth', () => {
     } catch {
       sessionExists.value = false
     }
+    if (!sessionExists.value && hasValidFrontTokenCookie()) {
+      sessionExists.value = true
+    }
+  }
+
+  function hasValidFrontTokenCookie(): boolean {
+    const raw = readCookie('sFrontToken')
+    if (!raw) return false
+    try {
+      const payload = JSON.parse(atob(decodeURIComponent(raw))) as {
+        up?: { exp?: number }
+      }
+      const expSec = payload?.up?.exp
+      if (typeof expSec !== 'number') return false
+      // `up.exp` is seconds-since-epoch (matches the embedded JWT claim).
+      return expSec * 1000 > Date.now()
+    } catch {
+      return false
+    }
+  }
+
+  function readCookie(name: string): string | null {
+    const prefix = `${name}=`
+    for (const part of document.cookie.split(';')) {
+      const trimmed = part.trim()
+      if (trimmed.startsWith(prefix)) return trimmed.slice(prefix.length)
+    }
+    return null
   }
 
   async function loginWithGoogle() {


### PR DESCRIPTION
## Summary
Fixes the long-running **'logout on navigation' bug**: hard browser navigation (page reload, address-bar navigation, OAuth redirect-back) to a protected route bounced the user to `/login` despite valid SuperTokens cookies being present.

## Root cause
On cold boot, `Session.doesSessionExist()` returns `false` before the supertokens-web-js SDK has hydrated its internal state from cookies. Sequence:

1. `auth.init()` calls `Session.doesSessionExist()` → returns `false` (race)
2. `sessionExists.value = false`
3. `app.mount('#app')` resolves initial route
4. Router guard sees `!isAuthenticated`, returns `'/login'`
5. SDK finishes hydrating, subsequent calls return `true` — but redirect already happened

Verified by reading `__supertokensSessionRecipe.doesSessionExist()` after the redirect: returns `true`, Pinia state shows authenticated, cookies all present. Hard truth was that the guard ran during the race window.

## Fix
After the SDK probe, fall back to parsing the `sFrontToken` cookie directly. If its embedded session expiry (`up.exp`) is in the future, trust the cookie and set `sessionExists = true`. The SDK catches up; the next authenticated API call works normally (and refreshes if needed).

The cookie is the same `sFrontToken` the SDK itself writes/reads via its default `cookieHandler`, so this is just reading from the SDK's storage one frame earlier.

## Test plan
- [x] Local typecheck + lint + unit tests pass
- [x] Hot-deployed bundle to demo box, verified end-to-end:
  - Hard-nav to `/raven/dashboard` → stays
  - Hard-nav to `/raven/settings` → stays
  - Hard-nav to `/raven/api-keys` → stays
  - Authed `GET /raven/api/v1/orgs/:id` returns 200
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session persistence during hard reloads to prevent unexpected logouts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ravencloak-org/Raven/pull/673?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->