### PR TITLE
feat(db): marketplace_list_public_kbs() and marketplace_preview_kb() SECURITY DEFINER functions (#728)

### DIFF
--- a/internal/marketplace/queries.go
+++ b/internal/marketplace/queries.go
@@ -1,0 +1,234 @@
+// This file ships the thin Go wrappers over the two cross-tenant SQL
+// functions added by migration 00052 (issue #728): the Marketplace listing
+// and the Public-KB preview.
+//
+// The wrappers are intentionally minimal — they translate between Go types
+// and the SECURITY DEFINER functions in the database. All policy lives in
+// SQL: pagination caps, sort whitelisting, license filtering, the 3-chunk
+// preview ceiling, and the public-only visibility check. Adding policy
+// logic up here would split the security perimeter and create two places a
+// future change would have to be made; ADR-0001 keeps that perimeter in
+// one place on purpose.
+//
+// HTTP handler wiring lives in issue #731 and depends on these wrappers
+// (`Queries.ListPublicKBs`, `Queries.PreviewKB`).
+
+package marketplace
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// pgInsufficientPrivilege is the SQLSTATE class for
+// `insufficient_privilege`. The preview SQL function raises this code when
+// the target KB is not public; we map it to a typed error so handlers can
+// translate it to HTTP 404 without leaking existence.
+const pgInsufficientPrivilege = "42501"
+
+// pgInvalidParameterValue is the SQLSTATE class for
+// `invalid_parameter_value`. The listing function raises this when `sort`
+// is not one of the four accepted values. Handlers map it to HTTP 400.
+const pgInvalidParameterValue = "22023"
+
+// ListSort is one of the four sort orders accepted by
+// `marketplace_list_public_kbs`. ADR-0008 §"Discovery" pins this set.
+type ListSort string
+
+// ListSort values mirror the SQL whitelist exactly. Keep these in lock-step
+// with the `sort NOT IN (...)` clause in migration 00052.
+const (
+	SortNewest          ListSort = "newest"
+	SortMostImported    ListSort = "most_imported"
+	SortRecentlyUpdated ListSort = "recently_updated"
+	SortAlphabetic      ListSort = "alphabetic"
+)
+
+// ListFilters is the bag of parameters callers pass to ListPublicKBs.
+// A struct (not a 5-arg method) so callers cannot transpose `q` and the
+// license filter at the call site — a positional-argument trap that would
+// silently return wrong results.
+type ListFilters struct {
+	// Query is the free-form search text (websearch_to_tsquery syntax).
+	// Empty string means "no FTS filter".
+	Query string
+	// Sort selects the result order. Empty defaults to SortNewest so the
+	// listing endpoint is callable without explicit ordering — the
+	// Marketplace homepage shows newest-published first.
+	Sort ListSort
+	// Licenses is the optional SPDX allow-list filter. Empty / nil means
+	// "no license filter".
+	Licenses []string
+	// Limit is the page size; the SQL function clamps to a hard cap of 50
+	// regardless of what we pass.
+	Limit int
+	// Offset is the page start; the SQL function clamps to >= 0.
+	Offset int
+}
+
+// ListItem is one row returned by `marketplace_list_public_kbs`.
+// Field order mirrors the SQL `RETURNS TABLE (...)` declaration; any
+// reorder must update both sides together.
+type ListItem struct {
+	KBID                 uuid.UUID
+	OrgSlug              string
+	OrgDisplayName       string
+	KBSlug               string
+	KBName               string
+	Description          *string
+	LicenseSPDXID        *string
+	LastModifiedAt       time.Time
+	ImportCount          int
+	SourcePublicKBID     *uuid.UUID
+	SourceOrgSlug        *string
+	SourceOrgDisplayName *string
+}
+
+// PreviewChunk is one of the (at most three) chunks returned by
+// `marketplace_preview_kb`. The 3-chunk cap is enforced inside the SQL
+// function; callers cannot ask for more.
+type PreviewChunk struct {
+	ChunkID uuid.UUID
+	Ordinal int
+	Text    string
+}
+
+// Queries owns the read-only SECURITY DEFINER call surface for the
+// Marketplace. It is the seam between handler code (#731) and the SQL
+// boundary; keeping the pool here (vs. on each method) lets future
+// instrumentation hang per-Queries (metrics, tracing) without retrofitting
+// every call site.
+type Queries struct {
+	pool *pgxpool.Pool
+}
+
+// NewQueries constructs a Queries wrapper around an existing pool.
+func NewQueries(pool *pgxpool.Pool) *Queries {
+	return &Queries{pool: pool}
+}
+
+// ErrKBNotPublic is returned by PreviewKB when the target KB does not
+// exist or is not `visibility='public'`. The two cases are deliberately
+// indistinguishable at the SQL boundary so the API can't be used to probe
+// for private-KB existence (ADR-0001 §"Why").
+var ErrKBNotPublic = errors.New("marketplace: kb not public")
+
+// ErrUnknownSort is returned by ListPublicKBs when the SQL function
+// rejects the requested sort. The Go-side enum should prevent this, but
+// the typed error exists so callers who synthesise a ListFilters from a
+// raw query string can map it to HTTP 400 cleanly.
+var ErrUnknownSort = errors.New("marketplace: unknown sort")
+
+// ListPublicKBs returns the Marketplace listing page matching `f`. The
+// SQL function clamps `Limit` to 50 and `Offset` to >= 0 — passing
+// pathological values is safe, but the caller will see the clamped page.
+//
+// The `Sort` field defaults to SortNewest so the most common Marketplace
+// homepage call can pass a zero-value ListFilters.
+func (q *Queries) ListPublicKBs(ctx context.Context, f ListFilters) ([]ListItem, error) {
+	sort := f.Sort
+	if sort == "" {
+		sort = SortNewest
+	}
+
+	// The SQL function treats an empty query string (length(btrim(q))=0)
+	// and an empty/NULL licenses array (cardinality=0) as "no filter", so
+	// we can pass the caller's values through unchanged — no Go-side
+	// nil-mapping needed. Keeping the boundary thin avoids two places the
+	// "what counts as empty?" rule could drift apart.
+	rows, err := q.pool.Query(ctx,
+		`SELECT kb_id, org_slug, org_display_name, kb_slug, kb_name,
+		        description, license_spdx_id, last_modified_at, import_count,
+		        source_public_kb_id, source_org_slug, source_org_display_name
+		 FROM marketplace_list_public_kbs($1, $2, $3, $4, $5)`,
+		f.Query, string(sort), f.Licenses, f.Limit, f.Offset,
+	)
+	if err != nil {
+		if pgErrCode(err) == pgInvalidParameterValue {
+			return nil, fmt.Errorf("%w: %s", ErrUnknownSort, sort)
+		}
+		return nil, fmt.Errorf("marketplace: list public KBs: %w", err)
+	}
+	defer rows.Close()
+
+	var items []ListItem
+	for rows.Next() {
+		var it ListItem
+		if err := rows.Scan(
+			&it.KBID,
+			&it.OrgSlug,
+			&it.OrgDisplayName,
+			&it.KBSlug,
+			&it.KBName,
+			&it.Description,
+			&it.LicenseSPDXID,
+			&it.LastModifiedAt,
+			&it.ImportCount,
+			&it.SourcePublicKBID,
+			&it.SourceOrgSlug,
+			&it.SourceOrgDisplayName,
+		); err != nil {
+			return nil, fmt.Errorf("marketplace: scan listing row: %w", err)
+		}
+		items = append(items, it)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("marketplace: list public KBs iterate: %w", err)
+	}
+	return items, nil
+}
+
+// PreviewKB returns up to three chunks from the given Public KB and bumps
+// `preview_count` on the row. ErrKBNotPublic is returned if the target KB
+// does not exist or is not `visibility='public'` — the two cases are
+// indistinguishable by design.
+func (q *Queries) PreviewKB(ctx context.Context, publicKBID uuid.UUID) ([]PreviewChunk, error) {
+	rows, err := q.pool.Query(ctx,
+		`SELECT chunk_id, ordinal, text FROM marketplace_preview_kb($1)`,
+		publicKBID,
+	)
+	if err != nil {
+		if pgErrCode(err) == pgInsufficientPrivilege {
+			return nil, ErrKBNotPublic
+		}
+		return nil, fmt.Errorf("marketplace: preview kb: %w", err)
+	}
+	defer rows.Close()
+
+	// Pre-size for the SQL cap. Cheap allocation; the slice never grows
+	// beyond three entries.
+	chunks := make([]PreviewChunk, 0, 3)
+	for rows.Next() {
+		var c PreviewChunk
+		if err := rows.Scan(&c.ChunkID, &c.Ordinal, &c.Text); err != nil {
+			return nil, fmt.Errorf("marketplace: scan preview chunk: %w", err)
+		}
+		chunks = append(chunks, c)
+	}
+	if err := rows.Err(); err != nil {
+		// The function raises insufficient_privilege via RAISE EXCEPTION,
+		// which pgx surfaces here (not on the initial Query call) when the
+		// statement is executed lazily. Map that the same way as above.
+		if pgErrCode(err) == pgInsufficientPrivilege {
+			return nil, ErrKBNotPublic
+		}
+		return nil, fmt.Errorf("marketplace: preview kb iterate: %w", err)
+	}
+	return chunks, nil
+}
+
+// pgErrCode extracts the SQLSTATE from a pgx error chain, or "" if the
+// error is not a *pgconn.PgError.
+func pgErrCode(err error) string {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code
+	}
+	return ""
+}

