### PR TITLE
feat(deploy): ship the Asynq worker so document processing actually runs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN CGO_ENABLED=1 GOOS=linux go build -ldflags="-s -w -extldflags '-static'" -o /api ./cmd/api
+RUN CGO_ENABLED=1 GOOS=linux go build -ldflags="-s -w -extldflags '-static'" -o /api ./cmd/api \
+ && CGO_ENABLED=1 GOOS=linux go build -ldflags="-s -w -extldflags '-static'" -o /worker ./cmd/worker
 
 # ── Stage 2: Runtime ─────────────────────────────────────────────────────────
 FROM alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
@@ -36,6 +37,10 @@ RUN apk add --no-cache ca-certificates tzdata curl \
     && adduser -u 1000 -G raven -D raven
 
 COPY --from=builder /api /app/api
+# The Asynq queue consumer. Same image, separate process — deploy as a
+# second container that overrides CMD to /app/worker. Lives in the same
+# image to keep the multi-arch build matrix from doubling.
+COPY --from=builder /worker /app/worker
 
 WORKDIR /app
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -382,7 +382,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to initialise LLM provider service: %v", err)
 	}
-	uploadSvc := service.NewUploadService(docRepo, pool, seaweedClient, cfg.Upload.MaxSizeBytes, cfg.Upload.AllowedTypes)
+	uploadSvc := service.NewUploadService(docRepo, pool, seaweedClient, queueClient, cfg.Upload.MaxSizeBytes, cfg.Upload.AllowedTypes)
 	processingSvc := service.NewProcessingEventService(processingEventRepo, docRepo, pool)
 	apiKeySvc := service.NewAPIKeyService(apiKeyRepo, pool)
 	routingSvc := service.NewRoutingService(routingRepo, kbRepo, pool)

--- a/deploy/ec2/docker-compose.server.yml
+++ b/deploy/ec2/docker-compose.server.yml
@@ -49,6 +49,31 @@ services:
       - raven-net
     restart: unless-stopped
 
+  # ─── Asynq queue worker ────────────────────────────────────────────────────
+  # Consumes the background-job queue (document processing, URL crawl,
+  # webhook delivery, email summaries). Same image as go-api but runs the
+  # `/app/worker` binary instead of `/app/api`. Without this container,
+  # every enqueue from the API silently piles up in Valkey forever — every
+  # uploaded document, every URL source, every queued webhook stays stuck
+  # at processing_status=queued until manually reprocessed.
+  worker:
+    image: ${GO_API_IMAGE:-ghcr.io/ravencloak-org/go-api:latest}
+    env_file: .env.server
+    environment:
+      SUPERTOKENS_CONNECTION_URI: "http://supertokens:3567"
+      SUPERTOKENS_API_KEY: "${SUPERTOKENS_API_KEY}"
+    entrypoint: ["dotenvx", "run", "--", "/app/worker"]
+    depends_on:
+      postgres:
+        condition: service_healthy
+      valkey:
+        condition: service_healthy
+      python-worker:
+        condition: service_started
+    networks:
+      - raven-net
+    restart: unless-stopped
+
   # ─── Python AI Worker (gRPC) ───────────────────────────────────────────────
   python-worker:
     image: ${PYTHON_WORKER_IMAGE:-ghcr.io/ravencloak-org/python-worker:latest}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,29 @@ services:
     restart: unless-stopped
     # eBPF capabilities (CAP_BPF, CAP_NET_ADMIN) are in docker-compose.ebpf.yml overlay
 
+  # ─── Asynq queue worker ────────────────────────────────────────────────────
+  # Shares the go-api image; entrypoint flips to /app/worker so the same
+  # binary set drives both the HTTP API and the Asynq consumer. Without
+  # this container, jobs enqueued by the API (document processing, URL
+  # crawls, webhook delivery, scheduled email summaries) pile up forever.
+  worker:
+    image: ${GO_API_IMAGE:-ghcr.io/ravencloak-org/go-api:latest}
+    build:
+      context: .
+      dockerfile: Dockerfile
+    env_file: .env
+    entrypoint: ["dotenvx", "run", "--", "/app/worker"]
+    depends_on:
+      postgres:
+        condition: service_healthy
+      valkey:
+        condition: service_healthy
+      python-worker:
+        condition: service_started
+    networks:
+      - raven-net
+    restart: unless-stopped
+
   # ─── Python AI Worker (gRPC) ───────────────────────────────────────────────
   python-worker:
     build:

