### PR TITLE
feat(llm-providers): add default-pill UI and optimistic switch

### DIFF
--- a/frontend/src/pages/llm-providers/LlmProviderListPage.vue
+++ b/frontend/src/pages/llm-providers/LlmProviderListPage.vue
@@ -26,6 +26,44 @@ const providerToDelete = ref<string | null>(null)
 const providerToDeleteName = ref('')
 const deleting = ref(false)
 
+// In-memory connection-test status keyed by provider id. The Create dialog
+// (and a future Edit flow) writes here when a "Test connection" call comes
+// back; the list page reads it to warn before switching default to a
+// provider whose last test failed. Not persisted — session-only.
+const testStatus = ref<Record<string, 'pass' | 'fail'>>({})
+
+// Tracks which provider's "Make default" button is mid-flight so we can
+// disable it and avoid duplicate clicks during the optimistic update.
+const settingDefaultId = ref<string | null>(null)
+
+// Non-blocking error toast for default-switch failures. Auto-dismissed
+// after 4s; user can also click to close. Re-uses the existing Tailwind
+// palette — no toast library to keep the page footprint small.
+const defaultError = ref<string | null>(null)
+let defaultErrorTimer: ReturnType<typeof setTimeout> | null = null
+
+function showDefaultError(msg: string) {
+  defaultError.value = msg
+  if (defaultErrorTimer) clearTimeout(defaultErrorTimer)
+  defaultErrorTimer = setTimeout(() => {
+    defaultError.value = null
+    defaultErrorTimer = null
+  }, 4000)
+}
+
+async function handleMakeDefault(providerId: string) {
+  if (settingDefaultId.value) return
+  settingDefaultId.value = providerId
+  try {
+    await store.setDefault(orgId.value, providerId)
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : 'Failed to set default provider'
+    showDefaultError(`Could not switch default: ${msg}`)
+  } finally {
+    settingDefaultId.value = null
+  }
+}
+
 
 const providerTypes: { value: ProviderType; label: string }[] = [
   { value: 'openai', label: 'OpenAI' },
@@ -141,6 +179,13 @@ onMounted(() => store.fetchProviders(orgId.value))
             <div class="flex items-center gap-2">
               <h3 class="font-semibold text-gray-900">{{ provider.display_name }}</h3>
               <span :class="['rounded-full px-2 py-0.5 text-xs font-medium', provider.status === 'active' ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-600']">{{ provider.status }}</span>
+              <span
+                v-if="provider.is_default"
+                data-testid="default-pill"
+                class="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 transition duration-200 ease-out"
+              >
+                Default
+              </span>
             </div>
             <p class="mt-1 text-sm text-gray-500">
               {{ provider.provider.toUpperCase() }} &middot; {{ provider.provider }}
@@ -149,8 +194,23 @@ onMounted(() => store.fetchProviders(orgId.value))
             <p class="mt-1 text-xs text-gray-400">
               API key {{ !!provider.api_key_hint ? 'configured' : 'not set' }}
             </p>
+            <p
+              v-if="!provider.is_default && testStatus[provider.id] === 'fail'"
+              class="mt-2 rounded border border-amber-300 bg-amber-50 px-2 py-1 text-xs text-amber-800"
+            >
+              Last connection test failed — switching default may break chat.
+            </p>
           </div>
           <div class="flex gap-2">
+            <button
+              v-if="!provider.is_default"
+              data-testid="make-default-btn"
+              :disabled="settingDefaultId === provider.id"
+              class="rounded border border-amber-300 px-3 py-1 text-xs font-medium text-amber-800 hover:bg-amber-50 disabled:opacity-50"
+              @click="handleMakeDefault(provider.id)"
+            >
+              {{ settingDefaultId === provider.id ? 'Setting...' : 'Make default' }}
+            </button>
             <button class="rounded border border-red-300 px-3 py-1 text-xs text-red-700 hover:bg-red-50" @click="confirmDelete(provider.id, provider.display_name)">
               Delete
             </button>
@@ -166,22 +226,45 @@ onMounted(() => store.fetchProviders(orgId.value))
         :key="provider.id"
         class="bg-slate-800 rounded-xl p-3.5"
       >
-        <!-- Header: name + status badge -->
+        <!-- Header: name + status badge + default pill -->
         <div class="flex items-start justify-between gap-2">
           <span class="text-white font-semibold text-[15px] truncate">{{ provider.display_name }}</span>
-          <span
-            class="shrink-0 inline-block rounded-full px-2 py-0.5 text-xs font-medium"
-          >
-            {{ provider.status }}
-          </span>
+          <div class="flex shrink-0 items-center gap-1.5">
+            <span class="inline-block rounded-full px-2 py-0.5 text-xs font-medium">
+              {{ provider.status }}
+            </span>
+            <span
+              v-if="provider.is_default"
+              data-testid="default-pill-mobile"
+              class="inline-block rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 transition duration-200 ease-out"
+            >
+              Default
+            </span>
+          </div>
         </div>
 
         <p class="text-slate-400 text-xs mt-1">
           {{ provider.provider.toUpperCase() }}
         </p>
 
+        <p
+          v-if="!provider.is_default && testStatus[provider.id] === 'fail'"
+          class="mt-2 rounded border border-amber-400/40 bg-amber-500/10 px-2 py-1 text-[11px] text-amber-300"
+        >
+          Last connection test failed — switching default may break chat.
+        </p>
+
         <!-- Action row -->
         <div class="border-t border-slate-700 mt-2.5 pt-2.5 flex items-center justify-end gap-2">
+          <button
+            v-if="!provider.is_default"
+            data-testid="make-default-btn-mobile"
+            :disabled="settingDefaultId === provider.id"
+            class="border border-amber-400 text-amber-300 text-xs px-3 py-1 rounded-lg disabled:opacity-50"
+            @click="handleMakeDefault(provider.id)"
+          >
+            {{ settingDefaultId === provider.id ? 'Setting...' : 'Make default' }}
+          </button>
           <button
             class="border border-red-500 text-red-400 text-xs px-3 py-1 rounded-lg"
             @click="confirmDelete(provider.id, provider.display_name)"
@@ -190,6 +273,17 @@ onMounted(() => store.fetchProviders(orgId.value))
           </button>
         </div>
       </div>
+    </div>
+
+    <!-- Default-switch error toast (non-blocking, auto-dismisses) -->
+    <div
+      v-if="defaultError"
+      data-testid="default-error-toast"
+      class="fixed bottom-4 right-4 z-50 max-w-sm rounded-lg border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-800 shadow-lg"
+      role="alert"
+      @click="defaultError = null"
+    >
+      {{ defaultError }}
     </div>
 
     <!-- Create Dialog -->

--- a/frontend/src/stores/llm-providers.spec.ts
+++ b/frontend/src/stores/llm-providers.spec.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useLlmProvidersStore } from './llm-providers'
+import * as llmApi from '../api/llm-providers'
+import type { LlmProvider } from '../api/llm-providers'
+
+vi.mock('../api/llm-providers')
+
+const openai: LlmProvider = {
+  id: 'p-openai',
+  org_id: 'org-1',
+  provider: 'openai',
+  display_name: 'OpenAI Prod',
+  base_url: null,
+  api_key_hint: 'sk-...abc',
+  is_default: true,
+  status: 'active',
+  config: {},
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+}
+
+const anthropic: LlmProvider = {
+  ...openai,
+  id: 'p-anthropic',
+  provider: 'anthropic',
+  display_name: 'Anthropic',
+  is_default: false,
+}
+
+describe('useLlmProvidersStore.setDefault', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('optimistically flips is_default and persists server response', async () => {
+    vi.mocked(llmApi.listLlmProviders).mockResolvedValue([
+      { ...openai },
+      { ...anthropic },
+    ])
+    // Resolve only after we have a chance to inspect the optimistic state.
+    let resolveSet: (v: LlmProvider) => void = () => {}
+    vi.mocked(llmApi.setDefaultProvider).mockImplementation(
+      () => new Promise<LlmProvider>((r) => { resolveSet = r }),
+    )
+
+    const store = useLlmProvidersStore()
+    await store.fetchProviders('org-1')
+
+    const promise = store.setDefault('org-1', 'p-anthropic')
+
+    // Optimistic flip applied immediately — before the API resolves.
+    expect(store.providers.find((p) => p.id === 'p-anthropic')!.is_default).toBe(true)
+    expect(store.providers.find((p) => p.id === 'p-openai')!.is_default).toBe(false)
+
+    resolveSet({ ...anthropic, is_default: true })
+    await promise
+
+    expect(store.providers.find((p) => p.id === 'p-anthropic')!.is_default).toBe(true)
+    expect(store.providers.find((p) => p.id === 'p-openai')!.is_default).toBe(false)
+    expect(store.error).toBeNull()
+  })
+
+  it('rolls back both rows when the server call fails', async () => {
+    vi.mocked(llmApi.listLlmProviders).mockResolvedValue([
+      { ...openai },
+      { ...anthropic },
+    ])
+    vi.mocked(llmApi.setDefaultProvider).mockRejectedValue(new Error('boom'))
+
+    const store = useLlmProvidersStore()
+    await store.fetchProviders('org-1')
+
+    await expect(store.setDefault('org-1', 'p-anthropic')).rejects.toThrow('boom')
+
+    expect(store.providers.find((p) => p.id === 'p-openai')!.is_default).toBe(true)
+    expect(store.providers.find((p) => p.id === 'p-anthropic')!.is_default).toBe(false)
+    expect(store.error).toBe('boom')
+  })
+
+  it('is a no-op when the target is already the default', async () => {
+    vi.mocked(llmApi.listLlmProviders).mockResolvedValue([{ ...openai }, { ...anthropic }])
+    const store = useLlmProvidersStore()
+    await store.fetchProviders('org-1')
+
+    const result = await store.setDefault('org-1', 'p-openai')
+
+    expect(result?.id).toBe('p-openai')
+    expect(llmApi.setDefaultProvider).not.toHaveBeenCalled()
+  })
+
+  it('throws if the provider does not exist', async () => {
+    vi.mocked(llmApi.listLlmProviders).mockResolvedValue([{ ...openai }])
+    const store = useLlmProvidersStore()
+    await store.fetchProviders('org-1')
+
+    await expect(store.setDefault('org-1', 'p-missing')).rejects.toThrow(
+      /not found/,
+    )
+    expect(llmApi.setDefaultProvider).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/stores/llm-providers.ts
+++ b/frontend/src/stores/llm-providers.ts
@@ -8,6 +8,7 @@ import {
   createLlmProvider,
   updateLlmProvider,
   deleteLlmProvider,
+  setDefaultProvider,
 } from '../api/llm-providers'
 
 export const useLlmProvidersStore = defineStore('llmProviders', () => {
@@ -52,6 +53,44 @@ export const useLlmProvidersStore = defineStore('llmProviders', () => {
     providers.value = providers.value.filter((p) => p.id !== providerId)
   }
 
+  /**
+   * Optimistically promotes `providerId` to be the org's default provider.
+   * Locally flips `is_default` on the target to `true` and on every other
+   * row to `false` BEFORE the network call so the UI updates instantly.
+   * On API failure the previous default snapshot is restored and the
+   * error is rethrown so callers can show a toast.
+   */
+  async function setDefault(orgId: string, providerId: string) {
+    const target = providers.value.find((p) => p.id === providerId)
+    if (!target) {
+      throw new Error(`Provider ${providerId} not found`)
+    }
+    if (target.is_default) {
+      return target
+    }
+    // Snapshot previous is_default state so we can roll back on failure.
+    const previous = providers.value.map((p) => ({ id: p.id, is_default: p.is_default }))
+    // Optimistic flip: exactly one row is the default at any time.
+    providers.value = providers.value.map((p) => ({
+      ...p,
+      is_default: p.id === providerId,
+    }))
+    try {
+      const updated = await setDefaultProvider(orgId, providerId)
+      const idx = providers.value.findIndex((p) => p.id === providerId)
+      if (idx !== -1) providers.value[idx] = updated
+      return updated
+    } catch (e) {
+      // Roll back optimistic state.
+      providers.value = providers.value.map((p) => {
+        const prev = previous.find((q) => q.id === p.id)
+        return prev ? { ...p, is_default: prev.is_default } : p
+      })
+      error.value = (e as Error).message
+      throw e
+    }
+  }
+
   return {
     providers,
     loading,
@@ -63,5 +102,6 @@ export const useLlmProvidersStore = defineStore('llmProviders', () => {
     addProvider,
     editProvider,
     removeProvider,
+    setDefault,
   }
 })


### PR DESCRIPTION
## Summary

- Default amber pill on the active provider card (desktop + mobile) with a 200 ms fade transition so the swap reads as motion.
- New "Make default" button on every non-default card. Click is fully optimistic — flips `is_default` on the target and the previous default before the API resolves; rolls both rows back on failure and surfaces a non-blocking error toast.
- Store gains `setDefault(orgId, providerId)`, which wraps `PUT /api/v1/orgs/:org_id/llm-providers/:provider_id/default` with snapshot-based rollback. Covered by unit tests for happy path, rollback, no-op, and missing-provider.
- Stale-test guard: if the click target's in-session `testStatus` is `fail`, the card renders an inline amber warning ("Last connection test failed — switching default may break chat.") but still allows the click. `testStatus` is a session-only ref the Create/Edit dialogs will populate when the connection-test flow lands.
- Desktop and mobile card layouts kept separate per Issue #744's scope.

## Test plan

- [ ] `pnpm --filter ./frontend lint` passes
- [ ] `pnpm --filter ./frontend test:unit src/stores/llm-providers.spec.ts` passes
- [ ] Manual: with two providers, click "Make default" on the non-default card; pill moves instantly, persists after refresh
- [ ] Manual: with the API stubbed to 500, click "Make default"; pill snaps back, red toast appears, auto-dismisses after 4 s
- [ ] Manual: mark a provider as testStatus = fail via devtools, confirm the amber warning renders on its card

Closes #740