### PR TITLE
deps(ai-worker): bump langsmith 0.7.33 → 0.8.5 (CVE-2026-45134)

### DIFF
--- a/ai-worker/uv.lock
+++ b/ai-worker/uv.lock
@@ -1181,7 +1181,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.7.33"
+version = "0.8.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1194,9 +1194,9 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/75/1ee27b3510bf5b1b569b9695c9466c256caab45885bd569c0c67720236ad/langsmith-0.7.33.tar.gz", hash = "sha256:fa2d81ad6e8374a81fda9291894f6fcae714e55fbf11a0b07578e3cd4b1ea384", size = 1186298, upload-time = "2026-04-20T16:17:54.583Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/eb/8883d1158c743d0aac350f09df7880714d27283497e8c80bb9fe3480f165/langsmith-0.8.5.tar.gz", hash = "sha256:3615243d99c12f4047f13042bdc05a373dce232d106a6511b3ca7b48c5af1c2c", size = 4462348, upload-time = "2026-05-15T21:31:41.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/76/53033db34ffccd25d62c32b23b9468f7228b455da6976e1c420ae31555c4/langsmith-0.7.33-py3-none-any.whl", hash = "sha256:5b535b991d52d3b664ebb8dc6f95afcf8d0acb42e062ac45a54a6a4820139f20", size = 378981, upload-time = "2026-04-20T16:17:52.503Z" },
+    { url = "https://files.pythonhosted.org/packages/23/85/968c88a63e32a59b3e5c68afd2fe114ce0708a125db0be1a85efc25fb2ea/langsmith-0.8.5-py3-none-any.whl", hash = "sha256:efc779f9d450dcaf9d97bc8894f4926276509d6e730e05289af9a64debce06ae", size = 399564, upload-time = "2026-05-15T21:31:39.046Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why
Trivy CI failing on HIGH CVE-2026-45134 in `ai-worker/uv.lock`:

```
langsmith 0.7.33  →  fixed in 0.8.0
'LangSmith SDK: Public prompt pull deserializes untrusted manifests
 without trust boundary warning'
```

`ai-worker/requirements.txt` already had `langsmith==0.8.3` — uv.lock had drifted.

## Fix
```
cd ai-worker && uv lock --upgrade-package langsmith
# → langsmith 0.7.33 → 0.8.5
```

langsmith is transitive (via `langchain-core` ← `langchain-text-splitters`), so no direct pin to update.

## Test plan
- [x] uv resolved cleanly (127 packages, no conflicts)
- [ ] CI Trivy goes green