--- a/internal/service/upload.go
+++ b/internal/service/upload.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"log/slog"
 	"strings"
 
 	"github.com/jackc/pgx/v5"
@@ -14,25 +15,40 @@ import (
 
 	"github.com/ravencloak-org/Raven/internal/db"
 	"github.com/ravencloak-org/Raven/internal/model"
+	"github.com/ravencloak-org/Raven/internal/queue"
 	"github.com/ravencloak-org/Raven/internal/repository"
 	"github.com/ravencloak-org/Raven/internal/storage"
 	"github.com/ravencloak-org/Raven/pkg/apierror"
 )
+
+// DocumentProcessEnqueuer is the narrow slice of the queue client this
+// service needs. Kept as an interface so the unit tests can pass a stub
+// without standing up a real Valkey.
+type DocumentProcessEnqueuer interface {
+	EnqueueDocumentProcess(ctx context.Context, p queue.DocumentProcessPayload) error
+}
 
 // UploadService contains business logic for document uploads.
 type UploadService struct {
 	repo         *repository.DocumentRepository
 	pool         *pgxpool.Pool
 	store        storage.Client
+	queueCli     DocumentProcessEnqueuer
 	maxSizeBytes int64
 	allowedTypes map[string]bool
 }
 
 // NewUploadService creates a new UploadService.
