### PR TITLE
docs(marketplace): foundation — CONTEXT.md + 8 ADRs + MVP plan

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,112 @@
+# Raven
+
+Multi-tenant RAG platform: orgs upload documents into knowledge bases, query them via chat or widget, and embed grounded answers into third-party apps.
+
+## Language
+
+**Organization** (Org):
+The top-level tenant. Owns billing, subscription, members, and all data created beneath it. Identified by `org_id` in RLS and throughout the codebase.
+_Avoid_: Account, tenant, customer.
+
+**Workspace**:
+A sub-grouping inside an Org that owns one or more Knowledge Bases. Used to scope membership, API keys, and (eventually) per-team plan limits.
+_Avoid_: Project, team.
+
+**Knowledge Base** (KB):
+A collection of Sources, Documents, Chunks, and their Embeddings against which Chats and Widgets are run. Belongs to exactly one Workspace.
+_Avoid_: Corpus, dataset, library.
+
+**Source**:
+An input to a KB — uploaded file, URL, connector. Materializes into one or more Documents on processing.
+
+**Chunk**:
+The atomic embeddable unit of text extracted from a Document. Sized by the chunker to fit the embedding model's token window.
+
+**Embedding**:
+A vector for a Chunk produced by an embedding model. Currently `vector(768)` from `nomic-embed-text`.
+
+**Subscription**:
+The billing relationship between an Org and a paid plan. One active subscription per Org. The **Free Plan** is the implicit state when no active paid subscription exists.
+
+**Free Plan Org**:
+An Org without an active paid Subscription. The phrase "free user" is shorthand for "a User belonging to a Free Plan Org" — the plan is a property of the Org, never the User. Free Plan Orgs are governed by the strict-flywheel rule in [ADR-0004](docs/adr/0004-free-tier-public-only-rule.md): every KB they hold — whether created or imported — is forced `visibility=public`.
+_Avoid_: Free user, free account (when used to imply a per-user concept).
+
+**Read-only-private KB**:
+A KB in the transitional state produced when a Paid Plan Org downgrades to Free Plan. Stays private but cannot accept new Sources, Documents, or Chats until the User Publishes it, Deletes it, or upgrades back. Represented by `kb_status = 'read_only_private'`.
+
+**Derivative Public KB**:
+A Public KB whose `source_public_kb_id` points at another Public KB — i.e. an Imported KB that was itself made public (either because the Importer chose to publish their fork, or because the Importer is a Free Plan Org and the strict-flywheel rule forced publication). Lineage is preserved indefinitely; takedowns of the original do not cascade.
+
+### Marketplace
+
+**Marketplace**:
+The cross-tenant discovery surface that lists Public KBs available for Import. Hosted at `raven.ravencloak.org/marketplace`. Accessible only to authenticated Users; no anonymous browsing.
+
+**Content-grade Publish**:
+The data boundary applied when a KB is Published or Imported. Chunks, Embeddings, and Source metadata cross the boundary; original file blobs, runtime artefacts (api_keys, chats, routing_rules, webhooks, response_cache, connectors), and any non-allow-listed `settings` keys do not. See [ADR-0002](docs/adr/0002-content-grade-publish-boundary.md).
+
+**Public KB**:
+A KB whose publishing Org has flipped its `visibility` to `public`, making it discoverable on the Marketplace. The KB itself still lives in its publishing Workspace; visibility is the only thing that changes.
+
+**Private KB**:
+A KB visible only inside its owning Org. The default state for every KB.
+
+**Publish**:
+The act of flipping a KB from `private` to `public`. Reversible (the publisher can unpublish), but unpublish does not affect already-Imported copies. The publisher of record is the **Org**, not the User who pressed the button. See [ADR-0005](docs/adr/0005-org-as-marketplace-publisher.md).
+
+**Org slug**:
+A globally-unique, URL-safe identifier for an Org. Forms the first segment of every Marketplace URL: `raven.ravencloak.org/marketplace/{org_slug}/{kb_slug}`. Backfilled from `display_name` at migration; subsequently editable but constrained for uniqueness.
+
+**Marketplace URL**:
+The canonical public address of a Public KB: `raven.ravencloak.org/marketplace/{org_slug}/{kb_slug}`. 404s if either slug is unknown or the target is private.
+
+**Import**:
+The act of an Org cloning a Public KB into one of its own Workspaces. Produces an independent KB row with its own Sources, Chunks, and Embeddings — a fork, not a live link. See [ADR-0001](docs/adr/0001-marketplace-fork-on-import.md).
+
+**Re-import**:
+A destructive overwrite of an existing Imported KB with the publisher's current state. Replaces the Importer's local Chunks and Embeddings; preserves the Importer's KB id, Chats, Widgets, and other runtime artefacts (these FK to the Imported KB id, not its content). Always confirmed.
+
+**`last_modified_at`**:
+Timestamp on a Public KB reflecting the most recent content-affecting change in the publisher's workspace. Shown as "Updated 3 days ago" on Marketplace listings; the Marketplace and Import operations both read live KB state per [ADR-0003](docs/adr/0003-always-fresh-publish-lifecycle.md) — there is no separate publication snapshot in MVP.
+
+**`imported_from_revision_at`**:
+Timestamp stamped on the Importer's local KB at the moment of Import, recording the publisher's `last_modified_at` value captured. Lets the Importer reason about what they have vs what's now available upstream.
+
+**Importer Org**:
+An Org that has Imported one or more Public KBs. Distinct from the **Publishing Org** that owns the original.
+
+**License (SPDX)**:
+A required declaration on every Public KB, chosen from a 7-item allow-list (`CC0-1.0`, `CC-BY-4.0`, `CC-BY-SA-4.0`, `CC-BY-NC-4.0`, `MIT`, `Apache-2.0`, `GPL-3.0`). Surfaced as a badge on every Marketplace card and Importer-side KB. See [ADR-0006](docs/adr/0006-licence-and-moderation.md).
+
+**Takedown**:
+The forced or voluntary removal of a Public KB from the Marketplace. Sources: publisher (self-unpublish), DMCA (third-party copyright claim via `dmca@ravencloak.org`), or admin (TOS violation). Does not cascade to Derivative Public KBs; derivative owners are notified instead.
+
+**Strike**:
+A confirmed Takedown attributable to an Org. Three strikes triggers Org-level suspension via admin runbook. Tracked on `organizations.takedown_strikes`.
+
+**Preview**:
+A narrow public surface returning ≤3 sample Chunks from a Public KB, served by a `SECURITY DEFINER` Postgres function so logged-in Users can assess content quality before deciding to Import. The only place Marketplace traffic reads published Chunks cross-tenant — bounded by the function's signature, not a general RLS hole. See [ADR-0007](docs/adr/0007-marketplace-lifecycle-behaviours.md).
+
+**Discovery**:
+The browse / search surface at `raven.ravencloak.org/marketplace`. Postgres full-text search over KB metadata (name, description, publishing Org's display name), with sort options (Newest, Most imported, Recently updated, Alphabetic) and a license multi-select filter. No categories, tags, or content search in MVP. See [ADR-0008](docs/adr/0008-marketplace-discovery-and-operations.md).
+
+## Relationships
+
+- An **Org** has one active **Subscription** (or none, in which case it is a **Free Plan Org**).
+- An **Org** has many **Workspaces**; each **Workspace** has many **KBs**.
+- A **KB** has many **Sources**; each **Source** produces many **Documents**; each **Document** produces many **Chunks**; each **Chunk** has one **Embedding**.
+- A **Public KB** can be **Imported** by many other **Orgs**, producing one **Imported KB** per Importer Org. Imported KBs do not track publisher edits — they are forks at the moment of import.
+- **Chats** and **Widgets** always belong to the **Importer Org** and FK to the **Imported KB**, never to the publisher's KB.
+
+## Example dialogue
+
+> **Dev:** "If a user on the **Free Plan** uploads a doc, where does it land?"
+> **Domain expert:** "Their **Org** is a Free Plan Org, so any **KB** they create has to be **Public**. The doc still uploads into that KB in their **Workspace** like normal — it's just discoverable from the **Marketplace**."
+
+> **Dev:** "If the publisher edits the **KB** after I've **Imported** it, do I see the changes?"
+> **Domain expert:** "No. **Import** is a fork. You'd have to re-import to get the new version."
+
+## Flagged ambiguities
+
+- "Account" was used to mean both **User** and **Org**. Resolved: **Org** is the billing and data-ownership unit; **User** is a person who is a member of one or more Orgs. "Free account" specifically means **Free Plan Org**.

--- a/docs/adr/0001-marketplace-fork-on-import.md
+++ b/docs/adr/0001-marketplace-fork-on-import.md
@@ -1,0 +1,30 @@
+# 0001 — Marketplace KBs use fork-on-import
+
+Status: accepted
+
+## Decision
+
+When an Importer Org imports a Public KB from the Marketplace, Raven **copies the KB row, its Sources, Chunks, and Embeddings into the Importer Org**. The Imported KB is an independent fork — it does not track publisher edits, and unpublishing or deleting the original has no effect on the Importer. Chats and Widgets created by the Importer FK to their local Imported KB, never to the publisher's KB.
+
+## Why
+
+Three rejected alternatives drove this:
+
+1. **Cross-tenant read (live link).** Importer's KB is a thin pointer at the publisher's chunks. Lower storage, automatic updates. Rejected: forces an RLS hole in `knowledge_bases`, `chunks`, and `embeddings` for every retrieval-path query (a hostile coupling — easy to leak), and silently changes Importers' chatbot answers when publishers edit. A publisher takedown breaks every Importer's product. The "Marketplace" stops being a marketplace and becomes a shared dependency graph.
+
+2. **Separate `marketplace_kbs` table.** Two domain concepts — a regular KB, and a marketplace KB you fork from. Rejected: doubles the storage path (writers must publish to both tables; retrieval code branches), and duplicates the KB concept in the domain language. A `visibility` column on `knowledge_bases` does the same work without forking the type.
+
+3. **Fork-on-import (chosen).** Importer's Org gets a real copy. RLS stays intact for all hot-path queries; the only cross-tenant read is the Marketplace listing query, which runs through a `SECURITY DEFINER` function over public-KB metadata only.
+
+## Trade-offs accepted
+
+- **Storage cost.** Each import re-stores Chunks and Embeddings in the Importer Org. With `vector(768)` and typical KB sizes this is tens of MB per import — manageable. A future optimisation can dedupe Embeddings by `(chunk_hash, embedding_model)` across orgs using a shared content-addressed pool, without breaking the fork contract.
+- **No auto-sync.** Importers stay on the version they imported. Pulling a new version is an explicit user action ("import again to get updates"). This is the package-manager model — predictable, but some users will expect Substack-style auto-update and need to be told otherwise.
+- **Re-embedding cost on import.** Avoided if and only if the Importer Org uses the same embedding model as the Publisher; otherwise Chunks must be re-embedded against the Importer's model. Acceptable: the alternative is non-portable embeddings.
+
+## Consequences
+
+- `knowledge_bases` gains a `visibility ENUM('private','public')` column and a `source_public_kb_id UUID NULL` lineage pointer.
+- Marketplace listing is a single `SECURITY DEFINER` function returning public-KB metadata (`id`, `org_id`, `name`, `description`, counts) across all Orgs. No cross-tenant read of Chunks or Embeddings is ever needed at query time.
+- Unpublish is non-destructive to Importers. The original KB flips back to `private`; existing forks continue to work.
+- Quota accounting must treat Imported KBs as owned by the Importer Org (they consume Importer storage and embedding budget), not by the Publisher.

--- a/docs/adr/0002-content-grade-publish-boundary.md
+++ b/docs/adr/0002-content-grade-publish-boundary.md
@@ -1,0 +1,33 @@
+# 0002 — Content-grade publish boundary
+
+Status: accepted
+
+## Decision
+
+When a KB is Published to the Marketplace (and on every subsequent Import), Raven copies a **content-grade** projection of the KB:
+
+- **Crosses the boundary**: KB metadata (`name`, `description`, `slug`), Source rows (without file-blob references), Documents, Chunks, Embeddings (if model matches; otherwise re-embed from Chunks), an allow-listed subset of `settings` (`chunker_config`, `embedding_model_id`, and explicitly-marked public keys), and publish metadata (`published_by_user_id`, `published_at`, license declaration).
+- **Never crosses the boundary**: original file blobs in SeaweedFS, `api_keys`, `chat_sessions`, `routing_rules`, `webhook_configs`, `response_cache`, `airbyte_connectors`, and any `settings` key not on the allow-list.
+
+The default for the `settings` JSONB scrub is **deny**: a key is copied only if it appears in an explicit allow-list maintained alongside the Publish code.
+
+## Why
+
+Three alternatives were considered:
+
+1. **Wide (source-grade)** — copy original file blobs to importers as well. Rejected: turns Raven into a piracy mirror for any copyrighted PDF a user uploads, complicates takedown response, and bloats Importer storage with files they will almost never re-read (chunks are what powers RAG).
+2. **Narrow (index-only)** — copy only KB metadata; Importer re-runs the chunker and embedder from scratch. Rejected: makes Import slow (minutes of worker time) and forces a Python AI-worker round-trip for every Import. The "package-manager UX" the marketplace promises is broken if `npm install` always recompiles.
+3. **Medium (content-grade, chosen)** — copy the *derived* text and vectors but not the source artefact or any runtime state.
+
+## Trade-offs accepted
+
+- **Importer cannot see original files.** They get the chunks (the text used for retrieval) but not the PDF/Word/etc. that produced them. UX cost is low: chunks are what RAG uses, and the source file is rarely consulted by an Importer.
+- **`settings` allow-list is a maintenance burden.** Every new setting requires a deliberate decision about whether it's public-safe. Mitigation: a CI test that asserts every key in the schema is either explicitly allow-listed or explicitly denied — no implicit silence.
+- **No "include blobs" escape hatch in MVP.** Some legitimate use cases (open citation archives, public-domain primary sources) would benefit from blob inclusion. Out of scope until a real publisher asks; default-deny is safer.
+
+## Consequences
+
+- The Publish code path becomes a projection function: `KB → PublishedKBProjection`. Not a `pg_dump`-style copy.
+- The Import code path is the same projection applied in reverse: `PublishedKBProjection → new KB in Importer Org`.
+- `airbyte_connectors`, `api_keys`, `routing_rules`, `webhook_configs`, `response_cache`, `chat_sessions` are **publisher-private by construction** — there is no path by which they reach an Importer. This is a structural guarantee, not a runtime check.
+- Schema needs: `knowledge_bases.visibility ENUM('private','public')`, `knowledge_bases.published_at TIMESTAMPTZ NULL`, `knowledge_bases.published_by_user_id UUID NULL`, `knowledge_bases.license TEXT NULL` (SPDX id), and `knowledge_bases.source_public_kb_id UUID NULL` for Importer-side lineage.

--- a/docs/adr/0003-always-fresh-publish-lifecycle.md
+++ b/docs/adr/0003-always-fresh-publish-lifecycle.md
@@ -1,0 +1,36 @@
+# 0003 — Always-fresh publish lifecycle for MVP
+
+Status: accepted
+
+## Decision
+
+A Published KB is **always-fresh**: the Marketplace listing and the Import operation both read from the live KB state at the moment of request. There are no immutable publication snapshots, no version history, and no explicit "Publish update" action separate from "Publish."
+
+The contract Raven offers Importers is timestamp-based, not version-based:
+
+- The Marketplace listing displays `last_modified_at` ("Updated 3 days ago").
+- An Imported KB stamps `imported_from_revision_at` so the Importer can see exactly which moment they captured.
+- **Re-import** is a destructive overwrite of the Importer's local KB, with confirmation, available from the Importer's local KB detail page.
+
+## Why
+
+Two publisher personas, one tier today:
+
+1. **Free-tier auto-publisher** (the MVP majority): uses Raven as their primary chatbot, KB is public because the plan requires it. Wants zero friction — upload doc, it's discoverable. Versioning UI is overhead they didn't ask for.
+2. **OSS curator** (deferred persona): wants stable releases with version pinning so importers can rely on a known revision. Real need — but not represented in the MVP user base.
+
+Always-fresh serves persona 1 at zero cost, and persona 2 is protected from silent breakage by the fork-on-import contract from [ADR-0001](0001-marketplace-fork-on-import.md) — their existing imports never change. Only *future* importers see the publisher's edits, and they see a timestamp telling them so.
+
+A versioned model (`marketplace_publications` table, "Publish update" button, v1/v2/v3 UI) was considered and rejected for MVP. It can be added later as an additive migration when a real curator persona materialises and asks for it.
+
+## Trade-offs accepted
+
+- **No version pinning for Importers in MVP.** The "what did I get?" question is answered by `imported_from_revision_at`, not a version number. If the publisher made breaking changes between two import events, Importers must reconcile manually.
+- **No rollback for publishers.** If a publisher accidentally deletes content from their KB, an Importer arriving in that window gets the broken state. The Importer's existing fork is fine (per ADR-0001); only new imports during the bad window are affected. Mitigated by standard backup/restore on the publisher's own KB, not a Marketplace feature.
+- **OSS curator persona is deferred.** When a serious open-knowledge publisher signs up and asks for versioned releases, we add the `marketplace_publications` table, backfill all existing public KBs as v1, and surface a "Publish update" action. The migration is additive; no Importer breaks.
+
+## Consequences
+
+- `knowledge_bases` gains a `last_modified_at TIMESTAMPTZ` column (updated by trigger on any Document/Source/Chunk write that affects the KB's content surface). Distinct from `updated_at`, which already exists and tracks any row mutation.
+- Importer-side `knowledge_bases` row carries `imported_from_revision_at TIMESTAMPTZ` set at Import time.
+- No `marketplace_publications` table is added in MVP. When added later it will join to `knowledge_bases` via `(org_id, kb_id, version_seq)` and Import will start reading from publication rows instead of live KB state — Importer schema does not need to change.

--- a/docs/adr/0004-free-tier-public-only-rule.md
+++ b/docs/adr/0004-free-tier-public-only-rule.md
@@ -1,0 +1,42 @@
+# 0004 — Free Plan Orgs hold only Public KBs
+
+Status: accepted
+
+## Decision
+
+For any Org without an active paid Subscription (a **Free Plan Org**):
+
+1. **Creating a KB** — `visibility` is forced to `public`. Private creation is not selectable.
+2. **Importing a Public KB** — the resulting Imported KB is also forced `public`. Free Plan Orgs cannot hold private forks.
+3. **Plan downgrade (Paid → Free)** — existing private KBs transition to status `read_only_private`. They remain private (not auto-published), but cannot accept new Sources, Documents, or Chats. The User must explicitly Publish, Delete, or upgrade back to restore the KB.
+4. **Plan upgrade (Free → Paid)** — no automatic state change. Existing Public KBs stay public until the User manually converts them.
+
+Enforcement is at write-time on `knowledge_bases` (and the Import code path), not via batch sweep — bad rows must be impossible to write, not eventually-corrected.
+
+## Why
+
+The user-stated rule "Free Plan can only create Public KBs" leaves three edge cases that determine whether the Marketplace is a flywheel or a faucet:
+
+1. **Import without forced-public** would create a loophole: a Free Plan user imports 50 Public KBs and now enjoys 50 effectively-private KBs in their workspace. The free tier becomes "private as long as someone else seeded the content." Marketplace stays one-way: stuff flows out, nothing flows back as derivatives.
+
+2. **Downgrade auto-publishing** would silently leak private content the User never consented to share — a hard-no.
+
+3. **Upgrade auto-privating** would retroactively yank Public KBs that Importers may be tracking; breaks the "Updated 3 days ago" contract on the Marketplace listing.
+
+Strict-flywheel + frozen-private + manual-upgrade is the only combination that closes the loophole, respects consent, and preserves Importer expectations.
+
+## Trade-offs accepted
+
+- **Derivative Public KBs create attribution tangle.** Acme Corp publishes → 200 Free Plan users import → 200 derivative Public KBs exist. Each is a separate row, each independently editable. UI must show lineage clearly (`source_public_kb_id` already on the row from ADR-0002). Solved in attribution design, not here.
+- **Takedown does not cascade.** Acme retracts → derivatives still exist. Standard OSS-attribution practice: the publisher's act of making something public is irrevocable for downstream users. Mitigated by mandatory licence declaration (separate decision) which gives downstream Orgs a legal basis to keep their forks.
+- **`read_only_private` is a new KB status that touches every read path.** Chat sessions must check it and surface a graceful "frozen" message; widgets must return a maintenance response; the worker must skip embedding new docs into it. Real implementation cost, but bounded — the status check piggybacks on the existing `status` column on `knowledge_bases`.
+- **No grace period on downgrade.** A Paid Org that cancels lands instantly in the frozen state; their dashboards stop letting them add to private KBs immediately. We've decided friction > silent privacy decisions. A future grace-period feature can be additive.
+
+## Consequences
+
+- `kb_status` enum gains `read_only_private` alongside the existing `active`, `archived`.
+- Downgrade flow (Hyperswitch webhook → subscription status change → org effective plan recompute) must run a transactional update: `UPDATE knowledge_bases SET status='read_only_private' WHERE org_id = $1 AND visibility='private' AND status='active'`. Idempotent.
+- Upgrade flow does nothing automatic.
+- KB creation API (`POST /api/v1/workspaces/:id/knowledge_bases`) reads the Org's effective plan and overrides `visibility=public` for Free Plan Orgs, regardless of request payload.
+- Import API (`POST /api/v1/marketplace/import/:public_kb_id`) applies the same override on the destination KB's row.
+- Plan transition observability: every downgrade emits an event listing affected KB ids — debuggable, auditable.

--- a/docs/adr/0005-org-as-marketplace-publisher.md
+++ b/docs/adr/0005-org-as-marketplace-publisher.md
@@ -1,0 +1,39 @@
+# 0005 — Org is the Marketplace publisher
+
+Status: accepted
+
+## Decision
+
+The public-facing publisher of a KB on the Marketplace is the **Org** that owns it, not the User who pressed Publish. Marketplace cards, URLs, and Importer-side lineage all display the Org's `display_name` and `slug`. The User who triggered the publish event is recorded in `published_by_user_id` for audit only and is never shown publicly.
+
+Marketplace KB URL: `raven.ravencloak.org/marketplace/{org_slug}/{kb_slug}`. This requires `org_slug` to become **globally unique and URL-safe** — a schema change from today's free-form `display_name`.
+
+Republish and unpublish rights are gated by Org membership + a `kb:publish` permission, not by the original publishing User. A KB outlives any individual User in the Org.
+
+For Derivative Public KBs (forks that were themselves published), the card shows the Importer Org as publisher and adds a "Forked from {original Org display_name}" line linking back. Only one level of lineage is rendered by default; deeper chains are reachable by following the link.
+
+## Why
+
+The data ownership model already names the Org as the legal owner of every KB row: `org_id` is the RLS axis, Subscriptions are per-Org, and `ON DELETE CASCADE` flows from Org to KB. Making the User the public-facing publisher would be a stack of small lies against this model:
+
+- Multi-user Orgs (the team-collaboration case) would publish with one engineer's name on collective work.
+- User offboarding would create orphan-attribution rows — KBs whose stated publisher no longer exists.
+- Republish/unpublish rights coupled to the original publishing User would lock out Org admins from managing their own data.
+- A future User-credit feature (an optional "Maintainer" field, User-controlled) can be added without changing the publisher-is-Org foundation. The reverse migration is much harder.
+
+For free-tier single-user Orgs, this degrades gracefully: the Org's `display_name` defaults to the User's name at signup, so the card reads "by Jobin Lawrance" naturally. No corporate cosplay.
+
+## Trade-offs accepted
+
+- **Org rename = Marketplace card rename.** No frozen historical attribution. If Acme rebrands, every Marketplace card under that Org renames live. Acceptable: same legal entity, same liability. If demand emerges, we can snapshot `published_org_display_name` per publish event.
+- **User credit is hidden in MVP.** A creator who wants personal recognition has no surface for it today. Mitigated by future optional "Maintainer" field; not in MVP.
+- **`org_slug` must become globally unique and URL-safe.** Today it's effectively free-form `display_name`. Migration: add `slug VARCHAR(64) UNIQUE` to `organizations`, backfill via slugified `display_name` with collision suffixes (`-2`, `-3`), enforce at the API.
+- **Derivative lineage is one-hop in UI.** A KB forked through three Orgs shows only its immediate predecessor by default. Deeper chains exist in data (`source_public_kb_id` traversal) but aren't UX-rendered to avoid noise. Power users can follow.
+
+## Consequences
+
+- New `organizations.slug` column, `UNIQUE` constraint, backfilled at migration.
+- `knowledge_bases.published_by_user_id UUID NULL REFERENCES users(id) ON DELETE SET NULL` (already in ADR-0002 plan) — kept for audit, never read by Marketplace endpoints.
+- `kb:publish` becomes a discrete permission on the role model; default for Org admins, optional for members per Org policy.
+- The Marketplace listing function (a `SECURITY DEFINER` view per ADR-0001) returns `(kb_id, org_slug, org_display_name, kb_slug, kb_name, description, last_modified_at, source_public_kb_id, source_org_slug, source_org_display_name)` and nothing tying back to individual Users.
+- URL routing: `/marketplace/{org_slug}/{kb_slug}` is the canonical public URL. 404s if either slug is unknown or the target is private.

--- a/docs/adr/0006-licence-and-moderation.md
+++ b/docs/adr/0006-licence-and-moderation.md
@@ -1,0 +1,32 @@
+# 0006 — Mandatory license + reactive moderation
+
+Status: accepted
+
+## Decision
+
+**License.** Every Public KB declares an SPDX license at first publish, chosen from a curated allow-list. No default, no override, no free-form text — publishers actively pick. Allow-list: `CC0-1.0`, `CC-BY-4.0`, `CC-BY-SA-4.0`, `CC-BY-NC-4.0`, `MIT`, `Apache-2.0`, `GPL-3.0`. The license badge is rendered on every Marketplace card and on Importer-side KB metadata. License compatibility across forks is not enforced — Raven displays badges, users reason about compatibility.
+
+**Moderation.** Reactive only: a "Report" button on every Public KB, an internal admin review queue, and a documented DMCA process at the designated agent address `dmca@ravencloak.org`. Repeat infringers tracked per Org via `organizations.takedown_strikes` (3 confirmed strikes → Org suspension via admin runbook).
+
+**Takedown cascade.** Takedowns (publisher, admin, or DMCA) **do not auto-cascade to derivatives**. Owners of Derivative Public KBs receive an email explaining the root was taken down and inviting them to review their fork; they decide whether to unpublish.
+
+## Why
+
+`NC-ND` and proprietary licenses are excluded because no-derivatives contradicts fork-on-import — the entire Import model produces derivative works. Defaulting (rather than requiring) a license invites publishers to ship under a default they never read; mandatory selection forces a conscious act. Reactive moderation is the only honest MVP — "none" is irresponsible the moment content goes public, and proactive ML moderation has false-positive UX costs we can't afford at MVP volume.
+
+Notify-don't-cascade protects legitimate forks from DMCA weaponisation. The OSS norm is that downstream users keep their freedoms when upstream retracts; a single bad-faith DMCA shouldn't kill hundreds of derivatives. Repeat-infringer suspension is at the Org axis (matches our Subscription axis), not the KB axis.
+
+## Trade-offs accepted
+
+- DMCA designated agent inbox must be staffed within reasonable response windows or Raven loses safe-harbor footing. Real ops commitment.
+- Bad actors can spin up fresh Orgs faster than admins can suspend them. Acceptable at MVP scale; revisit if abuse signal climbs.
+- License-compatibility across import chains is the user's problem. Documented in CONTEXT.md, not enforced.
+- No public-domain auto-detection: a publisher uploading Wikipedia content under the wrong license is on the publisher.
+
+## Consequences
+
+- `knowledge_bases.license_spdx_id TEXT NOT NULL` for `visibility='public'` rows. Enforced via partial CHECK constraint.
+- License allow-list is a Go const slice in `internal/marketplace/license.go`, not config — code review gates the set.
+- `organizations.takedown_strikes INTEGER NOT NULL DEFAULT 0`.
+- New tables (MVP): `marketplace_reports (id, reported_kb_id, reporter_user_id, reason, status, created_at)`, `marketplace_takedowns (id, target_kb_id, source enum('publisher','admin','dmca'), notes, created_at)`.
+- DMCA inbox `dmca@ravencloak.org` provisioned + runbook before public launch.

--- a/docs/adr/0007-marketplace-lifecycle-behaviours.md
+++ b/docs/adr/0007-marketplace-lifecycle-behaviours.md
@@ -1,0 +1,51 @@
+# 0007 — Marketplace lifecycle behaviours
+
+Status: accepted
+
+## Decision
+
+The Marketplace lifecycle is governed by five rules covering preview, re-import, unpublish, edit propagation, and Org slug migration.
+
+**7a Try-before-fork is not offered.** Logged-in Users cannot run a chat against a Public KB without Importing it first. Chat always executes against a workspace-local KB so that retrieval-path RLS stays single-tenant. A narrow preview surface — `GET /api/v1/marketplace/{org_slug}/{kb_slug}/preview` — returns at most 3 sample Chunks for content vetting. The endpoint is backed by a `SECURITY DEFINER` function `marketplace_preview_kb(public_kb_id UUID)` that is the only sanctioned cross-tenant read of Chunk rows in the system.
+
+**7b Re-import is a destructive overwrite, scoped to content.** A Re-import drops every Source, Document, Chunk, and Embedding row attached to the Importer's local KB and replaces them with the publisher's current projection (per [ADR-0002](0002-content-grade-publish-boundary.md)). The Importer's local `knowledge_bases.id` is preserved, and along with it: Chat sessions, Widgets, API keys, Routing rules, Webhook configs, Response cache — every artefact that FKs to the KB id, not its content. On success the Importer's `imported_from_revision_at` is updated to the publisher's current `last_modified_at`. UI requires explicit confirmation.
+
+**7c Unpublish flips visibility and holds the slug for 90 days.** When a Publisher unpublishes, `visibility` is set back to `private` and the KB stays in the Publisher's Workspace untouched. Already-Imported forks are unaffected (per [ADR-0001](0001-marketplace-fork-on-import.md)). The Marketplace URL `/marketplace/{org_slug}/{kb_slug}` returns **HTTP 410 Gone**, not 404, so Importers and link-checkers can distinguish "removed" from "never existed." The `(org_id, kb_slug)` pair is registered in `kb_slug_holds` with `held_until = now() + interval '90 days'`. During the hold window the same Org cannot publish a new KB under that slug.
+
+**7d Edits after publish need no new mechanism.** Already covered by [ADR-0003](0003-always-fresh-publish-lifecycle.md): `last_modified_at` is updated by trigger on any Document, Source, or Chunk write, and the Marketplace card renders it as "Updated N days ago." No publish-update action, no version row, no notification fan-out.
+
+**7e Org slug becomes a first-class column.** `organizations.slug VARCHAR(64) UNIQUE NOT NULL` is added. Backfill: `slugify(display_name)` with `-2`, `-3`, … collision suffixes. Org owners can rename their slug post-launch; the previous slug is held in `org_slug_holds` for 30 days as a soft-redirect so Marketplace URLs do not break. The existing `workspaces.slug` unique-within-org logic is untouched — workspace slugs live below the org axis and are not URL-public.
+
+## Why
+
+- **Cross-tenant Chunk reads at chat time would punch the RLS hole [ADR-0001](0001-marketplace-fork-on-import.md) explicitly avoided.** Try-before-fork sounds friendly but turns every retrieval query into "either my Org or a public KB" — a coupling we refused once and decline to re-introduce. A 3-chunk preview, behind a single `SECURITY DEFINER` function with no Embedding or Source-blob exposure, is the bounded escape valve.
+- **Re-import has to be destructive to be honest.** A merge model ("keep my edits, add their new docs") would be a lie — Importers don't edit Chunks, the publisher's projection is canonical. Destructive-with-confirm is the only model that matches what the user is actually doing.
+- **410 Gone is the correct semantic for unpublished URLs.** 404 ("never existed") would mislead Importers whose Chat panels link back to the publisher; 410 is the documented "this was here, it isn't anymore" signal.
+- **90-day slug hold blocks the squat-and-replace attack.** Without it, a Publisher could delete and re-create `acme/legal-handbook` with adversarial content, riding the old URL's trust and inbound links. 90 days is long enough that re-creation requires a deliberate wait; short enough that an honest Org wanting to reuse a slug is only mildly inconvenienced.
+- **Org slug needs to be public-URL-safe and globally unique** per [ADR-0005](0005-org-as-marketplace-publisher.md). `display_name` is neither. The 30-day soft-redirect on rename preserves Importer links across re-branding.
+
+## Trade-offs accepted
+
+- **Preview is the one cross-tenant Chunk read.** `marketplace_preview_kb` is a `SECURITY DEFINER` function — a deliberate, audited hole, capped at 3 chunks per call, callable only by an authenticated User against a KB whose `visibility='public'`. Bounded blast radius, single review surface.
+- **90-day slug hold creates friction for legitimate delete-and-recreate.** An Org that wants to retire `acme/legal-handbook` and ship a new one under the same slug must wait. Acceptable: famous-slug squatting is the worse failure.
+- **No try-before-buy UX as good as competitors'.** Other RAG marketplaces offer "ask a sample question" against the live publisher KB. Raven offers chunk previews instead. Friction cost is real but bounded; the alternative is a permanent cross-tenant retrieval coupling.
+- **Re-import wipes Importer-side annotations on Source/Document rows.** None exist today. If we add Importer-private metadata on Sources later, Re-import must explicitly carry it across the wipe-and-replace step.
+
+## Consequences
+
+- New endpoints:
+  - `POST /api/v1/knowledge_bases/{id}/publish`
+  - `POST /api/v1/knowledge_bases/{id}/unpublish`
+  - `POST /api/v1/knowledge_bases/{id}/re-import`
+  - `POST /api/v1/marketplace/import/{public_kb_id}`
+  - `GET /api/v1/marketplace`
+  - `GET /api/v1/marketplace/{org_slug}/{kb_slug}`
+  - `GET /api/v1/marketplace/{org_slug}/{kb_slug}/preview`
+- New SQL functions (`SECURITY DEFINER`):
+  - `marketplace_list_public_kbs()` returns `(kb_id, org_slug, org_display_name, kb_slug, kb_name, description, license_spdx_id, last_modified_at, source_public_kb_id, source_org_slug, source_org_display_name)`.
+  - `marketplace_preview_kb(public_kb_id UUID)` returns up to 3 Chunk rows (`chunk_id`, `text`, `ordinal`) for a `visibility='public'` KB; raises otherwise.
+- New tables:
+  - `kb_slug_holds (org_id UUID, slug VARCHAR(100), held_until TIMESTAMPTZ, PRIMARY KEY (org_id, slug))`.
+  - `org_slug_holds (slug VARCHAR(64) PRIMARY KEY, org_id UUID, held_until TIMESTAMPTZ)`.
+- HTTP handler for the public Marketplace URL returns `410 Gone` for any `(org_slug, kb_slug)` present in `kb_slug_holds` whose `held_until > now()`, `404` otherwise.
+- The Import handler stamps `imported_from_revision_at = source_kb.last_modified_at` on the new row; the Re-import handler updates the same column on the existing row.

--- a/docs/adr/0008-marketplace-discovery-and-operations.md
+++ b/docs/adr/0008-marketplace-discovery-and-operations.md
@@ -1,0 +1,45 @@
+# 0008 — Marketplace discovery and operations scope
+
+Status: accepted
+
+## Decision
+
+**Discovery (Q8).** `/marketplace` ships with:
+
+- A single text search box backed by Postgres full-text search over `name + description + org_display_name` (one `tsvector` column on `knowledge_bases`, one GIN index).
+- Four sort options: **Newest published**, **Most imported (lifetime)**, **Recently updated**, **Alphabetic**.
+- One filter: **License** (multi-select against the 7-item allow-list from ADR-0006).
+- Two denormalised counters on `knowledge_bases`: `import_count` (exact, trigger-maintained on Importer-side KB insert when `source_public_kb_id IS NOT NULL`) and `preview_count` (eventually consistent, incremented by the preview endpoint handler).
+- No categories, no tags, no semantic search over published chunks, no trending algorithm. Each is independently addable later.
+
+**Per-plan quotas (Q9).** Out of scope for the Marketplace architecture. The publish, import, KB-creation, and document-upload paths read the Org's `effective_plan` and call a single `enforceQuota(plan, action)` hook — config-driven, no schema dependency. The actual quota numbers are a billing decision tracked separately.
+
+**Admin review queue (Q10).** A minimal Vue page at `/admin/marketplace/reports`, gated by the existing `raven_admin` Postgres role used for RLS bypass elsewhere. Two binary actions per report: **Approve** (unpublishes the KB, increments `takedown_strikes` on the publisher Org, emails the publisher) and **Dismiss** (closes the report, no notification to reporter). A parallel `/admin/marketplace/dmca` page handles formal DMCA notices with the two-stage 14-day counter-notice window before takedown becomes effective.
+
+## Why
+
+Each sub-decision is the minimum viable surface that doesn't paint us into a corner:
+
+- **FTS on metadata only** keeps the marketplace search using the same infrastructure as in-org KB search — no new dependency, no Elasticsearch. Content search is layerable later as a separate SECURITY DEFINER function over published chunks.
+- **Four hard sorts, no ranking algorithm** because trending requires time-window counters, decay functions, and recurring jobs we don't need before measuring actual user behaviour.
+- **No categories, no tags** because taxonomy is a tar pit at MVP scale; we should let publisher behaviour reveal the natural axes before encoding them in schema.
+- **Quotas as a hook, not a schema** because we want to tune limits in config when product/billing decides, without redeploying.
+- **Binary admin actions** because intermediate states (warn, probation, etc.) compound runbook complexity without measurable benefit at MVP scale.
+- **Reporter not notified by default** because the report-confirms-takedown loop is a known harassment vector on other platforms.
+
+## Trade-offs accepted
+
+- **No content search at launch.** Users searching for "any KB containing pgvector tutorials" must rely on metadata or browse. Layerable later.
+- **`Most imported` is gameable.** Bot-spam imports can boost a KB's ranking. Acceptable at MVP volume; revisit when abuse appears.
+- **Counters are denormalised.** `import_count` and `preview_count` live on `knowledge_bases` to avoid expensive aggregations in the listing function. Trigger maintenance is small but real ongoing surface.
+- **Admin UI is internal-tooling-grade.** No accessibility polish, no admin-role granularity beyond `raven_admin`. Sufficient for the volumes we expect; revisit if we onboard non-engineer admins.
+- **Repeat-infringer suspension is manual.** Three strikes triggers a runbook task, not an automatic suspension. Acceptable: low-volume MVP; bad actors creating fresh Orgs are a known issue we won't solve mechanically yet.
+
+## Consequences
+
+- `knowledge_bases` gains `search_tsv tsvector` (GENERATED stored, GIN-indexed), `import_count INTEGER NOT NULL DEFAULT 0`, `preview_count INTEGER NOT NULL DEFAULT 0`.
+- Trigger on Importer-side KB insert increments `import_count` on the source Public KB via `source_public_kb_id`.
+- Listing endpoint surfaces: `q`, `sort`, `license[]` query params. SECURITY DEFINER `marketplace_list_public_kbs(q TEXT, sort TEXT, licenses TEXT[], limit INT, offset INT)`.
+- `enforceQuota(plan, action)` hook lives in `internal/billing/quota.go`; called from publish, import, KB create, doc upload paths. Implementation in MVP can be `func enforceQuota(...) error { return nil }` — wired into the call sites so future changes are config-only.
+- Admin pages live under `/admin/marketplace/*`, served by the same SPA but gated server-side by a session check that the User's Postgres role is `raven_admin`.
+- DMCA workflow: notice received → KB transitions to `dmca_pending`, publisher emailed with 14-day counter-notice window → if no counter-notice, transition to `private` + admin records takedown. New `kb_status` value: `dmca_pending`.

--- a/docs/plans/marketplace-mvp.md
+++ b/docs/plans/marketplace-mvp.md
@@ -1,0 +1,187 @@
+# Marketplace MVP — implementation plan
+
+Tracking doc for the walled Marketplace feature. Source decisions: [ADR-0001](../adr/0001-marketplace-fork-on-import.md) … [ADR-0007](../adr/0007-marketplace-lifecycle-behaviours.md). Branch: `feat/marketplace-mvp`.
+
+## 1. Goal
+
+The Marketplace is the cross-tenant discovery surface that lists Public KBs available for Import. It is hosted at `raven.ravencloak.org/marketplace`, accessible only to authenticated Users, and serves as the flywheel that turns Free Plan Orgs into a content supply for Importers without leaking private content from Paid Plan Orgs. Every Marketplace operation reads live KB state (no snapshots); every Import is a content-grade fork; every Public KB carries an SPDX license badge.
+
+## 2. Schema delta
+
+Seven sequential, independently reversible Goose migrations starting at `00047`.
+
+### `00047_kb_marketplace_columns.sql`
+
+Extend `knowledge_bases` with publish-state columns.
+
+- `visibility kb_visibility NOT NULL DEFAULT 'private'` — new enum `kb_visibility AS ENUM ('private','public')`.
+- `published_at TIMESTAMPTZ NULL`.
+- `published_by_user_id UUID NULL REFERENCES users(id) ON DELETE SET NULL`.
+- `source_public_kb_id UUID NULL REFERENCES knowledge_bases(id) ON DELETE SET NULL` — Importer-side lineage pointer.
+- `imported_from_revision_at TIMESTAMPTZ NULL` — set at Import time, updated by Re-import.
+- `last_modified_at TIMESTAMPTZ NOT NULL DEFAULT now()` — distinct from `updated_at`.
+- Trigger `trg_kb_last_modified_on_content` on `INSERT/UPDATE/DELETE` of `documents`, `sources`, `chunks` — bumps the parent KB's `last_modified_at`.
+- Partial unique index on `(org_id, slug)` where `visibility='public'` to allow Marketplace URL routing by `(org_slug, kb_slug)` once `org_slug` lands in 00048.
+- Indexes: `idx_kb_visibility_public` (partial, `WHERE visibility='public'`), `idx_kb_source_public_kb_id`.
+
+### `00048_org_slug.sql`
+
+Promote Org slug to a first-class column.
+
+- `organizations.slug VARCHAR(64) NOT NULL` with `UNIQUE` constraint and CHECK `slug ~ '^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$'`.
+- Backfill in the same migration: `slug = slugify(display_name)` with `-2`, `-3`, … collision suffixes.
+- `org_slug_holds (slug VARCHAR(64) PRIMARY KEY, org_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE, held_until TIMESTAMPTZ NOT NULL)` — 30-day soft-redirect on rename.
+
+### `00049_kb_status_read_only_private.sql`
+
+Extend the existing `kb_status` enum.
+
+- `ALTER TYPE kb_status ADD VALUE 'read_only_private';` (per ADR-0004).
+- Reverse migration: documented as no-op — Postgres cannot remove enum values; rollback is by reverting application reads.
+
+### `00050_kb_license_and_strikes.sql`
+
+License and moderation columns (ADR-0006).
+
+- `knowledge_bases.license_spdx_id TEXT NULL`.
+- Partial CHECK constraint: `CHECK (visibility = 'private' OR license_spdx_id IS NOT NULL)` so Public KBs must carry a license.
+- `organizations.takedown_strikes INTEGER NOT NULL DEFAULT 0`.
+
+### `00051_kb_slug_holds.sql`
+
+90-day slug holds on unpublish (ADR-0007).
+
+- `kb_slug_holds (org_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE, slug VARCHAR(100) NOT NULL, held_until TIMESTAMPTZ NOT NULL, PRIMARY KEY (org_id, slug))`.
+- Trigger `trg_kb_release_slug_on_unpublish` on `knowledge_bases` `AFTER UPDATE` when `visibility` flips `public→private` — inserts `(org_id, slug, now() + interval '90 days')` ON CONFLICT update `held_until`.
+- Publish handler reads this table to block re-use during the hold window.
+
+### `00052_marketplace_functions.sql`
+
+The two cross-tenant read functions.
+
+- `marketplace_list_public_kbs() RETURNS TABLE (...) LANGUAGE sql SECURITY DEFINER STABLE` — returns the row shape declared in ADR-0005 plus `license_spdx_id`. Filters `visibility='public'` and joins to `organizations` for slugs and display names.
+- `marketplace_preview_kb(public_kb_id UUID) RETURNS TABLE (chunk_id UUID, ordinal INT, text TEXT) LANGUAGE plpgsql SECURITY DEFINER` — raises `insufficient_privilege` if the target is not `visibility='public'`; otherwise returns at most 3 chunks ordered by `ordinal`.
+- `REVOKE ALL ... FROM PUBLIC` + `GRANT EXECUTE ... TO raven_app` on both; ownership set to `raven_admin`.
+
+### `00053_marketplace_moderation.sql`
+
+Report and takedown queues (ADR-0006).
+
+- `marketplace_reports (id UUID PK, reported_kb_id UUID REFERENCES knowledge_bases(id) ON DELETE CASCADE, reporter_user_id UUID REFERENCES users(id) ON DELETE SET NULL, reason TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open','reviewing','resolved','dismissed')), created_at TIMESTAMPTZ NOT NULL DEFAULT now())`.
+- `marketplace_takedowns (id UUID PK, target_kb_id UUID REFERENCES knowledge_bases(id) ON DELETE CASCADE, source TEXT NOT NULL CHECK (source IN ('publisher','admin','dmca')), notes TEXT, created_at TIMESTAMPTZ NOT NULL DEFAULT now())`.
+- Indexes: `idx_marketplace_reports_status`, `idx_marketplace_takedowns_target_kb_id`.
+- RLS: `marketplace_reports` exposes own-reports only to the reporter; `marketplace_takedowns` admin-only.
+
+## 3. Backend services
+
+New Go packages under `internal/`.
+
+| Path | Purpose |
+|------|---------|
+| `internal/marketplace/license.go` | SPDX allow-list const slice (7 entries per ADR-0006) and validation helper. |
+| `internal/marketplace/projection.go` | `KB → PublishedKBProjection` projector. Implements the allow-list scrub of `settings`. Single source of truth for what crosses the publish boundary (ADR-0002). |
+| `internal/marketplace/projection_settings_allowlist.go` | The settings allow-list constant; every key is either listed here or in the explicit-deny slice. |
+| `internal/marketplace/publish.go` | Service: publish, unpublish, slug-hold registration. Transactional. Validates license, plan rules, slug-hold window. |
+| `internal/marketplace/import.go` | Service: Import + Re-import. Wraps projection apply, sets `imported_from_revision_at`, applies Free Plan public-only override (ADR-0004). |
+| `internal/marketplace/preview.go` | Wraps the `marketplace_preview_kb` SQL function; 3-chunk cap enforced at the DB layer, defence-in-depth check here. |
+| `internal/marketplace/listing.go` | Wraps `marketplace_list_public_kbs` and applies any per-User filtering (e.g. hide reported KBs). |
+| `internal/marketplace/moderation.go` | Report submission, admin review queue ops, takedown writer, strike incrementer. |
+| `internal/marketplace/org_slug.go` | Slug generation + collision-suffix logic; soft-redirect lookup for `org_slug_holds`. |
+| `internal/api/handlers/marketplace_handler.go` | HTTP handlers for every endpoint in §4. |
+| `internal/api/handlers/kb_handler.go` (extend) | Add `publish`, `unpublish`, `re-import` handlers; enforce Free Plan public-only override on `POST /knowledge_bases`. |
+| `internal/jobs/marketplace_takedown_notifier.go` | Asynq task that emails owners of Derivative Public KBs when their root is taken down (ADR-0006). |
+| `internal/jobs/marketplace_slug_hold_sweeper.go` | Asynq cron task that deletes rows from `kb_slug_holds` and `org_slug_holds` where `held_until < now()`. Daily. |
+| `internal/billing/downgrade_freeze.go` (extend) | On Hyperswitch webhook → Free Plan transition, run the `UPDATE knowledge_bases SET status='read_only_private' …` from ADR-0004 inside the existing downgrade transaction. |
+
+### CI test (per ADR-0002)
+
+- `internal/marketplace/projection_test.go` includes `TestSettingsAllowListExhaustive`: enumerates every key seen in `knowledge_bases.settings` across the live test schema and asserts each is in either the allow-list or the explicit-deny list. Test fails the build when a new setting key is added without a deliberate decision.
+
+## 4. API endpoints
+
+All endpoints require an authenticated session (`Authorization: Bearer …` via SuperTokens). `org_id` comes from session, never the URL.
+
+| Method | Path | Auth | Request | Response | Errors |
+|--------|------|------|---------|----------|--------|
+| `GET` | `/api/v1/marketplace` | User session | `?q=&license=&limit=&cursor=` | `{ items: [{kb_id, org_slug, org_display_name, kb_slug, kb_name, description, license_spdx_id, last_modified_at, source_public_kb_id, source_org_slug, source_org_display_name}], next_cursor }` | 401 unauth |
+| `GET` | `/api/v1/marketplace/{org_slug}/{kb_slug}` | User session | — | Full Public KB detail row + counts (sources, documents, chunks) | 401, 404 (unknown slugs), 410 (in `kb_slug_holds`) |
+| `GET` | `/api/v1/marketplace/{org_slug}/{kb_slug}/preview` | User session | — | `{ chunks: [{chunk_id, ordinal, text}] }` (≤3) | 401, 403 (target private), 404, 410 |
+| `POST` | `/api/v1/marketplace/import/{public_kb_id}` | User session + `kb:create` | `{ workspace_id: UUID }` | `{ kb_id, imported_from_revision_at }` | 401, 403 (not member of target workspace; or KB not public; or plan-rule rejection) |
+| `POST` | `/api/v1/knowledge_bases/{id}/publish` | User session + `kb:publish` | `{ license_spdx_id }` | `{ visibility: 'public', published_at, marketplace_url }` | 401, 403, 404, 409 (slug held by `kb_slug_holds`), 422 (license not in allow-list; KB has no documents) |
+| `POST` | `/api/v1/knowledge_bases/{id}/unpublish` | User session + `kb:publish` | — | `{ visibility: 'private', slug_held_until }` | 401, 403, 404 |
+| `POST` | `/api/v1/knowledge_bases/{id}/re-import` | User session + `kb:write` | — | `{ kb_id, imported_from_revision_at }` | 401, 403, 404, 409 (KB is not an import — `source_public_kb_id IS NULL`), 410 (source KB unpublished) |
+| `POST` | `/api/v1/marketplace/reports` | User session | `{ kb_id, reason }` | `{ report_id, status: 'open' }` | 401, 404, 429 (per-User rate limit) |
+| `GET` | `/api/v1/admin/marketplace/reports` | Admin | `?status=open&limit=&cursor=` | Paginated reports | 401, 403 |
+| `POST` | `/api/v1/admin/marketplace/reports/{id}/approve` | Admin | — | `{ takedown_id, target_kb_id, strikes_after }` — unpublishes target KB, increments publisher Org `takedown_strikes`, emails publisher | 401, 403, 404 |
+| `POST` | `/api/v1/admin/marketplace/reports/{id}/dismiss` | Admin | — | `{ report_id, status: 'dismissed' }` | 401, 403, 404 |
+| `POST` | `/api/v1/admin/marketplace/dmca` | Admin | `{ target_kb_id, notice_text, claimant_email }` | `{ takedown_id, counter_notice_window_ends }` — KB transitions to `dmca_pending`, 14-day counter-notice clock starts | 401, 403, 404 |
+
+## 5. Frontend pages (Vue.js)
+
+New routes under `frontend/src/views/marketplace/`. KB detail page extended in `frontend/src/views/knowledge_bases/`.
+
+| Route | Component | Purpose |
+|-------|-----------|---------|
+| `/marketplace` | `MarketplaceListView.vue` | Search, filter by SPDX license, infinite-scroll grid of cards. Each card: KB name, Org display_name + slug link, license badge, "Updated N days ago", import count, Report button. |
+| `/marketplace/:orgSlug/:kbSlug` | `MarketplaceKbDetailView.vue` | Public KB detail. Description, license badge, source/document/chunk counts, "Forked from {parent Org}" line (one hop). Buttons: Preview, Import, Report. Handles 410 with a "This KB was unpublished" state. |
+| `/marketplace/:orgSlug/:kbSlug/preview` (modal, not full route) | `MarketplacePreviewDialog.vue` | Renders the ≤3 chunks returned by the preview endpoint, with a CTA to Import. |
+| `/marketplace/import/:publicKbId` (modal) | `MarketplaceImportDialog.vue` | Pick destination workspace; on confirm calls Import endpoint; redirects to the new local KB. |
+| Existing KB-detail page extensions | `KnowledgeBaseDetailView.vue` | Add: Publish/Unpublish toggle (with license picker on first publish), Re-import button (only when `source_public_kb_id IS NOT NULL`), license badge, lineage link to parent Public KB, frozen-state banner when `status='read_only_private'`. |
+| `/admin/marketplace/reports` | `AdminReportsView.vue` | Admin-only review queue: list reports, mark reviewing/resolved/dismissed, escalate to takedown. |
+| `/admin/marketplace/takedowns` | `AdminTakedownsView.vue` | Admin-only: takedown audit log + strike counter per Org. |
+
+Playwright coverage: publish → list → preview → import → re-import → unpublish; Free Plan create-KB forces public; downgrade freezes private KBs.
+
+## 6. Operational requirements
+
+- **DMCA inbox.** Provision `dmca@ravencloak.org` (Google Workspace alias → admin distribution list). Publish the designated agent details in `docs/legal/dmca.md` and at `raven.ravencloak.org/legal/dmca`. Must be in place before the Marketplace ships publicly.
+- **Admin takedown runbook.** Document in `docs/runbooks/marketplace-takedown.md`: triage SLA (48h initial response, 7d resolution), workflow for `marketplace_reports` → `marketplace_takedowns`, derivative-owner email template, strike increment procedure, and Org suspension steps when `takedown_strikes >= 3`.
+- **Repeat-infringer workflow.** Manual for MVP: admin reviews the 3rd strike, runs `supertokens-admin` flow to suspend the Org's signin, sets all of the Org's `visibility='public'` KBs to `private`, and emails the Org. No automatic suspension trigger in MVP.
+- **Observability.** OpenObserve dashboards for: publish rate, import rate, preview-to-import conversion, report submission rate, takedown response time. Beszel covers host metrics; no Marketplace-specific host work.
+- **Slug-hold sweepers.** Asynq cron tasks (§3) must be registered in `internal/jobs/scheduler.go` with the existing daily cadence.
+
+## 7. Deferred (explicitly NOT in MVP)
+
+- **Versioned publication snapshots** — deferred per [ADR-0003](../adr/0003-always-fresh-publish-lifecycle.md). No `marketplace_publications` table, no v1/v2/v3 UI, no "Publish update" button. Re-import reads live KB state.
+- **Original file blob inclusion** — deferred per [ADR-0002](../adr/0002-content-grade-publish-boundary.md). Importers never receive SeaweedFS blobs. No "include blobs" toggle on Publish.
+- **Proactive moderation** — deferred per [ADR-0006](../adr/0006-licence-and-moderation.md). No ML-based content scanning at publish time; reactive Report-button flow only.
+- **User credit / Maintainer field** — deferred per [ADR-0005](../adr/0005-org-as-marketplace-publisher.md). No `published_by_user_display_name`, no per-publisher User avatar on Marketplace cards. Org is the only public attribution.
+- **License compatibility enforcement** — deferred per [ADR-0006](../adr/0006-licence-and-moderation.md). Cross-fork SPDX compatibility (e.g. CC-BY-SA → CC-BY-NC mismatch) is documented but not enforced; users reason about it from badges.
+- **Per-plan quotas on publish / import / storage.** Free Plan public-only and read-only-private freeze land in MVP; numeric per-plan quotas (max public KBs, max imports per day, storage caps) are deferred to a follow-up milestone.
+- **Search ranking & categories.** Marketplace listing is timestamp-ordered (`last_modified_at DESC`) plus free-text search on `name` and `description`. Faceted browse, semantic search over Marketplace, category taxonomy: deferred.
+- **Marketplace-specific embedding dedupe.** ADR-0001 mentions a future `(chunk_hash, embedding_model)` shared pool. Not in MVP.
+- **Anonymous Marketplace browsing.** Login-required for all routes; SEO surface is deferred.
+
+## 8. Milestones
+
+Three squash-mergeable PRs onto `feat/marketplace-mvp`.
+
+### M1 — schema + Org slug + publish lifecycle
+
+- Migrations `00047`–`00051`.
+- `internal/marketplace/license.go`, `projection.go`, `projection_settings_allowlist.go`, `publish.go`, `org_slug.go`.
+- Endpoints: `POST /knowledge_bases/{id}/publish`, `POST /knowledge_bases/{id}/unpublish`.
+- Downgrade hook in `internal/billing/downgrade_freeze.go`.
+- Free Plan public-only override in `kb_handler.go`.
+- Slug-hold sweeper job.
+- Vue: KB detail Publish/Unpublish + license picker; frozen-state banner; license badge.
+- Tests: projection allow-list CI test, Playwright publish/unpublish, downgrade freeze.
+
+### M2 — import + re-import + preview + Marketplace listing
+
+- Migration `00052` (functions).
+- `internal/marketplace/import.go`, `preview.go`, `listing.go`.
+- Endpoints: `GET /marketplace`, `GET /marketplace/{org_slug}/{kb_slug}`, `GET …/preview`, `POST /marketplace/import/{public_kb_id}`, `POST /knowledge_bases/{id}/re-import`.
+- HTTP handler 410-Gone path against `kb_slug_holds`.
+- Vue: `MarketplaceListView`, `MarketplaceKbDetailView`, `MarketplacePreviewDialog`, `MarketplaceImportDialog`, Re-import button on imported KBs.
+- Playwright: list → preview → import → re-import → unpublish 410 round-trip.
+
+### M3 — license, reports, DMCA, admin queue
+
+- Migration `00053`.
+- `internal/marketplace/moderation.go`, takedown-notifier Asynq job.
+- Endpoints: `POST /marketplace/reports`, admin reports + takedowns endpoints.
+- Vue: `AdminReportsView`, `AdminTakedownsView`, Report button on Marketplace card + KB detail.
+- Ops: DMCA inbox provisioned, `docs/legal/dmca.md`, `docs/runbooks/marketplace-takedown.md`.
+- OpenObserve dashboards.
+- Playwright: report submission rate-limit, admin takedown flow, derivative-owner notification email asserted via Mailhog fixture.


### PR DESCRIPTION
## Summary

Lands the design foundation for the walled Marketplace feature. Source-of-truth artefacts for milestone #17 (Marketplace MVP) and the 15 issues filed under it.

| File | Purpose |
|---|---|
| \`CONTEXT.md\` | Term vocabulary (Org, Workspace, KB, Public KB, Publish, Import, Re-import, License, Takedown, Strike, Preview, Discovery, etc.) that the ADRs and plan reference by bold name. |
| \`docs/adr/0001-marketplace-fork-on-import.md\` | Fork-on-import is the architecture: importer gets a real copy of Chunks + Embeddings, not a live link to publisher's KB. Trust contract + RLS containment + takedown safety. |
| \`docs/adr/0002-content-grade-publish-boundary.md\` | What crosses the publish/import boundary: Chunks + Embeddings + Source metadata; not original file blobs, not runtime tables (api_keys, chats, routing_rules, etc.), not connectors. Settings JSONB is allow-listed. |
| \`docs/adr/0003-always-fresh-publish-lifecycle.md\` | MVP has no version snapshots — Marketplace listing and Import both read live KB state via \`last_modified_at\`. Versioned publications deferred until a real OSS-curator persona materialises. |
| \`docs/adr/0004-free-tier-public-only-rule.md\` | Free Plan Orgs hold only Public KBs — created or imported. Downgrade freezes private KBs into \`read_only_private\`. Strict-flywheel closes the loophole. |
| \`docs/adr/0005-org-as-marketplace-publisher.md\` | Org is the publisher of record on the Marketplace card, not the User. \`org_slug\` becomes globally unique. Derivative attribution shows one hop back. |
| \`docs/adr/0006-licence-and-moderation.md\` | Mandatory SPDX license at first publish (7-item allow-list). Reactive moderation with DMCA process at \`dmca@ravencloak.org\`. Takedowns notify derivatives but don't cascade. |
| \`docs/adr/0007-marketplace-lifecycle-behaviours.md\` | Lifecycle behaviours: no try-before-fork (preview is sample chunks only via SECURITY DEFINER), re-import preserves KB id + chats + widgets, unpublish returns 410 + 90-day slug hold, \`org_slug\` rename gets a 30-day soft-redirect. |
| \`docs/adr/0008-marketplace-discovery-and-operations.md\` | Discovery: Postgres FTS + 4 sort options + license filter; counters denormalised. Quotas as a hook, not a schema dependency. Minimal admin queue at \`/admin/marketplace/reports\`. |
| \`docs/plans/marketplace-mvp.md\` | Implementation plan: 7 sequential migrations (00047–00053), backend packages under \`internal/marketplace/\`, the \`KB → PublishedKBProjection\` projector with its settings-allow-list CI test, full endpoint table, Vue routes, ops requirements, deferred list, and the M1/M2/M3 phasing for the 15 issues in milestone #17. |

## Why this lands now

Issue #723 has already shipped via PR #741 (KB columns + Go model) — its commit body links to ADR-0001/-0002/-0003/-0005/-0008 by relative path. Until this PR lands, those references are pointing at files that do not exist on \`main\`.

## Quality pass

Cross-link validation: every \`docs/adr/NNNN-…md\` and \`(ADR-NNNN)\` mention in the bundle resolves to a present file. Key vocabulary terms (\`read_only_private\`, \`Public KB\`, \`Imported KB\`, \`Derivative Public KB\`) used consistently across CONTEXT.md, the relevant ADRs, and the plan doc. No content code touched.