### PR TITLE
fix(release): drop --oidc-issuer for cosign v3 keyless signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -430,9 +430,11 @@ jobs:
         env:
           VERSION: ${{ needs.preflight.outputs.version }}
         run: |
+          # cosign v3 derives the OIDC issuer + Fulcio/Rekor URLs from the
+          # bundled Sigstore signing config; passing --oidc-issuer here
+          # trips "cannot specify service URLs and use signing config".
           cosign sign-blob \
             --yes \
-            --oidc-issuer=https://token.actions.githubusercontent.com \
             --output-signature "frontend-${VERSION}.tgz.sig" \
             --output-certificate "frontend-${VERSION}.tgz.pem" \
             "frontend-${VERSION}.tgz"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -93,7 +93,9 @@ signs:
     certificate: "${artifact}.pem"
     args:
       - "sign-blob"
-      - "--oidc-issuer=https://token.actions.githubusercontent.com"
+      # cosign v3 derives the OIDC issuer from the bundled Sigstore
+      # signing config; passing --oidc-issuer trips "cannot specify
+      # service URLs and use signing config" and fails the step.
       - "--output-certificate=${certificate}"
       - "--output-signature=${signature}"
       - "${artifact}"


### PR DESCRIPTION
## Why
cosign v3.0+ derives the OIDC issuer (plus Fulcio/Rekor URLs) from the bundled Sigstore signing config. Passing `--oidc-issuer` alongside it trips:

```
Error: cannot specify service URLs and use signing config
```

That blocked both **v0.3.0-rc1** and the **post-merge tag run** for *Go binaries* (.goreleaser.yaml sign-blob) and *Frontend bundle* (release.yml sign-blob).

## Changes
- `.goreleaser.yaml`: remove `--oidc-issuer=https://token.actions.githubusercontent.com` from the `signs[0].args` for the checksum file.
- `.github/workflows/release.yml`: same removal from the frontend bundle's `cosign sign-blob` step.

Both default to the same GHA OIDC issuer when omitted, so the keyless flow is functionally unchanged.

## Test plan
- [ ] CI green
- [ ] After landing, cut a fresh tag and confirm Go binaries + Frontend bundle complete (both should produce `.sig` + `.pem` artifacts)