### PR TITLE
feat: tiered DB devops — VerifyMigrationsState + squawk PR review (Plan A)

### DIFF
--- a/.github/workflows/sql-review-selftest.yml
+++ b/.github/workflows/sql-review-selftest.yml
@@ -1,0 +1,46 @@
+name: SQL Review Policy Self-Test
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.squawk.toml'
+      - '.squawk/fixtures/**'
+      - '.github/workflows/sql-review-selftest.yml'
+  pull_request:
+    paths:
+      - '.squawk.toml'
+      - '.squawk/fixtures/**'
+      - '.github/workflows/sql-review-selftest.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  policy-selftest:
+    name: Squawk fires on banned fixtures
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run squawk against banned fixtures (must fail)
+        id: lint
+        continue-on-error: true
+        uses: sbdchd/squawk-action@v2
+        with:
+          pattern: '.squawk/fixtures/bad/*.sql'
+          version: 'latest'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Assert squawk rejected the fixtures
+        if: steps.lint.outcome == 'success'
+        run: |
+          echo "::error::Squawk did NOT reject the banned fixtures."
+          echo "Either the fixtures no longer match a rule, or .squawk.toml has weakened."
+          echo "Inspect .squawk/fixtures/bad/*.sql and .squawk.toml."
+          exit 1
+
+      - name: Confirm squawk fired
+        if: steps.lint.outcome == 'failure'
+        run: echo "Squawk correctly rejected the banned fixtures."

--- a/.github/workflows/sql-review.yml
+++ b/.github/workflows/sql-review.yml
@@ -1,0 +1,28 @@
+name: SQL Review
+
+on:
+  pull_request:
+    paths:
+      - 'migrations/**'
+      - '.squawk.toml'
+      - '.github/workflows/sql-review.yml'
+
+permissions:
+  contents: read
+  pull-requests: write  # squawk-action posts inline review comments
+
+jobs:
+  sql-review:
+    name: Squawk migration lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+
+      - name: Lint migrations with squawk
+        uses: sbdchd/squawk-action@v2
+        with:
+          pattern: 'migrations/*.sql'
+          version: 'latest'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sql-review.yml
+++ b/.github/workflows/sql-review.yml
@@ -9,20 +9,36 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write  # squawk-action posts inline review comments
+  pull-requests: write
 
 jobs:
   sql-review:
     name: Squawk migration lint
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout PR head
+      - name: Checkout full history (needed for diff vs base)
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Lint migrations with squawk
+      - name: Collect migrations modified in this PR
+        id: changed
+        run: |
+          modified="$(git diff --diff-filter=d --name-only \
+            origin/${GITHUB_BASE_REF}...origin/${GITHUB_HEAD_REF} \
+            -- 'migrations/*.sql' | tr '\n' ' ')"
+          echo "Modified migrations: ${modified:-<none>}"
+          echo "files=${modified}" >> "$GITHUB_OUTPUT"
+
+      - name: Skip if no migrations modified
+        if: steps.changed.outputs.files == ''
+        run: echo "No migrations changed in this PR — nothing to lint."
+
+      - name: Lint modified migrations with squawk
+        if: steps.changed.outputs.files != ''
         uses: sbdchd/squawk-action@v2
         with:
-          pattern: 'migrations/*.sql'
+          files: ${{ steps.changed.outputs.files }}
           version: 'latest'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.squawk.toml
+++ b/.squawk.toml
@@ -1,0 +1,20 @@
+# Squawk config — Postgres migration linter.
+# Triggered by .github/workflows/sql-review.yml on PRs touching migrations/.
+# Local equivalent: `make sql-lint-local`.
+
+# Goose wraps each `-- +goose Up` migration in a transaction. Lint rules that
+# care about transactional context (e.g. require-concurrent-index-creation)
+# need this hint to evaluate correctly.
+assume_in_transaction = true
+
+# Match Raven's runtime Postgres version so version-gated rules
+# (e.g. prefer-identity, prefer-bigint-over-int) lint against the right
+# capabilities.
+pg_version = "18.0"
+
+# Use squawk's default-on ruleset for all PR checks. Add rules to
+# excluded_rules below ONLY when there is a documented project-level
+# reason (e.g. an existing pattern that the codebase already follows
+# and is intentionally OK with). Per-statement exceptions belong in the
+# migration file as `-- squawk-ignore <rule>` comments, not here.
+excluded_rules = []

--- a/.squawk/fixtures/bad/00001_drop_table.sql
+++ b/.squawk/fixtures/bad/00001_drop_table.sql
@@ -1,0 +1,4 @@
+-- +goose Up
+-- Intentionally violates ban-drop-table. Used by
+-- .github/workflows/sql-review-selftest.yml to verify the rule fires.
+DROP TABLE IF EXISTS chunks;

--- a/.squawk/fixtures/bad/00002_adding_required_field.sql
+++ b/.squawk/fixtures/bad/00002_adding_required_field.sql
@@ -1,0 +1,4 @@
+-- +goose Up
+-- Intentionally violates adding-required-field: adds a NOT NULL column
+-- to an existing table with no default value — would break existing rows.
+ALTER TABLE users ADD COLUMN email_verified boolean NOT NULL;

--- a/.squawk/fixtures/bad/00003_blocking_index.sql
+++ b/.squawk/fixtures/bad/00003_blocking_index.sql
@@ -1,0 +1,4 @@
+-- +goose Up
+-- Intentionally violates require-concurrent-index-creation: blocking
+-- CREATE INDEX on a populated table prevents concurrent writes.
+CREATE INDEX idx_sources_workspace ON sources (workspace_id);

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-cover run dev test test-integration bench-integration coverage coverage-unit coverage-integration coverage-html coverage-clean lint migrate-up migrate-down proto swagger compose compose-down
+.PHONY: build build-cover run dev test test-integration bench-integration coverage coverage-unit coverage-integration coverage-html coverage-clean lint migrate-up migrate-down proto swagger compose compose-down sql-lint-local
 
 build:
 	go build -o bin/api ./cmd/api
@@ -67,3 +67,7 @@ compose:
 compose-down:
 	@if [ -f ./.env.keys ]; then set -a; . ./.env.keys; set +a; fi; \
 	docker compose down
+
+sql-lint-local:
+	@echo "Running squawk against migrations/*.sql ..."
+	@npx --yes squawk-cli@latest 'migrations/*.sql'

--- a/Makefile
+++ b/Makefile
@@ -69,5 +69,11 @@ compose-down:
 	docker compose down
 
 sql-lint-local:
-	@echo "Running squawk against migrations/*.sql ..."
-	@npx --yes squawk-cli@latest 'migrations/*.sql'
+	@base=$$(git merge-base HEAD origin/main 2>/dev/null || echo HEAD~); \
+	files=$$(git diff --diff-filter=d --name-only $$base...HEAD -- 'migrations/*.sql' | tr '\n' ' '); \
+	if [ -z "$$files" ]; then \
+		echo "No migrations modified vs origin/main — nothing to lint."; \
+	else \
+		echo "Linting modified migrations: $$files"; \
+		npx --yes squawk-cli@latest $$files; \
+	fi

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -272,6 +272,15 @@ func main() {
 		slog.Info("database migrations applied")
 	}
 
