### PR TITLE
fix(db): add web_page + web_site to source_type enum

### DIFF
--- a/migrations/00044_source_type_add_web_page_web_site.sql
+++ b/migrations/00044_source_type_add_web_page_web_site.sql
@@ -1,0 +1,28 @@
+-- +goose Up
+-- +goose NO TRANSACTION
+--
+-- Add 'web_page' and 'web_site' to the source_type enum so URL sources
+-- can be created. The Go model (internal/model/source.go) and the
+-- frontend (frontend/src/api/knowledge-bases.ts) both send 'web_page'
+-- when a user enters a single URL via the add-source UI; without this
+-- enum extension the insert fails with:
+--
+--   ERROR: invalid input value for enum source_type: "web_page"
+--   (SQLSTATE 22P02)
+--
+-- Postgres requires ALTER TYPE ADD VALUE to run outside any transaction
+-- (hence the NO TRANSACTION directive above). IF NOT EXISTS makes the
+-- migration idempotent so re-running against a partially-migrated DB
+-- is safe.
+ALTER TYPE source_type ADD VALUE IF NOT EXISTS 'web_page';
+ALTER TYPE source_type ADD VALUE IF NOT EXISTS 'web_site';
+
+-- +goose Down
+-- +goose NO TRANSACTION
+--
+-- Postgres has no ALTER TYPE ... REMOVE VALUE; rolling back the enum
+-- would require recreating the type and rewriting every column that
+-- references it. The risk-reward isn't worth it for an additive change,
+-- so the Down is a no-op. If a true rollback is ever needed, drop the
+-- sources table or write a bespoke rebuild migration.
+SELECT 1;


### PR DESCRIPTION
## Problem
DB enum `source_type` was `('url', 'sitemap', 'rss_feed')` but `internal/model/source.go` exposes `('web_page', 'web_site', 'sitemap', 'rss_feed')`. The frontend (since #668 / 91001ee6) sends `source_type: 'web_page'` when a user adds a single-URL source, and the insert fails with:

```
ERROR: invalid input value for enum source_type: "web_page" (SQLSTATE 22P02)
```

Caught via end-to-end Playwright smoke against the demo box: KB list / KB create / document upload were all green, but URL source add was completely broken.

## Fix
`migrations/00044_source_type_add_web_page_web_site.sql`:

```sql
ALTER TYPE source_type ADD VALUE IF NOT EXISTS 'web_page';
ALTER TYPE source_type ADD VALUE IF NOT EXISTS 'web_site';
```

- `+goose NO TRANSACTION` — Postgres requires `ALTER TYPE ... ADD VALUE` outside a transaction.
- `IF NOT EXISTS` — idempotent re-run safety.
- Down is a no-op (Postgres has no `ADD VALUE` inverse; additive change carries no risk worth a destructive rebuild migration).

## Test plan
- [x] `go test ./migrations/...` passes (full apply + rollback test)
- [x] Applied directly on demo box; URL source POST now returns 201 (was 500)
- [ ] CI green