+//
+// queueCli may be nil — in that case the service writes the document row
+// with status=queued but skips the background enqueue. Production wiring
+// in cmd/api/main.go always supplies a real client; nil is reserved for
+// tests and degraded modes where the queue can't be reached.
 func NewUploadService(
 	repo *repository.DocumentRepository,
 	pool *pgxpool.Pool,
 	store storage.Client,
+	queueCli DocumentProcessEnqueuer,
 	maxSizeBytes int64,
 	allowedTypes []string,
 ) *UploadService {
@@ -43,6 +59,7 @@ func NewUploadService(
 		repo:         repo,
 		pool:         pool,
 		store:        store,
+		queueCli:     queueCli,
 		maxSizeBytes: maxSizeBytes,
 		allowedTypes: allowed,
 	}
@@ -132,6 +149,27 @@ func (s *UploadService) Upload(ctx context.Context, params UploadParams) (*model
 		// Attempt to clean up the stored file on DB failure.
 		_ = s.store.Delete(ctx, fid)
 		return nil, apierror.NewInternal("failed to create document record: " + err.Error())
+	}
+
+	// Hand the document off to the Asynq worker for parsing → chunking →
+	// embedding. We log + continue on enqueue failure rather than rolling
+	// back the upload: the row is already in the DB with status=queued, so
+	// an operator (or a future reaper job) can re-enqueue it. Failing the
+	// HTTP request after the file has been stored would be more confusing
+	// for the user than a delayed processing run.
+	if s.queueCli != nil {
+		if enqErr := s.queueCli.EnqueueDocumentProcess(ctx, queue.DocumentProcessPayload{
+			DocumentID:      doc.ID,
+			OrgID:           doc.OrgID,
+			KnowledgeBaseID: doc.KnowledgeBaseID,
+		}); enqErr != nil {
+			slog.Default().Error("upload: enqueue document process failed",
+				"document_id", doc.ID,
+				"org_id", doc.OrgID,
+				"kb_id", doc.KnowledgeBaseID,
+				"error", enqErr.Error(),
+			)
+		}
 	}
 
 	return doc, nil

--- a/internal/service/upload_test.go
+++ b/internal/service/upload_test.go
@@ -40,7 +40,7 @@ func (m *mockStorageClient) Delete(ctx context.Context, fid string) error {
 
 func TestUploadService_ValidateFileType_Rejected(t *testing.T) {
 	store := &mockStorageClient{}
-	svc := service.NewUploadService(nil, nil, store, 50*1024*1024, []string{
+	svc := service.NewUploadService(nil, nil, store, nil, 50*1024*1024, []string{
 		"application/pdf",
 		"text/plain",
 	})
@@ -70,7 +70,7 @@ func TestUploadService_ValidateFileType_Rejected(t *testing.T) {
 
 func TestUploadService_ValidateFileSize_Rejected(t *testing.T) {
 	store := &mockStorageClient{}
-	svc := service.NewUploadService(nil, nil, store, 1024, []string{"text/plain"})
+	svc := service.NewUploadService(nil, nil, store, nil, 1024, []string{"text/plain"})
 
 	_, err := svc.Upload(context.Background(), service.UploadParams{
 		OrgID:           "org-1",
@@ -99,7 +99,7 @@ func TestUploadService_AllowedType_CaseInsensitive(t *testing.T) {
 	store := &mockStorageClient{}
 
 	// Configure with mixed-case type.
-	svc := service.NewUploadService(nil, nil, store, 50*1024*1024, []string{
+	svc := service.NewUploadService(nil, nil, store, nil, 50*1024*1024, []string{
 		"Application/PDF",
 	})
 


### PR DESCRIPTION
## TL;DR
The Go side of Raven's background queue was **inert in production from day one**. Documents have been silently piling up in Valkey forever.

## What was broken

### 1. The worker was never deployed
`cmd/worker/main.go` is the Asynq consumer that handles `document:process`, `webhook:delivery`, `airbyte:sync`, `email:summary`, `email:send`. It compiles, has tests, and exists in source — but:

- `Dockerfile` only built `/app/api` (the worker binary was never produced)
- No `worker` service in any `docker-compose.yml`

Every job ever enqueued has just sat in Valkey.

### 2. Upload doesn't enqueue
`UploadService.Upload` inserts the doc row with `processing_status=queued` and returns. The only caller of `EnqueueDocumentProcess` in the entire codebase was `internal/service/seed.go`. So even if a worker had been running, real uploads through the API never made it to the queue.

## Fix
- **Dockerfile**: build `/worker` alongside `/api` in the same multi-stage build; copy both into runtime. `CMD` stays at `/app/api` so the existing `go-api` service is unchanged.
- **`deploy/ec2/docker-compose.server.yml`** + **`docker-compose.yml`**: add `worker` service that reuses `GO_API_IMAGE`, overrides entrypoint to `/app/worker`, depends on postgres + valkey + python-worker.
- **`internal/service/upload.go`**: take a `DocumentProcessEnqueuer` (narrow interface), call `EnqueueDocumentProcess` after the DB insert succeeds. Log + continue on enqueue failure rather than rolling back the row (the file is already in storage; failing the HTTP call would be more confusing than a delayed run).
- **`cmd/api/main.go`**: wire `queueClient` into `NewUploadService`.
- **Tests**: pass `nil` queue (only exercise validation paths).

## Verified live
Hot-compiled `/app/worker` and the new `/app/api`, deployed both to the demo box, manually re-enqueued the two documents that had been stuck for days:

```
queued -> ready (chunks=1) in <1s once worker picked them up
```

## Follow-ups tracked separately
- **#30** URL source crawling (`TypeURLScrape`) — no handler, no enqueuer; fully unimplemented.
- Email summaries require `ALLOW_STUB_EMAIL_SENDER=true` when SES isn't configured, otherwise the worker crashloops on boot. Already set on the demo box; needs to be documented in `deploy/vultr/.env.server.example`.

## Test plan
- [x] Verified hot-deploy on demo: queued docs process to `ready`
- [x] `go test ./internal/service/... -run TestUpload` clean
- [x] `golangci-lint --new-from-rev=HEAD` clean
- [ ] CI green
- [ ] Post-merge on demo: container `worker` Up, fresh upload through SPA flows to `ready`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Introduced a dedicated background worker service deployed alongside the API for handling asynchronous document processing jobs
* Enhanced document uploads to automatically enqueue processing jobs to the background worker
* Worker service is configured to coordinate with the API server and manage the job processing queue

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ravencloak-org/Raven/pull/681?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->