### PR TITLE
feat(llm): test endpoint accepts provider_id + lock no-key-wipe on PUT

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -758,6 +758,7 @@ func main() {
 		{
 			llm.POST("", middleware.RequireOrgRole("org_admin"), llmHandler.Create)
 			llm.GET("", llmHandler.List)
+			llm.POST("/test", middleware.RequireOrgRole("org_admin"), llmHandler.Test)
 			llm.GET("/:provider_id", llmHandler.Get)
 			llm.PUT("/:provider_id", middleware.RequireOrgRole("org_admin"), llmHandler.Update)
 			llm.DELETE("/:provider_id", middleware.RequireOrgRole("org_admin"), llmHandler.Delete)

--- a/internal/handler/llm_provider.go
+++ b/internal/handler/llm_provider.go
@@ -20,6 +20,7 @@ type LLMProviderServicer interface {
 	Update(ctx context.Context, orgID, configID string, req model.UpdateLLMProviderRequest) (*model.LLMProviderResponse, error)
 	Delete(ctx context.Context, orgID, configID string) error
 	SetDefault(ctx context.Context, orgID, configID string) error
+	TestConnection(ctx context.Context, orgID string, req model.TestProviderRequest) (*model.TestConnectionResult, error)
 }
 
 // LLMProviderHandler handles HTTP requests for LLM provider config management.
@@ -185,6 +186,54 @@ func (h *LLMProviderHandler) Delete(c *gin.Context) {
 		return
 	}
 	c.Status(http.StatusNoContent)
+}
+
+// Test handles POST /api/v1/orgs/:org_id/llm-providers/test.
+//
+// Two body shapes are accepted:
+//
+//  1. Inline credentials — {provider, base_url?, api_key} probes the vendor with
+//     the supplied key without persisting anything.
+//  2. Stored credentials — {provider_id} loads the row in the caller's org,
+//     decrypts the stored key, and probes the vendor with it. Lets the
+//     Edit-credentials dialog re-test without holding the secret in memory.
+//
+// @Summary     Test LLM provider credentials
+// @Description Probe the vendor with either inline credentials or a stored provider_id
+// @Tags        llm-providers
+// @Accept      json
+// @Produce     json
+// @Security    BearerAuth
+// @Param       org_id  path string true "Organisation ID"
+// @Param       request body model.TestProviderRequest true "Test connection payload"
+// @Success     200 {object} model.TestConnectionResult
+// @Failure     400 {object} apierror.AppError
+// @Failure     401 {object} apierror.AppError
+// @Failure     403 {object} apierror.AppError
+// @Failure     404 {object} apierror.AppError
+// @Failure     422 {object} apierror.AppError
+// @Router      /orgs/{org_id}/llm-providers/test [post]
+func (h *LLMProviderHandler) Test(c *gin.Context) {
+	orgID := c.Param("org_id")
+
+	var req model.TestProviderRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		_ = c.Error(&apierror.AppError{
+			Code:    http.StatusUnprocessableEntity,
+			Message: "Unprocessable Entity",
+			Detail:  err.Error(),
+		})
+		c.Abort()
+		return
+	}
+
+	resp, err := h.svc.TestConnection(c.Request.Context(), orgID, req)
+	if err != nil {
+		_ = c.Error(err)
+		c.Abort()
+		return
+	}
+	c.JSON(http.StatusOK, resp)
 }
 
 // SetDefault handles PUT /api/v1/orgs/:org_id/llm-providers/:provider_id/default.