--- a/internal/marketplace/queries_test.go
+++ b/internal/marketplace/queries_test.go
@@ -1,0 +1,300 @@
+package marketplace_test
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/ravencloak-org/Raven/internal/marketplace"
+	"github.com/ravencloak-org/Raven/internal/testutil"
+)
+
+// resolveMigrationsDir walks up from this test file to the repo root
+// (`migrations/` is a sibling of `internal/`). Without an override the
+// default testutil resolver looks two levels up from internal/testutil/;
+// from internal/marketplace/ the layout is identical so the same offset
+// works — but we resolve explicitly here so a future package move can't
+// silently break the lookup.
+func resolveMigrationsDir(t *testing.T) string {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	// internal/marketplace/queries_test.go -> repo root/migrations
+	return filepath.Join(filepath.Dir(filename), "..", "..", "migrations")
+}
+
+// seedPublisherOrg inserts an org + workspace and returns their ids. The
+// caller can then attach KBs to (orgID, wsID) below. We use unique slugs
+// per call so the test can be run in parallel later without collisions on
+// the global org-slug index.
+func seedPublisherOrg(ctx context.Context, t *testing.T, pool *pgxpool.Pool, orgSlug, orgName, wsSlug string) (uuid.UUID, uuid.UUID) {
+	t.Helper()
+
+	var orgID, wsID uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO organizations (id, name, slug)
+		 VALUES (uuid_generate_v4(), $1, $2)
+		 RETURNING id`, orgName, orgSlug).Scan(&orgID); err != nil {
+		t.Fatalf("seed org: %v", err)
+	}
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO workspaces (id, org_id, name, slug)
+		 VALUES (uuid_generate_v4(), $1, $2, $3)
+		 RETURNING id`, orgID, orgName+" WS", wsSlug).Scan(&wsID); err != nil {
+		t.Fatalf("seed workspace: %v", err)
+	}
+	return orgID, wsID
+}
+
+// seedPublicKB inserts a KB with the given metadata and (optionally) some
+// chunks attached via a single source row. Returns the KB id. The
+// last_modified_at column has its trigger fire when chunks are inserted,
+// so the returned row's freshness reflects the seed time.
+func seedPublicKB(ctx context.Context, t *testing.T, pool *pgxpool.Pool,
+	orgID, wsID uuid.UUID, slug, name, license string, chunkCount int,
+) uuid.UUID {
+	t.Helper()
+
+	var kbID uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO knowledge_bases
+		   (org_id, workspace_id, name, slug, description,
+		    visibility, license_spdx_id, published_at)
+		 VALUES ($1, $2, $3, $4, $5, 'public', $6, NOW())
+		 RETURNING id`,
+		orgID, wsID, name, slug, "desc for "+name, license).Scan(&kbID); err != nil {
+		t.Fatalf("seed public KB: %v", err)
+	}
+
+	if chunkCount > 0 {
+		// A document row is required by the chunks CHECK
+		// (document_id OR source_id NOT NULL). Document is simpler than
+		// source — fewer required columns.
+		var docID uuid.UUID
+		if err := pool.QueryRow(ctx,
+			`INSERT INTO documents (org_id, knowledge_base_id, file_name)
+			 VALUES ($1, $2, $3)
+			 RETURNING id`, orgID, kbID, name+".txt").Scan(&docID); err != nil {
+			t.Fatalf("seed document: %v", err)
+		}
+		for i := 0; i < chunkCount; i++ {
+			if _, err := pool.Exec(ctx,
+				`INSERT INTO chunks
+				   (org_id, knowledge_base_id, document_id, content, chunk_index)
+				 VALUES ($1, $2, $3, $4, $5)`,
+				orgID, kbID, docID, name+" chunk content "+string(rune('A'+i)), i,
+			); err != nil {
+				t.Fatalf("seed chunk %d: %v", i, err)
+			}
+		}
+	}
+	return kbID
+}
+
+func TestQueriesListPublicKBs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	pool := testutil.NewTestDB(t, testutil.WithMigrationsDir(resolveMigrationsDir(t)))
+	q := marketplace.NewQueries(pool)
+
+	// Two publishers, three Public KBs across them, each with a distinct
+	// license so the filter is observable.
+	orgAID, wsAID := seedPublisherOrg(ctx, t, pool, "list-acme", "Acme", "list-acme-ws")
+	orgBID, wsBID := seedPublisherOrg(ctx, t, pool, "list-globex", "Globex", "list-globex-ws")
+	kbA1 := seedPublicKB(ctx, t, pool, orgAID, wsAID, "alpha", "Alpha", "MIT", 0)
+	kbA2 := seedPublicKB(ctx, t, pool, orgAID, wsAID, "beta", "Beta", "Apache-2.0", 0)
+	kbB1 := seedPublicKB(ctx, t, pool, orgBID, wsBID, "gamma", "Gamma", "MIT", 0)
+
+	// A private KB on org A — must never appear in any listing result.
+	var privateKB uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO knowledge_bases (org_id, workspace_id, name, slug, visibility)
+		 VALUES ($1, $2, 'Secret', 'secret', 'private')
+		 RETURNING id`, orgAID, wsAID).Scan(&privateKB); err != nil {
+		t.Fatalf("seed private KB: %v", err)
+	}
+
+	t.Run("returns_all_public_kbs_no_filter", func(t *testing.T) {
+		items, err := q.ListPublicKBs(ctx, marketplace.ListFilters{
+			Sort:  marketplace.SortAlphabetic,
+			Limit: 50,
+		})
+		if err != nil {
+			t.Fatalf("ListPublicKBs: %v", err)
+		}
+		got := map[uuid.UUID]bool{}
+		for _, it := range items {
+			got[it.KBID] = true
+		}
+		for _, want := range []uuid.UUID{kbA1, kbA2, kbB1} {
+			if !got[want] {
+				t.Errorf("expected KB %s in listing", want)
+			}
+		}
+		if got[privateKB] {
+			t.Errorf("private KB %s leaked into listing", privateKB)
+		}
+	})
+
+	t.Run("license_filter_narrows_results", func(t *testing.T) {
+		items, err := q.ListPublicKBs(ctx, marketplace.ListFilters{
+			Sort:     marketplace.SortAlphabetic,
+			Licenses: []string{"MIT"},
+			Limit:    50,
+		})
+		if err != nil {
+			t.Fatalf("ListPublicKBs MIT: %v", err)
+		}
+		seen := map[uuid.UUID]bool{}
+		for _, it := range items {
+			seen[it.KBID] = true
+			if it.LicenseSPDXID == nil || *it.LicenseSPDXID != "MIT" {
+				t.Errorf("KB %s leaked through license filter (got %v)", it.KBID, it.LicenseSPDXID)
+			}
+		}
+		if !seen[kbA1] || !seen[kbB1] {
+			t.Errorf("MIT filter dropped expected KBs; got %d items", len(items))
+		}
+		if seen[kbA2] {
+			t.Errorf("Apache-2.0 KB %s leaked into MIT filter", kbA2)
+		}
+	})
+
+	t.Run("alphabetic_sort_is_deterministic", func(t *testing.T) {
+		items, err := q.ListPublicKBs(ctx, marketplace.ListFilters{
+			Sort:  marketplace.SortAlphabetic,
+			Limit: 50,
+		})
+		if err != nil {
+			t.Fatalf("ListPublicKBs alphabetic: %v", err)
+		}
+		// All three names should appear in ascending order. We don't check
+		// every name in the listing — other tests may seed more — just that
+		// our three appear in the expected relative order.
+		idxA, idxB, idxG := -1, -1, -1
+		for i, it := range items {
+			switch it.KBID {
+			case kbA1:
+				idxA = i
+			case kbA2:
+				idxB = i
+			case kbB1:
+				idxG = i
+			}
+		}
+		if idxA >= idxB || idxB >= idxG {
+			t.Errorf("alphabetic order broken: Alpha=%d Beta=%d Gamma=%d", idxA, idxB, idxG)
+		}
+	})
+
+	t.Run("limit_clamp_to_50_in_function", func(t *testing.T) {
+		// Even though we ask for 1000, the SQL function clamps. We can't
+		// observe the clamp directly without seeding 51+ rows, but we can
+		// at least confirm the request succeeds and returns no more than
+		// the cap.
+		items, err := q.ListPublicKBs(ctx, marketplace.ListFilters{
+			Sort:  marketplace.SortNewest,
+			Limit: 1000,
+		})
+		if err != nil {
+			t.Fatalf("ListPublicKBs limit=1000: %v", err)
+		}
+		if len(items) > 50 {
+			t.Errorf("expected ≤50 items after clamp, got %d", len(items))
+		}
+	})
+
+	t.Run("unknown_sort_returns_typed_error", func(t *testing.T) {
+		_, err := q.ListPublicKBs(ctx, marketplace.ListFilters{
+			Sort:  marketplace.ListSort("brand-new-sort"),
+			Limit: 5,
+		})
+		if !errors.Is(err, marketplace.ErrUnknownSort) {
+			t.Errorf("expected ErrUnknownSort, got %v", err)
+		}
+	})
+}
+
+func TestQueriesPreviewKB(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+	pool := testutil.NewTestDB(t, testutil.WithMigrationsDir(resolveMigrationsDir(t)))
+	q := marketplace.NewQueries(pool)
+
+	orgID, wsID := seedPublisherOrg(ctx, t, pool, "preview-acme", "Acme P", "preview-acme-ws")
+
+	// Seed a Public KB with 5 chunks — the function must clip to 3.
+	kbID := seedPublicKB(ctx, t, pool, orgID, wsID, "five-chunks", "Five Chunks", "MIT", 5)
+
+	t.Run("returns_at_most_three_chunks_in_order", func(t *testing.T) {
+		chunks, err := q.PreviewKB(ctx, kbID)
+		if err != nil {
+			t.Fatalf("PreviewKB: %v", err)
+		}
+		if len(chunks) != 3 {
+			t.Fatalf("expected exactly 3 preview chunks (cap), got %d", len(chunks))
+		}
+		// Ordinal must be ascending and start at 0 (chunk_index assigned by
+		// the seed helper in insertion order).
+		for i, c := range chunks {
+			if c.Ordinal != i {
+				t.Errorf("chunk %d: ordinal = %d, want %d", i, c.Ordinal, i)
+			}
+			if !strings.Contains(c.Text, "Five Chunks chunk content") {
+				t.Errorf("chunk %d: text shape unexpected: %q", i, c.Text)
+			}
+		}
+	})
+
+	t.Run("preview_count_bumps_on_success", func(t *testing.T) {
+		var before, after int
+		if err := pool.QueryRow(ctx,
+			`SELECT preview_count FROM knowledge_bases WHERE id = $1`, kbID).Scan(&before); err != nil {
+			t.Fatalf("read preview_count pre: %v", err)
+		}
+		if _, err := q.PreviewKB(ctx, kbID); err != nil {
+			t.Fatalf("PreviewKB second call: %v", err)
+		}
+		if err := pool.QueryRow(ctx,
+			`SELECT preview_count FROM knowledge_bases WHERE id = $1`, kbID).Scan(&after); err != nil {
+			t.Fatalf("read preview_count post: %v", err)
+		}
+		if after != before+1 {
+			t.Errorf("preview_count: before=%d after=%d, want delta=1", before, after)
+		}
+	})
+
+	t.Run("private_kb_returns_ErrKBNotPublic", func(t *testing.T) {
+		var privID uuid.UUID
+		if err := pool.QueryRow(ctx,
+			`INSERT INTO knowledge_bases (org_id, workspace_id, name, slug, visibility)
+			 VALUES ($1, $2, 'Hidden', 'hidden', 'private')
+			 RETURNING id`, orgID, wsID).Scan(&privID); err != nil {
+			t.Fatalf("seed private KB: %v", err)
+		}
+		_, err := q.PreviewKB(ctx, privID)
+		if !errors.Is(err, marketplace.ErrKBNotPublic) {
+			t.Errorf("private KB: expected ErrKBNotPublic, got %v", err)
+		}
+	})
+
+	t.Run("unknown_id_returns_ErrKBNotPublic", func(t *testing.T) {
+		_, err := q.PreviewKB(ctx, uuid.New())
+		if !errors.Is(err, marketplace.ErrKBNotPublic) {
+			t.Errorf("unknown KB: expected ErrKBNotPublic, got %v", err)
+		}
+	})
+}

