### PR TITLE
chore(ci): catch frontend lint errors in pre-push hook + fix NBSP

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
-# Verify every commit being pushed carries a Signed-off-by trailer.
-# Mirrors the .github DCO check so failures surface locally instead of in CI.
+# Verify every commit being pushed carries a Signed-off-by trailer AND,
+# when the push touches frontend/, that ESLint passes. Mirrors the
+# .github DCO + Frontend CI lint gates so failures surface locally
+# instead of in CI.
 #
 # Install once per clone:
 #   git config core.hooksPath .githooks
@@ -8,6 +10,49 @@
 set -euo pipefail
 
 zero='0000000000000000000000000000000000000000'
+
+# ── frontend lint gate ────────────────────────────────────────────────
+# Runs once per push if any commit being sent touches frontend/. CI's
+# Frontend CI workflow runs `npm run lint`, so any miss here lands as a
+# PR-blocking red check minutes later — annoying enough to be worth a
+# few seconds locally. Skipped if npm is unavailable (CI containers,
+# fresh checkouts before `npm install`).
+frontend_lint_if_needed() {
+    if ! command -v npm > /dev/null 2>&1; then
+        return 0
+    fi
+    if [ ! -d frontend ]; then
+        return 0
+    fi
+
+    # Collect every revision range from the push payload (stdin was already
+    # consumed by the DCO loop, so this is invoked separately below with the
+    # ranges captured into an array).
+    local touched=0
+    for range in "$@"; do
+        if git diff --name-only "$range" 2>/dev/null | grep -q '^frontend/'; then
+            touched=1
+            break
+        fi
+    done
+    if [ "$touched" -eq 0 ]; then
+        return 0
+    fi
+
+    echo "pre-push: running 'npm run lint' (frontend/ touched)..."
+    if ! (cd frontend && npm run --silent lint > /tmp/raven-pre-push-lint.log 2>&1); then
+        cat /tmp/raven-pre-push-lint.log >&2
+        cat >&2 <<'EOF'
+
+Refusing to push: frontend ESLint failed. Fix the errors above (or
+`cd frontend && npm run lint:fix` for the auto-fixable ones), commit
+the result, then re-push.
+EOF
+        return 1
+    fi
+}
+
+ranges=()
 
 while IFS=' ' read -r _local_ref local_sha _remote_ref remote_sha; do
     # Branch deletion — nothing to verify.
@@ -29,6 +74,7 @@ while IFS=' ' read -r _local_ref local_sha _remote_ref remote_sha; do
     else
         range="${remote_sha}..${local_sha}"
     fi
+    ranges+=("$range")
 
     missing=0
     while read -r sha; do
@@ -58,5 +104,9 @@ EOF
         exit 1
     fi
 done
+
+if [ "${#ranges[@]}" -gt 0 ]; then
+    frontend_lint_if_needed "${ranges[@]}"
+fi
 
 exit 0

--- a/frontend/src/components/billing/SeatUpgradePanel.vue
+++ b/frontend/src/components/billing/SeatUpgradePanel.vue
@@ -310,7 +310,7 @@ const proratedDisplay = computed(() => {
         :class="seatInputError ? 'text-amber-400' : 'text-transparent'"
         role="status"
       >
-        {{ seatInputError ?? ' ' }}
+        {{ seatInputError ?? '\u00A0' }}
       </p>
 
       <p v-if="plansError" class="mt-1 text-xs text-slate-500">


### PR DESCRIPTION
## Why
Frontend ESLint errors were only catching at the CI 'Frontend CI' job, blocking PRs minutes after push. Local pre-push only verified DCO sign-off. Surfaces the gate where it belongs (per CLAUDE.md: 'ALL linters must pass locally before every push').

## Changes
1. `frontend/src/components/billing/SeatUpgradePanel.vue:313` — replaced a raw NBSP (U+00A0) with the JS escape sequence ` `. Same rendered output, but ESLint's `no-irregular-whitespace` rule no longer trips. This was a pre-existing error blocking recent PRs.
2. `.githooks/pre-push` — runs `npm run lint` (cd frontend) when any commit in the push range touches `frontend/`. Skips silently when `npm` isn't available (CI containers, fresh checkouts).

## Test plan
- [x] Local `npm run lint` clean (0 errors, 3 unrelated warnings)
- [x] Verified hook fires + blocks on intentional lint break, passes on clean
- [x] Push of this branch ran the new hook