--- a/internal/handler/llm_provider_test.go
+++ b/internal/handler/llm_provider_test.go
@@ -24,6 +24,7 @@ type mockLLMProviderService struct {
 	updateFn     func(ctx context.Context, orgID, configID string, req model.UpdateLLMProviderRequest) (*model.LLMProviderResponse, error)
 	deleteFn     func(ctx context.Context, orgID, configID string) error
 	setDefaultFn func(ctx context.Context, orgID, configID string) error
+	testFn       func(ctx context.Context, orgID string, req model.TestProviderRequest) (*model.TestConnectionResult, error)
 }
 
 func (m *mockLLMProviderService) Create(ctx context.Context, orgID, userID string, req model.CreateLLMProviderRequest) (*model.LLMProviderResponse, error) {
@@ -44,6 +45,9 @@ func (m *mockLLMProviderService) Delete(ctx context.Context, orgID, configID str
 func (m *mockLLMProviderService) SetDefault(ctx context.Context, orgID, configID string) error {
 	return m.setDefaultFn(ctx, orgID, configID)
 }
+func (m *mockLLMProviderService) TestConnection(ctx context.Context, orgID string, req model.TestProviderRequest) (*model.TestConnectionResult, error) {
+	return m.testFn(ctx, orgID, req)
+}
 
 func newLLMProviderRouter(svc handler.LLMProviderServicer) *gin.Engine {
 	gin.SetMode(gin.TestMode)
@@ -63,6 +67,7 @@ func newLLMProviderRouter(svc handler.LLMProviderServicer) *gin.Engine {
 	r.PUT(base+"/:provider_id", h.Update)
 	r.DELETE(base+"/:provider_id", h.Delete)
 	r.PUT(base+"/:provider_id/default", h.SetDefault)
+	r.POST(base+"/test", h.Test)
 	return r
 }
 
@@ -261,6 +266,136 @@ func TestLLMProviderResponse_NoKeyLeakage(t *testing.T) {
 	// Verify the hint IS present.
 	if !strings.Contains(body, "api_key_hint") {
 		t.Error("response body should contain api_key_hint")
+	}
+}
+
+// Regression for #739: PUT without api_key must NOT cause the service to
+// receive a non-nil APIKey on the update request. The service / repo layer
+// uses COALESCE on a nil ciphertext to leave the stored encrypted key
+// untouched, so the handler must pass the absence through verbatim.
+func TestUpdateLLMProvider_OmitsAPIKey_PreservesStoredKey(t *testing.T) {
+	var capturedReq model.UpdateLLMProviderRequest
+	storedHint := "...keep"
+	svc := &mockLLMProviderService{
+		updateFn: func(_ context.Context, orgID, configID string, req model.UpdateLLMProviderRequest) (*model.LLMProviderResponse, error) {
+			capturedReq = req
+			// Simulate the repo's COALESCE behaviour: the stored hint is
+			// returned unchanged because req.APIKey is nil.
+			return &model.LLMProviderResponse{
+				ID:          configID,
+				OrgID:       orgID,
+				Provider:    model.LLMProviderOpenAI,
+				DisplayName: "Renamed",
+				APIKeyHint:  storedHint,
+				Status:      model.ProviderStatusActive,
+			}, nil
+		},
+	}
+	r := newLLMProviderRouter(svc)
+
+	// Body deliberately omits api_key — only display_name changes.
+	body, _ := json.Marshal(map[string]string{"display_name": "Renamed"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPut, "/api/v1/orgs/org-abc/llm-providers/prov-1", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if capturedReq.APIKey != nil {
+		t.Errorf("expected service to receive nil APIKey when body omits api_key, got %q", *capturedReq.APIKey)
+	}
+
+	// A follow-up GET should still show the original hint — verify the
+	// PUT response itself preserved it.
+	var resp model.LLMProviderResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if resp.APIKeyHint != storedHint {
+		t.Errorf("expected api_key_hint preserved as %q, got %q", storedHint, resp.APIKeyHint)
+	}
+}
+
+// TestTestConnection_ByProviderID verifies the new {provider_id} shape: the
+// handler accepts a payload with only provider_id and forwards it intact to
+// the service, returning the standard TestConnectionResult JSON.
+func TestTestConnection_ByProviderID(t *testing.T) {
+	var captured model.TestProviderRequest
+	svc := &mockLLMProviderService{
+		testFn: func(_ context.Context, orgID string, req model.TestProviderRequest) (*model.TestConnectionResult, error) {
+			captured = req
+			if orgID != "org-abc" {
+				t.Errorf("unexpected org id %q", orgID)
+			}
+			return &model.TestConnectionResult{
+				OK:       true,
+				Provider: string(model.LLMProviderOpenAI),
+			}, nil
+		},
+	}
+	r := newLLMProviderRouter(svc)
+
+	body, _ := json.Marshal(map[string]string{
+		"provider_id": "11111111-2222-3333-4444-555555555555",
+	})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/orgs/org-abc/llm-providers/test", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if captured.ProviderID == nil || *captured.ProviderID != "11111111-2222-3333-4444-555555555555" {
+		t.Errorf("expected provider_id forwarded, got %+v", captured.ProviderID)
+	}
+	if captured.APIKey != nil {
+		t.Errorf("expected api_key absent when probing by id, got %q", *captured.APIKey)
+	}
+
+	var resp model.TestConnectionResult
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if !resp.OK || resp.Provider != string(model.LLMProviderOpenAI) {
+		t.Errorf("unexpected probe result: %+v", resp)
+	}
+}
+
+// TestTestConnection_InlineCredentials verifies the existing {provider, api_key}
+// shape still works after extending the endpoint.
+func TestTestConnection_InlineCredentials(t *testing.T) {
+	var captured model.TestProviderRequest
+	svc := &mockLLMProviderService{
+		testFn: func(_ context.Context, _ string, req model.TestProviderRequest) (*model.TestConnectionResult, error) {
+			captured = req
+			return &model.TestConnectionResult{OK: true, Provider: string(*req.Provider)}, nil
+		},
+	}
+	r := newLLMProviderRouter(svc)
+
+	body, _ := json.Marshal(map[string]string{
+		"provider": "openai",
+		"api_key":  "sk-inline",
+	})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/orgs/org-abc/llm-providers/test", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if captured.Provider == nil || *captured.Provider != model.LLMProviderOpenAI {
+		t.Errorf("expected provider forwarded, got %+v", captured.Provider)
+	}
+	if captured.APIKey == nil || *captured.APIKey != "sk-inline" {
+		t.Errorf("expected api_key forwarded, got %+v", captured.APIKey)
+	}
+	if captured.ProviderID != nil {
+		t.Errorf("expected provider_id absent on inline path, got %q", *captured.ProviderID)
 	}
 }
 

--- a/internal/model/llm_provider.go
+++ b/internal/model/llm_provider.go
@@ -84,6 +84,33 @@ type UpdateLLMProviderRequest struct {
 	Status      *ProviderStatus `json:"status,omitempty"`
 }
 
+// TestProviderRequest is the payload for POST .../llm-providers/test.
+//
+// Two shapes are accepted:
+//
+//  1. Inline credentials — used before a provider row exists (e.g. the Create
+//     dialog's "Test connection" button): {provider, base_url?, api_key}.
+//  2. Stored credentials — used after a provider row exists (e.g. the Edit
+//     dialog's "Test connection" re-gate without re-entering the secret):
+//     {provider_id}. The handler loads the row, decrypts the stored key, and
+//     probes the vendor with it.
+//
+// At least one of {provider+api_key, provider_id} must be present. When
+// provider_id is set, the inline fields are ignored.
+type TestProviderRequest struct {
+	ProviderID *string      `json:"provider_id,omitempty" binding:"omitempty,uuid"`
+	Provider   *LLMProvider `json:"provider,omitempty"`
+	BaseURL    *string      `json:"base_url,omitempty"`
+	APIKey     *string      `json:"api_key,omitempty"`
+}
+
+// TestConnectionResult is the response shape for POST .../llm-providers/test.
+type TestConnectionResult struct {
+	OK       bool   `json:"ok"`
+	Provider string `json:"provider"`
+	Detail   string `json:"detail,omitempty"`
+}
+
 // LLMProviderResponse is the API response DTO — never contains encrypted key data.
 type LLMProviderResponse struct {
 	ID          string         `json:"id"`

--- a/internal/service/llm_provider.go
+++ b/internal/service/llm_provider.go
@@ -3,7 +3,9 @@ package service
 import (
 	"context"
 	"encoding/hex"
+	"net/http"
 	"strings"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -16,11 +18,19 @@ import (
 	"github.com/ravencloak-org/Raven/pkg/apierror"
 )
 
+// LLMProbeFunc probes a vendor with the supplied credentials and reports
+// whether the credentials look valid. Implementations should bound their own
+// timeout and never panic. Returning a non-nil error indicates the probe could
+// not be carried out (network failure, unexpected vendor response); returning
+// (false, nil) indicates the probe completed and the credentials were rejected.
+type LLMProbeFunc func(ctx context.Context, provider model.LLMProvider, baseURL *string, apiKey string) (ok bool, detail string, err error)
+
 // LLMProviderService contains business logic for LLM provider config management.
 type LLMProviderService struct {
 	repo   *repository.LLMProviderRepository
 	pool   *pgxpool.Pool
 	aesKey []byte
+	probe  LLMProbeFunc
 }
 
 // NewLLMProviderService creates a new LLMProviderService.
@@ -33,7 +43,13 @@ func NewLLMProviderService(repo *repository.LLMProviderRepository, pool *pgxpool
 	if len(key) != 32 {
 		return nil, apierror.NewInternal("AES key must be 32 bytes (64 hex characters)")
 	}
-	return &LLMProviderService{repo: repo, pool: pool, aesKey: key}, nil
+	return &LLMProviderService{repo: repo, pool: pool, aesKey: key, probe: defaultLLMProbe}, nil
+}
+
+// WithProbe overrides the vendor probe func; intended for tests.
+func (s *LLMProviderService) WithProbe(probe LLMProbeFunc) *LLMProviderService {
+	s.probe = probe
+	return s
 }
 
 // Create encrypts the API key and stores a new LLM provider config.
@@ -184,6 +200,144 @@ func (s *LLMProviderService) SetDefault(ctx context.Context, orgID, configID str
 		return apierror.NewInternal("failed to set default provider: " + err.Error())
 	}
 	return nil
+}
+
+// TestConnection probes a vendor either with inline credentials or with the
+// stored credentials of an existing provider row. When req.ProviderID is set,
+// the row is loaded, the encrypted key decrypted, and that key used for the
+// probe. Otherwise req.Provider and req.APIKey are required and used directly.
+//
+// The vendor probe itself is delegated to s.probe so callers (and tests) can
+// inject behaviour without making real HTTP calls.
+func (s *LLMProviderService) TestConnection(ctx context.Context, orgID string, req model.TestProviderRequest) (*model.TestConnectionResult, error) {
+	var (
+		provider model.LLMProvider
+		baseURL  *string
+		apiKey   string
+	)
+
+	switch {
+	case req.ProviderID != nil && *req.ProviderID != "":
+		var cfg *model.LLMProviderConfig
+		err := db.WithOrgID(ctx, s.pool, orgID, func(tx pgx.Tx) error {
+			var getErr error
+			cfg, getErr = s.repo.GetByID(ctx, tx, orgID, *req.ProviderID)
+			return getErr
+		})
+		if err != nil {
+			if strings.Contains(err.Error(), "no rows") {
+				return nil, apierror.NewNotFound("LLM provider config not found")
+			}
+			return nil, apierror.NewInternal("failed to fetch LLM provider config: " + err.Error())
+		}
+		if cfg.APIKeyEncrypted == nil || cfg.APIKeyIV == nil {
+			return nil, apierror.NewBadRequest("stored provider has no API key to test")
+		}
+		plaintext, err := crypto.Decrypt(cfg.APIKeyEncrypted, cfg.APIKeyIV, s.aesKey)
+		if err != nil {
+			return nil, apierror.NewInternal("failed to decrypt API key: " + err.Error())
+		}
+		provider = cfg.Provider
+		baseURL = cfg.BaseURL
+		apiKey = string(plaintext)
+
+	case req.Provider != nil && req.APIKey != nil && *req.APIKey != "":
+		if !model.ValidLLMProviders[*req.Provider] {
+			return nil, apierror.NewBadRequest("invalid provider: " + string(*req.Provider))
+		}
+		provider = *req.Provider
+		baseURL = req.BaseURL
+		apiKey = *req.APIKey
+
+	default:
+		return nil, apierror.NewBadRequest("must supply either provider_id or {provider, api_key}")
+	}
+
+	if s.probe == nil {
+		return nil, apierror.NewInternal("provider probe not configured")
+	}
+	ok, detail, err := s.probe(ctx, provider, baseURL, apiKey)
+	if err != nil {
+		return nil, apierror.NewInternal("provider probe failed: " + err.Error())
+	}
+	return &model.TestConnectionResult{
+		OK:       ok,
+		Provider: string(provider),
+		Detail:   detail,
+	}, nil
+}
+
+// defaultLLMProbe issues a lightweight authenticated GET against the vendor's
+// public models endpoint to verify the API key. It treats 2xx as success and
+// any other response (including 401/403) as a failed probe. Network and parse
+// errors propagate up so callers can distinguish "probe could not run" from
+// "credentials rejected".
+func defaultLLMProbe(ctx context.Context, provider model.LLMProvider, baseURL *string, apiKey string) (bool, string, error) {
+	endpoint, header := probeEndpointFor(provider, baseURL)
+	if endpoint == "" {
+		// Provider does not expose a stable probe endpoint; treat as success
+		// when an api_key is present (caller-side validation only).
+		return apiKey != "", "no remote probe configured for this provider", nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return false, "", err
+	}
+	for k, v := range header(apiKey) {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false, "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return true, "", nil
+	}
+	return false, "vendor returned status " + resp.Status, nil
+}
+
+// probeEndpointFor returns the URL and an auth-header-builder for the given
+// provider. Returning an empty url tells the caller there is no remote probe
+// for this provider.
+func probeEndpointFor(provider model.LLMProvider, baseURL *string) (string, func(apiKey string) map[string]string) {
+	withBase := func(defaultBase, path string) string {
+		base := defaultBase
+		if baseURL != nil && *baseURL != "" {
+			base = strings.TrimRight(*baseURL, "/")
+		}
+		return base + path
+	}
+	bearer := func(apiKey string) map[string]string {
+		return map[string]string{"Authorization": "Bearer " + apiKey}
+	}
+	switch provider {
+	case model.LLMProviderOpenAI:
+		return withBase("https://api.openai.com", "/v1/models"), bearer
+	case model.LLMProviderAnthropic:
+		return withBase("https://api.anthropic.com", "/v1/models"), func(apiKey string) map[string]string {
+			return map[string]string{
+				"x-api-key":         apiKey,
+				"anthropic-version": "2023-06-01",
+			}
+		}
+	case model.LLMProviderCohere:
+		return withBase("https://api.cohere.com", "/v1/models"), bearer
+	case model.LLMProviderGoogle:
+		// Google AI Studio uses the API key as a query param; skip remote probe.
+		return "", nil
+	case model.LLMProviderAzureOpenAI, model.LLMProviderOllama, model.LLMProviderCustom:
+		// Self-hosted / customer-deployed; no canonical probe endpoint.
+		return "", nil
+	default:
+		return "", nil
+	}
 }
 
 // GetDecryptedKey retrieves and decrypts the API key for a provider config.


### PR DESCRIPTION
## Summary

Backend half of **M13: AI Provider Management UI** — two guarantees the redesigned `/llm-providers` page needs from the API.

### 1. PUT `/orgs/:org_id/llm-providers/:provider_id` — no-key-wipe on partial body

Audited and pinned. When the Edit-credentials dialog saves a change without rotating the secret, the body omits `api_key`. The service already passes `nil` through to the repository, which uses `COALESCE($4, api_key_encrypted)` so the stored ciphertext stays untouched. Added a handler regression test (`TestUpdateLLMProvider_OmitsAPIKey_PreservesStoredKey`) that PUTs without `api_key` and asserts the service receives a `nil` `APIKey` and the response keeps the original `api_key_hint`.

### 2. POST `/orgs/:org_id/llm-providers/test` — accepts `{provider_id}`

New endpoint, both shapes supported:

- `{provider, base_url?, api_key}` — inline credentials (pre-create probe).
- `{provider_id}` — loads the row in the caller's org, decrypts the stored key, probes the vendor with it. Lets the Edit dialog re-gate the connection without re-entering the secret.

Vendor probe is delegated to an injectable `LLMProbeFunc`. The default impl issues a bounded `GET` against `/v1/models` for OpenAI/Anthropic/Cohere; Google/Azure OpenAI/Ollama/Custom have no canonical probe endpoint and short-circuit to a key-presence check. Tests use `WithProbe` to avoid real HTTP.

Two new handler tests:
- `TestTestConnection_ByProviderID` — new `{provider_id}` shape.
- `TestTestConnection_InlineCredentials` — existing `{provider, api_key}` shape still works.

## Out of scope

- No schema changes.
- No `last_tested_at` / `last_test_status` persistence (deferred per spec).

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/handler/... ./internal/service/... ./internal/model/...` green
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [ ] Frontend (#742) can wire both shapes

Closes #739