### PR TITLE
feat(frontend): add AI Providers menu entries to header and sidebar

### DIFF
--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -24,6 +24,19 @@
         role="menu"
         class="absolute right-0 top-10 z-50 w-48 rounded-md border border-gray-200 bg-white py-1 shadow-lg"
       >
+        <RouterLink
+          to="/llm-providers"
+          role="menuitem"
+          class="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-50"
+          @click="menuOpen = false"
+        >
+          <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+            <rect x="6" y="6" width="12" height="12" rx="2" ry="2" stroke-linecap="round" stroke-linejoin="round" />
+            <rect x="9" y="9" width="6" height="6" rx="1" ry="1" stroke-linecap="round" stroke-linejoin="round" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9 3v3M15 3v3M9 18v3M15 18v3M3 9h3M3 15h3M18 9h3M18 15h3" />
+          </svg>
+          AI Providers
+        </RouterLink>
         <button
           class="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-50"
           @click="handleLogout"
@@ -42,6 +55,7 @@
 
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from 'vue'
+import { RouterLink } from 'vue-router'
 import { useAuthStore } from '../stores/auth'
 
 const authStore = useAuthStore()

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -156,6 +156,34 @@
           <span v-if="mobile" class="text-sm font-medium">Calls</span>
         </RouterLink>
 
+        <!-- AI Providers -->
+        <RouterLink
+          to="/llm-providers"
+          :class="[
+            'flex items-center rounded-lg text-slate-400 transition-colors hover:bg-slate-800 hover:text-white',
+            mobile
+              ? 'h-10 w-full gap-3 px-3'
+              : 'h-10 w-10 justify-center',
+          ]"
+          active-class="bg-slate-800 text-white"
+          title="AI Providers"
+          @click="mobile && $emit('close')"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            class="h-5 w-5 shrink-0"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="2"
+          >
+            <rect x="6" y="6" width="12" height="12" rx="2" ry="2" stroke-linecap="round" stroke-linejoin="round" />
+            <rect x="9" y="9" width="6" height="6" rx="1" ry="1" stroke-linecap="round" stroke-linejoin="round" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9 3v3M15 3v3M9 18v3M15 18v3M3 9h3M3 15h3M18 9h3M18 15h3" />
+          </svg>
+          <span v-if="mobile" class="text-sm font-medium">AI Providers</span>
+        </RouterLink>
+
         <!-- Billing section label (mobile only) -->
         <span v-if="mobile && orgPrefix" class="mt-4 px-1 text-xs font-semibold uppercase tracking-wider text-slate-500">
           Account


### PR DESCRIPTION
## Summary

Adds an "AI Providers" entry to two existing navigation surfaces so users can reach the LLM provider management page (`/llm-providers`, already routed) from anywhere in the app:

- **`AppHeader.vue`** — new `<RouterLink>` inside the `#user-menu` dropdown, above the existing "Sign out" button. `role="menuitem"`, closes the menu on click, uses an inline chip/cpu SVG glyph in the same stroked style as the logout icon.
- **`AppSidebar.vue`** — new `<RouterLink to="/llm-providers">` positioned between the primary-nav items (Dashboard / Voice / Phone Numbers / Calls) and the "Account" section header. Reuses the sibling Tailwind class pattern and active-class, with the mobile-vs-collapsed conditional classes. `title="AI Providers"` so the label shows as a tooltip when the sidebar is collapsed.

No router changes — the `/llm-providers` route already exists.

## Test plan

- [ ] Sign in, open the user-menu in the header, click "AI Providers" — lands on `/llm-providers` and the dropdown closes.
- [ ] Resize to mobile, open the sidebar — the "AI Providers" item appears between "Calls" and the "Account" label, with the chip icon and label.
- [ ] In desktop collapsed mode, hover the new sidebar item — tooltip reads "AI Providers".
- [ ] Navigate to `/llm-providers` and confirm both the sidebar entry and header dropdown entry highlight (active state for the sidebar).

Closes #743