### PR TITLE
feat(db): add Marketplace columns to knowledge_bases (#723)

### DIFF
--- a/internal/model/kb.go
+++ b/internal/model/kb.go
@@ -11,6 +11,19 @@ const (
 	KBStatusArchived KBStatus = "archived"
 )
 
+// KBVisibility represents the Marketplace publish state of a KB. Private
+// KBs are tenant-scoped (the default); Public KBs are listed on the
+// Marketplace and importable by other orgs. See ADR-0002 for the publish
+// boundary and migration 00047 for the underlying enum.
+type KBVisibility string
+
+// KBVisibilityPrivate and KBVisibilityPublic are the valid values of the
+// kb_visibility enum added in migration 00047 (issue #723).
+const (
+	KBVisibilityPrivate KBVisibility = "private"
+	KBVisibilityPublic  KBVisibility = "public"
+)
+
 // KnowledgeBase is a scoped document store within a workspace.
 type KnowledgeBase struct {
 	ID                       string         `json:"id"`
@@ -26,9 +39,44 @@ type KnowledgeBase struct {
 	// CacheSimilarityThreshold is the cosine-similarity floor (0.80–0.99)
 	// above which a stored cache entry is considered a HIT for an incoming
 	// query. Stricter values yield fewer hits but higher answer accuracy.
-	CacheSimilarityThreshold float32   `json:"cache_similarity_threshold"`
-	CreatedAt                time.Time `json:"created_at"`
-	UpdatedAt                time.Time `json:"updated_at"`
+	CacheSimilarityThreshold float32 `json:"cache_similarity_threshold"`
+
+	// Marketplace columns (migration 00047, issue #723). The zero values
+	// here describe a brand-new private KB that has never been published —
+	// the shape every existing row has after the migration runs.
+
+	// Visibility is the Marketplace publish state. See ADR-0002.
+	Visibility KBVisibility `json:"visibility"`
+	// PublishedAt is set when the KB first transitions private → public,
+	// and updated on each re-publish.
+	PublishedAt *time.Time `json:"published_at,omitempty"`
+	// PublishedByUserID records which org member ran the publish action.
+	// Nullable so the FK can survive a user delete (ON DELETE SET NULL).
+	PublishedByUserID *string `json:"published_by_user_id,omitempty"`
+	// SourcePublicKBID is the Importer-side lineage pointer to the source
+	// public KB this row was forked from (ADR-0001). Null for KBs that
+	// were authored locally rather than imported.
+	SourcePublicKBID *string `json:"source_public_kb_id,omitempty"`
+	// ImportedFromRevisionAt captures the source KB's last_modified_at at
+	// the moment of Import or Re-import, so the "stale relative to source"
+	// signal in ADR-0003 is computable without a Marketplace round-trip.
+	ImportedFromRevisionAt *time.Time `json:"imported_from_revision_at,omitempty"`
+	// LastModifiedAt is bumped by triggers on documents/sources/chunks so
+	// Marketplace listing can surface freshness without scanning children.
+	// Distinct from UpdatedAt, which only tracks row-level changes to the
+	// knowledge_bases tuple itself.
+	LastModifiedAt time.Time `json:"last_modified_at"`
+	// LicenseSPDXID is the SPDX identifier (e.g. "CC-BY-4.0") attached to
+	// the published KB. Nullable here; the partial CHECK enforcing non-null
+	// when visibility='public' lands in migration 00050 (ADR-0006).
+	LicenseSPDXID *string `json:"license_spdx_id,omitempty"`
+	// ImportCount and PreviewCount power the discovery surface (ADR-0008)
+	// and are bumped by the Importer / Preview handlers in later issues.
+	ImportCount  int `json:"import_count"`
+	PreviewCount int `json:"preview_count"`
+
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 // CreateKBRequest is the payload for POST .../knowledge-bases.

--- a/internal/model/kb_test.go
+++ b/internal/model/kb_test.go
@@ -1,0 +1,124 @@
+package model
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// TestKBVisibilityConstants pins the enum values to the strings stored in
+// Postgres so a typo here would surface at compile/test time rather than
+// when a query silently returns zero rows.
+func TestKBVisibilityConstants(t *testing.T) {
+	cases := map[KBVisibility]string{
+		KBVisibilityPrivate: "private",
+		KBVisibilityPublic:  "public",
+	}
+	for got, want := range cases {
+		if string(got) != want {
+			t.Errorf("KBVisibility constant: want %q, got %q", want, got)
+		}
+	}
+}
+
+// TestKnowledgeBase_MarketplaceFields_JSONShape verifies the JSON tags for
+// the Marketplace columns added in migration 00047 — Publish/Import handlers
+// in later issues rely on this exact wire shape.
+func TestKnowledgeBase_MarketplaceFields_JSONShape(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	userID := "11111111-1111-1111-1111-111111111111"
+	sourceKBID := "22222222-2222-2222-2222-222222222222"
+	license := "CC-BY-4.0"
+
+	kb := KnowledgeBase{
+		ID:                       "33333333-3333-3333-3333-333333333333",
+		OrgID:                    "44444444-4444-4444-4444-444444444444",
+		WorkspaceID:              "55555555-5555-5555-5555-555555555555",
+		Name:                     "Test KB",
+		Slug:                     "test-kb",
+		Settings:                 map[string]any{},
+		Status:                   KBStatusActive,
+		CacheEnabled:             true,
+		CacheSimilarityThreshold: 0.92,
+		Visibility:               KBVisibilityPublic,
+		PublishedAt:              &now,
+		PublishedByUserID:        &userID,
+		SourcePublicKBID:         &sourceKBID,
+		ImportedFromRevisionAt:   &now,
+		LastModifiedAt:           now,
+		LicenseSPDXID:            &license,
+		ImportCount:              3,
+		PreviewCount:             7,
+		CreatedAt:                now,
+		UpdatedAt:                now,
+	}
+
+	raw, err := json.Marshal(kb)
+	if err != nil {
+		t.Fatalf("marshal KnowledgeBase: %v", err)
+	}
+
+	var roundtripped map[string]any
+	if err := json.Unmarshal(raw, &roundtripped); err != nil {
+		t.Fatalf("unmarshal KnowledgeBase: %v", err)
+	}
+
+	expectedKeys := []string{
+		"visibility",
+		"published_at",
+		"published_by_user_id",
+		"source_public_kb_id",
+		"imported_from_revision_at",
+		"last_modified_at",
+		"license_spdx_id",
+		"import_count",
+		"preview_count",
+	}
+	for _, key := range expectedKeys {
+		if _, ok := roundtripped[key]; !ok {
+			t.Errorf("missing JSON key %q in marshalled KnowledgeBase", key)
+		}
+	}
+
+	if roundtripped["visibility"] != "public" {
+		t.Errorf("visibility field: want \"public\", got %v", roundtripped["visibility"])
+	}
+	if got, ok := roundtripped["import_count"].(float64); !ok || got != 3 {
+		t.Errorf("import_count: want 3, got %v", roundtripped["import_count"])
+	}
+}
+
+// TestKnowledgeBase_NilOptionalFields_OmitEmpty ensures the omitempty tags
+// keep the wire payload tidy for the default (never-published) row shape.
+func TestKnowledgeBase_NilOptionalFields_OmitEmpty(t *testing.T) {
+	kb := KnowledgeBase{
+		ID:         "id",
+		Visibility: KBVisibilityPrivate,
+	}
+	raw, err := json.Marshal(kb)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, key := range []string{
+		"published_at",
+		"published_by_user_id",
+		"source_public_kb_id",
+		"imported_from_revision_at",
+		"license_spdx_id",
+	} {
+		if _, present := out[key]; present {
+			t.Errorf("expected %q to be omitted when nil, but it was present", key)
+		}
+	}
+	// Non-pointer scalars must serialise even at their zero values so
+	// clients can rely on a stable shape.
+	for _, key := range []string{"visibility", "import_count", "preview_count", "last_modified_at"} {
+		if _, present := out[key]; !present {
+			t.Errorf("expected %q to always be present, but it was omitted", key)
+		}
+	}
+}

--- a/internal/repository/kb.go
+++ b/internal/repository/kb.go
@@ -20,16 +20,36 @@ func NewKBRepository(pool *pgxpool.Pool) *KBRepository {
 	return &KBRepository{pool: pool}
 }
 
-// kbColumns lists every column returned by KB reads. The M9 semantic cache
-// (#256) added cache_enabled and cache_similarity_threshold.
+// kbColumns lists every column returned by KB reads.
+//
+// History:
+//   - M9 semantic cache (#256) added cache_enabled, cache_similarity_threshold.
+//   - Marketplace MVP (#723, migration 00047) added the visibility / publish /
+//     lineage / freshness / license / discovery block.
+//
+// search_tsv is intentionally omitted: callers never need the raw tsvector,
+// and Marketplace search reads it server-side via dedicated SQL functions
+// (added in migration 00052).
 const kbColumns = `id, org_id, workspace_id, name, slug,
 	COALESCE(description, '') AS description, settings, status,
 	cache_enabled, cache_similarity_threshold,
+	visibility, published_at, published_by_user_id,
+	source_public_kb_id, imported_from_revision_at, last_modified_at,
+	license_spdx_id, import_count, preview_count,
 	created_at, updated_at`
 
 func scanKB(row pgx.Row) (*model.KnowledgeBase, error) {
 	var kb model.KnowledgeBase
-	err := row.Scan(
+	if err := scanKBInto(row, &kb); err != nil {
+		return nil, err
+	}
+	return &kb, nil
+}
+
+// scanKBInto is shared by single-row scans and the iterator loop in
+// ListByWorkspace so the column order stays defined in one place.
+func scanKBInto(row pgx.Row, kb *model.KnowledgeBase) error {
+	return row.Scan(
 		&kb.ID,
 		&kb.OrgID,
 		&kb.WorkspaceID,
@@ -40,13 +60,18 @@ func scanKB(row pgx.Row) (*model.KnowledgeBase, error) {
 		&kb.Status,
 		&kb.CacheEnabled,
 		&kb.CacheSimilarityThreshold,
+		&kb.Visibility,
+		&kb.PublishedAt,
+		&kb.PublishedByUserID,
+		&kb.SourcePublicKBID,
+		&kb.ImportedFromRevisionAt,
+		&kb.LastModifiedAt,
+		&kb.LicenseSPDXID,
+		&kb.ImportCount,
+		&kb.PreviewCount,
 		&kb.CreatedAt,
 		&kb.UpdatedAt,
 	)
-	if err != nil {
-		return nil, err
-	}
-	return &kb, nil
 }
 
 // Create inserts a new knowledge base within a workspace transaction.
@@ -96,10 +121,7 @@ func (r *KBRepository) ListByWorkspace(ctx context.Context, tx pgx.Tx, orgID, ws
 	var kbs []model.KnowledgeBase
 	for rows.Next() {
 		var kb model.KnowledgeBase
-		if err := rows.Scan(&kb.ID, &kb.OrgID, &kb.WorkspaceID, &kb.Name, &kb.Slug,
-			&kb.Description, &kb.Settings, &kb.Status,
-			&kb.CacheEnabled, &kb.CacheSimilarityThreshold,
-			&kb.CreatedAt, &kb.UpdatedAt); err != nil {
+		if err := scanKBInto(rows, &kb); err != nil {
 			return nil, fmt.Errorf("KBRepository.ListByWorkspace scan: %w", err)
 		}
 		kbs = append(kbs, kb)

--- a/internal/repository/kb_export_test.go
+++ b/internal/repository/kb_export_test.go
@@ -1,0 +1,6 @@
+package repository
+
+// KBColumnsForTest exposes kbColumns for unit tests.
+func KBColumnsForTest() string {
+	return kbColumns
+}

--- a/internal/repository/kb_test.go
+++ b/internal/repository/kb_test.go
@@ -1,0 +1,57 @@
+package repository_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ravencloak-org/Raven/internal/repository"
+)
+
+// TestKBRepository_Constructor verifies the constructor returns a non-nil
+// value even with a nil pool — matches the project's existing repository
+// unit-test pattern (see chunk_test.go).
+func TestKBRepository_Constructor(t *testing.T) {
+	repo := repository.NewKBRepository(nil)
+	if repo == nil {
+		t.Fatal("NewKBRepository should return non-nil even with nil pool")
+	}
+}
+
+// TestKBColumns_IncludesMarketplaceFields locks in the column list that
+// scanKB depends on. Adding a struct field without updating the SELECT
+// projection silently breaks RETURNING-based reads — this guard catches
+// that drift before it reaches a live DB.
+func TestKBColumns_IncludesMarketplaceFields(t *testing.T) {
+	cols := repository.KBColumnsForTest()
+	expected := []string{
+		// pre-marketplace baseline
+		"id", "org_id", "workspace_id", "name", "slug",
+		"description", "settings", "status",
+		"cache_enabled", "cache_similarity_threshold",
+		// marketplace (issue #723, migration 00047)
+		"visibility",
+		"published_at",
+		"published_by_user_id",
+		"source_public_kb_id",
+		"imported_from_revision_at",
+		"last_modified_at",
+		"license_spdx_id",
+		"import_count",
+		"preview_count",
+		"created_at", "updated_at",
+	}
+	for _, col := range expected {
+		if !strings.Contains(cols, col) {
+			t.Errorf("kbColumns missing field %q; full constant:\n%s", col, cols)
+		}
+	}
+}
+
+// TestKBColumns_OmitsSearchTSV documents the deliberate choice to exclude
+// search_tsv from the read shape — callers never need the raw tsvector,
+// and Marketplace search reads it server-side via SQL functions.
+func TestKBColumns_OmitsSearchTSV(t *testing.T) {
+	if strings.Contains(repository.KBColumnsForTest(), "search_tsv") {
+		t.Error("kbColumns should not select search_tsv; the tsvector is server-side only")
+	}
+}

--- a/migrations/00047_kb_marketplace_columns.sql
+++ b/migrations/00047_kb_marketplace_columns.sql
@@ -1,0 +1,134 @@
+-- +goose Up
+--
+-- Marketplace MVP schema groundwork (issue #723, M1).
+--
+-- Extends knowledge_bases with publish-state, lineage, freshness, license,
+-- and discovery columns. See:
+--   - docs/plans/marketplace-mvp.md §2 (00047_kb_marketplace_columns.sql)
+--   - ADR-0001 (fork on import) — source_public_kb_id lineage pointer
+--   - ADR-0002 (content-grade publish boundary) — visibility transitions
+--   - ADR-0003 (always-fresh publish lifecycle) — last_modified_at signal
+--   - ADR-0005 (org as marketplace publisher) — published_by_user_id audit
+--   - ADR-0008 (marketplace discovery and operations) — search_tsv + counters
+--
+-- This is a foundation slice. Publish/import handlers, the partial UNIQUE
+-- on (org_id, slug) WHERE visibility='public' (depends on org_slug from
+-- migration 00048), the license CHECK constraint (migration 00050), and
+-- the read-only-private kb_status value (migration 00049) all land in
+-- later migrations. Column shape + trigger + indexes only here.
+
+-- New enum: KB visibility flag. Marketplace listing reads filter
+-- visibility='public'; everything else stays private (the default).
+CREATE TYPE kb_visibility AS ENUM ('private', 'public');
+
+ALTER TABLE knowledge_bases
+    ADD COLUMN visibility kb_visibility NOT NULL DEFAULT 'private',
+    ADD COLUMN published_at TIMESTAMPTZ NULL,
+    ADD COLUMN published_by_user_id UUID NULL REFERENCES users(id) ON DELETE SET NULL,
+    ADD COLUMN source_public_kb_id UUID NULL REFERENCES knowledge_bases(id) ON DELETE SET NULL,
+    ADD COLUMN imported_from_revision_at TIMESTAMPTZ NULL,
+    ADD COLUMN last_modified_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    ADD COLUMN license_spdx_id TEXT NULL,
+    ADD COLUMN import_count INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN preview_count INTEGER NOT NULL DEFAULT 0,
+    -- search_tsv is GENERATED from in-row text only (name + description).
+    -- The publishing org's display_name lives on organizations and cannot be
+    -- referenced from a GENERATED expression on this table. The Marketplace
+    -- listing function (00052) JOINs organizations and concatenates its
+    -- display_name into the search expression at query time instead.
+    ADD COLUMN search_tsv tsvector GENERATED ALWAYS AS (
+        setweight(to_tsvector('english', COALESCE(name, '')), 'A') ||
+        setweight(to_tsvector('english', COALESCE(description, '')), 'B')
+    ) STORED;
+
+-- Discovery / freshness indexes. Partial indexes keep them tiny while the
+-- vast majority of rows stay private.
+CREATE INDEX idx_kb_visibility_public
+    ON knowledge_bases (visibility)
+    WHERE visibility = 'public';
+
+CREATE INDEX idx_kb_source_public_kb_id
+    ON knowledge_bases (source_public_kb_id)
+    WHERE source_public_kb_id IS NOT NULL;
+
+CREATE INDEX idx_kb_last_modified_at_public
+    ON knowledge_bases (last_modified_at DESC)
+    WHERE visibility = 'public';
+
+CREATE INDEX idx_kb_search_tsv_public
+    ON knowledge_bases USING gin (search_tsv)
+    WHERE visibility = 'public';
+
+-- Trigger function: bump the parent KB's last_modified_at on any
+-- INSERT/UPDATE/DELETE of documents, sources, or chunks. ADR-0003 makes
+-- last_modified_at the canonical "is this Public KB stale relative to
+-- the Importer's snapshot?" signal, so it must move whenever content
+-- mutates — not just when the KB row itself is updated.
+--
+-- The trigger reads knowledge_base_id from NEW for INSERT/UPDATE and from
+-- OLD for DELETE; both shapes carry the column on all three child tables.
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION bump_kb_last_modified()
+RETURNS TRIGGER AS $$
+DECLARE
+    target_kb_id UUID;
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        target_kb_id := OLD.knowledge_base_id;
+    ELSE
+        target_kb_id := NEW.knowledge_base_id;
+    END IF;
+
+    IF target_kb_id IS NOT NULL THEN
+        UPDATE knowledge_bases
+        SET last_modified_at = NOW()
+        WHERE id = target_kb_id;
+    END IF;
+
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+CREATE TRIGGER trg_kb_last_modified_on_documents
+    AFTER INSERT OR UPDATE OR DELETE ON documents
+    FOR EACH ROW EXECUTE FUNCTION bump_kb_last_modified();
+
+CREATE TRIGGER trg_kb_last_modified_on_sources
+    AFTER INSERT OR UPDATE OR DELETE ON sources
+    FOR EACH ROW EXECUTE FUNCTION bump_kb_last_modified();
+
+CREATE TRIGGER trg_kb_last_modified_on_chunks
+    AFTER INSERT OR UPDATE OR DELETE ON chunks
+    FOR EACH ROW EXECUTE FUNCTION bump_kb_last_modified();
+
+-- +goose Down
+--
+-- Reverse in dependency order: triggers → function → indexes → columns → enum.
+DROP TRIGGER IF EXISTS trg_kb_last_modified_on_chunks ON chunks;
+DROP TRIGGER IF EXISTS trg_kb_last_modified_on_sources ON sources;
+DROP TRIGGER IF EXISTS trg_kb_last_modified_on_documents ON documents;
+DROP FUNCTION IF EXISTS bump_kb_last_modified();
+
+DROP INDEX IF EXISTS idx_kb_search_tsv_public;
+DROP INDEX IF EXISTS idx_kb_last_modified_at_public;
+DROP INDEX IF EXISTS idx_kb_source_public_kb_id;
+DROP INDEX IF EXISTS idx_kb_visibility_public;
+
+ALTER TABLE knowledge_bases
+    DROP COLUMN IF EXISTS search_tsv,
+    DROP COLUMN IF EXISTS preview_count,
+    DROP COLUMN IF EXISTS import_count,
+    DROP COLUMN IF EXISTS license_spdx_id,
+    DROP COLUMN IF EXISTS last_modified_at,
+    DROP COLUMN IF EXISTS imported_from_revision_at,
+    DROP COLUMN IF EXISTS source_public_kb_id,
+    DROP COLUMN IF EXISTS published_by_user_id,
+    DROP COLUMN IF EXISTS published_at,
+    DROP COLUMN IF EXISTS visibility;
+
+DROP TYPE IF EXISTS kb_visibility;

--- a/migrations/migrations_test.go
+++ b/migrations/migrations_test.go
@@ -92,6 +92,7 @@ var allExpectedTypes = []string{
 	"user_status",
 	"workspace_role",
 	"kb_status",
+	"kb_visibility",
 	"processing_status",
 	"source_type",
 	"crawl_frequency",
@@ -325,6 +326,141 @@ func TestMigrationsUpAndDown(t *testing.T) {
 		}
 		if !strings.Contains(indexDef, "vector_cosine_ops") {
 			t.Errorf("expected HNSW index to use vector_cosine_ops, got: %s", indexDef)
+		}
+	})
+
+	t.Run("kb_marketplace_columns_and_trigger", func(t *testing.T) {
+		// Migration 00047 (issue #723): visibility / publish / lineage /
+		// freshness / license / discovery columns on knowledge_bases,
+		// plus the trg_kb_last_modified_on_documents/sources/chunks trigger
+		// that bumps last_modified_at when child content mutates.
+		//
+		// This sub-test:
+		//   1. Verifies every new column exists with the right default.
+		//   2. Verifies the four partial / GIN indexes are present.
+		//   3. Inserts a KB and asserts visibility defaults to 'private' and
+		//      counters default to 0.
+		//   4. Inserts a document under the KB and asserts last_modified_at
+		//      advances — proving the trigger fires across tables.
+
+		expectedColumns := map[string]string{
+			"visibility":                "kb_visibility",
+			"published_at":              "timestamp with time zone",
+			"published_by_user_id":      "uuid",
+			"source_public_kb_id":       "uuid",
+			"imported_from_revision_at": "timestamp with time zone",
+			"last_modified_at":          "timestamp with time zone",
+			"license_spdx_id":           "text",
+			"import_count":              "integer",
+			"preview_count":             "integer",
+			"search_tsv":                "tsvector",
+		}
+		for col, wantType := range expectedColumns {
+			var dataType string
+			err := db.QueryRowContext(ctx,
+				`SELECT data_type FROM information_schema.columns
+				 WHERE table_schema = 'public' AND table_name = 'knowledge_bases'
+				   AND column_name = $1`, col).Scan(&dataType)
+			if err != nil {
+				t.Errorf("missing column knowledge_bases.%s: %v", col, err)
+				continue
+			}
+			// The enum column reports its custom type as USER-DEFINED in
+			// information_schema; cross-check against pg_type for the real name.
+			if dataType == "USER-DEFINED" {
+				var typeName string
+				if err := db.QueryRowContext(ctx,
+					`SELECT udt_name FROM information_schema.columns
+					 WHERE table_schema = 'public' AND table_name = 'knowledge_bases'
+					   AND column_name = $1`, col).Scan(&typeName); err != nil {
+					t.Errorf("failed to read udt_name for %s: %v", col, err)
+					continue
+				}
+				if typeName != wantType {
+					t.Errorf("column %s: want type %s, got %s", col, wantType, typeName)
+				}
+				continue
+			}
+			if dataType != wantType {
+				t.Errorf("column %s: want type %s, got %s", col, wantType, dataType)
+			}
+		}
+
+		expectedIndexes := []string{
+			"idx_kb_visibility_public",
+			"idx_kb_source_public_kb_id",
+			"idx_kb_last_modified_at_public",
+			"idx_kb_search_tsv_public",
+		}
+		for _, idx := range expectedIndexes {
+			var exists bool
+			if err := db.QueryRowContext(ctx,
+				`SELECT EXISTS (SELECT 1 FROM pg_indexes
+				 WHERE tablename = 'knowledge_bases' AND indexname = $1)`, idx).
+				Scan(&exists); err != nil {
+				t.Errorf("failed to check index %s: %v", idx, err)
+			}
+			if !exists {
+				t.Errorf("expected index %s on knowledge_bases", idx)
+			}
+		}
+
+		// Bootstrap a workspace + KB so we can prove the trigger fires.
+		var orgID, wsID, kbID string
+		if err := db.QueryRowContext(ctx,
+			`INSERT INTO organizations (id, name, slug)
+			 VALUES (uuid_generate_v4(), 'KB Trigger Org', 'kb-trigger-org')
+			 RETURNING id`).Scan(&orgID); err != nil {
+			t.Fatalf("insert organization: %v", err)
+		}
+		if err := db.QueryRowContext(ctx,
+			`INSERT INTO workspaces (id, org_id, name, slug)
+			 VALUES (uuid_generate_v4(), $1, 'KB Trigger WS', 'kb-trigger-ws')
+			 RETURNING id`, orgID).Scan(&wsID); err != nil {
+			t.Fatalf("insert workspace: %v", err)
+		}
+		if err := db.QueryRowContext(ctx,
+			`INSERT INTO knowledge_bases (org_id, workspace_id, name, slug)
+			 VALUES ($1, $2, 'KB Trigger', 'kb-trigger')
+			 RETURNING id`, orgID, wsID).Scan(&kbID); err != nil {
+			t.Fatalf("insert knowledge_base: %v", err)
+		}
+
+		var visibility string
+		var importCount, previewCount int
+		var beforeLastModified time.Time
+		if err := db.QueryRowContext(ctx,
+			`SELECT visibility, import_count, preview_count, last_modified_at
+			 FROM knowledge_bases WHERE id = $1`, kbID).
+			Scan(&visibility, &importCount, &previewCount, &beforeLastModified); err != nil {
+			t.Fatalf("read marketplace defaults: %v", err)
+		}
+		if visibility != "private" {
+			t.Errorf("default visibility: want private, got %q", visibility)
+		}
+		if importCount != 0 || previewCount != 0 {
+			t.Errorf("default counters: want 0/0, got %d/%d", importCount, previewCount)
+		}
+
+		// Small sleep so the post-trigger timestamp can demonstrably exceed the
+		// pre-insert value.
+		time.Sleep(50 * time.Millisecond)
+
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO documents (org_id, knowledge_base_id, file_name)
+			 VALUES ($1, $2, 'trigger-doc.txt')`, orgID, kbID); err != nil {
+			t.Fatalf("insert document: %v", err)
+		}
+
+		var afterLastModified time.Time
+		if err := db.QueryRowContext(ctx,
+			`SELECT last_modified_at FROM knowledge_bases WHERE id = $1`, kbID).
+			Scan(&afterLastModified); err != nil {
+			t.Fatalf("read last_modified_at: %v", err)
+		}
+		if !afterLastModified.After(beforeLastModified) {
+			t.Errorf("expected trg_kb_last_modified_on_documents to bump last_modified_at; before=%v after=%v",
+				beforeLastModified, afterLastModified)
 		}
 	})
 


### PR DESCRIPTION
Closes #723.

## Summary

Foundation slice for the Marketplace MVP (M1). Extends `knowledge_bases` with publish-state, lineage, freshness, license, and discovery columns plus a content-mutation freshness trigger. Schema + Go model only — publish/import handlers and the downstream migrations land in separate issues.

## Migration `00047_kb_marketplace_columns.sql`

- New enum `kb_visibility AS ENUM ('private','public')`.
- Columns on `knowledge_bases`:
  - `visibility` (defaults to `'private'`)
  - `published_at`, `published_by_user_id` (FK to `users`, `ON DELETE SET NULL`)
  - `source_public_kb_id` (self-FK; Importer-side lineage per [ADR-0001](../blob/feat/issue-723-kb-marketplace-columns/docs/adr/0001-marketplace-fork-on-import.md))
  - `imported_from_revision_at`
  - `last_modified_at` (`DEFAULT now()`; bumped by trigger — distinct from `updated_at`)
  - `license_spdx_id` (nullable here; the `WHERE visibility='public'` partial CHECK lands in 00050 per [ADR-0006](../blob/feat/issue-723-kb-marketplace-columns/docs/adr/0006-licence-and-moderation.md))
  - `import_count`, `preview_count` (discovery counters per [ADR-0008](../blob/feat/issue-723-kb-marketplace-columns/docs/adr/0008-marketplace-discovery-and-operations.md))
  - `search_tsv tsvector GENERATED ALWAYS AS (... ) STORED` — built from `name + description` only, since GENERATED expressions cannot reference other tables. Org `display_name` is JOINed in at search time by the listing function (00052).
- Trigger function `bump_kb_last_modified()` + three `AFTER INSERT OR UPDATE OR DELETE` triggers on `documents`, `sources`, `chunks` bump the parent KB's `last_modified_at` whenever child content changes per [ADR-0003](../blob/feat/issue-723-kb-marketplace-columns/docs/adr/0003-always-fresh-publish-lifecycle.md).
- Indexes (all partial / GIN-on-public to stay cheap while most rows remain private):
  - `idx_kb_visibility_public WHERE visibility='public'`
  - `idx_kb_source_public_kb_id WHERE source_public_kb_id IS NOT NULL`
  - `idx_kb_last_modified_at_public WHERE visibility='public'`
  - `idx_kb_search_tsv_public USING gin (search_tsv) WHERE visibility='public'`
- `+goose Down` reverses triggers → function → indexes → columns → enum.

The partial UNIQUE on `(org_id, slug) WHERE visibility='public'` is intentionally deferred to migration 00048, where `organizations.slug` becomes a first-class column ([ADR-0007](../blob/feat/issue-723-kb-marketplace-columns/docs/adr/0007-marketplace-lifecycle-behaviours.md), follow-up issue per AC).

Schema authority: [`docs/plans/marketplace-mvp.md`](../blob/feat/issue-723-kb-marketplace-columns/docs/plans/marketplace-mvp.md) §2 (`00047_kb_marketplace_columns.sql`).

## Go changes

- `internal/model/kb.go`: new `KBVisibility` type + constants; `KnowledgeBase` struct extended with the 9 marketplace fields (`*time.Time` / `*string` for nullable columns).
- `internal/repository/kb.go`: `kbColumns` extended; `scanKB` refactored into shared `scanKBInto` so single-row reads and the `ListByWorkspace` iterator share one column order. `search_tsv` deliberately excluded from the read shape.
- No handler / job / publisher / importer changes — those belong to #726+ and #729+.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test -short ./...` green (only failures are pre-existing `internal/db` testcontainer-Ryuk issues with my local colima socket, unrelated to this PR)
- [x] `TESTCONTAINERS_RYUK_DISABLED=true go test -count=1 ./migrations/... -run TestMigrationsUpAndDown` — full UP / new-sub-test / DOWN cycle on pgvector:pg17, including the new `kb_marketplace_columns_and_trigger` sub-test (column shape, four indexes, defaults, trigger firing on document insert)
- [x] `TESTCONTAINERS_RYUK_DISABLED=true go test -count=1 ./internal/db/...` — `VerifyMigrationsState` happy + mismatch + rollback-and-reapply paths green
- [x] `golangci-lint run --new-from-rev=HEAD ./...` reports `0 issues.`
- [x] Migration round-trip: `goose up` → assertions → `goose downTo 0` leaves only `goose_db_version` and zero custom enum types (verified by the existing `clean_rollback` sub-test, which now includes `kb_visibility`)
- [ ] CI green