### PR TITLE
feat(llm): edit-credentials dialog with rotate-key + test re-gate

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -758,6 +758,7 @@ func main() {
 		{
 			llm.POST("", middleware.RequireOrgRole("org_admin"), llmHandler.Create)
 			llm.GET("", llmHandler.List)
+			llm.POST("/test", middleware.RequireOrgRole("org_admin"), llmHandler.Test)
 			llm.GET("/:provider_id", llmHandler.Get)
 			llm.PUT("/:provider_id", middleware.RequireOrgRole("org_admin"), llmHandler.Update)
 			llm.DELETE("/:provider_id", middleware.RequireOrgRole("org_admin"), llmHandler.Delete)

--- a/frontend/src/api/llm-providers.ts
+++ b/frontend/src/api/llm-providers.ts
@@ -37,6 +37,24 @@ export interface ProviderModelOption {
   label: string
 }
 
+// TestProviderRequest mirrors backend `model.TestProviderRequest`. Either
+// `provider_id` (probe stored encrypted key) OR `provider + api_key`
+// (probe inline credentials) is required; when both are supplied the
+// backend ignores the inline fields. `base_url` is optional in both
+// shapes.
+export interface TestProviderRequest {
+  provider_id?: string
+  provider?: ProviderType
+  base_url?: string | null
+  api_key?: string
+}
+
+export interface TestConnectionResult {
+  ok: boolean
+  provider: string
+  detail?: string
+}
+
 export const PROVIDER_MODELS: Record<ProviderType, ProviderModelOption[]> = {
   openai: [
     { value: 'gpt-4o', label: 'GPT-4o' },
@@ -108,6 +126,21 @@ export async function deleteLlmProvider(
 ): Promise<void> {
   await authFetch<void>(`/orgs/${orgId}/llm-providers/${providerId}`, {
     method: 'DELETE',
+  })
+}
+
+// testLlmProviderConnection probes the vendor via
+// POST /api/v1/orgs/:org_id/llm-providers/test. Pass `{provider_id}` to
+// re-test an existing row using its stored (encrypted) key — no secret
+// crosses the wire. Pass `{provider, api_key, base_url?}` for the inline
+// shape used by the Create dialog.
+export async function testLlmProviderConnection(
+  orgId: string,
+  payload: TestProviderRequest,
+): Promise<TestConnectionResult> {
+  return authFetch<TestConnectionResult>(`/orgs/${orgId}/llm-providers/test`, {
+    method: 'POST',
+    body: JSON.stringify(payload),
   })
 }
 

--- a/frontend/src/pages/llm-providers/LlmProviderListPage.vue
+++ b/frontend/src/pages/llm-providers/LlmProviderListPage.vue
@@ -1,9 +1,16 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import { useAuthStore } from "../../stores/auth"
 import { useLlmProvidersStore } from '../../stores/llm-providers'
 import { useMobile } from '../../composables/useMediaQuery'
-import { PROVIDER_MODELS, type ProviderType, type CreateLlmProviderRequest } from '../../api/llm-providers'
+import {
+  PROVIDER_MODELS,
+  testLlmProviderConnection,
+  type LlmProvider,
+  type ProviderType,
+  type CreateLlmProviderRequest,
+  type UpdateLlmProviderRequest,
+} from '../../api/llm-providers'
 
 const store = useLlmProvidersStore()
 const { isMobile } = useMobile()
@@ -39,24 +46,30 @@ const providerTypes: { value: ProviderType; label: string }[] = [
 // mint a key without leaving the flow; `keyPrefix` is shown in the
 // placeholder so they know what shape the key should have; `helpText`
 // is a one-liner above the API-key field. Keyed off ProviderType.
-const providerHelp: Record<ProviderType, { keyHref?: string; keyPrefix?: string; helpText: string }> = {
+// `requiresKey=false` hides API-key inputs entirely (Edit dialog skips
+// Rotate-key for these; today only Ollama).
+const providerHelp: Record<ProviderType, { keyHref?: string; keyPrefix?: string; helpText: string; requiresKey: boolean }> = {
   openai: {
     keyHref: 'https://platform.openai.com/api-keys',
     keyPrefix: 'sk-...',
     helpText: 'Generate a Secret Key in the OpenAI dashboard and paste it below.',
+    requiresKey: true,
   },
   anthropic: {
     keyHref: 'https://console.anthropic.com/settings/keys',
     keyPrefix: 'sk-ant-...',
     helpText: 'Generate an API key in the Anthropic Console and paste it below.',
+    requiresKey: true,
   },
   ollama: {
     keyPrefix: 'ollama',
     helpText: 'Ollama runs locally — no API key required, but the field can\'t be empty. Use any placeholder (e.g. "ollama") and set the Base URL to your daemon.',
+    requiresKey: false,
   },
   custom: {
     keyPrefix: 'your provider\'s key',
     helpText: 'For any OpenAI-compatible provider (Together, Groq, Fireworks, vLLM, etc.). Set Base URL to the provider\'s /v1 endpoint.',
+    requiresKey: true,
   },
 }
 
@@ -95,6 +108,185 @@ async function handleCreate() {
 }
 
 const currentProviderHelp = computed(() => providerHelp[form.value.provider])
+
+// ---------------------------------------------------------------------------
+// Edit-credentials dialog (#742)
+//
+// Reuses the Create dialog markup but:
+//   - provider is read-only (changing provider type is a delete-and-create);
+//   - api_key starts hidden — clicking "Rotate API key" reveals an empty
+//     input, and only then does the PUT carry `api_key`. Skip = key untouched
+//     server-side (backend preserves the stored ciphertext on partial PUT);
+//   - re-runs Test Connection when EITHER base_url changed OR the rotate
+//     input has a non-empty value. If neither changed the gate hits the
+//     /test endpoint with {provider_id} so the stored key is used without
+//     ever leaving the server;
+//   - any keystroke in provider / base_url / rotate-key rolls testStatus
+//     back to `idle`, so a passing probe can't be smuggled past a later
+//     edit.
+// ---------------------------------------------------------------------------
+const showEditDialog = ref(false)
+const editingProvider = ref<LlmProvider | null>(null)
+const editForm = ref<{
+  provider: ProviderType
+  display_name: string
+  base_url: string
+  model: string
+}>({
+  provider: 'openai',
+  display_name: '',
+  base_url: '',
+  model: '',
+})
+const editInitialBaseUrl = ref<string>('')
+const showRotateKey = ref(false)
+const rotateApiKey = ref('')
+const editTestStatus = ref<'idle' | 'testing' | 'pass' | 'fail'>('idle')
+const editTestDetail = ref('')
+const editError = ref('')
+const editSaving = ref(false)
+
+const editProviderHelp = computed(() => providerHelp[editForm.value.provider])
+const editProviderHasKey = computed(() => editProviderHelp.value.requiresKey)
+// Edit dialog needs Base URL whenever the provider type does — same
+// rule as Create.
+const editShowBaseUrl = computed(
+  () => editForm.value.provider === 'custom' || editForm.value.provider === 'ollama',
+)
+// Test-Connection re-gate is REQUIRED when either base_url changed from
+// what's persisted OR the user typed a new key into Rotate. Otherwise
+// nothing security-sensitive is changing and Save is allowed without
+// a probe.
+const editGateRequired = computed(() => {
+  const baseUrlChanged = editForm.value.base_url !== editInitialBaseUrl.value
+  const rotateProvided = showRotateKey.value && rotateApiKey.value.length > 0
+  return baseUrlChanged || rotateProvided
+})
+const editCanSave = computed(() => {
+  if (editSaving.value) return false
+  if (!editForm.value.display_name) return false
+  if (editGateRequired.value && editTestStatus.value !== 'pass') return false
+  return true
+})
+
+function openEditDialog(provider: LlmProvider) {
+  editingProvider.value = provider
+  const model =
+    typeof provider.config?.model === 'string' ? (provider.config.model as string) : ''
+  editForm.value = {
+    provider: provider.provider,
+    display_name: provider.display_name,
+    base_url: provider.base_url ?? '',
+    model,
+  }
+  editInitialBaseUrl.value = provider.base_url ?? ''
+  showRotateKey.value = false
+  rotateApiKey.value = ''
+  editTestStatus.value = 'idle'
+  editTestDetail.value = ''
+  editError.value = ''
+  showEditDialog.value = true
+}
+
+function closeEditDialog() {
+  showEditDialog.value = false
+  editingProvider.value = null
+}
+
+// Any keystroke in fields that affect the credential probe (provider,
+// base_url, rotate-key input) invalidates a prior pass. The provider
+// is read-only in the dialog but we still watch it to stay honest in
+// case that ever changes.
+watch(
+  [
+    () => editForm.value.provider,
+    () => editForm.value.base_url,
+    () => rotateApiKey.value,
+    () => showRotateKey.value,
+  ],
+  () => {
+    if (!showEditDialog.value) return
+    if (editTestStatus.value !== 'idle') {
+      editTestStatus.value = 'idle'
+      editTestDetail.value = ''
+    }
+  },
+)
+
+async function runEditTest() {
+  if (!editingProvider.value) return
+  editTestStatus.value = 'testing'
+  editTestDetail.value = ''
+  try {
+    // Decide which body shape to send. When base_url changed OR the
+    // user typed a new key, we have inline values to probe with. When
+    // neither changed we don't have a secret in memory — fall back to
+    // the {provider_id} shape so the server uses the stored key.
+    const baseUrlChanged = editForm.value.base_url !== editInitialBaseUrl.value
+    const rotateProvided = showRotateKey.value && rotateApiKey.value.length > 0
+    const payload = rotateProvided
+      ? {
+          provider: editForm.value.provider,
+          api_key: rotateApiKey.value,
+          ...(editShowBaseUrl.value
+            ? { base_url: editForm.value.base_url || null }
+            : {}),
+        }
+      : baseUrlChanged
+        ? {
+            provider_id: editingProvider.value.id,
+            ...(editShowBaseUrl.value
+              ? { base_url: editForm.value.base_url || null }
+              : {}),
+          }
+        : { provider_id: editingProvider.value.id }
+    const result = await testLlmProviderConnection(orgId.value, payload)
+    if (result.ok) {
+      editTestStatus.value = 'pass'
+      editTestDetail.value = result.detail ?? ''
+    } else {
+      editTestStatus.value = 'fail'
+      editTestDetail.value = result.detail ?? 'Probe rejected the credentials.'
+    }
+  } catch (e: unknown) {
+    editTestStatus.value = 'fail'
+    editTestDetail.value = e instanceof Error ? e.message : 'Test connection failed'
+  }
+}
+
+async function handleEditSave() {
+  if (!editingProvider.value) return
+  editSaving.value = true
+  editError.value = ''
+  try {
+    const payload: UpdateLlmProviderRequest = {
+      display_name: editForm.value.display_name,
+    }
+    // base_url: include when the dialog renders it. Empty string is
+    // explicitly nulled (matches Create behaviour); a value is sent as-is.
+    if (editShowBaseUrl.value) {
+      payload.base_url = editForm.value.base_url === '' ? null : editForm.value.base_url
+    }
+    // Rotate semantics: omit api_key entirely when the user did NOT
+    // click Rotate — backend (PR #749) preserves the stored ciphertext
+    // on a partial PUT.
+    if (showRotateKey.value && rotateApiKey.value.length > 0) {
+      payload.api_key = rotateApiKey.value
+    }
+    // Persist the selected model under config.model. Merge into the
+    // existing config so unrelated keys aren't dropped.
+    if (editForm.value.model) {
+      const existingConfig = (editingProvider.value.config ?? {}) as Record<string, unknown>
+      payload.config = { ...existingConfig, model: editForm.value.model }
+    }
+    await store.editProvider(orgId.value, editingProvider.value.id, payload)
+    closeEditDialog()
+  } catch (e: unknown) {
+    editError.value = e instanceof Error ? e.message : 'Failed to save provider'
+  } finally {
+    editSaving.value = false
+  }
+}
 
 function confirmDelete(id: string, name: string) {
   providerToDelete.value = id
@@ -151,6 +343,9 @@ onMounted(() => store.fetchProviders(orgId.value))
             </p>
           </div>
           <div class="flex gap-2">
+            <button class="rounded border border-gray-300 px-3 py-1 text-xs text-gray-700 hover:bg-gray-50" @click="openEditDialog(provider)">
+              Edit credentials
+            </button>
             <button class="rounded border border-red-300 px-3 py-1 text-xs text-red-700 hover:bg-red-50" @click="confirmDelete(provider.id, provider.display_name)">
               Delete
             </button>
@@ -182,6 +377,12 @@ onMounted(() => store.fetchProviders(orgId.value))
 
         <!-- Action row -->
         <div class="border-t border-slate-700 mt-2.5 pt-2.5 flex items-center justify-end gap-2">
+          <button
+            class="border border-slate-500 text-slate-200 text-xs px-3 py-1 rounded-lg"
+            @click="openEditDialog(provider)"
+          >
+            Edit credentials
+          </button>
           <button
             class="border border-red-500 text-red-400 text-xs px-3 py-1 rounded-lg"
             @click="confirmDelete(provider.id, provider.display_name)"
@@ -248,6 +449,139 @@ onMounted(() => store.fetchProviders(orgId.value))
             <button type="button" class="rounded px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" @click="showCreateDialog = false">Cancel</button>
             <button type="submit" :disabled="creating || !form.display_name || !form.api_key" class="rounded bg-indigo-600 px-4 py-2 text-sm text-white hover:bg-indigo-700 disabled:opacity-50">
               {{ creating ? 'Creating...' : 'Create' }}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+
+    <!-- Edit Credentials Dialog -->
+    <div v-if="showEditDialog" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div class="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+        <h2 class="mb-4 text-lg font-semibold">Edit credentials</h2>
+        <form class="space-y-4" @submit.prevent="handleEditSave">
+          <div>
+            <label class="block text-sm font-medium text-gray-700">Provider Type</label>
+            <input
+              :value="editForm.provider"
+              type="text"
+              readonly
+              disabled
+              class="mt-1 block w-full rounded border-gray-200 bg-gray-50 text-gray-600 shadow-sm"
+            />
+            <p class="mt-1 text-xs text-gray-400">
+              Provider type can't be changed. Delete and re-create to switch.
+            </p>
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700">Display Name</label>
+            <input
+              v-model="editForm.display_name"
+              type="text"
+              required
+              class="mt-1 block w-full rounded border-gray-300 shadow-sm"
+            />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700">Model</label>
+            <select v-model="editForm.model" class="mt-1 block w-full rounded border-gray-300 shadow-sm">
+              <option v-for="m in modelsForType(editForm.provider)" :key="m.value" :value="m.value">{{ m.label }}</option>
+            </select>
+          </div>
+          <div v-if="editShowBaseUrl">
+            <label class="block text-sm font-medium text-gray-700">Base URL</label>
+            <input
+              v-model="editForm.base_url"
+              type="url"
+              class="mt-1 block w-full rounded border-gray-300 shadow-sm"
+              placeholder="https://api.example.com/v1"
+            />
+          </div>
+
+          <!-- Rotate API key disclosure: hidden entirely for keyless providers (Ollama). -->
+          <div v-if="editProviderHasKey">
+            <button
+              v-if="!showRotateKey"
+              type="button"
+              class="rounded border border-gray-300 px-3 py-1 text-xs text-gray-700 hover:bg-gray-50"
+              @click="showRotateKey = true"
+            >
+              Rotate API key
+            </button>
+            <div v-else>
+              <label class="block text-sm font-medium text-gray-700">New API Key</label>
+              <p class="mt-1 text-xs text-gray-500">
+                {{ editProviderHelp.helpText }}
+                <a
+                  v-if="editProviderHelp.keyHref"
+                  :href="editProviderHelp.keyHref"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="ml-1 inline-flex items-center text-indigo-600 underline hover:text-indigo-800"
+                >
+                  Get a key
+                </a>
+              </p>
+              <input
+                v-model="rotateApiKey"
+                type="password"
+                autocomplete="off"
+                class="mt-2 block w-full rounded border-gray-300 shadow-sm"
+                :placeholder="editProviderHelp.keyPrefix ?? 'sk-...'"
+              />
+              <button
+                type="button"
+                class="mt-1 text-xs text-gray-500 hover:underline"
+                @click="showRotateKey = false; rotateApiKey = ''"
+              >
+                Cancel rotation
+              </button>
+            </div>
+          </div>
+
+          <!-- Test-Connection gate. Only visible when a credential-affecting
+               field changed; result is required to be `pass` before Save. -->
+          <div v-if="editGateRequired" class="rounded border border-gray-200 bg-gray-50 p-3">
+            <div class="flex items-center justify-between">
+              <span class="text-sm font-medium text-gray-700">Test connection</span>
+              <button
+                type="button"
+                :disabled="editTestStatus === 'testing'"
+                class="rounded bg-gray-700 px-3 py-1 text-xs text-white hover:bg-gray-800 disabled:opacity-50"
+                @click="runEditTest"
+              >
+                {{ editTestStatus === 'testing' ? 'Testing...' : 'Test now' }}
+              </button>
+            </div>
+            <p
+              v-if="editTestStatus === 'pass'"
+              class="mt-2 text-xs text-green-700"
+            >
+              ✓ Connection OK{{ editTestDetail ? ` — ${editTestDetail}` : '' }}
+            </p>
+            <p
+              v-else-if="editTestStatus === 'fail'"
+              class="mt-2 text-xs text-red-600"
+            >
+              ✕ {{ editTestDetail || 'Connection failed' }}
+            </p>
+            <p
+              v-else-if="editTestStatus === 'idle'"
+              class="mt-2 text-xs text-gray-500"
+            >
+              Required: the {{ showRotateKey && rotateApiKey ? 'new key' : 'updated Base URL' }} must pass before Save is enabled.
+            </p>
+          </div>
+
+          <p v-if="editError" class="text-red-500 text-sm">{{ editError }}</p>
+          <div class="flex justify-end gap-2 pt-2">
+            <button type="button" class="rounded px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" @click="closeEditDialog">Cancel</button>
+            <button
+              type="submit"
+              :disabled="!editCanSave"
+              class="rounded bg-indigo-600 px-4 py-2 text-sm text-white hover:bg-indigo-700 disabled:opacity-50"
+            >
+              {{ editSaving ? 'Saving...' : 'Save' }}
             </button>
           </div>
         </form>

--- a/internal/handler/llm_provider.go
+++ b/internal/handler/llm_provider.go
@@ -20,6 +20,7 @@ type LLMProviderServicer interface {
 	Update(ctx context.Context, orgID, configID string, req model.UpdateLLMProviderRequest) (*model.LLMProviderResponse, error)
 	Delete(ctx context.Context, orgID, configID string) error
 	SetDefault(ctx context.Context, orgID, configID string) error
+	TestConnection(ctx context.Context, orgID string, req model.TestProviderRequest) (*model.TestConnectionResult, error)
 }
 
 // LLMProviderHandler handles HTTP requests for LLM provider config management.
@@ -185,6 +186,54 @@ func (h *LLMProviderHandler) Delete(c *gin.Context) {
 		return
 	}
 	c.Status(http.StatusNoContent)
+}
+
+// Test handles POST /api/v1/orgs/:org_id/llm-providers/test.
+//
+// Two body shapes are accepted:
+//
+//  1. Inline credentials — {provider, base_url?, api_key} probes the vendor with
+//     the supplied key without persisting anything.
+//  2. Stored credentials — {provider_id} loads the row in the caller's org,
+//     decrypts the stored key, and probes the vendor with it. Lets the
+//     Edit-credentials dialog re-test without holding the secret in memory.
+//
+// @Summary     Test LLM provider credentials
+// @Description Probe the vendor with either inline credentials or a stored provider_id
+// @Tags        llm-providers
+// @Accept      json
+// @Produce     json
+// @Security    BearerAuth
+// @Param       org_id  path string true "Organisation ID"
+// @Param       request body model.TestProviderRequest true "Test connection payload"
+// @Success     200 {object} model.TestConnectionResult
+// @Failure     400 {object} apierror.AppError
+// @Failure     401 {object} apierror.AppError
+// @Failure     403 {object} apierror.AppError
+// @Failure     404 {object} apierror.AppError
+// @Failure     422 {object} apierror.AppError
+// @Router      /orgs/{org_id}/llm-providers/test [post]
+func (h *LLMProviderHandler) Test(c *gin.Context) {
+	orgID := c.Param("org_id")
+
+	var req model.TestProviderRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		_ = c.Error(&apierror.AppError{
+			Code:    http.StatusUnprocessableEntity,
+			Message: "Unprocessable Entity",
+			Detail:  err.Error(),
+		})
+		c.Abort()
+		return
+	}
+
+	resp, err := h.svc.TestConnection(c.Request.Context(), orgID, req)
+	if err != nil {
+		_ = c.Error(err)
+		c.Abort()
+		return
+	}
+	c.JSON(http.StatusOK, resp)
 }
 
 // SetDefault handles PUT /api/v1/orgs/:org_id/llm-providers/:provider_id/default.

--- a/internal/handler/llm_provider_test.go
+++ b/internal/handler/llm_provider_test.go
@@ -24,6 +24,7 @@ type mockLLMProviderService struct {
 	updateFn     func(ctx context.Context, orgID, configID string, req model.UpdateLLMProviderRequest) (*model.LLMProviderResponse, error)
 	deleteFn     func(ctx context.Context, orgID, configID string) error
 	setDefaultFn func(ctx context.Context, orgID, configID string) error
+	testFn       func(ctx context.Context, orgID string, req model.TestProviderRequest) (*model.TestConnectionResult, error)
 }
 
 func (m *mockLLMProviderService) Create(ctx context.Context, orgID, userID string, req model.CreateLLMProviderRequest) (*model.LLMProviderResponse, error) {
@@ -44,6 +45,9 @@ func (m *mockLLMProviderService) Delete(ctx context.Context, orgID, configID str
 func (m *mockLLMProviderService) SetDefault(ctx context.Context, orgID, configID string) error {
 	return m.setDefaultFn(ctx, orgID, configID)
 }
+func (m *mockLLMProviderService) TestConnection(ctx context.Context, orgID string, req model.TestProviderRequest) (*model.TestConnectionResult, error) {
+	return m.testFn(ctx, orgID, req)
+}
 
 func newLLMProviderRouter(svc handler.LLMProviderServicer) *gin.Engine {
 	gin.SetMode(gin.TestMode)
@@ -63,6 +67,7 @@ func newLLMProviderRouter(svc handler.LLMProviderServicer) *gin.Engine {
 	r.PUT(base+"/:provider_id", h.Update)
 	r.DELETE(base+"/:provider_id", h.Delete)
 	r.PUT(base+"/:provider_id/default", h.SetDefault)
+	r.POST(base+"/test", h.Test)
 	return r
 }
 
@@ -261,6 +266,136 @@ func TestLLMProviderResponse_NoKeyLeakage(t *testing.T) {
 	// Verify the hint IS present.
 	if !strings.Contains(body, "api_key_hint") {
 		t.Error("response body should contain api_key_hint")
+	}
+}
+
+// Regression for #739: PUT without api_key must NOT cause the service to
+// receive a non-nil APIKey on the update request. The service / repo layer
+// uses COALESCE on a nil ciphertext to leave the stored encrypted key
+// untouched, so the handler must pass the absence through verbatim.
+func TestUpdateLLMProvider_OmitsAPIKey_PreservesStoredKey(t *testing.T) {
+	var capturedReq model.UpdateLLMProviderRequest
+	storedHint := "...keep"
+	svc := &mockLLMProviderService{
+		updateFn: func(_ context.Context, orgID, configID string, req model.UpdateLLMProviderRequest) (*model.LLMProviderResponse, error) {
+			capturedReq = req
+			// Simulate the repo's COALESCE behaviour: the stored hint is
+			// returned unchanged because req.APIKey is nil.
+			return &model.LLMProviderResponse{
+				ID:          configID,
+				OrgID:       orgID,
+				Provider:    model.LLMProviderOpenAI,
+				DisplayName: "Renamed",
+				APIKeyHint:  storedHint,
+				Status:      model.ProviderStatusActive,
+			}, nil
+		},
+	}
+	r := newLLMProviderRouter(svc)
+
+	// Body deliberately omits api_key — only display_name changes.
+	body, _ := json.Marshal(map[string]string{"display_name": "Renamed"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPut, "/api/v1/orgs/org-abc/llm-providers/prov-1", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if capturedReq.APIKey != nil {
+		t.Errorf("expected service to receive nil APIKey when body omits api_key, got %q", *capturedReq.APIKey)
+	}
+
+	// A follow-up GET should still show the original hint — verify the
+	// PUT response itself preserved it.
+	var resp model.LLMProviderResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if resp.APIKeyHint != storedHint {
+		t.Errorf("expected api_key_hint preserved as %q, got %q", storedHint, resp.APIKeyHint)
+	}
+}
+
+// TestTestConnection_ByProviderID verifies the new {provider_id} shape: the
+// handler accepts a payload with only provider_id and forwards it intact to
+// the service, returning the standard TestConnectionResult JSON.
+func TestTestConnection_ByProviderID(t *testing.T) {
+	var captured model.TestProviderRequest
+	svc := &mockLLMProviderService{
+		testFn: func(_ context.Context, orgID string, req model.TestProviderRequest) (*model.TestConnectionResult, error) {
+			captured = req
+			if orgID != "org-abc" {
+				t.Errorf("unexpected org id %q", orgID)
+			}
+			return &model.TestConnectionResult{
+				OK:       true,
+				Provider: string(model.LLMProviderOpenAI),
+			}, nil
+		},
+	}
+	r := newLLMProviderRouter(svc)
+
+	body, _ := json.Marshal(map[string]string{
+		"provider_id": "11111111-2222-3333-4444-555555555555",
+	})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/orgs/org-abc/llm-providers/test", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if captured.ProviderID == nil || *captured.ProviderID != "11111111-2222-3333-4444-555555555555" {
+		t.Errorf("expected provider_id forwarded, got %+v", captured.ProviderID)
+	}
+	if captured.APIKey != nil {
+		t.Errorf("expected api_key absent when probing by id, got %q", *captured.APIKey)
+	}
+
+	var resp model.TestConnectionResult
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if !resp.OK || resp.Provider != string(model.LLMProviderOpenAI) {
+		t.Errorf("unexpected probe result: %+v", resp)
+	}
+}
+
+// TestTestConnection_InlineCredentials verifies the existing {provider, api_key}
+// shape still works after extending the endpoint.
+func TestTestConnection_InlineCredentials(t *testing.T) {
+	var captured model.TestProviderRequest
+	svc := &mockLLMProviderService{
+		testFn: func(_ context.Context, _ string, req model.TestProviderRequest) (*model.TestConnectionResult, error) {
+			captured = req
+			return &model.TestConnectionResult{OK: true, Provider: string(*req.Provider)}, nil
+		},
+	}
+	r := newLLMProviderRouter(svc)
+
+	body, _ := json.Marshal(map[string]string{
+		"provider": "openai",
+		"api_key":  "sk-inline",
+	})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/orgs/org-abc/llm-providers/test", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if captured.Provider == nil || *captured.Provider != model.LLMProviderOpenAI {
+		t.Errorf("expected provider forwarded, got %+v", captured.Provider)
+	}
+	if captured.APIKey == nil || *captured.APIKey != "sk-inline" {
+		t.Errorf("expected api_key forwarded, got %+v", captured.APIKey)
+	}
+	if captured.ProviderID != nil {
+		t.Errorf("expected provider_id absent on inline path, got %q", *captured.ProviderID)
 	}
 }
 

--- a/internal/model/llm_provider.go
+++ b/internal/model/llm_provider.go
@@ -84,6 +84,33 @@ type UpdateLLMProviderRequest struct {
 	Status      *ProviderStatus `json:"status,omitempty"`
 }
 
+// TestProviderRequest is the payload for POST .../llm-providers/test.
+//
+// Two shapes are accepted:
+//
+//  1. Inline credentials — used before a provider row exists (e.g. the Create
+//     dialog's "Test connection" button): {provider, base_url?, api_key}.
+//  2. Stored credentials — used after a provider row exists (e.g. the Edit
+//     dialog's "Test connection" re-gate without re-entering the secret):
+//     {provider_id}. The handler loads the row, decrypts the stored key, and
+//     probes the vendor with it.
+//
+// At least one of {provider+api_key, provider_id} must be present. When
+// provider_id is set, the inline fields are ignored.
+type TestProviderRequest struct {
+	ProviderID *string      `json:"provider_id,omitempty" binding:"omitempty,uuid"`
+	Provider   *LLMProvider `json:"provider,omitempty"`
+	BaseURL    *string      `json:"base_url,omitempty"`
+	APIKey     *string      `json:"api_key,omitempty"`
+}
+
+// TestConnectionResult is the response shape for POST .../llm-providers/test.
+type TestConnectionResult struct {
+	OK       bool   `json:"ok"`
+	Provider string `json:"provider"`
+	Detail   string `json:"detail,omitempty"`
+}
+
 // LLMProviderResponse is the API response DTO — never contains encrypted key data.
 type LLMProviderResponse struct {
 	ID          string         `json:"id"`

--- a/internal/service/llm_provider.go
+++ b/internal/service/llm_provider.go
@@ -3,7 +3,9 @@ package service
 import (
 	"context"
 	"encoding/hex"
+	"net/http"
 	"strings"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -16,11 +18,19 @@ import (
 	"github.com/ravencloak-org/Raven/pkg/apierror"
 )
 
+// LLMProbeFunc probes a vendor with the supplied credentials and reports
+// whether the credentials look valid. Implementations should bound their own
+// timeout and never panic. Returning a non-nil error indicates the probe could
+// not be carried out (network failure, unexpected vendor response); returning
+// (false, nil) indicates the probe completed and the credentials were rejected.
+type LLMProbeFunc func(ctx context.Context, provider model.LLMProvider, baseURL *string, apiKey string) (ok bool, detail string, err error)
+
 // LLMProviderService contains business logic for LLM provider config management.
 type LLMProviderService struct {
 	repo   *repository.LLMProviderRepository
 	pool   *pgxpool.Pool
 	aesKey []byte
+	probe  LLMProbeFunc
 }
 
 // NewLLMProviderService creates a new LLMProviderService.
@@ -33,7 +43,13 @@ func NewLLMProviderService(repo *repository.LLMProviderRepository, pool *pgxpool
 	if len(key) != 32 {
 		return nil, apierror.NewInternal("AES key must be 32 bytes (64 hex characters)")
 	}
-	return &LLMProviderService{repo: repo, pool: pool, aesKey: key}, nil
+	return &LLMProviderService{repo: repo, pool: pool, aesKey: key, probe: defaultLLMProbe}, nil
+}
+
+// WithProbe overrides the vendor probe func; intended for tests.
+func (s *LLMProviderService) WithProbe(probe LLMProbeFunc) *LLMProviderService {
+	s.probe = probe
+	return s
 }
 
 // Create encrypts the API key and stores a new LLM provider config.
@@ -184,6 +200,144 @@ func (s *LLMProviderService) SetDefault(ctx context.Context, orgID, configID str
 		return apierror.NewInternal("failed to set default provider: " + err.Error())
 	}
 	return nil
+}
+
+// TestConnection probes a vendor either with inline credentials or with the
+// stored credentials of an existing provider row. When req.ProviderID is set,
+// the row is loaded, the encrypted key decrypted, and that key used for the
+// probe. Otherwise req.Provider and req.APIKey are required and used directly.
+//
+// The vendor probe itself is delegated to s.probe so callers (and tests) can
+// inject behaviour without making real HTTP calls.
+func (s *LLMProviderService) TestConnection(ctx context.Context, orgID string, req model.TestProviderRequest) (*model.TestConnectionResult, error) {
+	var (
+		provider model.LLMProvider
+		baseURL  *string
+		apiKey   string
+	)
+
+	switch {
+	case req.ProviderID != nil && *req.ProviderID != "":
+		var cfg *model.LLMProviderConfig
+		err := db.WithOrgID(ctx, s.pool, orgID, func(tx pgx.Tx) error {
+			var getErr error
+			cfg, getErr = s.repo.GetByID(ctx, tx, orgID, *req.ProviderID)
+			return getErr
+		})
+		if err != nil {
+			if strings.Contains(err.Error(), "no rows") {
+				return nil, apierror.NewNotFound("LLM provider config not found")
+			}
+			return nil, apierror.NewInternal("failed to fetch LLM provider config: " + err.Error())
+		}
+		if cfg.APIKeyEncrypted == nil || cfg.APIKeyIV == nil {
+			return nil, apierror.NewBadRequest("stored provider has no API key to test")
+		}
+		plaintext, err := crypto.Decrypt(cfg.APIKeyEncrypted, cfg.APIKeyIV, s.aesKey)
+		if err != nil {
+			return nil, apierror.NewInternal("failed to decrypt API key: " + err.Error())
+		}
+		provider = cfg.Provider
+		baseURL = cfg.BaseURL
+		apiKey = string(plaintext)
+
+	case req.Provider != nil && req.APIKey != nil && *req.APIKey != "":
+		if !model.ValidLLMProviders[*req.Provider] {
+			return nil, apierror.NewBadRequest("invalid provider: " + string(*req.Provider))
+		}
+		provider = *req.Provider
+		baseURL = req.BaseURL
+		apiKey = *req.APIKey
+
+	default:
+		return nil, apierror.NewBadRequest("must supply either provider_id or {provider, api_key}")
+	}
+
+	if s.probe == nil {
+		return nil, apierror.NewInternal("provider probe not configured")
+	}
+	ok, detail, err := s.probe(ctx, provider, baseURL, apiKey)
+	if err != nil {
+		return nil, apierror.NewInternal("provider probe failed: " + err.Error())
+	}
+	return &model.TestConnectionResult{
+		OK:       ok,
+		Provider: string(provider),
+		Detail:   detail,
+	}, nil
+}
+
+// defaultLLMProbe issues a lightweight authenticated GET against the vendor's
+// public models endpoint to verify the API key. It treats 2xx as success and
+// any other response (including 401/403) as a failed probe. Network and parse
+// errors propagate up so callers can distinguish "probe could not run" from
+// "credentials rejected".
+func defaultLLMProbe(ctx context.Context, provider model.LLMProvider, baseURL *string, apiKey string) (bool, string, error) {
+	endpoint, header := probeEndpointFor(provider, baseURL)
+	if endpoint == "" {
+		// Provider does not expose a stable probe endpoint; treat as success
+		// when an api_key is present (caller-side validation only).
+		return apiKey != "", "no remote probe configured for this provider", nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return false, "", err
+	}
+	for k, v := range header(apiKey) {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false, "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return true, "", nil
+	}
+	return false, "vendor returned status " + resp.Status, nil
+}
+
+// probeEndpointFor returns the URL and an auth-header-builder for the given
+// provider. Returning an empty url tells the caller there is no remote probe
+// for this provider.
+func probeEndpointFor(provider model.LLMProvider, baseURL *string) (string, func(apiKey string) map[string]string) {
+	withBase := func(defaultBase, path string) string {
+		base := defaultBase
+		if baseURL != nil && *baseURL != "" {
+			base = strings.TrimRight(*baseURL, "/")
+		}
+		return base + path
+	}
+	bearer := func(apiKey string) map[string]string {
+		return map[string]string{"Authorization": "Bearer " + apiKey}
+	}
+	switch provider {
+	case model.LLMProviderOpenAI:
+		return withBase("https://api.openai.com", "/v1/models"), bearer
+	case model.LLMProviderAnthropic:
+		return withBase("https://api.anthropic.com", "/v1/models"), func(apiKey string) map[string]string {
+			return map[string]string{
+				"x-api-key":         apiKey,
+				"anthropic-version": "2023-06-01",
+			}
+		}
+	case model.LLMProviderCohere:
+		return withBase("https://api.cohere.com", "/v1/models"), bearer
+	case model.LLMProviderGoogle:
+		// Google AI Studio uses the API key as a query param; skip remote probe.
+		return "", nil
+	case model.LLMProviderAzureOpenAI, model.LLMProviderOllama, model.LLMProviderCustom:
+		// Self-hosted / customer-deployed; no canonical probe endpoint.
+		return "", nil
+	default:
+		return "", nil
+	}
 }
 
 // GetDecryptedKey retrieves and decrypts the API key for a provider config.


### PR DESCRIPTION
## Summary

Adds an **Edit credentials** dialog to `LlmProviderListPage.vue` so org admins can update `display_name`, `model`, and `base_url` without re-typing the API key on every save. Provider type is read-only inside the dialog (changing it means delete-and-create).

- **Rotate API key disclosure** — `api_key` input stays hidden by default; click "Rotate API key" to reveal a fresh `<input type="password">`. Skip it and the PUT body omits `api_key` entirely, letting the backend (#749) preserve the stored ciphertext. Hidden entirely for keyless providers (`providerHelp[provider].requiresKey === false`, today only Ollama).
- **Test Connection re-gate** — `idle | testing | pass | fail` state machine; gate is REQUIRED whenever `base_url` changed from its initial value OR the rotate input has a non-empty value. When neither changed, the dialog uses the new `{provider_id}` shape on `POST /llm-providers/test` so the stored encrypted key is probed without ever leaving the server. Save is disabled until `pass` when the gate is active.
- **Invalidation** — any keystroke in `provider` / `base_url` / rotate-key input rolls `testStatus` back to `idle`, so a passing probe can't be smuggled past a later edit.
- **API client** — adds `testLlmProviderConnection(orgId, payload)` plus `TestProviderRequest` / `TestConnectionResult` types matching backend `model.TestProviderRequest` (PR #749 / Issue #739).

Backend deps land in PR #749 (currently open); this PR is based on that branch so the `{provider_id}` shape and partial-PUT preservation are available.

## Test plan

- [ ] Open Edit on an OpenAI/Anthropic/Custom card → dialog pre-fills `provider` (read-only), `base_url`, `model`; `api_key` field is hidden.
- [ ] Open Edit on the Ollama card → no Rotate API key button is rendered.
- [ ] Rename only → no Test required → Save → reload → name persisted.
- [ ] Click Rotate → empty password input appears → type new key → Test required → pass → Save → reload → `api_key_hint` updated.
- [ ] Change `base_url` only → Test required → pass → Save → reload → new URL persisted.
- [ ] Click Test, get pass, then tweak `base_url` → gate flips back to `idle`, Save disabled until re-pass.
- [ ] `pnpm lint` clean (no new warnings).

Closes #742