### PR TITLE
chore(test): clear unusedwrite and rangeint lint hints

### DIFF
--- a/internal/repository/search_test.go
+++ b/internal/repository/search_test.go
@@ -35,6 +35,21 @@ func TestChunkWithRankFields(t *testing.T) {
 	if chunk.ID != "chunk-1" {
 		t.Errorf("expected ID 'chunk-1', got %q", chunk.ID)
 	}
+	if chunk.OrgID != "org-1" {
+		t.Errorf("expected OrgID 'org-1', got %q", chunk.OrgID)
+	}
+	if chunk.KnowledgeBaseID != "kb-1" {
+		t.Errorf("expected KnowledgeBaseID 'kb-1', got %q", chunk.KnowledgeBaseID)
+	}
+	if chunk.Content != "test content" {
+		t.Errorf("expected Content 'test content', got %q", chunk.Content)
+	}
+	if chunk.ChunkIndex != 0 {
+		t.Errorf("expected ChunkIndex 0, got %d", chunk.ChunkIndex)
+	}
+	if chunk.ChunkType != "text" {
+		t.Errorf("expected ChunkType 'text', got %q", chunk.ChunkType)
+	}
 	if chunk.Rank != 0.75 {
 		t.Errorf("expected Rank 0.75, got %f", chunk.Rank)
 	}

--- a/migrations/migrations_test.go
+++ b/migrations/migrations_test.go
@@ -194,7 +194,7 @@ func TestMigrationsUpAndDown(t *testing.T) {
 	}()
 
 	// Wait for DB to be fully ready.
-	for i := 0; i < 30; i++ {
+	for range 30 {
 		if err := db.PingContext(ctx); err == nil {
 			break
 		}


### PR DESCRIPTION
## Summary

Two pre-existing lint hints surfaced by gopls / golangci-lint, fixed in place:

- **`internal/repository/search_test.go:26-30`** — `TestChunkWithRankFields` was constructing a `ChunkWithRank` with all 8 fields populated but only asserting on 3 (`ID`, `Rank`, `Highlight`). The other 5 (`OrgID`, `KnowledgeBaseID`, `Content`, `ChunkIndex`, `ChunkType`) were flagged as `unusedwrite`. The test's docstring says it verifies the struct's expected fields, so the right fix is **adding the missing assertions** rather than removing the writes — keeps the test honest to its stated intent.

- **`migrations/migrations_test.go:196`** — DB-ready wait loop used the pre-Go-1.22 `for i := 0; i < 30; i++` shape with an unused loop variable. Modernized to `for range 30` (Go 1.25.7 in go.mod, well past the threshold).

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./internal/repository -run TestChunkWithRankFields\` — PASS
- [x] \`golangci-lint run --new-from-rev=origin/main\` — 0 issues
- [x] Pre-commit hook green (sign-off present, no new lint)

No behaviour change. Independent of in-flight #738 (OpenAPI stubs) and #741 (KB marketplace columns).