### PR TITLE
fix(api): set Cache-Control: no-store on every /api/v1 response

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -609,6 +609,13 @@ func main() {
 	// WriteTimeout. Endpoints without their own Deadline are bounded by
 	// WriteTimeout — acceptable for default-CRUD route groups.
 	api := root.Group("/api/v1")
+	// Mark every /api/v1 response as non-cacheable. Without this, browsers
+	// and shared HTTP caches pin authenticated GET responses (list endpoints
+	// in particular) and serve stale state after writes — caught by an
+	// end-to-end Playwright trace showing GET .../documents returning total=1
+	// while the DB had two rows. Must be installed before the body-producing
+	// middleware so the headers ship on every code path.
+	api.Use(middleware.NoStoreAPI())
 
 	// Single-user mode: inject synthetic local session without SuperTokens.
 	// Multi-user mode: verify session via SuperTokens and resolve DB user.

--- a/internal/middleware/nocache.go
+++ b/internal/middleware/nocache.go
@@ -1,0 +1,33 @@
+package middleware
+
+import "github.com/gin-gonic/gin"
+
+// NoStoreAPI marks API responses as private and non-cacheable so browsers,
+// shared HTTP caches, and Cloudflare edge cannot serve stale authenticated
+// data.
+//
+// Without this header browsers cache the response for any URL whose method
+// is GET (their default heuristic), which makes "list" endpoints return
+// stale results after the user creates / uploads / deletes through the same
+// SPA session. End-to-end Playwright traces against the demo box showed
+// GET .../knowledge-bases/:id/documents returning total=1 when the DB had
+// two rows because the first response had been pinned in the browser's
+// disk cache (same cf-ray on second hit).
+//
+// The header set mirrors what most JSON APIs recommend:
+//
+//	Cache-Control: no-store, max-age=0, private, must-revalidate
+//	Pragma: no-cache
+//	Expires: 0
+//
+// HTTP/1.1 clients honour Cache-Control; the other two are belt-and-braces
+// for older intermediaries that fall back to legacy directives.
+func NoStoreAPI() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		h := c.Writer.Header()
+		h.Set("Cache-Control", "no-store, max-age=0, private, must-revalidate")
+		h.Set("Pragma", "no-cache")
+		h.Set("Expires", "0")
+		c.Next()
+	}
+}

--- a/internal/middleware/nocache_test.go
+++ b/internal/middleware/nocache_test.go
@@ -1,0 +1,41 @@
+package middleware_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/ravencloak-org/Raven/internal/middleware"
+)
+
+// NoStoreAPI is mounted on every /api/v1 endpoint to keep authed JSON
+// responses out of the browser and shared HTTP caches. Pins the exact header
+// set so we can't silently weaken it later (e.g. someone setting just
+// "no-cache" which still allows storage with revalidation).
+func TestNoStoreAPI_SetsAllCacheBlockingHeaders(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(middleware.NoStoreAPI())
+	r.GET("/ping", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/ping", nil)
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	want := map[string]string{
+		"Cache-Control": "no-store, max-age=0, private, must-revalidate",
+		"Pragma":        "no-cache",
+		"Expires":       "0",
+	}
+	for k, v := range want {
+		if got := rec.Header().Get(k); got != v {
+			t.Errorf("header %s = %q, want %q", k, got, v)
+		}
+	}
+}


### PR DESCRIPTION
## Problem
Authenticated GET responses carried no `Cache-Control` header, so browsers (and shared HTTP caches) pinned them by default. Caught via end-to-end Playwright trace against the demo box:

```
GET .../documents                    → total: 1  (DB actually has 2 rows; browser cache hit, same cf-ray on retries)
GET .../documents?nocache=<ts>       → total: 2  (cache miss → origin)
```

This is **broader than document listing** — every list/get endpoint under `/api/v1` was vulnerable to:
1. Stale UI state after the SPA wrote / uploaded / deleted in the same session
2. Sensitive responses sticking in shared browser caches (multi-user laptop, etc.)

## Fix
Tiny `NoStoreAPI` middleware mounted on `api.Group("/api/v1")` before everything else, so the headers ship on every code path (including 401s, error returns, single-user mode):

```
Cache-Control: no-store, max-age=0, private, must-revalidate
Pragma: no-cache
Expires: 0
```

Unit test pins the exact header set to prevent silent weakening (e.g. someone setting just `no-cache` which still allows storage with revalidation).

## Test plan
- [x] `go test ./internal/middleware/... -run TestNoStoreAPI` passes
- [x] `go vet` + `golangci-lint --new-from-rev=HEAD` clean
- [ ] CI green
- [ ] Post-merge on demo: confirm `Cache-Control: no-store` shows up on `GET /raven/api/v1/...`, and the documents list reports the correct total without `?nocache=` hacks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API responses now include cache-control headers to prevent browsers and shared HTTP caches from serving stale content, ensuring authenticated requests always receive fresh data.

* **Tests**
  * Added tests to verify cache-blocking headers are correctly applied to all API responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ravencloak-org/Raven/pull/678?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->