### PR TITLE
fix(auth): populate users.email on first Google login via SuperTokens core lookup

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -983,7 +983,11 @@ func main() {
 	// relying on SessionMiddleware (cookies may not be available yet).
 	// Not registered in single-user mode — there is no sign-in flow.
 	demoJoiner := service.NewDemoOrgJoiner(orgSvc, wsSvc)
-	authHandler := handler.NewAuthHandler(userSvc, demoJoiner)
+	// authProvider already implements handler.EmailLookup (SuperTokens-backed
+	// ThirdParty user lookup) so we can pass it through. In single-user mode
+	// authProvider is the local stub which doesn't implement EmailLookup; the
+	// handler treats a nil lookup as "skip backfill" so this is safe either way.
+	authHandler := handler.NewAuthHandler(userSvc, demoJoiner, authProvider)
 	if !cfg.Server.SingleUser {
 		root.GET("/api/v1/auth/callback", middleware.Deadline(10*time.Second), func(c *gin.Context) {
 			info, err := authProvider.VerifySession(c.Request)

--- a/internal/auth/supertokens.go
+++ b/internal/auth/supertokens.go
@@ -1,11 +1,13 @@
 package auth
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 
 	"github.com/supertokens/supertokens-golang/recipe/session"
+	"github.com/supertokens/supertokens-golang/recipe/thirdparty"
 )
 
 // SuperTokensProvider implements AuthProvider using the SuperTokens Go SDK.
@@ -47,6 +49,26 @@ func (p *SuperTokensProvider) VerifySession(r *http.Request) (*SessionInfo, erro
 		Email:      email,
 		Name:       name,
 	}, nil
+}
+
+// LookupEmail resolves a user's email by their SuperTokens external ID via
+// the ThirdParty recipe's user record. Used by the auth callback handler to
+// backfill email on first login when the access-token payload is empty (the
+// default for Google signin). Returns an empty string + nil error when the
+// user has no email on record; returns a non-nil error only for transport /
+// SDK failures.
+func (p *SuperTokensProvider) LookupEmail(_ context.Context, externalID string) (string, error) {
+	if externalID == "" {
+		return "", fmt.Errorf("LookupEmail: empty external ID")
+	}
+	user, err := thirdparty.GetUserByID(externalID)
+	if err != nil {
+		return "", fmt.Errorf("thirdparty.GetUserByID(%s): %w", externalID, err)
+	}
+	if user == nil {
+		return "", nil
+	}
+	return user.Email, nil
 }
 
 // RevokeSession invalidates the session identified by the request's access token.

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -25,18 +25,41 @@ type DemoOrgJoiner interface {
 	JoinDemoOrg(ctx context.Context, userID string)
 }
 
+// EmailLookup is an optional dependency that fetches the user's email from the
+// auth provider's user record by external ID. Used as a fallback when the
+// session access-token payload doesn't carry an email — the default for
+// SuperTokens' ThirdParty (Google) signin, which doesn't bake claims into the
+// JWT. Implementations should return ("", error) on lookup failure so the
+// handler can fall back to creating the user with an empty email rather than
+// 500-ing the OAuth callback.
+type EmailLookup interface {
+	LookupEmail(ctx context.Context, externalID string) (string, error)
+}
+
 // AuthHandler handles authentication callback endpoints.
 type AuthHandler struct {
-	svc      AuthServicer
-	demoJoin DemoOrgJoiner
+	svc         AuthServicer
+	demoJoin    DemoOrgJoiner
+	emailLookup EmailLookup
 }
 
 // NewAuthHandler creates a new AuthHandler.
-// Pass optional DemoOrgJoiner instances (at most one) to enable auto-join on signup.
-func NewAuthHandler(svc AuthServicer, opts ...DemoOrgJoiner) *AuthHandler {
+//
+// Optional dependencies (zero or one of each):
+//   - DemoOrgJoiner: auto-joins new users to the demo org.
+//   - EmailLookup:   resolves the user's email from the auth provider's user
+//     record when the session claims don't include it (Google/ThirdParty).
+//
+// Detection is type-based, so callers can pass them in either order.
+func NewAuthHandler(svc AuthServicer, opts ...any) *AuthHandler {
 	h := &AuthHandler{svc: svc}
-	if len(opts) > 0 {
-		h.demoJoin = opts[0]
+	for _, opt := range opts {
+		switch v := opt.(type) {
+		case DemoOrgJoiner:
+			h.demoJoin = v
+		case EmailLookup:
+			h.emailLookup = v
+		}
 	}
 	return h
 }
@@ -57,6 +80,17 @@ func (h *AuthHandler) Callback(c *gin.Context) {
 	emailStr, _ := email.(string)
 	name, _ := c.Get(string(middleware.ContextKeyUserName))
 	nameStr, _ := name.(string)
+
+	// SuperTokens' ThirdParty (Google) signin doesn't include email in the
+	// access-token payload, so the middleware-populated emailStr is empty for
+	// Google logins. Fetch it from the SuperTokens core user record so newly
+	// created rows in our `users` table carry the email (used for emailing,
+	// audit logs, and the eventual /api/v1/me response).
+	if emailStr == "" && h.emailLookup != nil {
+		if resolved, err := h.emailLookup.LookupEmail(c.Request.Context(), externalIDStr); err == nil {
+			emailStr = resolved
+		}
+	}
 
 	// Check if user exists
 	user, err := h.svc.GetByExternalID(c.Request.Context(), externalIDStr)

--- a/internal/handler/auth_test.go
+++ b/internal/handler/auth_test.go
@@ -1,0 +1,136 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/ravencloak-org/Raven/internal/middleware"
+	"github.com/ravencloak-org/Raven/internal/model"
+	"github.com/ravencloak-org/Raven/pkg/apierror"
+)
+
+type stubAuthSvc struct {
+	getByExternalIDErr error
+	createdEmail       string
+	createdName        string
+	createdUser        *model.User
+}
+
+func (s *stubAuthSvc) GetByExternalID(_ context.Context, _ string) (*model.User, error) {
+	return nil, s.getByExternalIDErr
+}
+
+func (s *stubAuthSvc) Create(_ context.Context, _, email, name string) (*model.User, error) {
+	s.createdEmail = email
+	s.createdName = name
+	return s.createdUser, nil
+}
+
+type stubEmailLookup struct {
+	returnEmail string
+	err         error
+	calledWith  string
+}
+
+func (s *stubEmailLookup) LookupEmail(_ context.Context, externalID string) (string, error) {
+	s.calledWith = externalID
+	return s.returnEmail, s.err
+}
+
+func newCallbackCtx(externalID, email, name string) (*gin.Context, *httptest.ResponseRecorder) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/auth/callback", nil)
+	c.Set(string(middleware.ContextKeyExternalID), externalID)
+	c.Set(string(middleware.ContextKeyEmail), email)
+	c.Set(string(middleware.ContextKeyUserName), name)
+	return c, rec
+}
+
+// On Google ThirdParty signin the SuperTokens access-token payload doesn't
+// carry an email, so the handler-side EmailLookup fallback is what actually
+// populates users.email on first login. This test pins that wiring: when the
+// middleware-set email is empty and a new user is being created, the handler
+// must call EmailLookup and pass the resolved value through to svc.Create.
+func TestCallback_FallsBackToEmailLookupOnNewUserCreate(t *testing.T) {
+	svc := &stubAuthSvc{
+		getByExternalIDErr: apierror.NewNotFound("user not found"),
+		createdUser:        &model.User{ID: "user-1"},
+	}
+	lookup := &stubEmailLookup{returnEmail: "jobin@example.com"}
+	h := NewAuthHandler(svc, lookup)
+
+	c, rec := newCallbackCtx("st-user-abc", "", "Jobin Lawrance")
+	h.Callback(c)
+
+	if got, want := rec.Code, http.StatusOK; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+	if lookup.calledWith != "st-user-abc" {
+		t.Errorf("EmailLookup called with %q, want %q", lookup.calledWith, "st-user-abc")
+	}
+	if svc.createdEmail != "jobin@example.com" {
+		t.Errorf("svc.Create got email %q, want %q", svc.createdEmail, "jobin@example.com")
+	}
+	if svc.createdName != "Jobin Lawrance" {
+		t.Errorf("svc.Create got name %q, want %q", svc.createdName, "Jobin Lawrance")
+	}
+}
+
+// When the session claims already carry an email (e.g. SuperTokens custom
+// override is in use) we must NOT pay for the lookup round-trip.
+func TestCallback_SkipsLookupWhenEmailAlreadyInClaims(t *testing.T) {
+	svc := &stubAuthSvc{
+		getByExternalIDErr: apierror.NewNotFound("user not found"),
+		createdUser:        &model.User{ID: "user-1"},
+	}
+	lookup := &stubEmailLookup{returnEmail: "should-not-be-used@example.com"}
+	h := NewAuthHandler(svc, lookup)
+
+	c, _ := newCallbackCtx("st-user-abc", "in-claims@example.com", "")
+	h.Callback(c)
+
+	if lookup.calledWith != "" {
+		t.Errorf("EmailLookup should not have been called, but was called with %q", lookup.calledWith)
+	}
+	if svc.createdEmail != "in-claims@example.com" {
+		t.Errorf("svc.Create got email %q, want %q", svc.createdEmail, "in-claims@example.com")
+	}
+}
+
+// EmailLookup is optional — handler must keep working when it's not wired in
+// (e.g. unit tests, embedded deployments) and gracefully when the lookup
+// itself fails (transient SuperTokens core unreachable).
+func TestCallback_HandlesNilOrFailingEmailLookup(t *testing.T) {
+	tests := []struct {
+		name   string
+		lookup EmailLookup
+	}{
+		{name: "nil lookup", lookup: nil},
+		{name: "failing lookup", lookup: &stubEmailLookup{err: errors.New("core unreachable")}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := &stubAuthSvc{
+				getByExternalIDErr: apierror.NewNotFound("user not found"),
+				createdUser:        &model.User{ID: "user-1"},
+			}
+			h := NewAuthHandler(svc, tt.lookup)
+
+			c, rec := newCallbackCtx("st-user-abc", "", "")
+			h.Callback(c)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200", rec.Code)
+			}
+			if svc.createdEmail != "" {
+				t.Errorf("svc.Create email = %q, want empty (lookup unavailable)", svc.createdEmail)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem
Every Google signup landed in our `users` table with `email = ''`. The Callback handler reads email from the session payload (via `SessionMiddleware`), but SuperTokens' ThirdParty (Google) recipe doesn't embed provider claims into the access-token JWT — only `sub`, `iss`, `exp`, session bookkeeping. So our `extractSessionClaims` always returned an empty email for Google logins.

Downstream effects:
- Welcome mails (planned) have nowhere to send to
- Audit log identity is anonymous-looking
- The eventual `GET /api/v1/me` response is missing the canonical address

## Fix
When the session claims don't carry an email, look up the SuperTokens core's user record via `thirdparty.GetUserByID` and use the email from there.

### Wiring
- New optional `EmailLookup` interface on `AuthHandler` (mirrors the `DemoOrgJoiner` pattern — handler stays usable in tests where SuperTokens isn't running)
- `NewAuthHandler`'s opts becomes `...any` with a type-switch so callers can pass `DemoOrgJoiner` / `EmailLookup` in any order
- `SuperTokensProvider` implements the interface using the existing `thirdparty` recipe

## Cost
One extra SuperTokens-core call per **signin** (not per request). Negligible.

## Existing users
Not backfilled by this PR — affected rows get fixed organically the next time the user signs in. If a faster backfill is needed, a one-off SQL migration that pulls emails from the SuperTokens core's `thirdparty_users` table will do it.

## Test plan
- [x] Unit tests for: fallback fires when claims empty, lookup is skipped when claims have email, nil/failing lookup degrades gracefully (3 cases, ~0.8s)
- [x] `go vet` + `golangci-lint --new-from-rev=HEAD` clean
- [ ] CI green
- [ ] Sign in via Google on demo, check `users.email` is populated