### PR TITLE
feat(db): add read_only_private and dmca_pending to kb_status; canonicalise status gating (#725)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -384,12 +384,21 @@ func main() {
 	quotaChecker := service.NewQuotaChecker(billingRepo, subCache, pool)
 
 	// --- Wire services ---
+	// The KB lifecycle guard (issue #725) is a small policy object the
+	// write / chat paths consult before mutating or streaming. Sharing
+	// one instance across services keeps the freeze semantics centralised
+	// — adding a new lifecycle state means updating KBStatusGate, not
+	// every service constructor.
+	kbStatusGuard := service.NewKBStatusGuard(kbRepo, pool)
+
 	wsSvc := service.NewWorkspaceService(wsRepo, pool, quotaChecker)
 	orgSvc := service.NewOrgService(orgRepo, wsSvc)
 	userSvc := service.NewUserService(userRepo)
-	kbSvc := service.NewKBService(kbRepo, pool, quotaChecker)
-	sourceSvc := service.NewSourceService(sourceRepo, pool)
-	docSvc := service.NewDocumentService(docRepo, pool).WithCacheInvalidator(semCacheRepo)
+	kbSvc := service.NewKBService(kbRepo, pool, quotaChecker).WithKBStatusGuard(kbStatusGuard)
+	sourceSvc := service.NewSourceService(sourceRepo, pool).WithKBStatusGuard(kbStatusGuard)
+	docSvc := service.NewDocumentService(docRepo, pool).
+		WithCacheInvalidator(semCacheRepo).
+		WithKBStatusGuard(kbStatusGuard)
 	searchSvc := service.NewSearchService(searchRepo, pool, cfg.Retrieval)
 	hybridRetrievalSvc := service.NewHybridRetrievalService(
 		searchRepo, chEmbeddingRepo, pool,
@@ -401,7 +410,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to initialise LLM provider service: %v", err)
 	}
-	uploadSvc := service.NewUploadService(docRepo, pool, storageClient, queueClient, cfg.Upload.MaxSizeBytes, cfg.Upload.AllowedTypes)
+	uploadSvc := service.NewUploadService(docRepo, pool, storageClient, queueClient, cfg.Upload.MaxSizeBytes, cfg.Upload.AllowedTypes).
+		WithKBStatusGuard(kbStatusGuard)
 	processingSvc := service.NewProcessingEventService(processingEventRepo, docRepo, pool)
 	apiKeySvc := service.NewAPIKeyService(apiKeyRepo, pool)
 	routingSvc := service.NewRoutingService(routingRepo, kbRepo, pool)
@@ -425,7 +435,8 @@ func main() {
 	conversationSvc := service.NewConversationService(conversationRepo, posthogClient)
 	chatSvc := service.NewChatService(chatRepo, grpcClient, pool).
 		WithConversationMemory(conversationSvc).
-		WithLLMProviderRepo(llmRepo)
+		WithLLMProviderRepo(llmRepo).
+		WithKBStatusGuard(kbStatusGuard)
 	voiceRepo := repository.NewVoiceRepository(pool)
 	// Instantiate shared LiveKit client for WebRTC room management and token generation.
 	lkClient := lk.NewClient(lk.Config{

--- a/internal/model/kb.go
+++ b/internal/model/kb.go
@@ -2,13 +2,27 @@ package model
 
 import "time"
 
-// KBStatus represents the lifecycle state of a knowledge base.
+// KBStatus represents the lifecycle state of a knowledge base. The values
+// here are the canonical strings stored in the kb_status Postgres enum.
+//
+// Status-aware behaviour MUST go through KBStatusGate (kb_status.go); call
+// sites should never branch on the literal string directly. Adding a new
+// status means extending KBStatusGate and its capability table — by design.
 type KBStatus string
 
-// KBStatusActive and KBStatusArchived are the valid lifecycle states for a KnowledgeBase.
+// Lifecycle states of a KnowledgeBase. The kb_status enum is widened in
+// later migrations as the Marketplace lifecycle grows:
+//
+//   - active            — default; reads, writes, ingestion, chat all allowed.
+//   - archived          — soft-deleted; hidden from every surface (migration 00001).
+//   - read_only_private — Free Plan downgrade freeze (migration 00049, ADR-0004).
+//   - dmca_pending      — legal hold during DMCA counter-notice window
+//     (migration 00049, ADR-0006 / ADR-0008).
 const (
-	KBStatusActive   KBStatus = "active"
-	KBStatusArchived KBStatus = "archived"
+	KBStatusActive          KBStatus = "active"
+	KBStatusArchived        KBStatus = "archived"
+	KBStatusReadOnlyPrivate KBStatus = "read_only_private"
+	KBStatusDMCAPending     KBStatus = "dmca_pending"
 )
 
 // KBVisibility represents the Marketplace publish state of a KB. Private

--- a/internal/model/kb_status.go
+++ b/internal/model/kb_status.go
@@ -1,0 +1,114 @@
+package model
+
+// kbStatusCapabilities is the single source of truth for "what can a KB in
+// this status accept?". A new KBStatus value MUST get a row here, or the
+// gate's accessors will silently report "no" — fine as a safe default, but
+// the test suite (TestKBStatusGate_TableCoversAllStatuses) compiles only
+// when every declared KBStatus has an entry.
+//
+// Keeping the table package-private forces every consumer through the
+// KBStatusGate methods so the policy stays in one file. If you find
+// yourself wanting to read this map outside the package, add a method
+// instead — that's the abstraction earning its keep.
+var kbStatusCapabilities = map[KBStatus]struct {
+	read    bool
+	ingest  bool
+	chat    bool
+	publish bool
+	// reason is the human-facing explanation shown to chat / widget users
+	// when a frozen state blocks an interaction. Empty for states that
+	// either allow everything (active) or are invisible to end users
+	// (archived — they cannot reach the surface at all).
+	reason string
+}{
+	KBStatusActive: {
+		read:    true,
+		ingest:  true,
+		chat:    true,
+		publish: true,
+		reason:  "",
+	},
+	KBStatusReadOnlyPrivate: {
+		// ADR-0004: downgraded private KBs stay reachable so users can
+		// query the existing corpus, but every write path returns 409
+		// with a machine-readable kb_frozen code until the user upgrades
+		// back or publishes / deletes the KB.
+		read:    true,
+		ingest:  false,
+		chat:    true,
+		publish: false,
+		reason:  "This knowledge base is frozen because the workspace is on the Free Plan. Upgrade, publish, or delete it to resume ingestion.",
+	},
+	KBStatusDMCAPending: {
+		// ADR-0006 + ADR-0008: legal hold during the 14-day counter-
+		// notice window. The publisher still owns the row, so the
+		// metadata stays visible, but every user-facing surface (chat,
+		// widget, ingestion, publish) is locked.
+		read:    true,
+		ingest:  false,
+		chat:    false,
+		publish: false,
+		reason:  "This knowledge base is temporarily unavailable while a copyright notice is reviewed.",
+	},
+	KBStatusArchived: {
+		// Soft-deleted. Everything is closed; the row should never
+		// reach a user-facing call site because the read-path filters
+		// already drop it. The gate stays consistent regardless so a
+		// stale handle returns a clean refusal instead of a panic.
+		read:    false,
+		ingest:  false,
+		chat:    false,
+		publish: false,
+		reason:  "This knowledge base has been archived.",
+	},
+}
+
+// KBStatusGate is the canonical helper for "can this KB accept X right now?".
+// All status semantics live here so feature code can ask `gate.CanIngest()`
+// instead of sprinkling `if kb.Status == "active"` checks across the
+// codebase. Add a new state by extending kbStatusCapabilities, not by
+// branching on the enum literal at the call site.
+type KBStatusGate struct {
+	Status KBStatus
+}
+
+// NewKBStatusGate builds a gate for the given status. Unknown statuses fall
+// through to a closed-by-default capability set — same as Archived — so
+// future enum additions cannot silently widen access before the table is
+// updated.
+func NewKBStatusGate(s KBStatus) KBStatusGate {
+	return KBStatusGate{Status: s}
+}
+
+// CanRead reports whether the KB metadata + existing content is visible.
+func (g KBStatusGate) CanRead() bool {
+	return kbStatusCapabilities[g.Status].read
+}
+
+// CanIngest reports whether new sources, documents, or chunks may be
+// added. Settings updates that affect what the KB serves also gate on
+// this, since "frozen" includes "you cannot change what it answers with".
+func (g KBStatusGate) CanIngest() bool {
+	return kbStatusCapabilities[g.Status].ingest
+}
+
+// CanChat reports whether the chat / widget completion paths may run
+// against this KB. Read-only-private allows chat (the corpus is
+// queryable); DMCA-pending does not (legal hold).
+func (g KBStatusGate) CanChat() bool {
+	return kbStatusCapabilities[g.Status].chat
+}
+
+// CanPublish reports whether the publish-to-Marketplace action is allowed.
+// Only active KBs may publish — every other state is some flavour of
+// "frozen" and publishing during freeze would be a footgun.
+func (g KBStatusGate) CanPublish() bool {
+	return kbStatusCapabilities[g.Status].publish
+}
+
+// PublicReason returns a human-readable explanation suitable for surfacing
+// in chat / widget error payloads. Empty string when the KB is fully
+// available (no message to show).
+func (g KBStatusGate) PublicReason() string {
+	return kbStatusCapabilities[g.Status].reason
+}

--- a/internal/model/kb_status_test.go
+++ b/internal/model/kb_status_test.go
@@ -1,0 +1,101 @@
+package model
+
+import "testing"
+
+// TestKBStatusConstants pins the string values to the kb_status Postgres
+// enum labels added in migrations 00001 and 00049 (issue #725). A typo
+// here would surface as zero-row writes at runtime; we catch it at test
+// time instead.
+func TestKBStatusConstants(t *testing.T) {
+	cases := map[KBStatus]string{
+		KBStatusActive:          "active",
+		KBStatusArchived:        "archived",
+		KBStatusReadOnlyPrivate: "read_only_private",
+		KBStatusDMCAPending:     "dmca_pending",
+	}
+	for got, want := range cases {
+		if string(got) != want {
+			t.Errorf("KBStatus constant: want %q, got %q", want, got)
+		}
+	}
+}
+
+// TestKBStatusGate_CapabilityMatrix exhaustively covers every status × every
+// gate method against the policy table. If a future status row gets added
+// without an entry in the matrix here the build still passes — but the
+// per-status sub-tests below pin the contract so behaviour stays
+// observable.
+func TestKBStatusGate_CapabilityMatrix(t *testing.T) {
+	type want struct {
+		read, ingest, chat, publish bool
+		reasonNonEmpty              bool
+	}
+	cases := map[KBStatus]want{
+		KBStatusActive: {
+			read: true, ingest: true, chat: true, publish: true,
+			reasonNonEmpty: false,
+		},
+		KBStatusReadOnlyPrivate: {
+			// Free Plan freeze: reads + chat stay open, ingestion blocked.
+			read: true, ingest: false, chat: true, publish: false,
+			reasonNonEmpty: true,
+		},
+		KBStatusDMCAPending: {
+			// Legal hold: reads stay open (publisher owns the row) but
+			// every interactive surface is locked.
+			read: true, ingest: false, chat: false, publish: false,
+			reasonNonEmpty: true,
+		},
+		KBStatusArchived: {
+			// Soft-deleted: everything closed.
+			read: false, ingest: false, chat: false, publish: false,
+			reasonNonEmpty: true,
+		},
+	}
+
+	for status, w := range cases {
+		status, w := status, w
+		t.Run(string(status), func(t *testing.T) {
+			gate := NewKBStatusGate(status)
+			if got := gate.CanRead(); got != w.read {
+				t.Errorf("CanRead(%s): want %v, got %v", status, w.read, got)
+			}
+			if got := gate.CanIngest(); got != w.ingest {
+				t.Errorf("CanIngest(%s): want %v, got %v", status, w.ingest, got)
+			}
+			if got := gate.CanChat(); got != w.chat {
+				t.Errorf("CanChat(%s): want %v, got %v", status, w.chat, got)
+			}
+			if got := gate.CanPublish(); got != w.publish {
+				t.Errorf("CanPublish(%s): want %v, got %v", status, w.publish, got)
+			}
+			got := gate.PublicReason()
+			if w.reasonNonEmpty && got == "" {
+				t.Errorf("PublicReason(%s): expected non-empty, got empty", status)
+			}
+			if !w.reasonNonEmpty && got != "" {
+				t.Errorf("PublicReason(%s): expected empty, got %q", status, got)
+			}
+		})
+	}
+}
+
+// TestKBStatusGate_UnknownStatus closes a footgun: an enum value the Go
+// code hasn't been taught about must NOT silently grant capabilities.
+// Defaulting to "deny" means an unknown status reaches the call site as a
+// 409 / 423, not a permissive 200.
+func TestKBStatusGate_UnknownStatus(t *testing.T) {
+	gate := NewKBStatusGate(KBStatus("totally_made_up"))
+	if gate.CanRead() {
+		t.Error("unknown status: CanRead must default to false")
+	}
+	if gate.CanIngest() {
+		t.Error("unknown status: CanIngest must default to false")
+	}
+	if gate.CanChat() {
+		t.Error("unknown status: CanChat must default to false")
+	}
+	if gate.CanPublish() {
+		t.Error("unknown status: CanPublish must default to false")
+	}
+}

--- a/internal/repository/kb.go
+++ b/internal/repository/kb.go
@@ -89,12 +89,23 @@ func (r *KBRepository) Create(ctx context.Context, tx pgx.Tx, orgID, wsID, name,
 	return kb, nil
 }
 
-// GetByID fetches an active KB by its primary key.
+// kbReadableStatuses is the SQL fragment listing every kb_status value
+// whose rows should be visible to user-facing read paths. Archived rows
+// stay hidden (soft-delete); read_only_private and dmca_pending stay
+// visible so chat / metadata reads keep working during a freeze (see
+// model.KBStatusGate.CanRead). Centralising the list here keeps every
+// read query consistent — adding a new lifecycle state means updating
+// the gate, the capability table, and this fragment.
+const kbReadableStatuses = `('active', 'read_only_private', 'dmca_pending')`
+
+// GetByID fetches a KB by its primary key, including the two frozen
+// Marketplace states. Service-layer policy (model.KBStatusGate) decides
+// whether the caller may act on the returned row.
 func (r *KBRepository) GetByID(ctx context.Context, tx pgx.Tx, orgID, kbID string) (*model.KnowledgeBase, error) {
 	row := tx.QueryRow(ctx,
 		`SELECT `+kbColumns+`
 		 FROM knowledge_bases
-		 WHERE id = $1 AND org_id = $2 AND status = 'active'`,
+		 WHERE id = $1 AND org_id = $2 AND status IN `+kbReadableStatuses,
 		kbID, orgID,
 	)
 	kb, err := scanKB(row)
@@ -104,12 +115,32 @@ func (r *KBRepository) GetByID(ctx context.Context, tx pgx.Tx, orgID, kbID strin
 	return kb, nil
 }
 
-// ListByWorkspace returns all active KBs for a workspace.
+// LoadStatus returns the lifecycle status for a KB. It bypasses the
+// read-visibility filter so the service layer can distinguish "row missing"
+// from "row frozen" without two round-trips, and can present a 409 /
+// 423 instead of the generic 404 the read path would surface.
+//
+// Returns pgx.ErrNoRows when the KB id is unknown for this org.
+func (r *KBRepository) LoadStatus(ctx context.Context, tx pgx.Tx, orgID, kbID string) (model.KBStatus, error) {
+	var status model.KBStatus
+	err := tx.QueryRow(ctx,
+		`SELECT status FROM knowledge_bases WHERE id = $1 AND org_id = $2`,
+		kbID, orgID,
+	).Scan(&status)
+	if err != nil {
+		return "", fmt.Errorf("KBRepository.LoadStatus: %w", err)
+	}
+	return status, nil
+}
+
+// ListByWorkspace returns every KB in a workspace that is visible to user-
+// facing surfaces — i.e. excluding archived (soft-deleted) rows but
+// including frozen Marketplace states.
 func (r *KBRepository) ListByWorkspace(ctx context.Context, tx pgx.Tx, orgID, wsID string) ([]model.KnowledgeBase, error) {
 	rows, err := tx.Query(ctx,
 		`SELECT `+kbColumns+`
 		 FROM knowledge_bases
-		 WHERE org_id = $1 AND workspace_id = $2 AND status = 'active'
+		 WHERE org_id = $1 AND workspace_id = $2 AND status IN `+kbReadableStatuses+`
 		 ORDER BY created_at`,
 		orgID, wsID,
 	)
@@ -141,6 +172,10 @@ func (r *KBRepository) Update(
 	cacheEnabled *bool,
 	cacheThreshold *float32,
 ) (*model.KnowledgeBase, error) {
+	// Update stays bounded to non-archived rows so a soft-deleted KB cannot
+	// be revived via a settings PATCH. The read-only-private / dmca_pending
+	// freeze is enforced at the service layer (model.KBStatusGate) so the
+	// caller gets a precise 409 / 423 instead of a generic "not found".
 	row := tx.QueryRow(ctx,
 		`UPDATE knowledge_bases
 		 SET
@@ -149,7 +184,7 @@ func (r *KBRepository) Update(
 		   settings                   = CASE WHEN $5::jsonb IS NOT NULL THEN $5::jsonb ELSE settings END,
 		   cache_enabled              = COALESCE($6, cache_enabled),
 		   cache_similarity_threshold = COALESCE($7, cache_similarity_threshold)
-		 WHERE id = $1 AND org_id = $2 AND status = 'active'
+		 WHERE id = $1 AND org_id = $2 AND status IN `+kbReadableStatuses+`
 		 RETURNING `+kbColumns,
 		kbID, orgID, name, description, settings, cacheEnabled, cacheThreshold,
 	)

--- a/internal/service/chat.go
+++ b/internal/service/chat.go
@@ -85,6 +85,11 @@ type ChatService struct {
 	// literal. Without it, an org that has only Ollama (or only OpenAI)
 	// configured would 500 on every chat the SPA didn't pin a provider on.
 	llmRepo *repository.LLMProviderRepository
+	// kbGuard enforces KBStatusGate freeze semantics on the chat path.
+	// Read_only_private allows chat (the corpus is queryable), but
+	// dmca_pending and archived KBs reject it (issue #725, ADR-0006).
+	// Optional — nil-safe.
+	kbGuard *KBStatusGuard
 }
 
 // NewChatService creates a new ChatService.
@@ -109,6 +114,14 @@ func (s *ChatService) WithConversationMemory(m ConversationMemory) *ChatService 
 // fallback. Chainable.
 func (s *ChatService) WithLLMProviderRepo(r *repository.LLMProviderRepository) *ChatService {
 	s.llmRepo = r
+	return s
+}
+
+// WithKBStatusGuard wires the lifecycle freeze gate so StreamCompletion
+// rejects chat against a dmca_pending / archived KB before any AI worker
+// round-trip. Chainable.
+func (s *ChatService) WithKBStatusGuard(g *KBStatusGuard) *ChatService {
+	s.kbGuard = g
 	return s
 }
 
@@ -138,6 +151,13 @@ func (s *ChatService) resolveDefaultProvider(ctx context.Context, orgID string) 
 // the user message, streams the gRPC response, and persists the assistant
 // reply when complete.
 func (s *ChatService) StreamCompletion(ctx context.Context, orgID, kbID string, req *model.ChatCompletionRequest) (<-chan SSEEvent, error) {
+	// Lifecycle gate (issue #725). Run before we spin up a session or
+	// touch the AI worker — a dmca_pending KB must reject the request
+	// before any user-visible side effects.
+	if err := s.kbGuard.Require(ctx, orgID, kbID, KBActionChat); err != nil {
+		return nil, err
+	}
+
 	var session *model.ChatSession
 	var userMsg *model.ChatMessage
 	var convCtx *model.ConversationContext

--- a/internal/service/document.go
+++ b/internal/service/document.go
@@ -40,6 +40,9 @@ type DocumentService struct {
 	repo             *repository.DocumentRepository
 	pool             *pgxpool.Pool
 	cacheInvalidator CacheInvalidator // optional; see #256
+	// kbGuard enforces KBStatusGate freeze semantics on write paths
+	// (ADR-0004 / issue #725). Optional — nil-safe.
+	kbGuard *KBStatusGuard
 }
 
 // NewDocumentService creates a new DocumentService.
@@ -52,6 +55,14 @@ func NewDocumentService(repo *repository.DocumentRepository, pool *pgxpool.Pool)
 // that main.go can chain the call fluently.
 func (s *DocumentService) WithCacheInvalidator(inv CacheInvalidator) *DocumentService {
 	s.cacheInvalidator = inv
+	return s
+}
+
+// WithKBStatusGuard wires the lifecycle freeze gate so document mutations
+// against a frozen KB return 409 / 423 instead of corrupting a corpus the
+// user has been told is read-only. Chainable.
+func (s *DocumentService) WithKBStatusGuard(g *KBStatusGuard) *DocumentService {
+	s.kbGuard = g
 	return s
 }
 
@@ -129,11 +140,23 @@ func (s *DocumentService) List(ctx context.Context, orgID, kbID string, page, pa
 func (s *DocumentService) Update(ctx context.Context, orgID, docID string, req model.UpdateDocumentRequest) (*model.Document, error) {
 	var doc *model.Document
 	err := db.WithOrgID(ctx, s.pool, orgID, func(tx pgx.Tx) error {
+		// Resolve the owning KB inside the same transaction so a freeze
+		// flipping concurrently still wins (issue #725).
+		existing, getErr := s.repo.GetByID(ctx, tx, orgID, docID)
+		if getErr != nil {
+			return getErr
+		}
+		if gateErr := s.kbGuard.RequireInTx(ctx, tx, orgID, existing.KnowledgeBaseID, KBActionIngest); gateErr != nil {
+			return gateErr
+		}
 		var err error
 		doc, err = s.repo.Update(ctx, tx, orgID, docID, req.Title, req.Metadata)
 		return err
 	})
 	if err != nil {
+		if isAppErr(err) {
+			return nil, err
+		}
 		if strings.Contains(err.Error(), "no rows") {
 			return nil, apierror.NewNotFound("document not found")
 		}
@@ -152,22 +175,30 @@ func (s *DocumentService) Delete(ctx context.Context, orgID, docID string) error
 	var kbID string
 	err := db.WithOrgID(ctx, s.pool, orgID, func(tx pgx.Tx) error {
 		// Look up the owning KB before the row disappears so invalidation
-		// can target it. A failure here is non-fatal for the delete itself,
-		// but we log it so stale cache entries are visible to ops rather
-		// than silently orphaned.
-		if doc, lookupErr := s.repo.GetByID(ctx, tx, orgID, docID); lookupErr != nil {
+		// can target it AND so the lifecycle gate (issue #725) can refuse
+		// the delete on a frozen KB.
+		doc, lookupErr := s.repo.GetByID(ctx, tx, orgID, docID)
+		if lookupErr != nil {
+			// Fall through to the existing delete path; the repo will
+			// surface the canonical "not found" error there.
 			slog.Default().Warn(
 				"document_delete_kb_lookup_failed",
 				slog.String("org_id", orgID),
 				slog.String("doc_id", docID),
 				slog.Any("error", lookupErr),
 			)
-		} else if doc != nil {
-			kbID = doc.KnowledgeBaseID
+			return s.repo.Delete(ctx, tx, orgID, docID)
+		}
+		kbID = doc.KnowledgeBaseID
+		if gateErr := s.kbGuard.RequireInTx(ctx, tx, orgID, kbID, KBActionIngest); gateErr != nil {
+			return gateErr
 		}
 		return s.repo.Delete(ctx, tx, orgID, docID)
 	})
 	if err != nil {
+		if isAppErr(err) {
+			return err
+		}
 		if strings.Contains(err.Error(), "not found") {
 			return apierror.NewNotFound("document not found")
 		}

--- a/internal/service/kb.go
+++ b/internal/service/kb.go
@@ -17,11 +17,22 @@ type KBService struct {
 	repo  *repository.KBRepository
 	pool  *pgxpool.Pool
 	quota QuotaCheckerI
+	// kbGuard enforces KBStatusGate freeze semantics on the settings-
+	// update path (ADR-0004 / issue #725). Optional — nil-safe.
+	kbGuard *KBStatusGuard
 }
 
 // NewKBService creates a new KBService.
 func NewKBService(repo *repository.KBRepository, pool *pgxpool.Pool, quota QuotaCheckerI) *KBService {
 	return &KBService{repo: repo, pool: pool, quota: quota}
+}
+
+// WithKBStatusGuard wires the lifecycle freeze gate. Update returns 409 /
+// 423 when the KB is read_only_private / dmca_pending instead of silently
+// applying the patch.
+func (s *KBService) WithKBStatusGuard(g *KBStatusGuard) *KBService {
+	s.kbGuard = g
+	return s
 }
 
 // Create validates and creates a new knowledge base within a workspace.
@@ -86,6 +97,12 @@ func (s *KBService) ListByWorkspace(ctx context.Context, orgID, wsID string) ([]
 func (s *KBService) Update(ctx context.Context, orgID, kbID string, req model.UpdateKBRequest) (*model.KnowledgeBase, error) {
 	var kb *model.KnowledgeBase
 	err := db.WithOrgID(ctx, s.pool, orgID, func(tx pgx.Tx) error {
+		// Lifecycle gate (issue #725): settings updates count as ingest
+		// — a frozen KB must not silently accept config changes that
+		// would affect what it serves on the read path.
+		if gateErr := s.kbGuard.RequireInTx(ctx, tx, orgID, kbID, KBActionIngest); gateErr != nil {
+			return gateErr
+		}
 		var err error
 		kb, err = s.repo.Update(
 			ctx, tx, orgID, kbID,
@@ -95,6 +112,9 @@ func (s *KBService) Update(ctx context.Context, orgID, kbID string, req model.Up
 		return err
 	})
 	if err != nil {
+		if isAppErr(err) {
+			return nil, err
+		}
 		if strings.Contains(err.Error(), "no rows") {
 			return nil, apierror.NewNotFound("knowledge base not found")
 		}

--- a/internal/service/kb_status.go
+++ b/internal/service/kb_status.go
@@ -1,0 +1,148 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/ravencloak-org/Raven/internal/db"
+	"github.com/ravencloak-org/Raven/internal/model"
+	"github.com/ravencloak-org/Raven/pkg/apierror"
+)
+
+// KBStatusReader is the narrow slice of *repository.KBRepository the
+// service layer needs to enforce KBStatusGate semantics at write / chat
+// surfaces. Kept as an interface so tests can pass a stub without
+// standing up a real Postgres pool.
+type KBStatusReader interface {
+	LoadStatus(ctx context.Context, tx pgx.Tx, orgID, kbID string) (model.KBStatus, error)
+}
+
+// KBStatusGuard runs the gate check for a KB in its own transaction.
+// Services hold one of these (optional; nil disables the check for unit
+// tests that don't care about lifecycle gating) and dispatch every
+// status-sensitive operation through it. The capability argument decides
+// which gate method is consulted — the per-action error rendering lives
+// in capabilityAction so call sites stay as a single line.
+type KBStatusGuard struct {
+	reader KBStatusReader
+	pool   *pgxpool.Pool
+}
+
+// NewKBStatusGuard builds a guard. Production wiring supplies a real
+// repository + pool; tests that only care about the non-gate behaviour
+// of a service can leave both nil and call sites short-circuit.
+func NewKBStatusGuard(reader KBStatusReader, pool *pgxpool.Pool) *KBStatusGuard {
+	return &KBStatusGuard{reader: reader, pool: pool}
+}
+
+// KBAction names the capability being asserted against the gate. The set
+// is closed (no string sprawl at call sites) and each value maps to a
+// canonical AppError shape so handlers don't have to translate.
+type KBAction int
+
+const (
+	// KBActionIngest covers "mutate the corpus" — uploads, source CRUD,
+	// settings updates that affect what the KB returns.
+	KBActionIngest KBAction = iota
+	// KBActionChat covers chat / widget completion paths.
+	KBActionChat
+	// KBActionPublish covers the Marketplace publish action (ADR-0002).
+	KBActionPublish
+)
+
+// Require asserts that the KB identified by kbID currently permits the
+// given action. It returns nil for unknown KBs (the caller's existing
+// "not found" path stays in charge — keeping the guard cleanly additive
+// rather than coupling it to every service's missing-row policy).
+//
+// When the guard's reader is nil (test wiring) Require is a no-op so
+// existing unit tests that focus on validation logic don't need to
+// stand up a full Postgres fake.
+func (g *KBStatusGuard) Require(ctx context.Context, orgID, kbID string, action KBAction) error {
+	if g == nil || g.reader == nil || g.pool == nil {
+		return nil
+	}
+	var status model.KBStatus
+	err := db.WithOrgID(ctx, g.pool, orgID, func(tx pgx.Tx) error {
+		var loadErr error
+		status, loadErr = g.reader.LoadStatus(ctx, tx, orgID, kbID)
+		return loadErr
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) || strings.Contains(err.Error(), "no rows") {
+			// Unknown KB — leave the existing "not found" path to handle
+			// it. The guard is about freeze policy, not existence.
+			return nil
+		}
+		return apierror.NewInternal("failed to resolve knowledge base status: " + err.Error())
+	}
+	return checkKBStatus(status, action)
+}
+
+// RequireInTx is the in-transaction variant for callers that have
+// already opened a db.WithOrgID block. It avoids the second round-trip
+// the standalone Require would otherwise pay.
+func (g *KBStatusGuard) RequireInTx(ctx context.Context, tx pgx.Tx, orgID, kbID string, action KBAction) error {
+	if g == nil || g.reader == nil {
+		return nil
+	}
+	status, err := g.reader.LoadStatus(ctx, tx, orgID, kbID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) || strings.Contains(err.Error(), "no rows") {
+			return nil
+		}
+		return apierror.NewInternal("failed to resolve knowledge base status: " + err.Error())
+	}
+	return checkKBStatus(status, action)
+}
+
+// isAppErr reports whether err is an already-rendered *apierror.AppError.
+// Services that wrap the guard inside a db.WithOrgID closure use this to
+// short-circuit their generic "no rows → 404" / "wrapping" branches when
+// the guard has already produced a 409 / 423 — preserving the canonical
+// machine-readable code instead of laundering it into a 500.
+func isAppErr(err error) bool {
+	var appErr *apierror.AppError
+	return errors.As(err, &appErr)
+}
+
+// checkKBStatus is the shared policy: it asks the gate and renders the
+// canonical AppError for the rejected action. Keeping it package-private
+// means every service that gates uses identical wording and error codes.
+func checkKBStatus(status model.KBStatus, action KBAction) error {
+	gate := model.NewKBStatusGate(status)
+	switch action {
+	case KBActionIngest:
+		if gate.CanIngest() {
+			return nil
+		}
+	case KBActionChat:
+		if gate.CanChat() {
+			return nil
+		}
+	case KBActionPublish:
+		if gate.CanPublish() {
+			return nil
+		}
+	default:
+		return apierror.NewInternal(fmt.Sprintf("unknown KBAction: %d", action))
+	}
+
+	// Rejected. Pick the error code based on the underlying status, not
+	// the action — the SPA reacts to the lifecycle state, not the verb.
+	reason := gate.PublicReason()
+	switch status {
+	case model.KBStatusDMCAPending:
+		return apierror.NewKBDMCALocked(reason)
+	case model.KBStatusArchived:
+		return apierror.NewNotFound("knowledge base not found")
+	default:
+		// read_only_private and any future "soft freeze" land here.
+		return apierror.NewKBFrozen(reason)
+	}
+}

--- a/internal/service/kb_status_test.go
+++ b/internal/service/kb_status_test.go
@@ -1,0 +1,162 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/ravencloak-org/Raven/internal/model"
+	"github.com/ravencloak-org/Raven/pkg/apierror"
+)
+
+// stubKBStatusReader returns a pre-canned status / error for the in-tx
+// guard path. It's intentionally minimal — the guard never inspects the
+// pgx.Tx argument so a nil sentinel is sufficient.
+type stubKBStatusReader struct {
+	status model.KBStatus
+	err    error
+	calls  int
+}
+
+func (s *stubKBStatusReader) LoadStatus(_ context.Context, _ pgx.Tx, _, _ string) (model.KBStatus, error) {
+	s.calls++
+	return s.status, s.err
+}
+
+// TestKBStatusGuard_RequireInTx_MatrixByStatus is the integration-shape
+// test promised in the issue body: for every (status × action) pair we
+// confirm the HTTP shape returned to the handler. This is the gate's
+// contract; it pins both the status code AND the machine-readable error
+// code so the SPA / widget JS can branch deterministically.
+func TestKBStatusGuard_RequireInTx_MatrixByStatus(t *testing.T) {
+	type want struct {
+		// nilErr is true when the action is allowed.
+		nilErr bool
+		// code is the expected HTTP status when nilErr is false.
+		code int
+		// errorCode is the machine-readable identifier on the AppError.
+		errorCode string
+	}
+	type row struct {
+		status model.KBStatus
+		action KBAction
+		want   want
+	}
+
+	cases := []row{
+		// Active — everything green.
+		{model.KBStatusActive, KBActionIngest, want{nilErr: true}},
+		{model.KBStatusActive, KBActionChat, want{nilErr: true}},
+		{model.KBStatusActive, KBActionPublish, want{nilErr: true}},
+
+		// Read-only-private: 409 kb_frozen for write paths; chat allowed.
+		{model.KBStatusReadOnlyPrivate, KBActionIngest, want{code: http.StatusConflict, errorCode: "kb_frozen"}},
+		{model.KBStatusReadOnlyPrivate, KBActionChat, want{nilErr: true}},
+		{model.KBStatusReadOnlyPrivate, KBActionPublish, want{code: http.StatusConflict, errorCode: "kb_frozen"}},
+
+		// DMCA pending: 423 kb_dmca_locked across the board.
+		{model.KBStatusDMCAPending, KBActionIngest, want{code: http.StatusLocked, errorCode: "kb_dmca_locked"}},
+		{model.KBStatusDMCAPending, KBActionChat, want{code: http.StatusLocked, errorCode: "kb_dmca_locked"}},
+		{model.KBStatusDMCAPending, KBActionPublish, want{code: http.StatusLocked, errorCode: "kb_dmca_locked"}},
+
+		// Archived: 404 (the row should never have reached the gate, but
+		// if it does the user-facing answer is "doesn't exist", not
+		// "frozen" — we don't leak the soft-delete state).
+		{model.KBStatusArchived, KBActionIngest, want{code: http.StatusNotFound}},
+		{model.KBStatusArchived, KBActionChat, want{code: http.StatusNotFound}},
+		{model.KBStatusArchived, KBActionPublish, want{code: http.StatusNotFound}},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(string(c.status)+"/"+actionName(c.action), func(t *testing.T) {
+			reader := &stubKBStatusReader{status: c.status}
+			guard := NewKBStatusGuard(reader, nil)
+			err := guard.RequireInTx(context.Background(), nil, "org-1", "kb-1", c.action)
+			if c.want.nilErr {
+				if err != nil {
+					t.Fatalf("expected nil error, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			var appErr *apierror.AppError
+			if !errors.As(err, &appErr) {
+				t.Fatalf("expected *apierror.AppError, got %T", err)
+			}
+			if appErr.Code != c.want.code {
+				t.Errorf("HTTP code: want %d, got %d", c.want.code, appErr.Code)
+			}
+			if appErr.ErrorCode != c.want.errorCode {
+				t.Errorf("ErrorCode: want %q, got %q", c.want.errorCode, appErr.ErrorCode)
+			}
+		})
+	}
+}
+
+// TestKBStatusGuard_NoReader_IsNoop pins the test-wiring contract: a guard
+// constructed without a reader silently approves every action so existing
+// service unit tests that ignore lifecycle gating continue to pass.
+func TestKBStatusGuard_NoReader_IsNoop(t *testing.T) {
+	var nilGuard *KBStatusGuard
+	if err := nilGuard.Require(context.Background(), "org", "kb", KBActionIngest); err != nil {
+		t.Errorf("nil guard: expected no-op, got %v", err)
+	}
+	if err := nilGuard.RequireInTx(context.Background(), nil, "org", "kb", KBActionChat); err != nil {
+		t.Errorf("nil guard: expected no-op, got %v", err)
+	}
+
+	emptyGuard := &KBStatusGuard{}
+	if err := emptyGuard.RequireInTx(context.Background(), nil, "org", "kb", KBActionIngest); err != nil {
+		t.Errorf("empty guard: expected no-op, got %v", err)
+	}
+}
+
+// TestKBStatusGuard_RequireInTx_NoRowsIsNoop verifies that a missing KB
+// surfaces nil from the guard — the caller's existing "not found" path
+// stays in charge of that branch. Keeps the guard cleanly additive to
+// every service's existence-handling, rather than a second source of
+// truth.
+func TestKBStatusGuard_RequireInTx_NoRowsIsNoop(t *testing.T) {
+	reader := &stubKBStatusReader{err: pgx.ErrNoRows}
+	guard := NewKBStatusGuard(reader, nil)
+	if err := guard.RequireInTx(context.Background(), nil, "org", "kb", KBActionIngest); err != nil {
+		t.Errorf("no-rows from reader: expected nil, got %v", err)
+	}
+}
+
+// TestKBStatusGuard_RequireInTx_LoadError_500 verifies an unexpected DB
+// error is wrapped as 500, not silently approved (which would be a
+// permissive failure mode).
+func TestKBStatusGuard_RequireInTx_LoadError_500(t *testing.T) {
+	reader := &stubKBStatusReader{err: errors.New("connection refused")}
+	guard := NewKBStatusGuard(reader, nil)
+	err := guard.RequireInTx(context.Background(), nil, "org", "kb", KBActionIngest)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	var appErr *apierror.AppError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected *apierror.AppError, got %T", err)
+	}
+	if appErr.Code != http.StatusInternalServerError {
+		t.Errorf("want 500, got %d", appErr.Code)
+	}
+}
+
+func actionName(a KBAction) string {
+	switch a {
+	case KBActionIngest:
+		return "ingest"
+	case KBActionChat:
+		return "chat"
+	case KBActionPublish:
+		return "publish"
+	}
+	return "unknown"
+}

--- a/internal/service/source.go
+++ b/internal/service/source.go
@@ -19,11 +19,22 @@ import (
 type SourceService struct {
 	repo *repository.SourceRepository
 	pool *pgxpool.Pool
+	// kbGuard enforces KBStatusGate freeze semantics on the ingest path
+	// (ADR-0004 / issue #725). Optional — nil-safe.
+	kbGuard *KBStatusGuard
 }
 
 // NewSourceService creates a new SourceService.
 func NewSourceService(repo *repository.SourceRepository, pool *pgxpool.Pool) *SourceService {
 	return &SourceService{repo: repo, pool: pool}
+}
+
+// WithKBStatusGuard wires the lifecycle freeze gate so Source CRUD against
+// a read_only_private / dmca_pending KB returns 409 / 423 instead of
+// mutating a frozen corpus. Chainable.
+func (s *SourceService) WithKBStatusGuard(g *KBStatusGuard) *SourceService {
+	s.kbGuard = g
+	return s
 }
 
 // validSourceTypes is the set of allowed source_type values.
@@ -82,6 +93,12 @@ func (s *SourceService) Create(ctx context.Context, orgID, kbID string, req mode
 	}
 	if req.CrawlFrequency != "" && !validCrawlFrequencies[req.CrawlFrequency] {
 		return nil, apierror.NewBadRequest("invalid crawl_frequency: " + string(req.CrawlFrequency))
+	}
+
+	// Lifecycle gate (issue #725). Reject before the row hits the table
+	// so a frozen KB can't accumulate orphan sources.
+	if err := s.kbGuard.Require(ctx, orgID, kbID, KBActionIngest); err != nil {
+		return nil, err
 	}
 
 	var src *model.Source
@@ -160,11 +177,24 @@ func (s *SourceService) Update(ctx context.Context, orgID, sourceID string, req 
 
 	var src *model.Source
 	err := db.WithOrgID(ctx, s.pool, orgID, func(tx pgx.Tx) error {
+		// Resolve the owning KB and gate before mutating. Doing both in
+		// the same transaction means a freeze that flips after we read
+		// the existing source still wins atomically.
+		existing, getErr := s.repo.GetByID(ctx, tx, orgID, sourceID)
+		if getErr != nil {
+			return getErr
+		}
+		if gateErr := s.kbGuard.RequireInTx(ctx, tx, orgID, existing.KnowledgeBaseID, KBActionIngest); gateErr != nil {
+			return gateErr
+		}
 		var err error
 		src, err = s.repo.Update(ctx, tx, orgID, sourceID, req)
 		return err
 	})
 	if err != nil {
+		if isAppErr(err) {
+			return nil, err
+		}
 		if strings.Contains(err.Error(), "no rows") {
 			return nil, apierror.NewNotFound("source not found")
 		}
@@ -176,10 +206,20 @@ func (s *SourceService) Update(ctx context.Context, orgID, sourceID string, req 
 // Delete permanently removes a source.
 func (s *SourceService) Delete(ctx context.Context, orgID, sourceID string) error {
 	err := db.WithOrgID(ctx, s.pool, orgID, func(tx pgx.Tx) error {
+		existing, getErr := s.repo.GetByID(ctx, tx, orgID, sourceID)
+		if getErr != nil {
+			return getErr
+		}
+		if gateErr := s.kbGuard.RequireInTx(ctx, tx, orgID, existing.KnowledgeBaseID, KBActionIngest); gateErr != nil {
+			return gateErr
+		}
 		return s.repo.Delete(ctx, tx, orgID, sourceID)
 	})
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
+		if isAppErr(err) {
+			return err
+		}
+		if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "no rows") {
 			return apierror.NewNotFound("source not found")
 		}
 		return apierror.NewInternal("failed to delete source: " + err.Error())

--- a/internal/service/upload.go
+++ b/internal/service/upload.go
@@ -53,6 +53,10 @@ type UploadService struct {
 	queueCli     DocumentProcessEnqueuer
 	maxSizeBytes int64
 	allowedTypes map[string]bool
+	// kbGuard enforces KBStatusGate freeze semantics on the ingest path
+	// (ADR-0004 / issue #725). Optional: nil means unit tests that focus
+	// on file-type / size validation don't need a real KB fixture.
+	kbGuard *KBStatusGuard
 }
 
 // NewUploadService creates a new UploadService.
@@ -82,6 +86,14 @@ func NewUploadService(
 	}
 }
 
+// WithKBStatusGuard wires the lifecycle freeze gate so uploads against a
+// read_only_private / dmca_pending KB return 409 / 423 instead of writing
+// a row the user can't subsequently act on. Chainable at construction.
+func (s *UploadService) WithKBStatusGuard(g *KBStatusGuard) *UploadService {
+	s.kbGuard = g
+	return s
+}
+
 // UploadParams holds the parameters for a document upload.
 type UploadParams struct {
 	OrgID           string
@@ -95,6 +107,12 @@ type UploadParams struct {
 
 // Upload validates, deduplicates, stores, and records a new document upload.
 func (s *UploadService) Upload(ctx context.Context, params UploadParams) (*model.Document, error) {
+	// Lifecycle gate (issue #725). Run before any expensive work so a
+	// frozen KB rejects the request before we read the file into memory.
+	if err := s.kbGuard.Require(ctx, params.OrgID, params.KnowledgeBaseID, KBActionIngest); err != nil {
+		return nil, err
+	}
+
 	// Validate file type. Normalise away MIME parameters (charset etc.) so
 	// "text/plain; charset=utf-8" matches the bare "text/plain" entry in
 	// the allow-list. The user-facing error retains the original header

--- a/migrations/00049_kb_status_marketplace_states.sql
+++ b/migrations/00049_kb_status_marketplace_states.sql
@@ -1,0 +1,48 @@
+-- +goose Up
+--
+-- Marketplace MVP (issue #725, M1).
+--
+-- Adds two new values to the kb_status enum so the lifecycle column on
+-- knowledge_bases can express the two Marketplace-specific frozen states:
+--
+--   - read_only_private — Free Plan downgrade lands previously private KBs
+--     here per ADR-0004. Reads stay open; ingestion / mutation is blocked.
+--     The user must Publish, Delete, or upgrade back to thaw the KB.
+--
+--   - dmca_pending — DMCA notice received per ADR-0006 / ADR-0008. The KB
+--     is in legal hold during the 14-day counter-notice window: reads
+--     allowed (the publisher still owns the row) but chat, ingestion, and
+--     all surfaces that look like "active use" are blocked.
+--
+-- Status-aware behaviour lives behind a single policy helper —
+-- internal/model.KBStatusGate — so every read/write call site asks the
+-- gate, not the enum literal. See ADR-0004 §Consequences and ADR-0008
+-- §Consequences for the surface contracts.
+--
+-- !! ROLLBACK LIMITATION !!
+--
+-- Postgres does NOT support `ALTER TYPE … DROP VALUE`. The values added
+-- below are permanent for the lifetime of the kb_status type — `goose
+-- down` to this migration cannot actually remove them.
+--
+-- The Down half therefore takes the only sane fallback: rewrite any row
+-- still sitting in one of the new states back to 'active'. That restores
+-- the pre-migration invariant (every kb_status value the application sees
+-- is one the application code knows about) without pretending the enum
+-- values themselves can disappear. The enum stays widened; the data shape
+-- the previous app version expected is reinstated.
+--
+-- A real removal of the values requires dropping and recreating the type
+-- — out of scope for a rollback and dangerous on a populated table.
+
+ALTER TYPE kb_status ADD VALUE IF NOT EXISTS 'read_only_private';
+ALTER TYPE kb_status ADD VALUE IF NOT EXISTS 'dmca_pending';
+
+-- +goose Down
+--
+-- Cannot drop enum values (Postgres limitation, see header). Instead,
+-- normalise any row sitting in one of the new states back to 'active' so
+-- the pre-migration application code does not crash on an unknown enum.
+UPDATE knowledge_bases
+SET status = 'active'
+WHERE status IN ('read_only_private', 'dmca_pending');

--- a/migrations/migrations_test.go
+++ b/migrations/migrations_test.go
@@ -329,6 +329,35 @@ func TestMigrationsUpAndDown(t *testing.T) {
 		}
 	})
 
+	t.Run("kb_status_marketplace_states", func(t *testing.T) {
+		// Migration 00049 (issue #725): adds 'read_only_private' and
+		// 'dmca_pending' to the kb_status enum so the lifecycle column
+		// can express the two Marketplace-specific frozen states. The
+		// migration is additive only — Postgres cannot drop enum values,
+		// so the rollback half can only normalise data and leaves the
+		// widened type in place. See the migration file header.
+		expectedValues := []string{
+			"active",
+			"archived",
+			"read_only_private",
+			"dmca_pending",
+		}
+		for _, v := range expectedValues {
+			var exists bool
+			if err := db.QueryRowContext(ctx, `
+				SELECT EXISTS (
+					SELECT 1 FROM pg_enum e
+					JOIN pg_type t ON t.oid = e.enumtypid
+					WHERE t.typname = 'kb_status' AND e.enumlabel = $1
+				)`, v).Scan(&exists); err != nil {
+				t.Errorf("failed to check kb_status enum value %s: %v", v, err)
+			}
+			if !exists {
+				t.Errorf("expected kb_status enum to contain value %q", v)
+			}
+		}
+	})
+
 	t.Run("kb_marketplace_columns_and_trigger", func(t *testing.T) {
 		// Migration 00047 (issue #723): visibility / publish / lineage /
 		// freshness / license / discovery columns on knowledge_bases,

--- a/pkg/apierror/apierror.go
+++ b/pkg/apierror/apierror.go
@@ -13,10 +13,18 @@ import (
 )
 
 // AppError represents a structured API error response.
+//
+// ErrorCode is an optional machine-readable identifier (snake_case) clients
+// can branch on without parsing the human-facing Detail string. It is only
+// populated by helpers that want to expose a stable contract — e.g.
+// NewKBFrozen / NewKBDMCAPending for KB lifecycle freezes (issue #725) —
+// and stays absent from the JSON when empty so existing payloads are
+// unaffected.
 type AppError struct {
-	Code    int    `json:"code"`
-	Message string `json:"message"`
-	Detail  string `json:"detail,omitempty"`
+	Code      int    `json:"code"`
+	Message   string `json:"message"`
+	Detail    string `json:"detail,omitempty"`
+	ErrorCode string `json:"error,omitempty"`
 }
 
 // Error implements the error interface.
@@ -78,6 +86,31 @@ func NewInternal(detail string) *AppError {
 		Code:    http.StatusInternalServerError,
 		Message: "Internal Server Error",
 		Detail:  detail,
+	}
+}
+
+// NewKBFrozen creates a 409 Conflict for a write that targeted a KB which
+// the lifecycle policy (model.KBStatusGate) currently has frozen against
+// ingestion / mutation. The "kb_frozen" code is the stable identifier the
+// SPA + widgets branch on (ADR-0004 §Consequences).
+func NewKBFrozen(detail string) *AppError {
+	return &AppError{
+		Code:      http.StatusConflict,
+		Message:   "Conflict",
+		Detail:    detail,
+		ErrorCode: "kb_frozen",
+	}
+}
+
+// NewKBDMCALocked creates a 423 Locked for an interaction that targeted a
+// KB sitting in the DMCA counter-notice window. Distinct status code from
+// kb_frozen so clients can branch on legal-hold UX (ADR-0006 / ADR-0008).
+func NewKBDMCALocked(detail string) *AppError {
+	return &AppError{
+		Code:      http.StatusLocked,
+		Message:   "Locked",
+		Detail:    detail,
+		ErrorCode: "kb_dmca_locked",
 	}
 }
 


### PR DESCRIPTION
Closes #725.

## Summary

- Adds **migration 00049** that widens the `kb_status` Postgres enum with `read_only_private` (Free Plan downgrade freeze, ADR-0004) and `dmca_pending` (DMCA two-stage workflow, ADR-0006 / ADR-0008).
- Centralises every lifecycle check behind a single `model.KBStatusGate` policy helper + `service.KBStatusGuard` so feature code never branches on the enum literal — adding a new status means updating the capability table, not the call sites.
- Wires the guard into chat, upload, source, document and KB-settings paths. `read_only_private` → 409 with machine-readable code `kb_frozen`; `dmca_pending` → 423 with `kb_dmca_locked`; `archived` → 404.
- Read queries widened so frozen KBs stay queryable while archived rows remain hidden. Behaviour for `active` and `archived` is unchanged.

## References

- ADR-0004 — `docs/adr/0004-free-tier-public-only-rule.md`
- ADR-0006 — `docs/adr/0006-licence-and-moderation.md`
- ADR-0008 — `docs/adr/0008-marketplace-discovery-and-operations.md`
- Plan §2 — `docs/plans/marketplace-mvp.md`

## Rollback note (in the migration header)

Postgres does **not** support `ALTER TYPE … DROP VALUE`. The `+goose Down` half therefore can't actually remove the enum values; it normalises any row sitting in one of the new states back to `'active'` so the previous app version doesn't crash on an unknown enum, and leaves the widened type in place. Documented explicitly in the SQL file header.

## Self-review notes (thermo-nuclear pass)

Followed `/Users/jobinlawrance/.claude/skills/thermo-nuclear-code-quality-review/SKILL.md`:

- **Spaghetti audit (clean).** `grep -n 'kb\.Status ==\|KBStatusActive\|KBStatusArchived\|KBStatusReadOnly\|KBStatusDMCA' internal/{service,handler,repository}/*.go` returns matches only inside `internal/service/kb_status.go` (the policy itself). All other code asks the gate.
- **Code-judo considered.** The capability map is the single source of truth; methods (`CanRead` / `CanIngest` / `CanChat` / `CanPublish`) are thin readers over it. Unknown statuses default closed so a future enum addition cannot silently widen access.
- **Canonical helpers.** No existing status-policy struct in the repo to mirror; the only adjacent pattern is per-handler ad-hoc checks (e.g. `validStatusTransitions` in document.go) and feature-specific 409 helpers. The new `apierror.NewKBFrozen` / `NewKBDMCALocked` match the existing helper shape (`NewBadRequest`, `NewConflict`, etc.). `AppError.ErrorCode` is `omitempty` so existing payloads are unchanged.
- **File-size.** `internal/model/kb.go` would have been bloated by ~140 lines; split into a new `kb_status.go` instead. No file crosses 700 LOC.
- **Boundary cleanliness.** `KBStatus` stays a typed string alias; the unexported capability table forces every consumer through gate methods. `KBStatusReader` is a one-method interface so tests can stub without standing up Postgres.
- **Nil-safe guard.** Existing service unit tests (e.g. `upload_test.go`) construct services with nil repos. The guard short-circuits when reader or pool is nil, so no test scaffolding had to change.
- **Read-filter widening.** Repository `GetByID` / `ListByWorkspace` / `Update` previously filtered `status = 'active'`; widened to `IN ('active', 'read_only_private', 'dmca_pending')` via a single `kbReadableStatuses` const. Active and archived behaviour is identical to before.

## Test plan

- [ ] CI green (golangci-lint `--new-from-rev=origin/main` reports 0 issues locally)
- [ ] `go test -short ./...` green (only pre-existing docker-required `internal/db` failures, expected)
- [ ] Migration up applies cleanly, both new enum values present (`migrations_test.go` `kb_status_marketplace_states`)
- [ ] `KBStatusGate` matrix tests pass for every status × every gate method (`internal/model/kb_status_test.go`)
- [ ] `KBStatusGuard` integration-shape tests confirm 409 `kb_frozen` / 423 `kb_dmca_locked` / 404 for archived / nil for active (`internal/service/kb_status_test.go`)