+	// Always verify migration state, regardless of profile. In edge mode this
+	// confirms RunMigrations applied everything; in cloud mode (AutoMigrate=false)
+	// this gates startup on the out-of-band migrator having finished. The error
+	// is fatal — surface it loudly rather than serving traffic against a stale
+	// schema.
+	if err := db.VerifyMigrationsState(context.Background(), cfg.Database.URL); err != nil {
+		log.Fatalf("verify migration state: %v", err)
+	}
+
 	// --- Database pool ---
 	pool, err := db.New(context.Background(), cfg.Database.URL)
 	if err != nil {

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -272,11 +272,7 @@ func main() {
 		slog.Info("database migrations applied")
 	}
 
-	// Always verify migration state, regardless of profile. In edge mode this
-	// confirms RunMigrations applied everything; in cloud mode (AutoMigrate=false)
-	// this gates startup on the out-of-band migrator having finished. The error
-	// is fatal — surface it loudly rather than serving traffic against a stale
-	// schema.
+	// Fatal: ensures schema matches before serving traffic.
 	if err := db.VerifyMigrationsState(context.Background(), cfg.Database.URL); err != nil {
 		log.Fatalf("verify migration state: %v", err)
 	}

--- a/docs/runbooks/migrations.md
+++ b/docs/runbooks/migrations.md
@@ -1,0 +1,96 @@
+# Migrations Runbook
+
+## How migrations work in Raven
+
+- **Source-of-truth:** `migrations/NNNNN_<name>.sql`, applied by `pressly/goose v3`.
+- **Embedding:** the API binary embeds `migrations/` at build time (`migrations/embed.go`). Operators do not ship the SQL files separately.
+- **Apply path (today):** edge profile sets `RAVEN_DB_AUTO_MIGRATE=true` (default); `db.RunMigrations` applies pending migrations at startup.
+- **Apply path (cloud, Plan B):** `RAVEN_DB_AUTO_MIGRATE=false`; an out-of-band migrator (Bytebase server, introduced in Plan B) applies migrations through a `dev → staging → prod` pipeline with human approval at the prod stage.
+- **Startup safety check:** `db.VerifyMigrationsState` ALWAYS runs after `RunMigrations`. It compares the count of distinct currently-applied versions in `goose_db_version` (latest row per `version_id`) with the count of embedded `*.sql` files. Mismatch → `log.Fatalf` → process exits → `/readyz` stays red. This gates the cloud profile on its out-of-band migrator catching up; on edge it is belt-and-braces.
+
+## Authoring a migration
+
+1. Create `migrations/NNNNN_<descriptive_name>.sql`. `NNNNN` is the next sequential 5-digit prefix.
+2. Use the `-- +goose Up` directive at the top. **No down migrations** — rollbacks happen via a new forward migration or `pgBackRest` restore.
+3. Run the local lint before pushing:
+
+   ```bash
+   make sql-lint-local
+   ```
+
+   This runs squawk against the migrations modified on your branch versus `origin/main` — same files CI will lint on your PR.
+
+4. Open a PR. The **SQL Review** GitHub Actions check runs `squawk` against the modified migrations and posts inline review comments on findings. Findings fail the check → PR cannot merge until resolved.
+
+## The SQL review check
+
+- **Workflow:** `.github/workflows/sql-review.yml`
+- **Engine:** `sbdchd/squawk-action@v2` (server-less, downloads the `squawk` CLI binary in CI)
+- **Config:** `.squawk.toml` at repo root (`assume_in_transaction=true`, `pg_version=18.0`, default ruleset)
+- **Scope:** lints only migrations **modified in the current PR** (diff-based selection vs the PR base). Pre-existing migrations are NOT re-linted, mirroring this repo's `golangci-lint --new-from-rev=HEAD` convention.
+
+The pre-existing backlog (271 findings across the 43 shipped migrations under squawk's default ruleset) is tracked in the design spec at `docs/superpowers/specs/2026-05-23-bytebase-tiered-design.md`. It will be paid down incrementally — do NOT bundle backlog cleanup into unrelated PRs.
+
+### Escape hatch — intentional rule violation
+
+Some legitimate migrations need an operation squawk would normally flag (e.g. dropping a column after a multi-PR deprecation, or doing a small `CREATE INDEX` synchronously on a table guaranteed to be empty at apply time).
+
+Per-statement override is an inline comment immediately before the offending SQL:
+
+```sql
+-- +goose Up
+-- Removes the legacy zitadel_users mirror table; superseded by SuperTokens
+-- session storage in migration 00037. Confirmed empty in prod via Bytebase
+-- before this PR; see ADR-2026-05-12 for the full sequence.
+-- squawk-ignore ban-drop-table
+DROP TABLE zitadel_users;
+```
+
+- The `-- squawk-ignore <rule-name>` comment skips that one rule for the next statement.
+- Multiple rules in one comment: `-- squawk-ignore ban-drop-column, renaming-column`.
+- File-wide skip is supported (`-- squawk-ignore-file <rule>`) but use sparingly — it removes a guard rail for everything in that file.
+- **Reviewer responsibility:** every `squawk-ignore` line in a PR diff requires explicit reviewer attention. Look at the comment immediately above for the rationale. If it's not justified, reject the PR.
+
+### Policy self-test
+
+`.github/workflows/sql-review-selftest.yml` runs squawk against `.squawk/fixtures/bad/*.sql` and asserts the rules fire. If a future PR weakens `.squawk.toml` (e.g. adds a default-on rule to `excluded_rules`), the self-test fails — catching the regression at PR time.
+
+The fixtures intentionally violate `ban-drop-table`, `adding-required-field`, and `require-concurrent-index-creation`. They are NOT real migrations and are not under the `migrations/` directory.
+
+## Recovery from a failed migration
+
+### Edge profile
+
+If `RunMigrations` fails:
+
+1. The `cmd/api` process exits non-zero. The operator sees the goose error in the API logs.
+2. Restore the database from the last pre-migration `pgBackRest` base backup + WAL replay up to the LSN immediately before the failed migration's `BEGIN`. Detailed procedure: `docs/runbooks/demo-restore.md`.
+3. Fix the migration in a new PR.
+4. Re-deploy.
+
+If `RunMigrations` succeeds but `VerifyMigrationsState` fails:
+
+- This indicates an embedded-file count vs `goose_db_version` mismatch. Most likely cause: a partial restore from backup that left `goose_db_version` out of sync.
+- Inspect `goose_db_version` (`SELECT version_id, is_applied, tstamp FROM goose_db_version ORDER BY id`).
+- Run `goose status` against the live DB using the on-disk migrations directory (not the embed) for a side-by-side view.
+- Resolve by either re-applying missed migrations through `goose up` or restoring further back via `pgBackRest`.
+
+### Cloud profile (planned, Plan B)
+
+Bytebase marks the migration Issue `FAILED` and halts the dev/staging/prod pipeline. The DBA inspects the SQL in the Bytebase UI, fixes it (either via a hotfix issue in Bytebase or by raising a forward-fix PR), and retries the stage. The affected tenant's `cmd/api` pods stay on the old version because `/readyz` stays red while `VerifyMigrationsState` fails. Other tenants are unaffected.
+
+## Required CI checks (branch protection)
+
+The following job must be a required status check on `main`:
+
+- `Squawk migration lint` (the `sql-review` job in `.github/workflows/sql-review.yml`)
+
+This is configured manually under **Settings → Branches → Branch protection rules → main → Require status checks to pass before merging**. Add the check name above. The check is registered with GitHub only after the workflow has run at least once.
+
+## References
+
+- Design spec: `docs/superpowers/specs/2026-05-23-bytebase-tiered-design.md`
+- Implementation plan: `docs/superpowers/plans/2026-05-23-bytebase-tiered-plan-a.md`
+- Squawk rules reference: https://squawkhq.com/docs/rules
+- Squawk CLI: https://squawkhq.com/docs/cli
+- pgBackRest restore: `docs/runbooks/demo-restore.md`

--- a/docs/superpowers/plans/2026-05-23-bytebase-tiered-plan-a.md
+++ b/docs/superpowers/plans/2026-05-23-bytebase-tiered-plan-a.md
@@ -1,0 +1,730 @@
+# Bytebase Tiered Adoption — Plan A: PR-time SQL Review + Edge Readiness
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the ship-anywhere half of the Bytebase tiered adoption — PR-time SQL Review action against `migrations/*.sql`, plus a `VerifyMigrationsState` startup check that gates `cmd/api` readiness. No Bytebase server runtime is introduced. This delivers value to both edge and cloud profiles today.
+
+**Architecture:** Two coordinated changes. (1) A new Go function `db.VerifyMigrationsState` compares `count(goose_db_version where is_applied=true and version_id>0)` against the count of embedded `*.sql` files; called unconditionally from `cmd/api/main.go` after the existing `RunMigrations` block. (2) A new GitHub Actions workflow runs `bytebase/sql-review-action` against PR diffs touching `migrations/**`, using a policy at `.bytebase/sql-review.json`. A self-test workflow exercises the policy against intentionally-bad fixtures so regressions in the rules surface immediately.
+
+**Tech Stack:** Go 1.x, `github.com/pressly/goose/v3`, `github.com/lib/pq`, `github.com/testcontainers/testcontainers-go`, `github.com/stretchr/testify/require`, GitHub Actions, `bytebase/sql-review-action` (v1), JSON policy file.
+
+**Source spec:** `docs/superpowers/specs/2026-05-23-bytebase-tiered-design.md`
+
+**Out of scope for Plan A (deferred to Plan B):** Bytebase server deployment, VCS provider config, dev→staging→prod pipeline, drift detection, Layer 3 & 4 integration tests, history-table override on cloud DBs, SSO integration. Plan B will be written when cloud-profile orchestration choices (Helm vs compose, SSO domain) are settled.
+
+---
+
+## File Structure
+
+| File | Purpose | Action |
+|---|---|---|
+| `internal/db/migrate.go` | Add `VerifyMigrationsState` next to `RunMigrations` | Modify |
+| `internal/db/migrate_test.go` | New unit + integration tests for `VerifyMigrationsState` | Create |
+| `cmd/api/main.go` | Call `VerifyMigrationsState` after the existing migration block | Modify |
+| `.bytebase/sql-review.json` | SQL review policy (rules + severities) | Create |
+| `.bytebase/fixtures/bad/00001_dropped_table_no_label.sql` | Self-test fixture: destructive op without label | Create |
+| `.bytebase/fixtures/bad/00002_pascal_case_column.sql` | Self-test fixture: naming violation | Create |
+| `.bytebase/fixtures/bad/00003_truncate_in_migration.sql` | Self-test fixture: banned TRUNCATE | Create |
+| `.github/workflows/sql-review.yml` | PR-time SQL review job | Create |
+| `.github/workflows/sql-review-selftest.yml` | Push-to-main self-test of the policy | Create |
+| `Makefile` | Add `sql-review-local` target | Modify |
+| `docs/runbooks/migrations.md` | Migration SOP — authoring, escape-hatch label, troubleshooting | Create |
+
+**Decomposition rationale:** `migrate.go` already owns the goose runner; `VerifyMigrationsState` is the natural sibling. Workflow self-test lives in its own file so its trigger (push-to-main) doesn't muddy the PR-time workflow. Fixtures live under `.bytebase/fixtures/` so they're discoverable next to the policy and obviously not real migrations.
+
+---
+
+## Task 1: Add `VerifyMigrationsState` (TDD)
+
+**Files:**
+- Modify: `internal/db/migrate.go`
+- Create: `internal/db/migrate_test.go`
+
+The function counts applied migrations in `goose_db_version` (excluding goose's seed row at `version_id=0`) and compares against the count of `*.sql` files embedded by `migrations.FS`. Mismatch returns a descriptive error.
+
+- [ ] **Step 1: Write the failing test for the happy path**
+
+Create `internal/db/migrate_test.go`:
+
+```go
+package db_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ravencloak-org/Raven/internal/db"
+	"github.com/ravencloak-org/Raven/internal/testutil"
+)
+
+func TestVerifyMigrationsState_AllAppliedPasses(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// NewTestDB spins up Postgres + pgvector and runs every migration in
+	// migrations/*.sql via goose.UpContext. After it returns, goose_db_version
+	// should hold one row per file (plus the seed row at version_id=0).
+	pool := testutil.NewTestDB(t)
+	dsn := pool.Config().ConnString()
+
+	require.NoError(t, db.VerifyMigrationsState(ctx, dsn))
+}
+```
+
+- [ ] **Step 2: Run the test, verify it fails to compile (function does not exist)**
+
+Run: `go test ./internal/db/... -run TestVerifyMigrationsState_AllAppliedPasses -v`
+Expected: build error `undefined: db.VerifyMigrationsState`
+
+- [ ] **Step 3: Implement `VerifyMigrationsState` in `internal/db/migrate.go`**
+
+Append below `RunMigrations`:
+
+```go
+// VerifyMigrationsState confirms the database has applied exactly the set of
+// migrations embedded in the binary. It is cheap (one COUNT(*) plus a directory
+// walk of migrations.FS) and runs at startup in both edge and cloud profiles.
+//
+// In the edge profile this is a belt-and-braces check that RunMigrations did
+// what it claimed. In the cloud profile (AutoMigrate=false, Bytebase applies
+// migrations out-of-band) it gates /readyz: pods stay un-ready until Bytebase
+// has caught up. Returning an error here surfaces a clear mismatch instead of
+// silently serving traffic against a stale schema.
+//
+// Goose seeds the version table with version_id=0 on first use; that row is
+// excluded from the applied count.
+func VerifyMigrationsState(ctx context.Context, databaseURL string) error {
+	sqlDB, err := sql.Open("postgres", databaseURL)
+	if err != nil {
+		return fmt.Errorf("open postgres for verify: %w", err)
+	}
+	defer func() { _ = sqlDB.Close() }()
+
+	if err := sqlDB.PingContext(ctx); err != nil {
+		return fmt.Errorf("ping postgres for verify: %w", err)
+	}
+
+	var appliedCount int
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM goose_db_version WHERE is_applied = true AND version_id > 0`,
+	).Scan(&appliedCount); err != nil {
+		return fmt.Errorf("count goose_db_version: %w", err)
+	}
+
+	expectedCount, err := countEmbeddedMigrations()
+	if err != nil {
+		return fmt.Errorf("count embedded migrations: %w", err)
+	}
+
+	if appliedCount != expectedCount {
+		return fmt.Errorf(
+			"migration state mismatch: %d applied in goose_db_version, %d expected from embedded migrations",
+			appliedCount, expectedCount,
+		)
+	}
+	return nil
+}
+
+func countEmbeddedMigrations() (int, error) {
+	entries, err := fs.ReadDir(migrations.FS, ".")
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".sql") {
+			count++
+		}
+	}
+	return count, nil
+}
+```
+
+Add the new imports to the existing `import ( ... )` block in `migrate.go`:
+
+```go
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"io/fs"      // NEW
+	"strings"    // NEW
+
+	_ "github.com/lib/pq"
+	"github.com/pressly/goose/v3"
+
+	"github.com/ravencloak-org/Raven/migrations"
+)
+```
+
+- [ ] **Step 4: Run the happy-path test, verify it passes**
+
+Run: `go test ./internal/db/... -run TestVerifyMigrationsState_AllAppliedPasses -v`
+Expected: PASS
+
+- [ ] **Step 5: Add the failing-path test — manually corrupt goose_db_version, expect mismatch error**
+
+Append to `internal/db/migrate_test.go`:
+
+```go
+func TestVerifyMigrationsState_MismatchReturnsError(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	pool := testutil.NewTestDB(t)
+	dsn := pool.Config().ConnString()
+
+	// Delete one applied row to simulate a partial restore / manual edit.
+	_, err := pool.Exec(ctx,
+		`DELETE FROM goose_db_version WHERE version_id = (
+			SELECT MAX(version_id) FROM goose_db_version WHERE is_applied = true
+		)`,
+	)
+	require.NoError(t, err)
+
+	err = db.VerifyMigrationsState(ctx, dsn)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "migration state mismatch")
+}
+```
+
+- [ ] **Step 6: Run both tests, verify both pass**
+
+Run: `go test ./internal/db/... -run TestVerifyMigrationsState -v`
+Expected: 2 tests, both PASS.
+
+- [ ] **Step 7: Run repo-wide lint**
+
+Run: `golangci-lint run --new-from-rev=HEAD ./internal/db/...`
+Expected: no new issues. (Per CLAUDE.md, only newly-introduced violations are flagged.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/db/migrate.go internal/db/migrate_test.go
+git commit -s -m "feat(db): add VerifyMigrationsState startup check
+
+Adds a cheap COUNT(*) + embed.FS scan that confirms the DB has applied
+exactly the set of migrations the binary ships with. Returns a clear
+mismatch error on divergence so /readyz can keep traffic off pods that
+booted before an out-of-band migrator (Bytebase, in cloud profile)
+caught up.
+
+Two tests exercise the happy path and a forced-mismatch."
+```
+
+---
+
+## Task 2: Wire `VerifyMigrationsState` into `cmd/api/main.go`
+
+**Files:**
+- Modify: `cmd/api/main.go`
+
+`VerifyMigrationsState` must run on every startup regardless of `AutoMigrate`. In edge mode it confirms goose's work; in cloud mode it gates readiness on Bytebase having applied pending migrations.
+
+- [ ] **Step 1: Read the current shape of the migration block in `cmd/api/main.go`**
+
+Run: `grep -n -A2 -B1 'RunMigrations\|AutoMigrate' cmd/api/main.go`
+Expected: lines showing the existing `if cfg.Database.AutoMigrate { … RunMigrations … }` block. Note the exact surrounding context so the edit lands cleanly.
+
+- [ ] **Step 2: Add the `VerifyMigrationsState` call immediately after the existing migration block**
+
+After the closing `}` of the `if cfg.Database.AutoMigrate { … }` block, insert:
+
+```go
+// Always verify migration state, regardless of profile. In edge mode this
+// confirms RunMigrations applied everything; in cloud mode (AutoMigrate=false)
+// this gates startup on the out-of-band migrator having finished. The error
+// is fatal — surface it loudly rather than serving traffic against a stale
+// schema.
+if err := db.VerifyMigrationsState(ctx, cfg.Database.URL); err != nil {
+	return fmt.Errorf("verify migration state: %w", err)
+}
+```
+
+Confirm `db` and `fmt` are already imported by the file (they are, since `RunMigrations` lives in the same package and is already called here).
+
+- [ ] **Step 3: Build the binary**
+
+Run: `go build ./cmd/api`
+Expected: exits 0 with no output.
+
+- [ ] **Step 4: Run repo-wide lint**
+
+Run: `golangci-lint run --new-from-rev=HEAD ./cmd/api/...`
+Expected: no new issues.
+
+- [ ] **Step 5: Existing integration tests should still pass**
+
+Run: `go test -tags=integration ./internal/integration/... -run 'Migration' -v`
+Expected: existing migration integration tests PASS — the verify call after the existing block is additive and `NewTestDB` already runs all migrations.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/api/main.go
+git commit -s -m "feat(api): gate startup on VerifyMigrationsState
+
+Calls VerifyMigrationsState after the existing RunMigrations block on
+every boot. In edge mode this is belt-and-braces; in cloud mode it is
+the primary defence against a pod coming up before Bytebase finishes
+applying pending migrations."
+```
+
+---
+
+## Task 3: Create the SQL review policy
+
+**Files:**
+- Create: `.bytebase/sql-review.json`
+
+The policy encodes the ten rules listed in the design spec. Bytebase's policy schema is documented at <https://www.bytebase.com/docs/sql-review/review-rules>; the rule IDs below are stable since v1.
+
+- [ ] **Step 1: Create `.bytebase/sql-review.json` with the initial policy**
+
+```json
+{
+  "name": "raven-sql-review",
+  "engine": "POSTGRES",
+  "rules": [
+    { "type": "naming.column",                       "level": "ERROR",   "payload": { "format": "^[a-z][a-z0-9_]*$", "maxLength": 63 } },
+    { "type": "column.required",                     "level": "WARNING", "payload": { "list": ["created_at", "updated_at"] } },
+    { "type": "column.no-null",                      "level": "ERROR",   "payload": { "list": ["id", "tenant_id", "workspace_id", "user_id"] } },
+    { "type": "statement.disallow-commit",           "level": "ERROR" },
+    { "type": "statement.disallow-truncate",         "level": "ERROR" },
+    { "type": "statement.disallow-rm-tbl-cascade",   "level": "ERROR" },
+    { "type": "statement.add-column-without-default","level": "WARNING" },
+    { "type": "statement.create-index-concurrently", "level": "WARNING" },
+    { "type": "index.no-duplicate",                  "level": "ERROR" },
+    { "type": "schema.backward-compatibility",       "level": "WARNING" }
+  ]
+}
+```
+
+Notes:
+- `naming.column` `maxLength: 63` matches Postgres's identifier limit.
+- `column.no-null` lists known FK / tenancy columns; extend as new shared columns appear.
+- Severities match the spec table verbatim.
+
+- [ ] **Step 2: Validate the JSON parses**
+
+Run: `python3 -c 'import json; json.load(open(".bytebase/sql-review.json"))'`
+Expected: exit code 0, no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .bytebase/sql-review.json
+git commit -s -m "feat(ci): add Bytebase SQL review policy
+
+Encodes the ten review rules from the tiered-adoption design spec.
+Severities: ERROR blocks PR merge, WARNING surfaces as a reviewer
+checklist. Consumed by .github/workflows/sql-review.yml (added in a
+follow-up commit) via the bytebase/sql-review-action."
+```
+
+---
+
+## Task 4: Create banned-pattern fixtures for the self-test
+
+**Files:**
+- Create: `.bytebase/fixtures/bad/00001_dropped_table_no_label.sql`
+- Create: `.bytebase/fixtures/bad/00002_pascal_case_column.sql`
+- Create: `.bytebase/fixtures/bad/00003_truncate_in_migration.sql`
+
+Each fixture intentionally violates one ERROR-severity rule. The self-test workflow (Task 6) runs the policy against this directory and asserts a non-zero exit. This guarantees that future edits to `sql-review.json` that accidentally weaken a rule fail loudly in CI.
+
+- [ ] **Step 1: Create the destructive-op fixture**
+
+`.bytebase/fixtures/bad/00001_dropped_table_no_label.sql`:
+
+```sql
+-- +goose Up
+-- Intentionally violates statement.disallow-rm-tbl-cascade.
+-- Used by .github/workflows/sql-review-selftest.yml to verify the policy fires.
+DROP TABLE IF EXISTS chunks CASCADE;
+```
+
+- [ ] **Step 2: Create the naming-violation fixture**
+
+`.bytebase/fixtures/bad/00002_pascal_case_column.sql`:
+
+```sql
+-- +goose Up
+-- Intentionally violates naming.column (PascalCase).
+CREATE TABLE bad_naming (
+    id            uuid PRIMARY KEY,
+    UserEmail     text NOT NULL,
+    CreatedAt     timestamptz NOT NULL DEFAULT now()
+);
+```
+
+- [ ] **Step 3: Create the TRUNCATE fixture**
+
+`.bytebase/fixtures/bad/00003_truncate_in_migration.sql`:
+
+```sql
+-- +goose Up
+-- Intentionally violates statement.disallow-truncate.
+TRUNCATE TABLE response_cache;
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .bytebase/fixtures/
+git commit -s -m "test(ci): add banned-pattern SQL fixtures for policy self-test
+
+Three intentionally-bad SQL files exercising one ERROR rule each:
+DROP CASCADE, PascalCase column names, TRUNCATE. Consumed by
+sql-review-selftest.yml to detect regressions in sql-review.json."
+```
+
+---
+
+## Task 5: Create the PR-time SQL review workflow
+
+**Files:**
+- Create: `.github/workflows/sql-review.yml`
+
+Path-filtered to `migrations/**` so it only runs when a PR touches a real migration. Becomes a required check on `main` (manual step in Task 9).
+
+- [ ] **Step 1: Create the workflow**
+
+`.github/workflows/sql-review.yml`:
+
+```yaml
+name: SQL Review
+
+on:
+  pull_request:
+    paths:
+      - 'migrations/**'
+      - '.bytebase/sql-review.json'
+      - '.github/workflows/sql-review.yml'
+
+permissions:
+  contents: read
+  pull-requests: write  # post inline review comments
+
+jobs:
+  sql-review:
+    name: Bytebase SQL Review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+
+      - name: Run Bytebase SQL review
+        uses: bytebase/sql-review-action@v1
+        with:
+          pattern: 'migrations/*.sql'
+          template: |
+            ${{ format('{0}/.bytebase/sql-review.json', github.workspace) }}
+          fail-on-error: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Notes:
+- `bytebase/sql-review-action@v1` is the official action. Confirm input names against its current README at <https://github.com/bytebase/sql-review-action> at execution time and adjust if the upstream action has renamed any field.
+- `fail-on-error: true` blocks the PR check on any ERROR-severity finding; WARNING findings post comments but don't fail.
+- `pull-requests: write` is the minimum permission needed for the action to leave inline comments. No other write scope is granted.
+
+- [ ] **Step 2: Validate workflow YAML syntax**
+
+Run: `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/sql-review.yml"))'`
+Expected: exit code 0, no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/sql-review.yml
+git commit -s -m "ci: add Bytebase SQL review check on PRs touching migrations
+
+Runs bytebase/sql-review-action against migrations/*.sql whenever a PR
+touches migrations/, the policy file, or this workflow. Fails on
+ERROR-severity findings; WARNING surfaces as inline review comments.
+Will be made a required status check on main as a follow-up manual
+step (see migrations runbook)."
+```
+
+---
+
+## Task 6: Create the policy self-test workflow
+
+**Files:**
+- Create: `.github/workflows/sql-review-selftest.yml`
+
+Runs on every push to `main` and on PRs that change `.bytebase/sql-review.json` or the fixtures. Runs the action against the fixtures from Task 4 and asserts a **non-zero** exit. If the policy ever silently weakens, CI screams.
+
+- [ ] **Step 1: Create the self-test workflow**
+
+`.github/workflows/sql-review-selftest.yml`:
+
+```yaml
+name: SQL Review Policy Self-Test
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.bytebase/sql-review.json'
+      - '.bytebase/fixtures/**'
+      - '.github/workflows/sql-review-selftest.yml'
+  pull_request:
+    paths:
+      - '.bytebase/sql-review.json'
+      - '.bytebase/fixtures/**'
+      - '.github/workflows/sql-review-selftest.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  policy-selftest:
+    name: Policy fires on banned patterns
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Bytebase SQL review against banned fixtures
+        id: review
+        continue-on-error: true
+        uses: bytebase/sql-review-action@v1
+        with:
+          pattern: '.bytebase/fixtures/bad/*.sql'
+          template: |
+            ${{ format('{0}/.bytebase/sql-review.json', github.workspace) }}
+          fail-on-error: true
+
+      - name: Assert policy rejected the fixtures
+        if: steps.review.outcome == 'success'
+        run: |
+          echo "::error::SQL review policy did NOT reject the banned fixtures."
+          echo "Either the fixtures no longer match a rule, or sql-review.json has weakened."
+          echo "Inspect .bytebase/fixtures/bad/*.sql and .bytebase/sql-review.json."
+          exit 1
+
+      - name: Confirm policy fired
+        if: steps.review.outcome == 'failure'
+        run: echo "Policy correctly rejected the banned fixtures."
+```
+
+- [ ] **Step 2: Validate workflow YAML syntax**
+
+Run: `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/sql-review-selftest.yml"))'`
+Expected: exit code 0, no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/sql-review-selftest.yml
+git commit -s -m "ci: add SQL review policy self-test
+
+Runs the policy against intentionally-bad fixtures and asserts it
+rejects them. Triggered on push to main and on PRs that touch the
+policy or fixtures. Catches regressions where a future edit to
+sql-review.json silently weakens a rule."
+```
+
+---
+
+## Task 7: Add `sql-review-local` Makefile target
+
+**Files:**
+- Modify: `Makefile`
+
+Developers should be able to run the same check locally before pushing. The action publishes a container image (`bytebase/sql-review-action:v1`) we can run via Docker.
+
+- [ ] **Step 1: Confirm Makefile uses tabs (it must, GNU make)**
+
+Run: `cat -A Makefile | head -5`
+Expected: lines beginning with `^I` (TAB) for recipe bodies. Use tabs, not spaces, in the recipe below.
+
+- [ ] **Step 2: Append the target to `Makefile`**
+
+```makefile
+.PHONY: sql-review-local
+sql-review-local: ## Run Bytebase SQL review against the local migrations/ tree
+	@echo "Running Bytebase SQL review against migrations/*.sql ..."
+	@docker run --rm \
+		-v $(CURDIR):/repo:ro \
+		-w /repo \
+		ghcr.io/bytebase/sql-review-action:v1 \
+		--pattern 'migrations/*.sql' \
+		--template '.bytebase/sql-review.json' \
+		--fail-on-error
+```
+
+Notes:
+- `$(CURDIR)` is GNU make's absolute current dir; the existing Makefile already uses this style (verify with `grep CURDIR Makefile`).
+- The image tag `ghcr.io/bytebase/sql-review-action:v1` mirrors the action; confirm against the action's README at execution time.
+
+- [ ] **Step 3: Run the new target against the current tree to make sure it works**
+
+Run: `make sql-review-local`
+Expected: existing 43 migrations clear the policy → exit 0. (If a real migration trips a rule, that's a finding to fix in a separate PR, not a Plan A blocker — but it's surfacing in time, which is the point.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Makefile
+git commit -s -m "build: add sql-review-local make target
+
+Runs the Bytebase SQL review action's container image against the
+local migrations/ tree with the same policy CI uses. Lets authors
+catch policy violations before pushing."
+```
+
+---
+
+## Task 8: Write the migrations runbook
+
+**Files:**
+- Create: `docs/runbooks/migrations.md`
+
+Captures how to author a migration, what the SQL review check does, when the escape-hatch label applies, and how to recover from a failed apply on edge.
+
+- [ ] **Step 1: Create the runbook**
+
+`docs/runbooks/migrations.md`:
+
+````markdown
+# Migrations Runbook
+
+## How migrations work in Raven
+
+- Source-of-truth: `migrations/NNNNN_<name>.sql`, applied by `pressly/goose v3`.
+- The API binary embeds the migrations directory (`migrations/embed.go`) and applies them at startup when `RAVEN_DB_AUTO_MIGRATE=true` (default for edge).
+- After applying (or skipping, in cloud profile), `cmd/api` always calls `db.VerifyMigrationsState` to confirm `goose_db_version` matches the embedded set. Mismatch → process exits non-zero, `/readyz` stays red.
+
+## Authoring a migration
+
+1. Create `migrations/NNNNN_<descriptive_name>.sql`. `NNNNN` is the next sequential 5-digit prefix.
+2. Use the `-- +goose Up` directive at the top. No down migrations — rollbacks happen via a new forward migration or `pgBackRest` restore.
+3. Open a PR. The **SQL Review** check runs automatically and posts inline comments. ERROR findings block merge.
+4. Run `make sql-review-local` before pushing to catch issues early.
+
+## The SQL review check
+
+- Workflow: `.github/workflows/sql-review.yml`
+- Policy: `.bytebase/sql-review.json`
+- Engine: `bytebase/sql-review-action@v1` (no Bytebase server needed)
+- Triggered on PRs that touch `migrations/**`, the policy file, or the workflow file.
+
+### Severities
+
+- **ERROR**: blocks PR merge.
+- **WARNING**: posts an inline comment; the reviewer must read it but it doesn't block.
+
+### Escape hatch — destructive operations
+
+Some legitimate migrations need destructive operations (e.g., dropping a column after a multi-PR deprecation). The destructive-op rules can be skipped on a per-PR basis:
+
+1. The PR author requests the override in the PR description, with the **previous PRs that deprecated the thing** linked.
+2. A repo maintainer (codeowner) applies the label `migration:approved-destructive` to the PR.
+3. The SQL review action skips destructive-op rules on the next run.
+
+The label is only applicable by maintainers (enforced via CODEOWNERS). Document the override in the PR description so the audit trail is preserved.
+
+## Recovery from a failed migration
+
+### Edge profile
+
+If `RunMigrations` fails:
+
+1. The `cmd/api` process exits non-zero. The operator sees the goose error in the logs.
+2. Restore the database from the last pre-migration `pgBackRest` base backup + WAL up to the LSN immediately before the failed migration's `BEGIN`.
+3. Fix the migration in a new PR.
+4. Re-deploy.
+
+The detailed pgBackRest procedure lives in `docs/runbooks/demo-restore.md`.
+
+### Cloud profile (future)
+
+Bytebase marks the Issue `FAILED` and halts the pipeline. The DBA inspects the SQL, fixes it (either via Bytebase UI for a hotfix or by raising a forward-fix PR), and retries the stage. The affected tenant's `cmd/api` pods stay on the old version because `/readyz` stays red while `VerifyMigrationsState` fails. Other tenants are unaffected.
+
+## Required CI checks (branch protection)
+
+The following checks must be required on `main`:
+
+- `Bytebase SQL Review / sql-review` (from `sql-review.yml`)
+
+Manually configured under **Settings → Branches → Branch protection rules → main → Require status checks to pass before merging**. See Task 9 of the implementation plan for the one-time setup step.
+````
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/runbooks/migrations.md
+git commit -s -m "docs(runbook): add migrations runbook
+
+Documents the goose+SQL-review workflow: how to author a migration,
+how the PR-time check works, when and how to use the destructive-op
+escape-hatch label, and how to recover from a failed apply on edge."
+```
+
+---
+
+## Task 9: Mark `sql-review` as a required status check (manual, document only)
+
+**Files:** none — this is a one-time GitHub UI step.
+
+- [ ] **Step 1: Document the change request to repo settings**
+
+After the first run of `sql-review.yml` against a PR has completed (so the check name is registered with GitHub), the repo owner / admin must:
+
+1. Open `https://github.com/ravencloak-org/Raven/settings/branches`.
+2. Edit the rule for `main`.
+3. Under **Require status checks to pass before merging**, add `sql-review` (the job name from `sql-review.yml`).
+4. Save.
+
+No code change. Capture this step in the PR description so the reviewer knows to follow up after merge.
+
+- [ ] **Step 2: No commit needed for this task**
+
+It's documented in the migrations runbook (Task 8) and called out in the PR description.
+
+---
+
+## Final verification
+
+- [ ] **Step 1: Run all unit + integration tests**
+
+Run: `go test ./internal/db/... -v && go test -tags=integration ./internal/integration/... -v`
+Expected: all green.
+
+- [ ] **Step 2: Lint clean for the diff**
+
+Run: `golangci-lint run --new-from-rev=origin/main ./...`
+Expected: no new issues.
+
+- [ ] **Step 3: SQL review against current migrations passes locally**
+
+Run: `make sql-review-local`
+Expected: exit 0 (all 43 existing migrations clear the policy). If one fails, the policy is over-strict for the existing tree — narrow that rule before merging.
+
+- [ ] **Step 4: Push branch and open PR**
+
+```bash
+git push -u origin <branch-name>
+gh pr create --fill
+```
+
+In the PR description, link to the spec (`docs/superpowers/specs/2026-05-23-bytebase-tiered-design.md`) and call out the manual branch-protection step from Task 9.
+
+- [ ] **Step 5: Queue auto-merge per CLAUDE.md**
+
+```bash
+gh pr merge <PR_NUMBER> --auto --squash
+```
+
+---
+
+## Self-review notes (already addressed)
+
+- **Spec coverage:** every section of the spec that is in-scope for Plan A has a task. SQL review rules → Task 3. Self-test (Layer 1 from spec testing section) → Tasks 4 + 6. Edge-side unit test for `VerifyMigrationsState` (Layer 2 from spec) → Task 1. cmd/api wiring → Task 2. Makefile (`sql-review-local`) → Task 7. SOP doc → Task 8. Required-check branch protection → Task 9. Drift detection, Bytebase server runtime, history-table override, Layers 3 & 4 integration tests are explicitly **deferred to Plan B** and called out in the plan header.
+- **Placeholder scan:** no TBD/TODO. Every code block is complete and self-contained.
+- **Type consistency:** `VerifyMigrationsState(ctx context.Context, databaseURL string) error` referenced identically in Task 1 (definition), Task 2 (call site), and Task 8 (runbook).

--- a/docs/superpowers/plans/2026-05-23-bytebase-tiered-plan-a.md
+++ b/docs/superpowers/plans/2026-05-23-bytebase-tiered-plan-a.md
@@ -1,12 +1,20 @@
 # Bytebase Tiered Adoption — Plan A: PR-time SQL Review + Edge Readiness
 
+> **POST-EXECUTION PIVOT NOTE (2026-05-25):** Tasks 3–7 below were written assuming `bytebase/sql-review-action` existed as a server-less PR linter. It does not — `bytebase-action check` requires a running Bytebase server. During execution we pivoted to [`sbdchd/squawk-action@v2`](https://github.com/sbdchd/squawk-action) (a Postgres-specific server-less linter) and re-did Tasks 3–7. The high-level goal and `VerifyMigrationsState`/cmd-api wiring (Tasks 1 & 2) are unchanged. For the as-shipped configuration and tool details, read the updated design spec at `docs/superpowers/specs/2026-05-23-bytebase-tiered-design.md` and the runbook at `docs/runbooks/migrations.md`. The Task 3–7 text below is preserved as historical record of what was originally proposed.
+>
+> **Key as-shipped facts:**
+> - PR-time linter: `sbdchd/squawk-action@v2` (not Bytebase). Config: `.squawk.toml` (TOML, not JSON). Fixtures: `.squawk/fixtures/bad/` (not `.bytebase/fixtures/bad/`).
+> - PR workflow is **diff-based** (`git diff origin/$BASE...origin/$HEAD`), not full-tree — 271 pre-existing findings on the 43 shipped migrations are tracked in the spec as backlog, not blocking new PRs. Same convention as `golangci-lint --new-from-rev=HEAD` in this repo.
+> - Escape hatch is inline `-- squawk-ignore <rule>` comments, not a `migration:approved-destructive` PR label (squawk has no concept of labels).
+> - Makefile target is `make sql-lint-local` (not `sql-review-local`), uses `npx squawk-cli`.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Land the ship-anywhere half of the Bytebase tiered adoption — PR-time SQL Review action against `migrations/*.sql`, plus a `VerifyMigrationsState` startup check that gates `cmd/api` readiness. No Bytebase server runtime is introduced. This delivers value to both edge and cloud profiles today.
+**Goal:** Land the ship-anywhere half of the tiered adoption — PR-time SQL review against `migrations/*.sql`, plus a `VerifyMigrationsState` startup check that gates `cmd/api` readiness. No Bytebase server runtime is introduced in Plan A. This delivers value to both edge and cloud profiles today.
 
-**Architecture:** Two coordinated changes. (1) A new Go function `db.VerifyMigrationsState` compares `count(goose_db_version where is_applied=true and version_id>0)` against the count of embedded `*.sql` files; called unconditionally from `cmd/api/main.go` after the existing `RunMigrations` block. (2) A new GitHub Actions workflow runs `bytebase/sql-review-action` against PR diffs touching `migrations/**`, using a policy at `.bytebase/sql-review.json`. A self-test workflow exercises the policy against intentionally-bad fixtures so regressions in the rules surface immediately.
+**Architecture (as shipped):** Two coordinated changes. (1) A new Go function `db.VerifyMigrationsState` compares the count of distinct currently-applied migration versions in `goose_db_version` (latest row per `version_id`) against the count of embedded `*.sql` files; called unconditionally from `cmd/api/main.go` after the existing `RunMigrations` block. (2) `.github/workflows/sql-review.yml` runs `sbdchd/squawk-action@v2` against PR-modified migration files only (diff-based) using `.squawk.toml` config. A self-test workflow exercises the policy against intentionally-bad fixtures so regressions in the rules surface immediately.
 
-**Tech Stack:** Go 1.x, `github.com/pressly/goose/v3`, `github.com/lib/pq`, `github.com/testcontainers/testcontainers-go`, `github.com/stretchr/testify/require`, GitHub Actions, `bytebase/sql-review-action` (v1), JSON policy file.
+**Tech Stack:** Go 1.x, `github.com/pressly/goose/v3`, `github.com/lib/pq`, `github.com/testcontainers/testcontainers-go`, `github.com/stretchr/testify/require`, GitHub Actions, `sbdchd/squawk-action@v2`, TOML config file.
 
 **Source spec:** `docs/superpowers/specs/2026-05-23-bytebase-tiered-design.md`
 

--- a/docs/superpowers/specs/2026-05-23-bytebase-tiered-design.md
+++ b/docs/superpowers/specs/2026-05-23-bytebase-tiered-design.md
@@ -261,3 +261,30 @@ Bytebase's auto-rollback feature is **disabled** in project config — we don't 
 - Bytebase SQL Review GH Action: <https://github.com/bytebase/sql-review-action>
 - pgBackRest restore runbook: existing internal docs
 - OpenObserve audit log pipeline: existing internal docs
+
+## Squawk Backlog Snapshot (2026-05-25)
+
+Initial `squawk` run against the 43 existing migrations surfaced 271
+findings under the default ruleset. These are pre-existing debt, NOT
+blockers for Plan A — the PR-time workflow is configured to lint only
+files modified in a PR (same convention as `golangci-lint --new-from-rev`
+in this repo).
+
+Counts by rule:
+
+| Rule | Count |
+|------|-------|
+| `require-timeout-settings` | 82 |
+| `prefer-text-field` | 68 |
+| `ban-drop-table` | 40 |
+| `prefer-bigint-over-int` | 33 |
+| `require-concurrent-index-deletion` | 20 |
+| `ban-drop-column` | 13 |
+| `require-concurrent-index-creation` | 9 |
+| `renaming-column` | 2 |
+| Other | 4 |
+
+Tracking issue to be opened post-merge for incremental cleanup. Each
+legitimate destructive op should land an inline `-- squawk-ignore <rule>`
+comment with rationale; other findings should be fixed via forward
+migrations where feasible.

--- a/docs/superpowers/specs/2026-05-23-bytebase-tiered-design.md
+++ b/docs/superpowers/specs/2026-05-23-bytebase-tiered-design.md
@@ -126,7 +126,7 @@ Bytebase by default writes to its own `bytebase` schema per managed DB. We overr
 | Profile | `AutoMigrate` | Source |
 |---|---|---|
 | Edge (default) | `true` | Hardcoded default in `config.Defaults()` |
-| Cloud | `false` | Environment override of `Database.AutoMigrate` in cloud Helm/compose values (exact env-var name per existing `internal/config` conventions) |
+| Cloud | `false` | `RAVEN_DB_AUTO_MIGRATE=false` in cloud Helm/compose values |
 
 **`cmd/api/main.go` changes:**
 
@@ -242,7 +242,7 @@ Bytebase's auto-rollback feature is **disabled** in project config — we don't 
 | `.bytebase/sql-review.json` | New policy file. |
 | `Makefile` | New `sql-review-local` target. |
 | Edge compose | No change. |
-| Cloud Helm/compose | New `bytebase` service in control plane; `AutoMigrate=false` env override on `cmd/api`. |
+| Cloud Helm/compose | New `bytebase` service in control plane; `RAVEN_DB_AUTO_MIGRATE=false` on `cmd/api`. |
 | Branch protection on `main` | Add `sql-review` as required check. |
 | Migration SOP doc | Update with escape-hatch label + Bytebase approval flow. |
 

--- a/docs/superpowers/specs/2026-05-23-bytebase-tiered-design.md
+++ b/docs/superpowers/specs/2026-05-23-bytebase-tiered-design.md
@@ -1,0 +1,263 @@
+# Bytebase — Tiered Adoption (Edge + Cloud) Design
+
+**Date:** 2026-05-23
+**Status:** Draft (awaiting approval)
+**Owner:** Jobin Lawrance
+
+## Summary
+
+Adopt [Bytebase](https://github.com/bytebase/bytebase) as a database DevOps layer on top of Raven's existing `pressly/goose` migration tooling, **without** changing the migration source-of-truth and **without** adding new mandatory infrastructure to the edge deployment profile.
+
+The adoption is tiered:
+
+- **Edge profile (Pi / single-VPS):** unchanged. `goose` continues to apply embedded migrations at API startup.
+- **Cloud profile (multi-tenant SaaS):** Bytebase runs in the control plane, gates migrations through a `dev → staging → prod` pipeline with human approval, and writes to the same `goose_db_version` history table goose uses.
+- **PR-time (everyone, always):** Bytebase's SQL Review GitHub Action lints `migrations/*.sql` against a policy and blocks merge on unsafe DDL. No runtime server needed for this path.
+
+This solves four pain points the user identified: SQL review before merge, schema drift / audit visibility, multi-env approval workflow, and decoupling schema changes from API binary startup — while honoring the standing constraint that Raven must remain deployable on Raspberry Pi-class edge nodes with minimal footprint.
+
+## Current State
+
+| Aspect | Today |
+|---|---|
+| Migration tool | `github.com/pressly/goose/v3` |
+| Migration files | 43 files in `migrations/NNNNN_*.sql` (00001–00043) |
+| Embedding | `migrations/embed.go` via `go:embed` |
+| Runner | `internal/db/migrate.go` → `RunMigrations(ctx, databaseURL)` |
+| Trigger | `cmd/api/main.go` when `cfg.Database.AutoMigrate == true` |
+| Driver | `github.com/lib/pq` |
+| History table | `public.goose_db_version` (goose default) |
+
+## Architecture
+
+Two deployment profiles share one source-of-truth (the `migrations/` directory in this repo).
+
+```
+                migrations/*.sql (canonical, goose-numbered)
+                embed.go + go:embed (unchanged)
+                         │
+        ┌────────────────┴────────────────┐
+        │                                 │
+   EDGE profile                      CLOUD profile
+   (Pi / single-VPS)                 (multi-tenant SaaS)
+        │                                 │
+   AutoMigrate=true                  AutoMigrate=false
+   goose.UpContext()                 Bytebase server (control plane)
+   at cmd/api startup                ├─ GitOps watches migrations/
+        │                            ├─ dev → staging → prod
+   goose_db_version                  ├─ approval gates
+        │                            └─ applies to tenant DBs
+   No Bytebase runtime                  ↓
+                                     goose_db_version (shared)
+        │                                 │
+        └────────────────┬────────────────┘
+                         │
+            PR-time (both profiles)
+            Bytebase SQL Review GitHub Action
+            runs against migrations/*.sql diff
+            fails PR on unsafe DDL
+```
+
+### Key decisions
+
+1. **Bytebase is control-plane only.** Never bundled into the edge compose file. Cloud-only runtime dependency.
+2. **`migrations/*.sql` stays canonical.** Goose numbering (`NNNNN_name.sql`) is unchanged. We do not re-author migrations in Bytebase's UI; Bytebase consumes the directory via GitOps.
+3. **Shared history table.** Both goose and Bytebase write to `public.goose_db_version` using the same row schema. Bytebase is configured to point at this table rather than creating its own `bytebase` schema in tenant DBs.
+4. **Profile selection via existing config.** Reuse `cfg.Database.AutoMigrate`; no new `Deployment.Mode` enum.
+5. **Edge users see zero change.** Same binary, same compose, same boot behavior.
+
+## PR-time SQL Review (Layer 1)
+
+**Tool:** `bytebase/sql-review-action` (official GitHub Action, no server required).
+
+**Workflow:** new job `sql-review` in `.github/workflows/sql-review.yml`. Triggers on PRs that touch `migrations/**`. Wired into branch protection on `main` as a required check.
+
+**Policy file:** `.bytebase/sql-review.json`. Initial ruleset:
+
+| Rule | Severity | Reason |
+|---|---|---|
+| `naming.column` (snake_case) | ERROR | Consistency with 43 existing migrations |
+| `column.required` (created_at, updated_at on new tables) | WARNING | Matches existing convention |
+| `column.no-null` on PK / FK columns | ERROR | Catch obvious mistakes |
+| `statement.disallow-commit` | ERROR | Migrations must be transactional |
+| `statement.disallow-truncate` | ERROR | Destructive ops need explicit override |
+| `statement.disallow-rm-tbl-cascade` | ERROR | Destructive ops need explicit override |
+| `statement.add-column-without-default` (non-null) | WARNING | Forces backfill thinking |
+| `statement.create-index-concurrently` | WARNING | Edge OK, cloud tenants may be large |
+| `index.no-duplicate` | ERROR | Catch redundant indexes |
+| `schema.backward-compatibility` | WARNING | Heads-up on breaking renames/drops |
+
+**Failure UX:** action posts inline review comments on offending file/line. ERROR blocks merge; WARNING surfaces as a reviewer checklist.
+
+**Escape hatch:** PR label `migration:approved-destructive` skips destructive-op rules. Label applicable only by maintainers (codeowner enforcement). Documented in the migration SOP.
+
+## GitOps Wiring + History Coexistence (Cloud, Layer 2)
+
+Bytebase **pulls** from GitHub.
+
+1. Cloud-mode Bytebase server has a project `raven` with a VCS provider bound to `github.com/ravencloak-org/Raven`, branch `main`, base path `migrations/`.
+2. On every push to `main` touching `migrations/**`, Bytebase's webhook receiver enumerates new files (goose numeric prefix doubles as a valid Bytebase migration version) and opens an Issue of type "Database Schema Update" per file.
+3. The Issue runs through a pipeline with three stages — `dev → staging → prod` — each applying to its tenant DB pool, with per-stage approval policies:
+   - `dev`: auto-apply
+   - `staging`: auto-apply after dev success
+   - `prod`: requires one human approver (Bytebase role: `DBA` or `Owner`)
+4. SQL Review runs again on each stage (defense in depth) using the same policy file as PR-time.
+
+### History-table coexistence
+
+Bytebase by default writes to its own `bytebase` schema per managed DB. We override this:
+
+- Each Bytebase database connection is registered with a migration-history hint pointing at `public.goose_db_version`.
+- When Bytebase applies migration `00044_foo.sql`, it writes `(version_id=44, is_applied=true, tstamp=now())` — same row shape goose writes.
+- When goose applies the same file on an edge node, it writes the same row.
+- A migration is "applied" iff its row exists with `is_applied=true`. Both systems agree.
+
+**Trade-off accepted:** Bytebase's own schema-comparison features (its `bytebase` metadata schema) won't exist in tenant DBs. We choose shared state with goose over those.
+
+### Drift detection
+
+- Bytebase's drift-detection job runs hourly per tenant DB. Diffs live schema against expected schema derived from applied `migrations/*.sql`. Opens a `drift`-tagged Issue on mismatch.
+- Edge profile adds a startup check `db.VerifyMigrationsState(ctx)` (see next section) — cheap row-count assertion against `goose_db_version`.
+
+## Cloud-mode Config + `cmd/api` Changes
+
+**Config:** reuse existing `cfg.Database.AutoMigrate`. No new field.
+
+| Profile | `AutoMigrate` | Source |
+|---|---|---|
+| Edge (default) | `true` | Hardcoded default in `config.Defaults()` |
+| Cloud | `false` | Environment override of `Database.AutoMigrate` in cloud Helm/compose values (exact env-var name per existing `internal/config` conventions) |
+
+**`cmd/api/main.go` changes:**
+
+```go
+// existing
+if cfg.Database.AutoMigrate {
+    if err := db.RunMigrations(ctx, cfg.Database.URL); err != nil {
+        return fmt.Errorf("run migrations: %w", err)
+    }
+}
+
+// NEW — always run, both profiles
+if err := db.VerifyMigrationsState(ctx, cfg.Database.URL); err != nil {
+    return fmt.Errorf("verify migrations: %w", err)
+}
+```
+
+`VerifyMigrationsState` lives next to `RunMigrations` in `internal/db/migrate.go`. It compares `count(* from goose_db_version where is_applied=true)` to `len(migrations.FS files)`. Mismatch → return error → `cmd/api` exits or readiness probe stays red.
+
+**Readiness:** `/readyz` depends on `VerifyMigrationsState` passing. `/healthz` (liveness) does not — we don't want K8s killing pods during a temporary mismatch.
+
+**Cloud deploy ordering (Kubernetes / ArgoCD):**
+
+1. CI merges PR to `main`.
+2. Bytebase webhook fires → creates Issue → pipeline starts.
+3. Bytebase applies migration to staging tenants (auto).
+4. Human approves prod stage in Bytebase UI.
+5. Bytebase applies to prod tenants → writes `goose_db_version` row.
+6. Bytebase "applied" event triggers ArgoCD/Flux sync of `cmd/api`.
+7. `cmd/api` pods roll out.
+8. Each pod runs `VerifyMigrationsState` → passes → ready.
+
+If step 7 fires before step 5 completes for a tenant: `VerifyMigrationsState` fails on the affected pod, readiness stays red, traffic doesn't shift, K8s holds at old version. Self-healing.
+
+**Edge profile:** unchanged code path — `AutoMigrate=true`, goose runs at startup, `VerifyMigrationsState` confirms goose did its job. Belt and braces.
+
+## Error Handling, Rollback, Audit
+
+### Failure modes
+
+| Failure | Detection | Response |
+|---|---|---|
+| Edge: goose migration fails mid-apply | `RunMigrations` returns error → `cmd/api` exits non-zero | Operator runbook: `pgBackRest restore` to last good base + WAL replay to pre-migration LSN. Existing playbook. |
+| Cloud: Bytebase fails to apply to a tenant | Bytebase Issue marked `FAILED`, pipeline halts | Tenant's API pods stay on old version (readiness gating). DBA fixes in Bytebase UI, retries stage. Other tenants unaffected. |
+| Cloud: API pod starts before Bytebase finishes | `VerifyMigrationsState` fails → `/readyz` red | K8s holds traffic on old pods. Self-heals when Bytebase catches up. No alert paged. |
+| Drift detected (manual edit, partial restore) | Bytebase hourly drift job → `drift`-tagged Issue | Alerts on-call via existing OpenObserve → PagerDuty path. DBA investigates. |
+| SQL Review false positive | PR author argues with bot | Maintainer applies `migration:approved-destructive` label. Documented in SOP. |
+
+### Rollbacks
+
+Forward-only. Rollbacks happen via:
+
+- (a) a new forward migration that undoes the change, authored as a normal PR, **or**
+- (b) `pgBackRest` restore when forward-fix isn't feasible.
+
+Bytebase's auto-rollback feature is **disabled** in project config — we don't want anyone trusting auto-generated rollback SQL.
+
+### Audit trail (SOC2 / GDPR evidence)
+
+- **PR-time:** GitHub records authorship/review/merge. SQL Review action results stored as check-run annotations.
+- **Cloud-apply:** Bytebase Issue records who created (webhook), who approved each stage (human user), exact SQL, timestamp, target DB, success/failure, duration. Retained in Bytebase metadata DB. Exported daily to OpenObserve via Bytebase Activity API.
+- **Edge-apply:** `goose_db_version` rows + existing app audit-log `migration_applied` events at startup.
+
+**Known compliance gap:** edge deployments lack per-stage human approval (single-operator boxes can't ask themselves). Documented in the threat model. Cloud SaaS is the profile that needs the controls.
+
+## Testing Strategy
+
+**Layer 1 — PR SQL Review action.**
+
+- Self-test: fixture PR in CI with an intentionally banned pattern must be rejected. `.github/workflows/sql-review-selftest.yml`, runs on push to `main`.
+- Policy file `.bytebase/sql-review.json` linted in CI with `bb sql-review --check-policy`.
+
+**Layer 2 — Migration unit tests.**
+
+- Existing `migrations/migrations_test.go` validates goose can parse and apply every file against a throwaway Postgres (testcontainers). Keep as-is.
+- **Add:** test that runs all migrations then `db.VerifyMigrationsState` — asserts pass. Plus a negative test (delete a row → expect failure).
+
+**Layer 3 — Integration test for Bytebase ingest (cloud only).**
+
+- New `internal/integration/bytebase_test.go` (gated by `//go:build integration`):
+  1. Spin up Postgres + Bytebase via testcontainers.
+  2. Configure project against a local git fixture with 2 migration files.
+  3. Trigger sync; assert Bytebase opens an Issue per file.
+  4. Approve programmatically via Bytebase API.
+  5. Assert files applied to target Postgres AND `goose_db_version` rows present.
+- Runs in CI on `migrations/**` or `internal/db/**` changes only.
+
+**Layer 4 — Drift detection test.**
+
+- Apply all migrations.
+- Manually `ALTER TABLE` out-of-band.
+- Trigger Bytebase drift scan via API.
+- Assert `drift`-tagged Issue is opened.
+
+**Out of scope:**
+
+- Bytebase server's own correctness (third-party; pin a known-good version).
+- GitHub webhook path end-to-end (would need real GitHub; test the receiver-side by feeding migration files directly).
+- New tests for edge migration path — `migrations_test.go` already covers it.
+
+**Local dev:** `make sql-review-local` runs the action against current branch's `migrations/**` diff so authors get the same feedback they'd get from CI before pushing.
+
+## What Changes vs What Stays
+
+| Area | Change? |
+|---|---|
+| `migrations/*.sql` | No change. Goose numbering preserved. |
+| `migrations/embed.go` | No change. |
+| `internal/db/migrate.go` | Add `VerifyMigrationsState(ctx, url) error`. |
+| `cmd/api/main.go` | Add unconditional call to `VerifyMigrationsState` after the existing `AutoMigrate` block. |
+| `internal/config/config.go` | No change (reuse `Database.AutoMigrate`). |
+| `.github/workflows/` | New `sql-review.yml`, `sql-review-selftest.yml`. |
+| `.bytebase/sql-review.json` | New policy file. |
+| `Makefile` | New `sql-review-local` target. |
+| Edge compose | No change. |
+| Cloud Helm/compose | New `bytebase` service in control plane; `AutoMigrate=false` env override on `cmd/api`. |
+| Branch protection on `main` | Add `sql-review` as required check. |
+| Migration SOP doc | Update with escape-hatch label + Bytebase approval flow. |
+
+## Open Questions / Plan-Time Decisions
+
+- Exact Bytebase version to pin (latest stable at plan time).
+- Helm chart vs raw compose for cloud Bytebase deployment — depends on the cloud profile's overall orchestration choice, which is outside this spec.
+- Whether to expose Bytebase UI behind the Raven control-plane SSO (SuperTokens) or as a separate auth domain initially. Defer to the cloud-profile rollout plan.
+
+## References
+
+- `internal/db/migrate.go` — current goose runner
+- `migrations/` — 43 SQL files (00001–00043)
+- `migrations/embed.go`, `migrations/migrations_test.go`
+- Bytebase docs: <https://www.bytebase.com/docs/>
+- Bytebase SQL Review GH Action: <https://github.com/bytebase/sql-review-action>
+- pgBackRest restore runbook: existing internal docs
+- OpenObserve audit log pipeline: existing internal docs

--- a/docs/superpowers/specs/2026-05-23-bytebase-tiered-design.md
+++ b/docs/superpowers/specs/2026-05-23-bytebase-tiered-design.md
@@ -68,28 +68,31 @@ Two deployment profiles share one source-of-truth (the `migrations/` directory i
 
 ## PR-time SQL Review (Layer 1)
 
-**Tool:** `bytebase/sql-review-action` (official GitHub Action, no server required).
+> **Pivot note (2026-05-25):** the original design proposed `bytebase/sql-review-action` as a server-less PR-time linter. During implementation we confirmed no such standalone action exists — Bytebase's `bytebase-action check` requires a running Bytebase server (`--url`, `--service-account`). Plan A pivoted to [`sbdchd/squawk-action@v2`](https://github.com/sbdchd/squawk-action), a Postgres-specific server-less linter. The Plan A goals (catch unsafe DDL before merge, no server runtime, edge-footprint-friendly) are unchanged; only the tool differs. Plan B still introduces a Bytebase server in the cloud control plane for workflow/approval features.
 
-**Workflow:** new job `sql-review` in `.github/workflows/sql-review.yml`. Triggers on PRs that touch `migrations/**`. Wired into branch protection on `main` as a required check.
+**Tool:** [`sbdchd/squawk-action@v2`](https://github.com/sbdchd/squawk-action) — wraps the [`squawk`](https://squawkhq.com) CLI, no server required.
 
-**Policy file:** `.bytebase/sql-review.json`. Initial ruleset:
+**Workflow:** `.github/workflows/sql-review.yml`. Triggers on PRs that touch `migrations/**`, `.squawk.toml`, or the workflow file itself. Wired into branch protection on `main` as a required check (manual step — documented in `docs/runbooks/migrations.md`).
 
-| Rule | Severity | Reason |
-|---|---|---|
-| `naming.column` (snake_case) | ERROR | Consistency with 43 existing migrations |
-| `column.required` (created_at, updated_at on new tables) | WARNING | Matches existing convention |
-| `column.no-null` on PK / FK columns | ERROR | Catch obvious mistakes |
-| `statement.disallow-commit` | ERROR | Migrations must be transactional |
-| `statement.disallow-truncate` | ERROR | Destructive ops need explicit override |
-| `statement.disallow-rm-tbl-cascade` | ERROR | Destructive ops need explicit override |
-| `statement.add-column-without-default` (non-null) | WARNING | Forces backfill thinking |
-| `statement.create-index-concurrently` | WARNING | Edge OK, cloud tenants may be large |
-| `index.no-duplicate` | ERROR | Catch redundant indexes |
-| `schema.backward-compatibility` | WARNING | Heads-up on breaking renames/drops |
+**Scope:** lints only migrations **modified in the current PR** (diff-based selection via `git diff origin/$BASE...origin/$HEAD`). The initial squawk run against the 43 shipped migrations surfaced 271 findings under the default ruleset, which is pre-existing debt — diff-based linting protects new PRs from it while a separate backlog initiative pays it down. Mirrors the `golangci-lint --new-from-rev=HEAD` convention used elsewhere in the repo.
 
-**Failure UX:** action posts inline review comments on offending file/line. ERROR blocks merge; WARNING surfaces as a reviewer checklist.
+**Config file:** `.squawk.toml` at the repo root. Squawk auto-discovers it.
 
-**Escape hatch:** PR label `migration:approved-destructive` skips destructive-op rules. Label applicable only by maintainers (codeowner enforcement). Documented in the migration SOP.
+```toml
+assume_in_transaction = true   # goose wraps each migration in BEGIN/COMMIT
+pg_version = "18.0"            # matches Raven runtime; gates version-specific rules
+excluded_rules = []            # full default ruleset on; per-statement exceptions go inline
+```
+
+**Initial ruleset:** squawk's default-on set (~30 rules), including `ban-drop-table`, `ban-drop-column`, `ban-truncate-cascade`, `require-concurrent-index-creation`, `require-concurrent-index-deletion`, `adding-required-field`, `prefer-text-field`, `prefer-bigint-over-int`, `require-timeout-settings`, `transaction-nesting`, `renaming-column`, `renaming-table`, `changing-column-type`, and more. Full list: <https://squawkhq.com/docs/rules>. Customisation lives in `.squawk.toml` (`excluded_rules`/`included_rules`).
+
+**Failure UX:** the action posts findings as inline review comments on the PR. Any finding fails the job → PR cannot merge until resolved.
+
+**Escape hatch:** per-statement `-- squawk-ignore <rule-name>` comment immediately before the offending SQL line. The audit trail co-locates with the change — every `squawk-ignore` in a PR diff requires explicit reviewer attention. This replaces the original PR-label-based escape hatch (squawk has no concept of labels and the inline form is cleaner). See `docs/runbooks/migrations.md` for the SOP.
+
+**Policy self-test:** `.github/workflows/sql-review-selftest.yml` runs squawk against `.squawk/fixtures/bad/*.sql` (three fixtures violating `ban-drop-table`, `adding-required-field`, `require-concurrent-index-creation`) and asserts non-zero exit. Catches regressions where a future PR weakens `.squawk.toml`.
+
+**Local equivalent:** `make sql-lint-local` runs squawk via `npx squawk-cli@latest` against migrations modified versus `origin/main` — same semantics as CI.
 
 ## GitOps Wiring + History Coexistence (Cloud, Layer 2)
 
@@ -196,8 +199,8 @@ Bytebase's auto-rollback feature is **disabled** in project config — we don't 
 
 **Layer 1 — PR SQL Review action.**
 
-- Self-test: fixture PR in CI with an intentionally banned pattern must be rejected. `.github/workflows/sql-review-selftest.yml`, runs on push to `main`.
-- Policy file `.bytebase/sql-review.json` linted in CI with `bb sql-review --check-policy`.
+- Self-test: `.github/workflows/sql-review-selftest.yml` runs squawk against `.squawk/fixtures/bad/*.sql` and asserts non-zero exit. Triggered on push to `main` and on PRs touching `.squawk.toml`, fixtures, or the workflow itself.
+- `.squawk.toml` syntax is a TOML file; if invalid, squawk-action fails fast on first use — no separate linter needed.
 
 **Layer 2 — Migration unit tests.**
 
@@ -227,7 +230,7 @@ Bytebase's auto-rollback feature is **disabled** in project config — we don't 
 - GitHub webhook path end-to-end (would need real GitHub; test the receiver-side by feeding migration files directly).
 - New tests for edge migration path — `migrations_test.go` already covers it.
 
-**Local dev:** `make sql-review-local` runs the action against current branch's `migrations/**` diff so authors get the same feedback they'd get from CI before pushing.
+**Local dev:** `make sql-lint-local` runs squawk (via `npx squawk-cli@latest`) against the current branch's `migrations/**` diff vs `origin/main` so authors get the same feedback they'd get from CI before pushing.
 
 ## What Changes vs What Stays
 
@@ -238,13 +241,14 @@ Bytebase's auto-rollback feature is **disabled** in project config — we don't 
 | `internal/db/migrate.go` | Add `VerifyMigrationsState(ctx, url) error`. |
 | `cmd/api/main.go` | Add unconditional call to `VerifyMigrationsState` after the existing `AutoMigrate` block. |
 | `internal/config/config.go` | No change (reuse `Database.AutoMigrate`). |
-| `.github/workflows/` | New `sql-review.yml`, `sql-review-selftest.yml`. |
-| `.bytebase/sql-review.json` | New policy file. |
-| `Makefile` | New `sql-review-local` target. |
+| `.github/workflows/` | New `sql-review.yml`, `sql-review-selftest.yml` (Plan A). |
+| `.squawk.toml` | New squawk config at repo root (Plan A). |
+| `.squawk/fixtures/bad/*.sql` | Three banned-rule fixtures for the self-test workflow (Plan A). |
+| `Makefile` | New `sql-lint-local` target running squawk via npx (Plan A). |
+| `docs/runbooks/migrations.md` | New developer-facing SOP (Plan A). |
 | Edge compose | No change. |
-| Cloud Helm/compose | New `bytebase` service in control plane; `RAVEN_DB_AUTO_MIGRATE=false` on `cmd/api`. |
-| Branch protection on `main` | Add `sql-review` as required check. |
-| Migration SOP doc | Update with escape-hatch label + Bytebase approval flow. |
+| Cloud Helm/compose | New `bytebase` service in control plane; `RAVEN_DB_AUTO_MIGRATE=false` on `cmd/api` (Plan B). |
+| Branch protection on `main` | Add `Squawk migration lint` as required check after first workflow run (Plan A, manual step). |
 
 ## Open Questions / Plan-Time Decisions
 
@@ -257,8 +261,9 @@ Bytebase's auto-rollback feature is **disabled** in project config — we don't 
 - `internal/db/migrate.go` — current goose runner
 - `migrations/` — 43 SQL files (00001–00043)
 - `migrations/embed.go`, `migrations/migrations_test.go`
-- Bytebase docs: <https://www.bytebase.com/docs/>
-- Bytebase SQL Review GH Action: <https://github.com/bytebase/sql-review-action>
+- Bytebase docs (Plan B): <https://www.bytebase.com/docs/>
+- Squawk action (Plan A): <https://github.com/sbdchd/squawk-action>
+- Squawk rule reference (Plan A): <https://squawkhq.com/docs/rules>
 - pgBackRest restore runbook: existing internal docs
 - OpenObserve audit log pipeline: existing internal docs
 

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"io/fs"
+	"strings"
 
 	_ "github.com/lib/pq" // postgres driver for the database/sql handle goose requires
 	"github.com/pressly/goose/v3"
@@ -41,4 +43,62 @@ func RunMigrations(ctx context.Context, databaseURL string) error {
 		return fmt.Errorf("goose.Up: %w", err)
 	}
 	return nil
+}
+
+// VerifyMigrationsState confirms the database has applied exactly the set of
+// migrations embedded in the binary. It is cheap (one COUNT(*) plus a directory
+// walk of migrations.FS) and runs at startup in both edge and cloud profiles.
+//
+// In the edge profile this is a belt-and-braces check that RunMigrations did
+// what it claimed. In the cloud profile (AutoMigrate=false, Bytebase applies
+// migrations out-of-band) it gates /readyz: pods stay un-ready until Bytebase
+// has caught up. Returning an error here surfaces a clear mismatch instead of
+// silently serving traffic against a stale schema.
+//
+// Goose seeds the version table with version_id=0 on first use; that row is
+// excluded from the applied count.
+func VerifyMigrationsState(ctx context.Context, databaseURL string) error {
+	sqlDB, err := sql.Open("postgres", databaseURL)
+	if err != nil {
+		return fmt.Errorf("open postgres for verify: %w", err)
+	}
+	defer func() { _ = sqlDB.Close() }()
+
+	if err := sqlDB.PingContext(ctx); err != nil {
+		return fmt.Errorf("ping postgres for verify: %w", err)
+	}
+
+	var appliedCount int
+	if err := sqlDB.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM goose_db_version WHERE is_applied = true AND version_id > 0`,
+	).Scan(&appliedCount); err != nil {
+		return fmt.Errorf("count goose_db_version: %w", err)
+	}
+
+	expectedCount, err := countEmbeddedMigrations()
+	if err != nil {
+		return fmt.Errorf("count embedded migrations: %w", err)
+	}
+
+	if appliedCount != expectedCount {
+		return fmt.Errorf(
+			"migration state mismatch: %d applied in goose_db_version, %d expected from embedded migrations",
+			appliedCount, expectedCount,
+		)
+	}
+	return nil
+}
+
+func countEmbeddedMigrations() (int, error) {
+	entries, err := fs.ReadDir(migrations.FS, ".")
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".sql") {
+			count++
+		}
+	}
+	return count, nil
 }

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -68,9 +68,22 @@ func VerifyMigrationsState(ctx context.Context, databaseURL string) error {
 		return fmt.Errorf("ping postgres for verify: %w", err)
 	}
 
+	// goose_db_version is append-only: every Up and Down appends a row, so a
+	// rollback+re-apply produces multiple is_applied=true rows for the same
+	// version_id. Count only the LATEST row per version_id (highest id) and
+	// keep it iff its is_applied=true. bool_and across the history would
+	// incorrectly drop versions that were rolled back and re-applied.
 	var appliedCount int
 	if err := sqlDB.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM goose_db_version WHERE is_applied = true AND version_id > 0`,
+		`SELECT COUNT(*)
+		FROM goose_db_version g
+		WHERE g.version_id > 0
+		  AND g.is_applied = true
+		  AND g.id = (
+		      SELECT MAX(sub.id)
+		      FROM goose_db_version sub
+		      WHERE sub.version_id = g.version_id
+		  )`,
 	).Scan(&appliedCount); err != nil {
 		return fmt.Errorf("count goose_db_version: %w", err)
 	}

--- a/internal/db/migrate_test.go
+++ b/internal/db/migrate_test.go
@@ -38,3 +38,31 @@ func TestVerifyMigrationsState_MismatchReturnsError(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "migration state mismatch")
 }
+
+func TestVerifyMigrationsState_RollbackThenReapplyPasses(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	pool := testutil.NewTestDB(t)
+	dsn := pool.Config().ConnString()
+
+	// Simulate a rollback then re-apply of the latest migration by appending
+	// two extra rows for its version_id — one with is_applied=false (the
+	// rollback event), one with is_applied=true (the re-apply). Goose's table
+	// is append-only; VerifyMigrationsState must look at the LATEST row per
+	// version_id, not COUNT(*) of is_applied=true rows.
+	var latestVersion int64
+	err := pool.QueryRow(ctx,
+		`SELECT MAX(version_id) FROM goose_db_version WHERE version_id > 0`,
+	).Scan(&latestVersion)
+	require.NoError(t, err)
+
+	_, err = pool.Exec(ctx,
+		`INSERT INTO goose_db_version (version_id, is_applied, tstamp)
+		 VALUES ($1, false, now()), ($1, true, now())`,
+		latestVersion,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, db.VerifyMigrationsState(ctx, dsn))
+}

--- a/internal/db/migrate_test.go
+++ b/internal/db/migrate_test.go
@@ -1,0 +1,40 @@
+package db_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ravencloak-org/Raven/internal/db"
+	"github.com/ravencloak-org/Raven/internal/testutil"
+)
+
+func TestVerifyMigrationsState_AllAppliedPasses(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	pool := testutil.NewTestDB(t)
+	dsn := pool.Config().ConnString()
+
+	require.NoError(t, db.VerifyMigrationsState(ctx, dsn))
+}
+
+func TestVerifyMigrationsState_MismatchReturnsError(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	pool := testutil.NewTestDB(t)
+	dsn := pool.Config().ConnString()
+
+	_, err := pool.Exec(ctx,
+		`DELETE FROM goose_db_version WHERE version_id = (
+			SELECT MAX(version_id) FROM goose_db_version WHERE is_applied = true
+		)`,
+	)
+	require.NoError(t, err)
+
+	err = db.VerifyMigrationsState(ctx, dsn)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "migration state mismatch")
+}


### PR DESCRIPTION
## Summary

Plan A of the [tiered DB-devops design](docs/superpowers/specs/2026-05-23-bytebase-tiered-design.md). Two coordinated changes:

1. **Edge-safety startup gate (`db.VerifyMigrationsState`):** counts the latest-state-per-version_id rows in `goose_db_version` against the embedded `*.sql` file count. Mismatch → `log.Fatalf` → `/readyz` stays red. Edge: belt-and-braces after goose. Cloud (Plan B): primary gate against API pods coming up before the out-of-band migrator finishes.

2. **PR-time SQL review with `sbdchd/squawk-action@v2`:** server-less Postgres-specific linter against migrations modified in the current PR (diff-based, like `golangci-lint --new-from-rev=HEAD`). Self-test workflow asserts the rules fire against banned-pattern fixtures.

### Pivot vs original spec

The original spec proposed `bytebase/sql-review-action` as a server-less PR linter. **That action doesn't exist** — Bytebase's own `bytebase-action check` requires a running Bytebase server (`--url`, `--service-account`). Plan A pivoted to squawk mid-execution. The spec + plan docs have been updated to reflect the as-shipped state, with a clear pivot note. Plan B (Bytebase server in cloud control plane) is still the design for workflow/approval features.

## Files

- `internal/db/migrate.go` — new `VerifyMigrationsState` + `countEmbeddedMigrations` helper
- `internal/db/migrate_test.go` — 3 tests (happy path, mismatch, rollback+re-apply)
- `cmd/api/main.go` — unconditional `VerifyMigrationsState` call after the existing `AutoMigrate` block
- `.squawk.toml` — squawk config (`assume_in_transaction=true`, `pg_version=18.0`, full default ruleset)
- `.squawk/fixtures/bad/*.sql` — 3 fixtures violating `ban-drop-table`, `adding-required-field`, `require-concurrent-index-creation`
- `.github/workflows/sql-review.yml` — PR-time squawk run, diff-based
- `.github/workflows/sql-review-selftest.yml` — asserts squawk rejects the fixtures
- `Makefile` — new `sql-lint-local` target (runs squawk via `npx` against modified migrations)
- `docs/runbooks/migrations.md` — developer SOP: authoring, escape hatch, recovery
- `docs/superpowers/specs/2026-05-23-bytebase-tiered-design.md` — design spec + pivot note + backlog snapshot
- `docs/superpowers/plans/2026-05-23-bytebase-tiered-plan-a.md` — implementation plan + pivot note

## Squawk backlog

The initial full-tree squawk run against the 43 shipped migrations surfaced **271 findings** under the default ruleset. These are pre-existing and **not blocked by this PR** — the workflow only lints PR-modified files. Counts by rule are recorded in the spec ("Squawk Backlog Snapshot"). A separate initiative will pay this down incrementally.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/db/...` — 3 new tests pass (PASS in 3.6s)
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 new issues
- [x] `make sql-lint-local` on this branch — "nothing to lint" (no migrations modified)
- [x] Diff vs `origin/main` is exactly the 13 files I touched (rebased on latest main)
- [ ] CI green on this PR
- [ ] **Manual post-merge step:** add `Squawk migration lint` as a required status check on `main` under Settings → Branches → Branch protection rules. The check name registers with GitHub only after the workflow runs at least once (which happens on this PR). See `docs/runbooks/migrations.md` for full instructions.

## Deferred to Plan B

Cloud-profile Bytebase server, `dev → staging → prod` approval pipeline, drift detection, history-table override on tenant DBs, SSO integration. Plan B will be written when cloud-profile orchestration choices (Helm vs compose, SSO domain) are settled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * SQL migrations are now automatically reviewed in pull requests to catch potential issues
  * Database startup includes migration state verification to ensure consistency
  * Added local SQL migration linting capability for developers

* **Documentation**
  * Comprehensive migration operations runbook with authoring conventions, review process, and recovery procedures
  * Design specification documenting the database migration management approach

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ravencloak-org/Raven/pull/679?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->