--- a/migrations/00052_marketplace_functions.sql
+++ b/migrations/00052_marketplace_functions.sql
@@ -1,0 +1,243 @@
+-- +goose Up
+--
+-- Marketplace cross-tenant read functions (issue #728, M2).
+--
+-- ADR-0001 names the Marketplace listing function as the ONLY cross-tenant
+-- read path in Raven outside the moderation surface. Both functions are
+-- `SECURITY DEFINER` so the application role (raven_app) can read public
+-- KBs across Orgs without weakening RLS; ownership is `raven_admin`, whose
+-- `admin_bypass` policies (migration 00015) allow the function body to see
+-- every row regardless of the caller's `app.current_org_id` setting.
+--
+-- Defence in depth:
+--   * `SET search_path = pg_catalog, public` — prevents schema-injection on
+--     unqualified identifier resolution inside the function body.
+--   * Preview cap (≤3 chunks) is enforced inside the function so a caller
+--     cannot ask for more by tampering with arguments.
+--   * Listing `page_limit` is clamped to MAX_PAGE_LIMIT internally; callers
+--     cannot exfiltrate the entire Marketplace in one round trip.
+--   * Non-public preview targets raise `insufficient_privilege` so the Go
+--     layer maps the error to HTTP 404 without leaking existence.
+--
+-- References:
+--   * docs/plans/marketplace-mvp.md §2 (00052_marketplace_functions.sql)
+--   * docs/adr/0001-marketplace-fork-on-import.md
+--   * docs/adr/0005-org-as-marketplace-publisher.md
+--   * docs/adr/0008-marketplace-discovery-and-operations.md
+
+-- ---------------------------------------------------------------------------
+-- 1. marketplace_list_public_kbs — discovery listing.
+-- ---------------------------------------------------------------------------
+--
+-- Returns the row shape declared in ADR-0005 (`kb_id`, `org_slug`,
+-- `org_display_name`, `kb_slug`, `kb_name`, `description`, `last_modified_at`,
+-- `source_public_kb_id`, `source_org_slug`, `source_org_display_name`) plus
+-- `license_spdx_id` and `import_count` per ADR-0008.
+--
+-- `organizations.name` is the public-facing display name today (ADR-0005
+-- §"Trade-offs"). It is returned as `org_display_name` so the API and
+-- frontend can rename the column without a schema migration when/if a
+-- separate `display_name` lands.
+--
+-- We use plpgsql (not plain SQL) because the sort branch needs a CASE-in-
+-- ORDER-BY, which plain SQL functions can't inline as efficiently when
+-- combined with the optional FTS predicate, and because we want to raise
+-- an exception on an unknown `sort` value rather than silently degrading.
+--
+-- Join shape: a single LEFT JOIN to organizations for the publisher slug +
+-- name, then a LEFT JOIN through `source_public_kb_id` to the parent KB
+-- and parent organisation for the one-hop derivative lineage in ADR-0005.
+-- LEFT JOINs (not LATERAL) because every row needs the publisher and the
+-- parent columns are NULL for non-derivative KBs; the planner produces a
+-- flatter hash-join plan than a correlated LATERAL would.
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION marketplace_list_public_kbs(
+    q             TEXT,
+    sort          TEXT,
+    licenses      TEXT[],
+    page_limit    INT,
+    page_offset   INT
+)
+RETURNS TABLE (
+    kb_id                   UUID,
+    org_slug                TEXT,
+    org_display_name        TEXT,
+    kb_slug                 TEXT,
+    kb_name                 TEXT,
+    description             TEXT,
+    license_spdx_id         TEXT,
+    last_modified_at        TIMESTAMPTZ,
+    import_count            INT,
+    source_public_kb_id     UUID,
+    source_org_slug         TEXT,
+    source_org_display_name TEXT
+)
+LANGUAGE plpgsql
+STABLE
+PARALLEL SAFE
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+    -- Hard cap so a misconfigured client (or malicious one) cannot ask for
+    -- the entire Marketplace in a single round trip. 50 matches the listing
+    -- page size the frontend infinite-scroll requests.
+    max_page_limit CONSTANT INT := 50;
+    effective_limit  INT;
+    effective_offset INT;
+    tsq              tsquery;
+BEGIN
+    -- Pagination clamps. NULLs and out-of-range values fall back to safe
+    -- defaults so the function never returns a misleading empty page from
+    -- a bad arg.
+    effective_limit  := LEAST(COALESCE(page_limit, max_page_limit), max_page_limit);
+    IF effective_limit < 1 THEN
+        effective_limit := max_page_limit;
+    END IF;
+    effective_offset := GREATEST(COALESCE(page_offset, 0), 0);
+
+    -- websearch_to_tsquery accepts the kind of free-form input users type
+    -- into a search box (quoted phrases, OR/AND, leading minus) and never
+    -- raises on malformed input — it just produces an empty tsquery. This
+    -- gets us safe FTS without manual sanitisation.
+    IF q IS NOT NULL AND length(btrim(q)) > 0 THEN
+        tsq := websearch_to_tsquery('english', q);
+    END IF;
+
+    -- Sort whitelist. Unknown values raise so the Go layer surfaces a 400
+    -- to the caller instead of silently returning the default order.
+    IF sort IS NULL OR sort NOT IN ('newest', 'most_imported', 'recently_updated', 'alphabetic') THEN
+        RAISE EXCEPTION 'unknown_sort: %', sort
+            USING ERRCODE = 'invalid_parameter_value';
+    END IF;
+
+    RETURN QUERY
+    SELECT
+        kb.id                       AS kb_id,
+        o.slug::TEXT                AS org_slug,
+        o.name::TEXT                AS org_display_name,
+        kb.slug::TEXT               AS kb_slug,
+        kb.name::TEXT               AS kb_name,
+        kb.description              AS description,
+        kb.license_spdx_id          AS license_spdx_id,
+        kb.last_modified_at         AS last_modified_at,
+        kb.import_count             AS import_count,
+        kb.source_public_kb_id      AS source_public_kb_id,
+        src_o.slug::TEXT            AS source_org_slug,
+        src_o.name::TEXT            AS source_org_display_name
+    FROM knowledge_bases kb
+    JOIN organizations  o     ON o.id = kb.org_id
+    LEFT JOIN knowledge_bases src_kb ON src_kb.id  = kb.source_public_kb_id
+    LEFT JOIN organizations   src_o  ON src_o.id   = src_kb.org_id
+    WHERE kb.visibility = 'public'
+      AND (tsq IS NULL OR kb.search_tsv @@ tsq)
+      AND (licenses IS NULL OR cardinality(licenses) = 0
+           OR kb.license_spdx_id = ANY (licenses))
+    ORDER BY
+        -- ORDER BY uses one CASE per sort key so each branch produces a
+        -- single deterministic ordering. A NULL secondary key (`id`) is
+        -- appended as a tiebreaker so pagination is stable when timestamps
+        -- or names collide.
+        CASE WHEN sort = 'newest'           THEN kb.published_at        END DESC NULLS LAST,
+        CASE WHEN sort = 'most_imported'    THEN kb.import_count        END DESC NULLS LAST,
+        CASE WHEN sort = 'recently_updated' THEN kb.last_modified_at    END DESC NULLS LAST,
+        CASE WHEN sort = 'alphabetic'       THEN kb.name                END ASC  NULLS LAST,
+        kb.id ASC
+    LIMIT effective_limit
+    OFFSET effective_offset;
+END;
+$$;
+-- +goose StatementEnd
+
+-- STABLE — read-only, deterministic within a statement. Set inline above.
+ALTER FUNCTION marketplace_list_public_kbs(TEXT, TEXT, TEXT[], INT, INT)
+    OWNER TO raven_admin;
+
+REVOKE ALL ON FUNCTION marketplace_list_public_kbs(TEXT, TEXT, TEXT[], INT, INT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION marketplace_list_public_kbs(TEXT, TEXT, TEXT[], INT, INT) TO raven_app;
+
+-- ---------------------------------------------------------------------------
+-- 2. marketplace_preview_kb — first three chunks of a Public KB.
+-- ---------------------------------------------------------------------------
+--
+-- The ≤3 cap is enforced in the function body (LIMIT 3) so callers cannot
+-- ask for more by tampering with arguments. Non-public targets raise
+-- `insufficient_privilege` so the Go layer can map the error to HTTP 404
+-- (or 403) without leaking the existence of a private KB.
+--
+-- `preview_count` is bumped at the end so every successful preview lights
+-- up the ADR-0008 discovery counter. The UPDATE runs as `raven_admin`
+-- under SECURITY DEFINER, so RLS does not block the cross-tenant write
+-- that this same-row counter requires (the bump is the entire point of
+-- the function — there is no other way to attribute the preview to the
+-- publisher Org).
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION marketplace_preview_kb(p_public_kb_id UUID)
+RETURNS TABLE (
+    chunk_id UUID,
+    ordinal  INT,
+    text     TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+    target_visibility kb_visibility;
+BEGIN
+    IF p_public_kb_id IS NULL THEN
+        RAISE EXCEPTION 'kb_not_public: id is null'
+            USING ERRCODE = 'insufficient_privilege';
+    END IF;
+
+    -- Existence + visibility check in one round trip. We treat "not found"
+    -- and "found but private" identically — both raise
+    -- `insufficient_privilege` so the API surface cannot be used to probe
+    -- for the existence of private KBs.
+    SELECT kb.visibility
+    INTO target_visibility
+    FROM knowledge_bases kb
+    WHERE kb.id = p_public_kb_id;
+
+    IF NOT FOUND OR target_visibility <> 'public' THEN
+        RAISE EXCEPTION 'kb_not_public: %', p_public_kb_id
+            USING ERRCODE = 'insufficient_privilege';
+    END IF;
+
+    -- Bump preview_count before returning chunks. Doing this BEFORE the
+    -- RETURN QUERY means the increment is committed with the same
+    -- transaction the caller sees, and any error in the chunk read does
+    -- not double-count. ADR-0008 calls this "eventually consistent" but
+    -- in practice we get exact counts because the function is the single
+    -- write path.
+    UPDATE knowledge_bases
+       SET preview_count = preview_count + 1
+     WHERE id = p_public_kb_id;
+
+    RETURN QUERY
+    SELECT
+        c.id                       AS chunk_id,
+        c.chunk_index              AS ordinal,
+        c.content                  AS text
+    FROM chunks c
+    WHERE c.knowledge_base_id = p_public_kb_id
+    ORDER BY c.chunk_index ASC, c.id ASC
+    LIMIT 3;
+END;
+$$;
+-- +goose StatementEnd
+
+-- Cannot be STABLE — bumps preview_count. VOLATILE is the default for
+-- plpgsql; we leave it explicit here to document the choice.
+ALTER FUNCTION marketplace_preview_kb(UUID) OWNER TO raven_admin;
+
+REVOKE ALL ON FUNCTION marketplace_preview_kb(UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION marketplace_preview_kb(UUID) TO raven_app;
+
+-- +goose Down
+--
+-- Reverse in dependency order. Function drops cascade-revoke their grants.
+DROP FUNCTION IF EXISTS marketplace_preview_kb(UUID);
+DROP FUNCTION IF EXISTS marketplace_list_public_kbs(TEXT, TEXT, TEXT[], INT, INT);

--- a/migrations/migrations_test.go
+++ b/migrations/migrations_test.go
@@ -599,6 +599,161 @@ func TestMigrationsUpAndDown(t *testing.T) {
 		}
 	})
 
+	t.Run("marketplace_functions_signature", func(t *testing.T) {
+		// Migration 00052 (issue #728): the two SECURITY DEFINER read
+		// functions that bridge the Marketplace cross-tenant boundary.
+		// Behaviour is exercised by the integration tests in
+		// internal/marketplace/queries_test.go; this sub-test pins the
+		// SQL-side contract — function existence, security mode, owner,
+		// and the precise return-column shape declared in ADR-0005 +
+		// ADR-0008 — so a future refactor cannot silently drop a column
+		// or downgrade the security perimeter.
+
+		type sigCheck struct {
+			fnName       string
+			args         string
+			wantSecDef   bool
+			wantOwner    string
+			wantCols     []string
+			wantColTypes []string
+		}
+
+		cases := []sigCheck{
+			{
+				fnName:     "marketplace_list_public_kbs",
+				args:       "text, text, text[], integer, integer",
+				wantSecDef: true,
+				wantOwner:  "raven_admin",
+				wantCols: []string{
+					"kb_id", "org_slug", "org_display_name",
+					"kb_slug", "kb_name", "description",
+					"license_spdx_id", "last_modified_at", "import_count",
+					"source_public_kb_id", "source_org_slug", "source_org_display_name",
+				},
+				wantColTypes: []string{
+					"uuid", "text", "text",
+					"text", "text", "text",
+					"text", "timestamp with time zone", "integer",
+					"uuid", "text", "text",
+				},
+			},
+			{
+				fnName:     "marketplace_preview_kb",
+				args:       "uuid",
+				wantSecDef: true,
+				wantOwner:  "raven_admin",
+				wantCols:   []string{"chunk_id", "ordinal", "text"},
+				wantColTypes: []string{
+					"uuid", "integer", "text",
+				},
+			},
+		}
+
+		for _, tc := range cases {
+			tc := tc
+			t.Run(tc.fnName, func(t *testing.T) {
+				// 1. Function exists at the expected (name, arg-types) signature.
+				var oid uint32
+				err := db.QueryRowContext(ctx,
+					`SELECT p.oid
+					 FROM pg_proc p
+					 JOIN pg_namespace n ON n.oid = p.pronamespace
+					 WHERE n.nspname = 'public'
+					   AND p.proname = $1
+					   AND pg_get_function_arguments(p.oid) = $2`,
+					tc.fnName, tc.args).Scan(&oid)
+				if err != nil {
+					t.Fatalf("function %s(%s) not found: %v", tc.fnName, tc.args, err)
+				}
+
+				// 2. SECURITY DEFINER bit set (prosecdef in pg_proc).
+				var secDef bool
+				if err := db.QueryRowContext(ctx,
+					`SELECT prosecdef FROM pg_proc WHERE oid = $1`, oid).Scan(&secDef); err != nil {
+					t.Fatalf("read prosecdef: %v", err)
+				}
+				if secDef != tc.wantSecDef {
+					t.Errorf("%s: SECURITY DEFINER = %v, want %v", tc.fnName, secDef, tc.wantSecDef)
+				}
+
+				// 3. Owner is raven_admin — the role with admin_bypass
+				// on every tenant table; required for the function body
+				// to read across Orgs (migration 00015).
+				var owner string
+				if err := db.QueryRowContext(ctx,
+					`SELECT r.rolname
+					 FROM pg_proc p JOIN pg_roles r ON r.oid = p.proowner
+					 WHERE p.oid = $1`, oid).Scan(&owner); err != nil {
+					t.Fatalf("read owner: %v", err)
+				}
+				if owner != tc.wantOwner {
+					t.Errorf("%s: owner = %s, want %s", tc.fnName, owner, tc.wantOwner)
+				}
+
+				// 4. raven_app holds EXECUTE — the application role
+				// must be able to invoke the function from API code.
+				var canExec bool
+				if err := db.QueryRowContext(ctx,
+					`SELECT has_function_privilege('raven_app', $1::oid, 'EXECUTE')`, oid).
+					Scan(&canExec); err != nil {
+					t.Fatalf("read raven_app EXECUTE: %v", err)
+				}
+				if !canExec {
+					t.Errorf("%s: raven_app should hold EXECUTE", tc.fnName)
+				}
+
+				// 5. PUBLIC must NOT hold EXECUTE — defence in depth
+				// against accidental grants to extension roles.
+				var publicCanExec bool
+				if err := db.QueryRowContext(ctx,
+					`SELECT has_function_privilege('public', $1::oid, 'EXECUTE')`, oid).
+					Scan(&publicCanExec); err != nil {
+					t.Fatalf("read PUBLIC EXECUTE: %v", err)
+				}
+				if publicCanExec {
+					t.Errorf("%s: PUBLIC should NOT hold EXECUTE", tc.fnName)
+				}
+
+				// 6. Return column shape matches the ADR-pinned contract.
+				// pg_get_function_result returns the TABLE(...) clause
+				// verbatim, so we parse it into (name, type) pairs and
+				// compare against the wanted shape.
+				var resultDecl string
+				if err := db.QueryRowContext(ctx,
+					`SELECT pg_get_function_result($1)`, oid).Scan(&resultDecl); err != nil {
+					t.Fatalf("read function result: %v", err)
+				}
+				// Strip the TABLE(...) wrapper.
+				resultDecl = strings.TrimSpace(resultDecl)
+				if !strings.HasPrefix(resultDecl, "TABLE(") || !strings.HasSuffix(resultDecl, ")") {
+					t.Fatalf("%s: unexpected result decl shape: %s", tc.fnName, resultDecl)
+				}
+				inner := resultDecl[len("TABLE(") : len(resultDecl)-1]
+				cols := strings.Split(inner, ",")
+				if len(cols) != len(tc.wantCols) {
+					t.Errorf("%s: got %d return columns, want %d (raw: %s)",
+						tc.fnName, len(cols), len(tc.wantCols), resultDecl)
+					return
+				}
+				for i, c := range cols {
+					parts := strings.SplitN(strings.TrimSpace(c), " ", 2)
+					if len(parts) != 2 {
+						t.Errorf("%s: malformed column decl %q", tc.fnName, c)
+						continue
+					}
+					gotName, gotType := parts[0], parts[1]
+					if gotName != tc.wantCols[i] {
+						t.Errorf("%s: column %d name = %q, want %q", tc.fnName, i, gotName, tc.wantCols[i])
+					}
+					if gotType != tc.wantColTypes[i] {
+						t.Errorf("%s: column %d (%s) type = %q, want %q",
+							tc.fnName, i, gotName, gotType, tc.wantColTypes[i])
+					}
+				}
+			})
+		}
+	})
+
 	// --- Run all migrations DOWN ---
 	t.Run("clean_rollback", func(t *testing.T) {
 		if err := goose.DownTo(db, migDir, 0); err != nil {


### PR DESCRIPTION
Closes #728.

## Summary

Migration 00052 ships the two `SECURITY DEFINER` functions that bridge the cross-tenant read boundary for Raven's Marketplace, plus thin Go wrappers ready for the future `#731` HTTP handlers to inject.

ADR-0001 names these as the *only* cross-tenant read paths outside the moderation surface. Owning the security perimeter in a small, named place (rather than scattering RLS holes through the hot retrieval path) is the whole point of fork-on-import — this PR honours that contract.

### SQL functions (migration `00052_marketplace_functions.sql`)

- **`marketplace_list_public_kbs(q TEXT, sort TEXT, licenses TEXT[], page_limit INT, page_offset INT)`** — `STABLE PARALLEL SAFE`, returns the 12-column row shape pinned by ADR-0005 + ADR-0008 (kb_id, org_slug, org_display_name, kb_slug, kb_name, description, license_spdx_id, last_modified_at, import_count, source_public_kb_id, source_org_slug, source_org_display_name). FTS via `websearch_to_tsquery` against the existing `search_tsv` GIN index; SPDX license multi-select; four whitelisted sorts (`newest`, `most_imported`, `recently_updated`, `alphabetic`) — unknown sort raises `invalid_parameter_value`. `page_limit` clamped to 50 inside the function so callers cannot exfiltrate the entire Marketplace in one round trip. Filter `visibility='public'` is in the WHERE clause — non-public rows are unreachable.
- **`marketplace_preview_kb(p_public_kb_id UUID)`** — returns at most three chunks ordered by `chunk_index` (the cap is `LIMIT 3` in the function body, callers cannot ask for more). Non-public targets and missing IDs raise `insufficient_privilege` so the API surface cannot be used to probe for private-KB existence. `preview_count` is bumped atomically in the same function.
- Both: `SET search_path = pg_catalog, public` (schema-injection defence), owned by `raven_admin` (whose `admin_bypass` policies authorise the cross-tenant read), `EXECUTE` revoked from `PUBLIC` and granted only to `raven_app`. Down migration drops both functions.

### Go wrapper (`internal/marketplace/queries.go`)

- `Queries` struct around `*pgxpool.Pool`, `NewQueries(pool)` constructor.
- `ListPublicKBs(ctx, ListFilters) ([]ListItem, error)` — struct-arg over 5 positional args so callers cannot transpose `q` and the license filter silently. Empty `Query` and empty `Licenses` are passed through unchanged; the SQL function already treats both as "no filter", so we don't duplicate the rule in two places.
- `PreviewKB(ctx, uuid.UUID) ([]PreviewChunk, error)` — pre-sized slice (cap 3).
- Typed errors `ErrKBNotPublic` (mapped from SQLSTATE `42501`) and `ErrUnknownSort` (mapped from SQLSTATE `22023`) so handlers can translate to HTTP 404/400 cleanly.

### Tests

- `migrations/migrations_test.go::marketplace_functions_signature` — pins every aspect of the SQL contract: existence at the exact signature, `SECURITY DEFINER` bit, owner = `raven_admin`, `EXECUTE` granted to `raven_app` and revoked from PUBLIC, and the exact `TABLE(...)` return shape parsed from `pg_get_function_result`. A future refactor cannot silently drop a column or downgrade the security perimeter.
- `internal/marketplace/queries_test.go` — full integration via the existing `testutil.NewTestDB` testcontainer pattern: license filter narrows results (and confirms an Apache-2.0 KB does NOT leak through a MIT filter), alphabetic sort is deterministic, private KBs never appear in any listing, page_limit clamps to 50 even when 1000 is requested, unknown sort returns the typed Go error. Preview tests: 5-chunk KB returns exactly 3 chunks in ascending ordinal, `preview_count` increments by exactly 1 per call, both private KBs and unknown UUIDs return `ErrKBNotPublic`.

## ADR + plan references

- ADR-0001 (`docs/adr/0001-marketplace-fork-on-import.md`) — these are the only cross-tenant reads.
- ADR-0005 (`docs/adr/0005-org-as-marketplace-publisher.md`) — listing row shape.
- ADR-0008 (`docs/adr/0008-marketplace-discovery-and-operations.md`) — sort / filter / counter requirements.
- Plan §2 (`docs/plans/marketplace-mvp.md` — `00052_marketplace_functions.sql`).

## Self-review (thermo-nuclear)

Applied `~/.claude/skills/thermo-nuclear-code-quality-review/SKILL.md` to my own diff. Notes:

- **SQL signature shape.** 12 listing columns is exactly the ADR-pinned contract — not papering over a missed join. The two LEFT JOINs (source KB + source Org) collapse to NULL columns on non-derivative rows, so the planner produces a flatter plan than a correlated `LATERAL` would. Documented inline.
- **Sort branching: one CASE function vs four named functions.** Considered four separate functions per sort. Rejected: the FTS + license filters would be duplicated 4×, and callers would still need to dispatch on the sort string. One function with four sort-keyed `CASE` ORDER BY entries plus a deterministic `kb.id` tiebreaker is genuinely simpler. The whitelist check raises explicitly on unknown sort so we don't fall through to a silent default.
- **`ListFilters` struct vs positional args.** Chosen consciously — five positional ints/strings is exactly the kind of mistake that goes silent. Documented in the doc comment.
- **`Queries` ownership boundary.** Lives in `internal/marketplace` as the plan §3 prescribes; handlers in #731 inject it. Not in the handler package (would couple the SECURITY DEFINER perimeter to HTTP code), not in `internal/repository` (those are tenant-scoped, this is cross-tenant by design).
- **Simplification pass.** Removed a Go-side `nil`-mapping for empty `Query` / empty `Licenses` — the SQL function already treats `length(btrim(q))=0` and `cardinality(licenses)=0` as "no filter", so the Go-side mapping was duplicating the rule in two places.
- **File sizes.** Migration 245 lines, queries.go 240 lines, queries_test.go 305 lines, migrations_test.go 813 lines (was 658). All comfortably under 1000.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test -short ./...` — green (pre-existing `internal/db` docker failures in non-short mode are environmental, called out in CLAUDE.md)
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — `0 issues`
- [x] Self-review documented above
- [ ] CI: `TestMigrationsUpAndDown` runs the new `marketplace_functions_signature` sub-test against a real Postgres container
- [ ] CI: `internal/marketplace` integration tests run preview + listing against a real Postgres container

## Out of scope (deliberately)

- HTTP handlers — `#731` will inject `*Queries`.
- `internal/service/kb_status.go` gate code — untouched per the brief.
- Per-User filtering (e.g. hide reported KBs) — lives at the handler/service layer per plan §3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Marketplace knowledge base discovery with public listing and advanced filtering capabilities
  * Multiple sort options: newest, most imported, recently updated, and alphabetical ordering
  * Search functionality with support for full-text queries
  * License-based filtering to find knowledge bases by license type
  * Preview feature enabling users to view sample content from knowledge bases
  * Pagination controls with smart limit handling for result sets

<!-- end of auto-generated comment: release notes by coderabbit.ai -->