### PR TITLE
feat(llm): add 'ollama' to llm_provider enum + Go const

### DIFF
--- a/internal/model/llm_provider.go
+++ b/internal/model/llm_provider.go
@@ -12,16 +12,21 @@ const (
 	LLMProviderCohere     LLMProvider = "cohere"
 	LLMProviderGoogle     LLMProvider = "google"
 	LLMProviderAzureOpenAI LLMProvider = "azure_openai"
+	LLMProviderOllama     LLMProvider = "ollama"
 	LLMProviderCustom     LLMProvider = "custom"
 )
 
 // ValidLLMProviders is the set of valid LLM provider enum values.
+// Must stay in sync with the llm_provider Postgres enum (see
+// migrations/00045_llm_provider_add_ollama.sql) and the
+// `_SUPPORTED_PROVIDERS` set in ai-worker/raven_worker/providers/registry.py.
 var ValidLLMProviders = map[LLMProvider]bool{
 	LLMProviderOpenAI:      true,
 	LLMProviderAnthropic:   true,
 	LLMProviderCohere:      true,
 	LLMProviderGoogle:      true,
 	LLMProviderAzureOpenAI: true,
+	LLMProviderOllama:      true,
 	LLMProviderCustom:      true,
 }
 

--- a/migrations/00045_llm_provider_add_ollama.sql
+++ b/migrations/00045_llm_provider_add_ollama.sql
@@ -1,0 +1,21 @@
+-- +goose Up
+-- +goose NO TRANSACTION
+--
+-- Add 'ollama' to the llm_provider enum so users can register a local
+-- Ollama daemon as a chat provider. The frontend already speaks
+-- 'ollama' (LLM provider dialog, PROVIDER_MODELS map) and the Python
+-- AI worker already has an OllamaEmbeddingProvider — only the
+-- backend's validator + DB enum were missing the value, so any POST
+-- /llm-providers with provider=ollama 400'd at validation.
+--
+-- Postgres requires ALTER TYPE ADD VALUE outside any transaction.
+-- IF NOT EXISTS makes the migration idempotent.
+ALTER TYPE llm_provider ADD VALUE IF NOT EXISTS 'ollama';
+
+-- +goose Down
+-- +goose NO TRANSACTION
+--
+-- Postgres has no ALTER TYPE ... REMOVE VALUE. Rolling back would
+-- require rebuilding the enum and rewriting every column that
+-- references it — not worth it for an additive change. No-op down.
+SELECT 1;


### PR DESCRIPTION
## Problem
Every `POST /orgs/:id/llm-providers` with `provider=ollama` 400'd because the value wasn't in:
- the Go `ValidLLMProviders` map (`internal/model/llm_provider.go`)
- the Postgres `llm_provider` enum

even though the frontend already speaks 'ollama' (`PROVIDER_MODELS`, `ProviderType`, the new tunnel-hint flow) and the Python AI worker has an `OllamaEmbeddingProvider` registered in `raven_worker.providers.registry`.

## Fix
- Migration `00045_llm_provider_add_ollama.sql` — `ALTER TYPE llm_provider ADD VALUE IF NOT EXISTS 'ollama'` (NO TRANSACTION + idempotent re-run safety).
- New const `LLMProviderOllama` + `ValidLLMProviders[LLMProviderOllama] = true`.
- Cross-reference comment so future additions stay in sync across DB enum, Go const, and Python registry.

## Verified live
- Applied migration on demo box; `enum_range(NULL::llm_provider)` returns 7 values including ollama.
- Hot-deployed go-api restarted healthy.

Pairs with PR #689 (Test-connection gate) — Ollama now actually creates instead of 400-ing after the green test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Ollama as a new LLM provider option, expanding available language model integration choices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ravencloak-org/Raven/pull/690?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->