### PR TITLE
feat(db): marketplace_reports + marketplace_takedowns schema and repos (#733)

### DIFF
--- a/internal/marketplace/moderation.go
+++ b/internal/marketplace/moderation.go
@@ -1,0 +1,240 @@
+// Package marketplace — moderation: shared types, errors, and the canonical
+// ReportStatus state machine used by both the database CHECK constraint and
+// the Go transition helper.
+//
+// The split across files in this package:
+//
+//   - moderation.go (this file): shared types, sentinel errors, the
+//     ReportStatus state-machine table. No SQL, no I/O.
+//   - reports.go: Reports repository — Create, List, Transition, plus the
+//     per-user open-report rate limiter.
+//   - takedowns.go: Takedowns repository — Create + List.
+//
+// Two tables, two repositories. Combining them into a single "moderation"
+// store would couple two concerns whose RLS shapes are deliberately
+// different (reports: reporter-scoped; takedowns: admin-only audit log)
+// and whose access patterns share nothing beyond the foreign key to
+// knowledge_bases. The separation matches the schema (00053) and the API
+// surface (one POST /reports endpoint, distinct admin endpoints per table).
+package marketplace
+
+import (
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ReportStatus is the canonical type for the marketplace_reports.status
+// column. Use this anywhere the status string crosses a function boundary —
+// it prevents stringly-typed "open"/"reviewing" comparisons scattered
+// across the codebase and lets the state-machine helpers stay in one place.
+type ReportStatus string
+
+const (
+	// ReportStatusOpen is the initial state of a newly created report.
+	// The admin review queue lists reports in this state.
+	ReportStatusOpen ReportStatus = "open"
+
+	// ReportStatusReviewing means an admin has acknowledged the report and
+	// is investigating. It is the only state from which a terminal state
+	// (resolved or dismissed) may be reached.
+	ReportStatusReviewing ReportStatus = "reviewing"
+
+	// ReportStatusResolved is a terminal state: the report led to action
+	// (typically a takedown + strike increment per ADR-0006).
+	ReportStatusResolved ReportStatus = "resolved"
+
+	// ReportStatusDismissed is a terminal state: the report was reviewed
+	// and rejected as without merit. The reporter is not notified by
+	// default (ADR-0008 §Why — report-confirms-takedown loop is a known
+	// harassment vector).
+	ReportStatusDismissed ReportStatus = "dismissed"
+)
+
+// allReportStatuses lists every legal ReportStatus value. Mirrors the
+// CHECK constraint in migration 00053. Used by IsValid below and by tests
+// asserting parity between the Go enum and the DB CHECK.
+var allReportStatuses = []ReportStatus{
+	ReportStatusOpen,
+	ReportStatusReviewing,
+	ReportStatusResolved,
+	ReportStatusDismissed,
+}
+
+// IsValid reports whether s is one of the four legal ReportStatus values.
+// The DB CHECK is the backstop; this guards against bad inputs at the
+// service boundary before a round-trip to Postgres.
+func (s ReportStatus) IsValid() bool {
+	for _, v := range allReportStatuses {
+		if s == v {
+			return true
+		}
+	}
+	return false
+}
+
+// IsTerminal reports whether s is a state from which no further transition
+// is legal. Used by Transition to short-circuit illegal moves before the
+// table lookup.
+func (s ReportStatus) IsTerminal() bool {
+	return s == ReportStatusResolved || s == ReportStatusDismissed
+}
+
+// reportTransitions encodes the legal state-machine moves:
+//
+//	open       -> reviewing
+//	reviewing  -> resolved | dismissed
+//	resolved   -> (terminal — no moves)
+//	dismissed  -> (terminal — no moves)
+//
+// Encoding this in code rather than relying solely on the DB CHECK gives
+// us a structured ErrIllegalTransition diagnostic at the service boundary
+// — the alternative ("SQL violated check constraint X on column Y") is
+// opaque to API callers.
+var reportTransitions = map[ReportStatus]map[ReportStatus]struct{}{
+	ReportStatusOpen: {
+		ReportStatusReviewing: {},
+	},
+	ReportStatusReviewing: {
+		ReportStatusResolved:  {},
+		ReportStatusDismissed: {},
+	},
+	// Terminal states intentionally have no outgoing edges; we leave them
+	// out of the map so a Transition attempt falls through to "not found"
+	// and returns ErrIllegalTransition.
+}
+
+// CanTransition reports whether from -> to is a legal state-machine move.
+// Both states must be valid; an unknown ReportStatus is rejected even if
+// some accidental map entry would otherwise allow it.
+func CanTransition(from, to ReportStatus) bool {
+	if !from.IsValid() || !to.IsValid() {
+		return false
+	}
+	outgoing, ok := reportTransitions[from]
+	if !ok {
+		return false
+	}
+	_, ok = outgoing[to]
+	return ok
+}
+
+// Report is the row shape for marketplace_reports. The repository returns
+// this type from Create and List.
+type Report struct {
+	// ID is the report's primary key.
+	ID uuid.UUID
+	// ReportedKBID is the Public KB being reported.
+	ReportedKBID uuid.UUID
+	// ReporterUserID is the user who submitted the report. Nullable —
+	// becomes NULL when the user is deleted (ON DELETE SET NULL on the FK).
+	ReporterUserID *uuid.UUID
+	// Reason is the free-text justification (1..4000 chars, per CHECK).
+	Reason string
+	// Status is the current report state.
+	Status ReportStatus
+	// CreatedAt is the report submission timestamp.
+	CreatedAt time.Time
+}
+
+// TakedownSource is the canonical type for marketplace_takedowns.source.
+// Three legal values per ADR-0006: publisher self-takedown, admin
+// (report-driven) takedown, or DMCA notice.
+type TakedownSource string
+
+const (
+	// TakedownSourcePublisher is a publisher-initiated unpublish that is
+	// being audit-logged. See POST /knowledge_bases/{id}/unpublish.
+	TakedownSourcePublisher TakedownSource = "publisher"
+
+	// TakedownSourceAdmin is an admin action driven by a confirmed report.
+	// Increments organizations.takedown_strikes per ADR-0006.
+	TakedownSourceAdmin TakedownSource = "admin"
+
+	// TakedownSourceDMCA is a DMCA notice. Drives the 14-day counter-notice
+	// workflow per ADR-0008; the KB transitions to kb_status='dmca_pending'
+	// during that window.
+	TakedownSourceDMCA TakedownSource = "dmca"
+)
+
+// allTakedownSources lists every legal TakedownSource value. Mirrors the
+// CHECK constraint in migration 00053.
+var allTakedownSources = []TakedownSource{
+	TakedownSourcePublisher,
+	TakedownSourceAdmin,
+	TakedownSourceDMCA,
+}
+
+// IsValid reports whether s is one of the three legal TakedownSource values.
+func (s TakedownSource) IsValid() bool {
+	for _, v := range allTakedownSources {
+		if s == v {
+			return true
+		}
+	}
+	return false
+}
+
+// Takedown is the row shape for marketplace_takedowns. Append-only — there
+// is no Update method on the repository.
+type Takedown struct {
+	// ID is the takedown event's primary key.
+	ID uuid.UUID
+	// TargetKBID is the Public KB that was taken down.
+	TargetKBID uuid.UUID
+	// Source attributes the takedown (publisher / admin / dmca).
+	Source TakedownSource
+	// Notes is free-text context (empty string if unset — the column is
+	// nullable but we present it as "" to callers for ergonomic reasons).
+	Notes string
+	// CreatedAt is the takedown event timestamp.
+	CreatedAt time.Time
+}
+
+// ─── Sentinel errors ─────────────────────────────────────────────────────────
+//
+// Errors are sentinel values (errors.Is-friendly) rather than wrapped
+// strings so HTTP handlers and tests can branch on them cleanly.
+
+// ErrInvalidReason is returned by Reports.Create when the supplied reason
+// is empty or exceeds 4000 characters. Matches the DB CHECK; surfaced
+// before round-trip for a useful API error (vs. opaque PG SQLSTATE 23514).
+var ErrInvalidReason = errors.New("marketplace: report reason must be 1..4000 chars")
+
+// ErrInvalidReportStatus is returned by Reports.Transition when either
+// the destination status or (if read from the DB) the current status is
+// not one of the four legal ReportStatus values.
+var ErrInvalidReportStatus = errors.New("marketplace: invalid report status")
+
+// ErrIllegalTransition is returned by Reports.Transition when the requested
+// (from -> to) move is not in the legal transition table. The from-state is
+// included by the caller via fmt.Errorf("%w: from=%s to=%s", ...) where
+// useful; the sentinel itself is the branch point for callers.
+var ErrIllegalTransition = errors.New("marketplace: illegal report status transition")
+
+// ErrReportNotFound is returned by Reports.Transition when the report id
+// does not match any row visible under the caller's RLS context.
+var ErrReportNotFound = errors.New("marketplace: report not found")
+
+// ErrInvalidTakedownSource is returned by Takedowns.Create when the
+// supplied source is not one of the three legal TakedownSource values.
+var ErrInvalidTakedownSource = errors.New("marketplace: invalid takedown source")
+
+// ErrRateLimit is returned by Reports.Create when the user has hit the
+// per-user open-report cap (MaxOpenReportsPerUser). The HTTP handler
+// translates this to 429 Too Many Requests per the API table in
+// docs/plans/marketplace-mvp.md §4.
+var ErrRateLimit = errors.New("marketplace: user has too many open reports")
+
+// MaxOpenReportsPerUser is the per-user cap on simultaneous open reports.
+// A constant rather than configuration because:
+//  1. The MVP review queue runs at human latency — a single user being
+//     able to file 5 open reports is already generous.
+//  2. Tuning this requires a code review (catch coordinated spam attempts
+//     in the diff), not a config push.
+//
+// Five chosen so a good-faith reporter on a typical Marketplace browsing
+// session is never blocked, while a script firing reports in a loop hits
+// the cap within seconds.
+const MaxOpenReportsPerUser = 5

--- a/internal/marketplace/moderation_integration_test.go
+++ b/internal/marketplace/moderation_integration_test.go
@@ -1,0 +1,327 @@
+// Integration tests for the moderation repositories. These spin up a real
+// Postgres via testutil.NewTestDB and exercise marketplace_reports +
+// marketplace_takedowns through the Reports / Takedowns repositories.
+//
+// Tests are skipped under `go test -short` so the fast unit-test loop
+// stays free of testcontainers.
+
+package marketplace_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/ravencloak-org/Raven/internal/marketplace"
+	"github.com/ravencloak-org/Raven/internal/testutil"
+)
+
+// modFixture is the minimal set of seeded IDs every moderation integration
+// test needs: a Public-KB target, a user to act as reporter, and the
+// org+workspace they live under (FK chain on knowledge_bases / users).
+//
+// All four IDs are freshly generated per call so tests are isolated from
+// each other when they share the same testcontainer.
+type modFixture struct {
+	OrgID  uuid.UUID
+	WSID   uuid.UUID
+	UserID uuid.UUID
+	KBID   uuid.UUID
+}
+
+// seedModFixture inserts an org, workspace, user, and KB. Slugs are
+// derived from the generated UUID prefix so parallel tests under the
+// same DB cannot collide on the unique slug index.
+//
+// Runs as the testcontainer superuser — RLS is bypassed for fixtures.
+func seedModFixture(ctx context.Context, t *testing.T, pool *pgxpool.Pool, label string) modFixture {
+	t.Helper()
+	f := modFixture{
+		OrgID:  uuid.New(),
+		WSID:   uuid.New(),
+		UserID: uuid.New(),
+		KBID:   uuid.New(),
+	}
+
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO organizations (id, name, slug)
+		 VALUES ($1, $2, $2 || '-' || substring($1::text from 1 for 8))`,
+		f.OrgID, label+"-org",
+	); err != nil {
+		t.Fatalf("seed organization: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO workspaces (id, org_id, name, slug)
+		 VALUES ($1, $2, $3, $3 || '-' || substring($1::text from 1 for 8))`,
+		f.WSID, f.OrgID, label+"-ws",
+	); err != nil {
+		t.Fatalf("seed workspace: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO users (id, org_id, email, status)
+		 VALUES ($1, $2, $3 || '-' || substring($1::text from 1 for 8) || '@example.com', 'active')`,
+		f.UserID, f.OrgID, label,
+	); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO knowledge_bases (id, org_id, workspace_id, name, slug)
+		 VALUES ($1, $2, $3, $4, $4 || '-' || substring($1::text from 1 for 8))`,
+		f.KBID, f.OrgID, f.WSID, label+"-kb",
+	); err != nil {
+		t.Fatalf("seed knowledge_base: %v", err)
+	}
+	return f
+}
+
+// TestReportsRepository_CreateAndRateLimit verifies the per-user rate
+// limiter blocks the 6th open report.
+func TestReportsRepository_CreateAndRateLimit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+	f := seedModFixture(ctx, t, pool, "rate")
+
+	repo := marketplace.NewReports(pool)
+
+	// Fill the cap (5 reports). Each must succeed.
+	for i := 0; i < marketplace.MaxOpenReportsPerUser; i++ {
+		if _, err := repo.Create(ctx, f.KBID, f.UserID, "spam attempt"); err != nil {
+			t.Fatalf("create report %d: %v", i+1, err)
+		}
+	}
+
+	// 6th must hit the rate-limit gate.
+	_, err := repo.Create(ctx, f.KBID, f.UserID, "one too many")
+	if !errors.Is(err, marketplace.ErrRateLimit) {
+		t.Errorf("6th report: want ErrRateLimit, got %v", err)
+	}
+
+	// CountOpenForUser should report exactly the cap (the rejected attempt
+	// was never inserted).
+	n, err := repo.CountOpenForUser(ctx, f.UserID)
+	if err != nil {
+		t.Fatalf("CountOpenForUser: %v", err)
+	}
+	if n != marketplace.MaxOpenReportsPerUser {
+		t.Errorf("CountOpenForUser: want %d, got %d", marketplace.MaxOpenReportsPerUser, n)
+	}
+}
+
+// TestReportsRepository_InvalidReason verifies the empty / oversize reason
+// guard fires before any SQL round-trip.
+func TestReportsRepository_InvalidReason(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+	repo := marketplace.NewReports(pool)
+
+	// Empty.
+	_, err := repo.Create(ctx, uuid.New(), uuid.New(), "")
+	if !errors.Is(err, marketplace.ErrInvalidReason) {
+		t.Errorf("empty reason: want ErrInvalidReason, got %v", err)
+	}
+
+	// Oversize: 4001 chars.
+	oversize := make([]byte, 4001)
+	for i := range oversize {
+		oversize[i] = 'a'
+	}
+	_, err = repo.Create(ctx, uuid.New(), uuid.New(), string(oversize))
+	if !errors.Is(err, marketplace.ErrInvalidReason) {
+		t.Errorf("oversize reason: want ErrInvalidReason, got %v", err)
+	}
+}
+
+// TestReportsRepository_TransitionStateMachine drives a report through
+// the legal chain (open -> reviewing -> resolved) and asserts the illegal
+// shortcut (open -> resolved) is rejected.
+func TestReportsRepository_TransitionStateMachine(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+	f := seedModFixture(ctx, t, pool, "trans")
+
+	repo := marketplace.NewReports(pool)
+	rep, err := repo.Create(ctx, f.KBID, f.UserID, "transition test")
+	if err != nil {
+		t.Fatalf("create report: %v", err)
+	}
+	if rep.Status != marketplace.ReportStatusOpen {
+		t.Fatalf("initial status: want %q, got %q", marketplace.ReportStatusOpen, rep.Status)
+	}
+
+	// Illegal shortcut.
+	err = repo.Transition(ctx, rep.ID, marketplace.ReportStatusResolved)
+	if !errors.Is(err, marketplace.ErrIllegalTransition) {
+		t.Errorf("open -> resolved: want ErrIllegalTransition, got %v", err)
+	}
+
+	// Legal chain.
+	if err := repo.Transition(ctx, rep.ID, marketplace.ReportStatusReviewing); err != nil {
+		t.Fatalf("open -> reviewing: %v", err)
+	}
+	if err := repo.Transition(ctx, rep.ID, marketplace.ReportStatusResolved); err != nil {
+		t.Fatalf("reviewing -> resolved: %v", err)
+	}
+
+	// Terminal state: any further transition is illegal.
+	err = repo.Transition(ctx, rep.ID, marketplace.ReportStatusDismissed)
+	if !errors.Is(err, marketplace.ErrIllegalTransition) {
+		t.Errorf("resolved -> dismissed: want ErrIllegalTransition, got %v", err)
+	}
+
+	// Unknown id.
+	err = repo.Transition(ctx, uuid.New(), marketplace.ReportStatusReviewing)
+	if !errors.Is(err, marketplace.ErrReportNotFound) {
+		t.Errorf("unknown id: want ErrReportNotFound, got %v", err)
+	}
+
+	// Invalid newStatus.
+	err = repo.Transition(ctx, rep.ID, marketplace.ReportStatus("garbage"))
+	if !errors.Is(err, marketplace.ErrInvalidReportStatus) {
+		t.Errorf("invalid status: want ErrInvalidReportStatus, got %v", err)
+	}
+}
+
+// TestReportsRepository_CascadeOnKBDelete verifies that deleting the KB
+// row hard-cascades to its reports (FK ON DELETE CASCADE).
+func TestReportsRepository_CascadeOnKBDelete(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+	f := seedModFixture(ctx, t, pool, "cascade")
+
+	reports := marketplace.NewReports(pool)
+	tdowns := marketplace.NewTakedowns(pool)
+
+	if _, err := reports.Create(ctx, f.KBID, f.UserID, "report before cascade"); err != nil {
+		t.Fatalf("create report: %v", err)
+	}
+	if _, err := tdowns.Create(ctx, f.KBID, marketplace.TakedownSourceAdmin, "before cascade"); err != nil {
+		t.Fatalf("create takedown: %v", err)
+	}
+
+	// Delete the KB. ON DELETE CASCADE on both FKs should erase the rows.
+	if _, err := pool.Exec(ctx, `DELETE FROM knowledge_bases WHERE id = $1`, f.KBID); err != nil {
+		t.Fatalf("delete kb: %v", err)
+	}
+
+	var reportCount, takedownCount int
+	if err := pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM marketplace_reports WHERE reported_kb_id = $1`, f.KBID,
+	).Scan(&reportCount); err != nil {
+		t.Fatalf("count reports after cascade: %v", err)
+	}
+	if reportCount != 0 {
+		t.Errorf("reports after KB cascade: want 0, got %d", reportCount)
+	}
+	if err := pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM marketplace_takedowns WHERE target_kb_id = $1`, f.KBID,
+	).Scan(&takedownCount); err != nil {
+		t.Fatalf("count takedowns after cascade: %v", err)
+	}
+	if takedownCount != 0 {
+		t.Errorf("takedowns after KB cascade: want 0, got %d", takedownCount)
+	}
+}
+
+// TestTakedownsRepository_CreateAndList exercises Create + ListForKB and
+// verifies the source CHECK constraint via ErrInvalidTakedownSource.
+func TestTakedownsRepository_CreateAndList(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+	f := seedModFixture(ctx, t, pool, "td")
+
+	repo := marketplace.NewTakedowns(pool)
+
+	// Invalid source is rejected before any SQL round-trip.
+	if _, err := repo.Create(ctx, f.KBID, marketplace.TakedownSource("badsource"), ""); !errors.Is(err, marketplace.ErrInvalidTakedownSource) {
+		t.Errorf("bad source: want ErrInvalidTakedownSource, got %v", err)
+	}
+
+	// Three legal sources, one with notes, one without.
+	if _, err := repo.Create(ctx, f.KBID, marketplace.TakedownSourcePublisher, ""); err != nil {
+		t.Fatalf("create publisher: %v", err)
+	}
+	if _, err := repo.Create(ctx, f.KBID, marketplace.TakedownSourceAdmin, "report #42 confirmed"); err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+	if _, err := repo.Create(ctx, f.KBID, marketplace.TakedownSourceDMCA, "DMCA notice 2026-06-01"); err != nil {
+		t.Fatalf("create dmca: %v", err)
+	}
+
+	tds, err := repo.ListForKB(ctx, f.KBID)
+	if err != nil {
+		t.Fatalf("ListForKB: %v", err)
+	}
+	if len(tds) != 3 {
+		t.Fatalf("want 3 takedowns, got %d", len(tds))
+	}
+
+	// Order: created_at ASC. Publisher was inserted first.
+	if tds[0].Source != marketplace.TakedownSourcePublisher {
+		t.Errorf("tds[0].Source: want publisher, got %q", tds[0].Source)
+	}
+	if tds[0].Notes != "" {
+		t.Errorf("tds[0].Notes: want empty, got %q", tds[0].Notes)
+	}
+	if tds[1].Source != marketplace.TakedownSourceAdmin {
+		t.Errorf("tds[1].Source: want admin, got %q", tds[1].Source)
+	}
+	if tds[1].Notes != "report #42 confirmed" {
+		t.Errorf("tds[1].Notes: %q", tds[1].Notes)
+	}
+}
+
+// TestReportsRepository_ReporterCleanupSetsNull verifies that deleting
+// the reporter user (ON DELETE SET NULL) anonymises the report rather
+// than cascading it. This protects the audit trail per ADR-0006.
+func TestReportsRepository_ReporterCleanupSetsNull(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+	f := seedModFixture(ctx, t, pool, "anon")
+
+	repo := marketplace.NewReports(pool)
+	rep, err := repo.Create(ctx, f.KBID, f.UserID, "anonymise me")
+	if err != nil {
+		t.Fatalf("create report: %v", err)
+	}
+
+	if _, err := pool.Exec(ctx, `DELETE FROM users WHERE id = $1`, f.UserID); err != nil {
+		t.Fatalf("delete user: %v", err)
+	}
+
+	var reporter *uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`SELECT reporter_user_id FROM marketplace_reports WHERE id = $1`,
+		rep.ID,
+	).Scan(&reporter); err != nil {
+		t.Fatalf("read reporter after user delete: %v", err)
+	}
+	if reporter != nil {
+		t.Errorf("reporter_user_id: want NULL, got %v", *reporter)
+	}
+}

--- a/internal/marketplace/moderation_test.go
+++ b/internal/marketplace/moderation_test.go
@@ -1,0 +1,138 @@
+package marketplace_test
+
+import (
+	"testing"
+
+	"github.com/ravencloak-org/Raven/internal/marketplace"
+)
+
+// TestReportStatusIsValid documents which strings are accepted as a
+// ReportStatus. The CHECK constraint in migration 00053 must accept
+// exactly the same set; the DB-backed migration test below pins that.
+func TestReportStatusIsValid(t *testing.T) {
+	t.Parallel()
+	good := []marketplace.ReportStatus{
+		marketplace.ReportStatusOpen,
+		marketplace.ReportStatusReviewing,
+		marketplace.ReportStatusResolved,
+		marketplace.ReportStatusDismissed,
+	}
+	for _, s := range good {
+		if !s.IsValid() {
+			t.Errorf("IsValid(%q) = false, want true", s)
+		}
+	}
+	bad := []marketplace.ReportStatus{"", "OPEN", "approved", "rejected", "pending"}
+	for _, s := range bad {
+		if s.IsValid() {
+			t.Errorf("IsValid(%q) = true, want false", s)
+		}
+	}
+}
+
+// TestReportStatusIsTerminal pins which states are terminal. A regression
+// here is interesting: adding a new state must declare its terminal-ness
+// explicitly, or transitions stop being closed under the state machine.
+func TestReportStatusIsTerminal(t *testing.T) {
+	t.Parallel()
+	cases := map[marketplace.ReportStatus]bool{
+		marketplace.ReportStatusOpen:       false,
+		marketplace.ReportStatusReviewing:  false,
+		marketplace.ReportStatusResolved:   true,
+		marketplace.ReportStatusDismissed:  true,
+	}
+	for s, want := range cases {
+		if got := s.IsTerminal(); got != want {
+			t.Errorf("IsTerminal(%q) = %v, want %v", s, got, want)
+		}
+	}
+}
+
+// TestCanTransition exhaustively pins the legal state-machine moves. Any
+// future change to reportTransitions MUST update this table — the test is
+// the canonical reference for "which moves does the moderation API accept".
+func TestCanTransition(t *testing.T) {
+	t.Parallel()
+	type move struct {
+		from marketplace.ReportStatus
+		to   marketplace.ReportStatus
+		ok   bool
+	}
+	// 16 cells (4 x 4): every from x to combination, including self-edges.
+	// Encoding the full grid prevents drift between the table in
+	// moderation.go and the test's intent.
+	all := []marketplace.ReportStatus{
+		marketplace.ReportStatusOpen,
+		marketplace.ReportStatusReviewing,
+		marketplace.ReportStatusResolved,
+		marketplace.ReportStatusDismissed,
+	}
+	legal := map[marketplace.ReportStatus]map[marketplace.ReportStatus]struct{}{
+		marketplace.ReportStatusOpen: {
+			marketplace.ReportStatusReviewing: {},
+		},
+		marketplace.ReportStatusReviewing: {
+			marketplace.ReportStatusResolved:  {},
+			marketplace.ReportStatusDismissed: {},
+		},
+	}
+
+	var moves []move
+	for _, from := range all {
+		for _, to := range all {
+			_, ok := legal[from][to]
+			moves = append(moves, move{from: from, to: to, ok: ok})
+		}
+	}
+
+	// Self-edges (open -> open, etc.) are illegal: there is no benefit to
+	// modelling a no-op transition. The grid above already encodes that
+	// since `legal` has no self-entries.
+	for _, m := range moves {
+		got := marketplace.CanTransition(m.from, m.to)
+		if got != m.ok {
+			t.Errorf("CanTransition(%q -> %q) = %v, want %v", m.from, m.to, got, m.ok)
+		}
+	}
+
+	// Invalid status values must always reject.
+	bad := marketplace.ReportStatus("garbage")
+	if marketplace.CanTransition(bad, marketplace.ReportStatusOpen) {
+		t.Error("CanTransition(garbage -> open) should be false")
+	}
+	if marketplace.CanTransition(marketplace.ReportStatusOpen, bad) {
+		t.Error("CanTransition(open -> garbage) should be false")
+	}
+}
+
+// TestTakedownSourceIsValid pins the three legal source strings. CHECK
+// constraint parity is asserted by the DB-backed migration test below.
+func TestTakedownSourceIsValid(t *testing.T) {
+	t.Parallel()
+	good := []marketplace.TakedownSource{
+		marketplace.TakedownSourcePublisher,
+		marketplace.TakedownSourceAdmin,
+		marketplace.TakedownSourceDMCA,
+	}
+	for _, s := range good {
+		if !s.IsValid() {
+			t.Errorf("IsValid(%q) = false, want true", s)
+		}
+	}
+	bad := []marketplace.TakedownSource{"", "ADMIN", "user", "moderator", "system"}
+	for _, s := range bad {
+		if s.IsValid() {
+			t.Errorf("IsValid(%q) = true, want false", s)
+		}
+	}
+}
+
+// TestMaxOpenReportsPerUser is a sanity gate on the rate-limit constant.
+// If a future change wants to tune this number, the test must move with
+// it — and the diff makes the tuning visible in code review.
+func TestMaxOpenReportsPerUser(t *testing.T) {
+	t.Parallel()
+	if marketplace.MaxOpenReportsPerUser != 5 {
+		t.Errorf("MaxOpenReportsPerUser changed: want 5, got %d", marketplace.MaxOpenReportsPerUser)
+	}
+}

--- a/internal/marketplace/reports.go
+++ b/internal/marketplace/reports.go
@@ -1,0 +1,227 @@
+package marketplace
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Reports is the data-access repository for the marketplace_reports table.
+//
+// Construction takes a pgxpool.Pool; the repository does NOT manage
+// transactions itself — callers wrap related operations (e.g. "create
+// report and increment strike on KB" in #735's admin approval path) in
+// their own pgx.Tx. The repository's job is one statement per method.
+//
+// RLS: every method runs under the caller's existing session context. The
+// migration 00053 policies make a reporter see only their own rows; the
+// admin path (List) MUST be called from a session that has switched to
+// the raven_admin role — the repository does NOT change roles for you.
+type Reports struct {
+	pool *pgxpool.Pool
+}
+
+// NewReports returns a Reports repository backed by the given pool.
+func NewReports(pool *pgxpool.Pool) *Reports {
+	return &Reports{pool: pool}
+}
+
+// Create inserts a new report against kbID submitted by userID with the
+// given free-text reason. Returns ErrInvalidReason if reason is empty or
+// over 4000 chars, ErrRateLimit if the user already has MaxOpenReportsPerUser
+// reports in the 'open' state, and any underlying pgx error otherwise.
+//
+// The rate-limit check and the INSERT run in a single transaction so a
+// concurrent burst of submissions cannot slip past the cap (read-then-write
+// without a transaction would race).
+func (r *Reports) Create(ctx context.Context, kbID, userID uuid.UUID, reason string) (Report, error) {
+	// Validate before opening a transaction — a malformed reason should
+	// never even touch the connection pool.
+	if l := len(reason); l < 1 || l > 4000 {
+		return Report{}, ErrInvalidReason
+	}
+
+	tx, err := r.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return Report{}, fmt.Errorf("Reports.Create: begin: %w", err)
+	}
+	// Rollback is a no-op if Commit succeeded.
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// Per-user rate limit. Count the user's OPEN reports — once one moves
+	// to reviewing/resolved/dismissed it stops counting against the cap,
+	// which is the right shape: the limit exists so an attacker cannot
+	// flood the review queue, and once admins process a row that pressure
+	// is gone.
+	var openCount int
+	if err := tx.QueryRow(ctx,
+		`SELECT COUNT(*) FROM marketplace_reports
+		 WHERE reporter_user_id = $1 AND status = $2`,
+		userID, ReportStatusOpen,
+	).Scan(&openCount); err != nil {
+		return Report{}, fmt.Errorf("Reports.Create: count open: %w", err)
+	}
+	if openCount >= MaxOpenReportsPerUser {
+		return Report{}, ErrRateLimit
+	}
+
+	var rep Report
+	var reporter uuid.NullUUID
+	if err := tx.QueryRow(ctx,
+		`INSERT INTO marketplace_reports
+		   (reported_kb_id, reporter_user_id, reason)
+		 VALUES ($1, $2, $3)
+		 RETURNING id, reported_kb_id, reporter_user_id, reason, status, created_at`,
+		kbID, userID, reason,
+	).Scan(&rep.ID, &rep.ReportedKBID, &reporter, &rep.Reason, &rep.Status, &rep.CreatedAt); err != nil {
+		return Report{}, fmt.Errorf("Reports.Create: insert: %w", err)
+	}
+	if reporter.Valid {
+		uid := reporter.UUID
+		rep.ReporterUserID = &uid
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return Report{}, fmt.Errorf("Reports.Create: commit: %w", err)
+	}
+	return rep, nil
+}
+
+// List returns reports filtered by status, ordered by created_at ASC
+// (oldest first — the review queue is FIFO).
+//
+// This is the admin path. The caller MUST be running under the raven_admin
+// role so the admin_bypass RLS policy lets the SELECT see every row.
+// Calling this from a non-admin session silently returns the caller's own
+// rows only — that is a per-RLS guarantee, not a bug, but the API surface
+// in #735 is admin-only by HTTP gating.
+//
+// status must be one of the four legal ReportStatus values; an empty or
+// invalid status returns ErrInvalidReportStatus. limit must be > 0; offset
+// must be >= 0. These bounds are validated here so the SQL never sees
+// a malformed pagination request.
+func (r *Reports) List(ctx context.Context, status ReportStatus, limit, offset int) ([]Report, error) {
+	if !status.IsValid() {
+		return nil, ErrInvalidReportStatus
+	}
+	if limit <= 0 {
+		return nil, fmt.Errorf("Reports.List: limit must be positive, got %d", limit)
+	}
+	if offset < 0 {
+		return nil, fmt.Errorf("Reports.List: offset must be non-negative, got %d", offset)
+	}
+
+	rows, err := r.pool.Query(ctx,
+		`SELECT id, reported_kb_id, reporter_user_id, reason, status, created_at
+		 FROM marketplace_reports
+		 WHERE status = $1
+		 ORDER BY created_at ASC
+		 LIMIT $2 OFFSET $3`,
+		status, limit, offset,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("Reports.List: query: %w", err)
+	}
+	defer rows.Close()
+
+	// Pre-allocate to `limit` to avoid repeated slice growth on the
+	// happy path where the result fills the page.
+	out := make([]Report, 0, limit)
+	for rows.Next() {
+		var rep Report
+		var reporter uuid.NullUUID
+		if err := rows.Scan(
+			&rep.ID, &rep.ReportedKBID, &reporter,
+			&rep.Reason, &rep.Status, &rep.CreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("Reports.List: scan: %w", err)
+		}
+		if reporter.Valid {
+			uid := reporter.UUID
+			rep.ReporterUserID = &uid
+		}
+		out = append(out, rep)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("Reports.List: rows: %w", err)
+	}
+	return out, nil
+}
+
+// Transition moves report id from its current status to newStatus, but
+// only if (current -> newStatus) is a legal state-machine move. Returns:
+//
+//   - ErrInvalidReportStatus if newStatus is not a valid status.
+//   - ErrReportNotFound if no report with the given id is visible to the
+//     caller (or does not exist at all).
+//   - ErrIllegalTransition if the move is not legal per reportTransitions.
+//   - Any pgx error from the SELECT/UPDATE round-trip otherwise.
+//
+// Performed in a transaction with FOR UPDATE so a concurrent transition
+// attempt against the same report cannot race (e.g. two admins clicking
+// "Resolve" simultaneously).
+func (r *Reports) Transition(ctx context.Context, id uuid.UUID, newStatus ReportStatus) error {
+	if !newStatus.IsValid() {
+		return ErrInvalidReportStatus
+	}
+
+	tx, err := r.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("Reports.Transition: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var current ReportStatus
+	if err := tx.QueryRow(ctx,
+		`SELECT status FROM marketplace_reports WHERE id = $1 FOR UPDATE`,
+		id,
+	).Scan(&current); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrReportNotFound
+		}
+		return fmt.Errorf("Reports.Transition: load current: %w", err)
+	}
+
+	// Defensive: a status pulled from the DB that does not match the Go
+	// enum means the schema has drifted (or someone bypassed the CHECK
+	// with SET session_replication_role = replica). Refuse to act.
+	if !current.IsValid() {
+		return fmt.Errorf("%w: stored value %q", ErrInvalidReportStatus, current)
+	}
+
+	if !CanTransition(current, newStatus) {
+		return fmt.Errorf("%w: from=%s to=%s", ErrIllegalTransition, current, newStatus)
+	}
+
+	if _, err := tx.Exec(ctx,
+		`UPDATE marketplace_reports SET status = $2 WHERE id = $1`,
+		id, newStatus,
+	); err != nil {
+		return fmt.Errorf("Reports.Transition: update: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("Reports.Transition: commit: %w", err)
+	}
+	return nil
+}
+
+// CountOpenForUser returns the number of reports in the OPEN state for
+// the given user. Exposed as a helper for callers that want to surface a
+// "you have N open reports" UI hint before submission — Create runs the
+// same count inside its transaction so this method is purely advisory.
+func (r *Reports) CountOpenForUser(ctx context.Context, userID uuid.UUID) (int, error) {
+	var n int
+	if err := r.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM marketplace_reports
+		 WHERE reporter_user_id = $1 AND status = $2`,
+		userID, ReportStatusOpen,
+	).Scan(&n); err != nil {
+		return 0, fmt.Errorf("Reports.CountOpenForUser: %w", err)
+	}
+	return n, nil
+}

--- a/internal/marketplace/takedowns.go
+++ b/internal/marketplace/takedowns.go
@@ -1,0 +1,103 @@
+package marketplace
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Takedowns is the data-access repository for the marketplace_takedowns
+// table — the append-only audit log for KB removals (ADR-0006).
+//
+// RLS: every method runs under the caller's session context. The migration
+// 00053 policy is admin-only (no non-admin policy is defined), so a
+// non-admin session sees zero rows from List and cannot write via Create
+// (RLS would silently elide the insert). Callers MUST switch to raven_admin
+// before calling these methods.
+type Takedowns struct {
+	pool *pgxpool.Pool
+}
+
+// NewTakedowns returns a Takedowns repository backed by the given pool.
+func NewTakedowns(pool *pgxpool.Pool) *Takedowns {
+	return &Takedowns{pool: pool}
+}
+
+// Create inserts a new takedown audit-log row against kbID with the given
+// source and notes. Notes may be empty (stored as NULL); a non-empty notes
+// string is stored verbatim.
+//
+// Returns ErrInvalidTakedownSource if source is not one of the three legal
+// TakedownSource values; any pgx error from the round-trip otherwise.
+//
+// Append-only — there is no Update path. If a takedown row was created
+// in error, the correction is a new row with an explanatory note.
+func (t *Takedowns) Create(ctx context.Context, kbID uuid.UUID, source TakedownSource, notes string) (Takedown, error) {
+	if !source.IsValid() {
+		return Takedown{}, ErrInvalidTakedownSource
+	}
+
+	// Map empty notes to a SQL NULL so the column reflects "no note" rather
+	// than the empty string. The Notes field on the returned struct is
+	// always a Go string for ergonomic reasons — empty == NULL on read.
+	var notesArg any
+	if notes != "" {
+		notesArg = notes
+	}
+
+	var td Takedown
+	var storedNotes *string
+	if err := t.pool.QueryRow(ctx,
+		`INSERT INTO marketplace_takedowns
+		   (target_kb_id, source, notes)
+		 VALUES ($1, $2, $3)
+		 RETURNING id, target_kb_id, source, notes, created_at`,
+		kbID, source, notesArg,
+	).Scan(&td.ID, &td.TargetKBID, &td.Source, &storedNotes, &td.CreatedAt); err != nil {
+		return Takedown{}, fmt.Errorf("Takedowns.Create: insert: %w", err)
+	}
+	if storedNotes != nil {
+		td.Notes = *storedNotes
+	}
+	return td, nil
+}
+
+// ListForKB returns every takedown audit-log row for the given KB,
+// ordered by created_at ASC (oldest first — the audit log reads forward
+// through history). The slice is nil-on-empty; callers using `len()` get
+// 0 in both cases.
+//
+// Admin-only (see package doc). The HTTP gate in #735 enforces this at
+// the handler layer; the RLS policy is the in-database backstop.
+func (t *Takedowns) ListForKB(ctx context.Context, kbID uuid.UUID) ([]Takedown, error) {
+	rows, err := t.pool.Query(ctx,
+		`SELECT id, target_kb_id, source, notes, created_at
+		 FROM marketplace_takedowns
+		 WHERE target_kb_id = $1
+		 ORDER BY created_at ASC`,
+		kbID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("Takedowns.ListForKB: query: %w", err)
+	}
+	defer rows.Close()
+
+	var out []Takedown
+	for rows.Next() {
+		var td Takedown
+		var notes *string
+		if err := rows.Scan(&td.ID, &td.TargetKBID, &td.Source, &notes, &td.CreatedAt); err != nil {
+			return nil, fmt.Errorf("Takedowns.ListForKB: scan: %w", err)
+		}
+		if notes != nil {
+			td.Notes = *notes
+		}
+		out = append(out, td)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("Takedowns.ListForKB: rows: %w", err)
+	}
+	return out, nil
+}

--- a/migrations/00053_marketplace_moderation.sql
+++ b/migrations/00053_marketplace_moderation.sql
@@ -1,0 +1,135 @@
+-- +goose Up
+--
+-- Marketplace MVP (issue #733, M3).
+--
+-- Stand up the moderation backbone for Public KBs:
+--
+--   - marketplace_reports — user-submitted abuse reports against a Public KB.
+--     A reporter sees only their own rows; raven_admin bypasses RLS for the
+--     review queue. Status is a finite state machine:
+--         open -> reviewing -> { resolved | dismissed }
+--     enforced both by a CHECK constraint (data integrity backstop) and by
+--     the Go repository's Transition helper (structured diagnostics — see
+--     internal/marketplace/moderation.go).
+--
+--   - marketplace_takedowns — append-only audit log for KB removals. The
+--     "source" column attributes the removal to a publisher (self-takedown),
+--     an admin action (report-driven), or a DMCA notice. Admin-only read and
+--     write — non-admin sessions cannot even see this table.
+--
+-- Out of scope for this migration (deliberately):
+--   - organizations.takedown_strikes — landed by issue #726 / migration 00050.
+--   - knowledge_bases.license_spdx_id CHECK constraint — landed by #726 / 00050.
+--   - kb_status enum values 'read_only_private' / 'dmca_pending' — already
+--     in place from migration 00049.
+--
+-- See:
+--   docs/plans/marketplace-mvp.md §2 (00053_marketplace_moderation.sql)
+--   docs/adr/0006-licence-and-moderation.md (report / takedown semantics)
+--   docs/adr/0008-marketplace-discovery-and-operations.md (admin queue)
+--   migrations/00015_rls_policies.sql (tenant_isolation + admin_bypass pattern)
+
+-- ─── marketplace_reports ─────────────────────────────────────────────────────
+--
+-- One row per report submission. The reporter is referenced as a nullable
+-- FK with ON DELETE SET NULL so a user-deletion cascade does not erase
+-- the audit trail — the report row survives, its reporter is anonymised.
+-- The reported KB cascades on delete: if the underlying KB is dropped,
+-- the report has no target and is moot.
+--
+-- reason length is capped to keep abusive payloads from blowing up rows;
+-- the lower bound of 1 forces callers to send a non-empty reason rather
+-- than silently bypassing the CHECK with an empty string.
+
+CREATE TABLE marketplace_reports (
+    id               UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    reported_kb_id   UUID NOT NULL REFERENCES knowledge_bases(id) ON DELETE CASCADE,
+    reporter_user_id UUID NULL REFERENCES users(id) ON DELETE SET NULL,
+    reason           TEXT NOT NULL
+                     CHECK (length(reason) BETWEEN 1 AND 4000),
+    status           TEXT NOT NULL DEFAULT 'open'
+                     CHECK (status IN ('open', 'reviewing', 'resolved', 'dismissed')),
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Status filter index: the admin review queue's primary query is
+-- `WHERE status = 'open' ORDER BY created_at`, with occasional sweeps for
+-- `reviewing`. A full b-tree on status is cheap on a low-cardinality
+-- column and lets the planner pick it for both queries.
+CREATE INDEX idx_marketplace_reports_status
+    ON marketplace_reports (status);
+
+-- KB-target lookup: when admins approve a report, they look up "are there
+-- other open reports against this same KB?" (de-duplicate strike events)
+-- via reported_kb_id; the rate-limit helper in moderation.go uses
+-- reporter_user_id but a single-column status-filter index covers that.
+CREATE INDEX idx_marketplace_reports_kb
+    ON marketplace_reports (reported_kb_id);
+
+ALTER TABLE marketplace_reports ENABLE ROW LEVEL SECURITY;
+
+-- Reporter sees own rows. We use a NULL-tolerant cast — if the session
+-- variable is unset, current_setting returns the empty string (with the
+-- `true` missing_ok flag), nullif maps that to NULL, and the cast yields
+-- NULL — which never equals reporter_user_id, so the policy denies.
+CREATE POLICY reporter_self_read ON marketplace_reports
+    FOR ALL
+    USING (
+        reporter_user_id = nullif(current_setting('app.current_user_id', true), '')::uuid
+    )
+    WITH CHECK (
+        reporter_user_id = nullif(current_setting('app.current_user_id', true), '')::uuid
+    );
+
+-- raven_admin bypass — the review queue handler runs as raven_admin and
+-- needs to see every report regardless of reporter.
+CREATE POLICY admin_bypass ON marketplace_reports
+    FOR ALL TO raven_admin
+    USING (true);
+
+-- ─── marketplace_takedowns ───────────────────────────────────────────────────
+--
+-- Append-only audit log. There is no "update a takedown" path — corrections
+-- are made by inserting a new row referencing the same target KB with a
+-- note explaining the correction. This keeps the log forensically clean.
+--
+-- target_kb_id cascades on delete: when a KB row is hard-deleted, its
+-- takedown log entries go with it (the publisher Org's strike counter on
+-- the organizations row survives — that is the durable record).
+
+CREATE TABLE marketplace_takedowns (
+    id           UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    target_kb_id UUID NOT NULL REFERENCES knowledge_bases(id) ON DELETE CASCADE,
+    source       TEXT NOT NULL
+                 CHECK (source IN ('publisher', 'admin', 'dmca')),
+    notes        TEXT NULL,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Per-KB lookup: "show me the takedown history for this KB". The
+-- admin/takedowns view filters by target_kb_id; no other access pattern
+-- is in-scope.
+CREATE INDEX idx_marketplace_takedowns_target_kb
+    ON marketplace_takedowns (target_kb_id);
+
+ALTER TABLE marketplace_takedowns ENABLE ROW LEVEL SECURITY;
+
+-- Admin-only read+write. No tenant policy is defined — non-admin sessions
+-- see zero rows because no USING clause matches. This is the correct
+-- shape for an internal-only audit log per ADR-0008 §Consequences.
+CREATE POLICY admin_bypass ON marketplace_takedowns
+    FOR ALL TO raven_admin
+    USING (true);
+
+-- +goose Down
+--
+-- Reverse in dependency order: policies → indexes → tables.
+DROP POLICY IF EXISTS admin_bypass ON marketplace_takedowns;
+DROP INDEX IF EXISTS idx_marketplace_takedowns_target_kb;
+DROP TABLE IF EXISTS marketplace_takedowns;
+
+DROP POLICY IF EXISTS admin_bypass ON marketplace_reports;
+DROP POLICY IF EXISTS reporter_self_read ON marketplace_reports;
+DROP INDEX IF EXISTS idx_marketplace_reports_kb;
+DROP INDEX IF EXISTS idx_marketplace_reports_status;
+DROP TABLE IF EXISTS marketplace_reports;

--- a/migrations/migrations_test.go
+++ b/migrations/migrations_test.go
@@ -599,6 +599,181 @@ func TestMigrationsUpAndDown(t *testing.T) {
 		}
 	})
 
+	t.Run("marketplace_moderation_schema", func(t *testing.T) {
+		// Migration 00053 (issue #733): marketplace_reports +
+		// marketplace_takedowns, two RLS-gated tables plus three indexes.
+		//
+		// This sub-test asserts:
+		//   1. Both tables exist.
+		//   2. Both have RLS enabled.
+		//   3. The three indexes (status, kb, target_kb) are present.
+		//   4. The CHECK constraints reject illegal status / source values
+		//      and out-of-range reason lengths.
+		//   5. ON DELETE CASCADE on reported_kb_id / target_kb_id fires
+		//      when the parent KB is deleted.
+
+		for _, table := range []string{"marketplace_reports", "marketplace_takedowns"} {
+			var exists bool
+			if err := db.QueryRowContext(ctx,
+				`SELECT EXISTS (
+				    SELECT 1 FROM information_schema.tables
+				    WHERE table_schema = 'public' AND table_name = $1
+				 )`, table).Scan(&exists); err != nil {
+				t.Errorf("check table %s: %v", table, err)
+			}
+			if !exists {
+				t.Errorf("expected table %s to exist", table)
+			}
+
+			var rlsEnabled bool
+			if err := db.QueryRowContext(ctx,
+				`SELECT relrowsecurity FROM pg_class WHERE relname = $1`,
+				table).Scan(&rlsEnabled); err != nil {
+				t.Errorf("check RLS for %s: %v", table, err)
+			}
+			if !rlsEnabled {
+				t.Errorf("expected RLS to be enabled on %s", table)
+			}
+		}
+
+		expectedIndexes := map[string]string{
+			"idx_marketplace_reports_status":      "marketplace_reports",
+			"idx_marketplace_reports_kb":          "marketplace_reports",
+			"idx_marketplace_takedowns_target_kb": "marketplace_takedowns",
+		}
+		for idx, table := range expectedIndexes {
+			var exists bool
+			if err := db.QueryRowContext(ctx,
+				`SELECT EXISTS (SELECT 1 FROM pg_indexes
+				 WHERE tablename = $1 AND indexname = $2)`, table, idx).
+				Scan(&exists); err != nil {
+				t.Errorf("check index %s on %s: %v", idx, table, err)
+			}
+			if !exists {
+				t.Errorf("expected index %s on %s", idx, table)
+			}
+		}
+
+		// Expected RLS policies. The reporter_self_read policy on
+		// marketplace_reports gates the reporter view; admin_bypass on
+		// both tables gates the raven_admin review queue.
+		expectedPolicies := map[string][]string{
+			"marketplace_reports":   {"reporter_self_read", "admin_bypass"},
+			"marketplace_takedowns": {"admin_bypass"},
+		}
+		for table, policies := range expectedPolicies {
+			for _, name := range policies {
+				var exists bool
+				if err := db.QueryRowContext(ctx,
+					`SELECT EXISTS (
+					    SELECT 1 FROM pg_policies
+					    WHERE schemaname = 'public'
+					      AND tablename = $1
+					      AND policyname = $2
+					 )`, table, name).Scan(&exists); err != nil {
+					t.Errorf("check policy %s on %s: %v", name, table, err)
+				}
+				if !exists {
+					t.Errorf("expected policy %s on %s", name, table)
+				}
+			}
+		}
+
+		// Bootstrap an org, workspace, user, and KB so we can exercise
+		// the CHECK constraints and cascade behaviour.
+		var orgID, wsID, userID, kbID string
+		if err := db.QueryRowContext(ctx,
+			`INSERT INTO organizations (id, name, slug)
+			 VALUES (uuid_generate_v4(), 'Mod Org', 'mod-mig-org')
+			 RETURNING id`).Scan(&orgID); err != nil {
+			t.Fatalf("insert organization: %v", err)
+		}
+		if err := db.QueryRowContext(ctx,
+			`INSERT INTO workspaces (id, org_id, name, slug)
+			 VALUES (uuid_generate_v4(), $1, 'Mod WS', 'mod-mig-ws')
+			 RETURNING id`, orgID).Scan(&wsID); err != nil {
+			t.Fatalf("insert workspace: %v", err)
+		}
+		if err := db.QueryRowContext(ctx,
+			`INSERT INTO users (id, org_id, email, status)
+			 VALUES (uuid_generate_v4(), $1, 'mod-mig@example.com', 'active')
+			 RETURNING id`, orgID).Scan(&userID); err != nil {
+			t.Fatalf("insert user: %v", err)
+		}
+		if err := db.QueryRowContext(ctx,
+			`INSERT INTO knowledge_bases (id, org_id, workspace_id, name, slug)
+			 VALUES (uuid_generate_v4(), $1, $2, 'Mod KB', 'mod-mig-kb')
+			 RETURNING id`, orgID, wsID).Scan(&kbID); err != nil {
+			t.Fatalf("insert knowledge_base: %v", err)
+		}
+
+		// CHECK constraint: status must be in the four-value set.
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO marketplace_reports (reported_kb_id, reporter_user_id, reason, status)
+			 VALUES ($1, $2, 'bad', 'INVALID_STATE')`,
+			kbID, userID,
+		); err == nil {
+			t.Error("expected CHECK to reject invalid report status")
+		}
+
+		// CHECK constraint: reason must be 1..4000 chars.
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO marketplace_reports (reported_kb_id, reporter_user_id, reason)
+			 VALUES ($1, $2, '')`,
+			kbID, userID,
+		); err == nil {
+			t.Error("expected CHECK to reject empty reason")
+		}
+
+		// CHECK constraint: takedown source must be in the three-value set.
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO marketplace_takedowns (target_kb_id, source)
+			 VALUES ($1, 'badsource')`, kbID,
+		); err == nil {
+			t.Error("expected CHECK to reject invalid takedown source")
+		}
+
+		// Insert valid rows so we can test ON DELETE CASCADE.
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO marketplace_reports (reported_kb_id, reporter_user_id, reason)
+			 VALUES ($1, $2, 'cascade target')`, kbID, userID,
+		); err != nil {
+			t.Fatalf("insert valid report: %v", err)
+		}
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO marketplace_takedowns (target_kb_id, source, notes)
+			 VALUES ($1, 'admin', 'cascade target')`, kbID,
+		); err != nil {
+			t.Fatalf("insert valid takedown: %v", err)
+		}
+
+		if _, err := db.ExecContext(ctx,
+			`DELETE FROM knowledge_bases WHERE id = $1`, kbID,
+		); err != nil {
+			t.Fatalf("delete kb to trigger cascade: %v", err)
+		}
+
+		var reportCount, takedownCount int
+		if err := db.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM marketplace_reports WHERE reported_kb_id = $1`,
+			kbID,
+		).Scan(&reportCount); err != nil {
+			t.Fatalf("count reports after cascade: %v", err)
+		}
+		if reportCount != 0 {
+			t.Errorf("reports after KB cascade: want 0, got %d", reportCount)
+		}
+		if err := db.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM marketplace_takedowns WHERE target_kb_id = $1`,
+			kbID,
+		).Scan(&takedownCount); err != nil {
+			t.Fatalf("count takedowns after cascade: %v", err)
+		}
+		if takedownCount != 0 {
+			t.Errorf("takedowns after KB cascade: want 0, got %d", takedownCount)
+		}
+	})
+
 	// --- Run all migrations DOWN ---
 	t.Run("clean_rollback", func(t *testing.T) {
 		if err := goose.DownTo(db, migDir, 0); err != nil {


### PR DESCRIPTION
Closes #733.

## Summary

Stand up the moderation backbone for the Marketplace MVP (M3):

- **Migration `00053_marketplace_moderation.sql`** — `marketplace_reports`
  (reporter-scoped abuse queue) and `marketplace_takedowns` (admin-only
  append-only audit log). Indexes, CHECK constraints, and RLS policies as
  specified in the plan.
- **Go package `internal/marketplace`** — adds `moderation.go`,
  `reports.go`, `takedowns.go`. Canonical `ReportStatus` / `TakedownSource`
  enums, a code-side state-machine helper (`CanTransition`), per-user
  rate-limiter (`MaxOpenReportsPerUser = 5`), and a transactional
  `Reports.Transition` with `FOR UPDATE` to defeat concurrent admin races.
- **Tests** — pure-Go state-machine pinning, testcontainer-backed
  integration coverage of rate limit / illegal transitions / KB cascade /
  reporter anonymisation, plus the migrations test subtest asserting
  tables, RLS, indexes, CHECK constraints, and cascade behaviour.

## Out of scope

- `organizations.takedown_strikes` and the `license_spdx_id` partial CHECK
  are claimed by #726's migration 00050.
- `kb_status` enum values `read_only_private` / `dmca_pending` are already
  present from migration 00049.
- No HTTP handlers — those land in #734 / #735 / #736.

## References

- ADR-0006 — `docs/adr/0006-licence-and-moderation.md`
- ADR-0008 — `docs/adr/0008-marketplace-discovery-and-operations.md`
- Plan §2 — `docs/plans/marketplace-mvp.md`

## Self-review notes (thermo-nuclear)

- **Two tables vs one with a discriminator.** Two: distinct RLS shapes
  (reporter-scoped vs admin-only audit log), zero shared access patterns,
  distinct API surfaces. Combining would couple unrelated concerns.
- **State machine in code, not just CHECK.** Encoded in `reportTransitions`
  so callers get a structured `ErrIllegalTransition` instead of a
  SQLSTATE 23514. CHECK is the in-database backstop.
- **No file crosses 1k lines.** Largest touched file is
  `migrations/migrations_test.go` at 833 lines (was 658). All new package
  files under 330 lines.
- **No scattered status-string checks.** Single canonical `ReportStatus`
  type, all comparisons go through it. Same for `TakedownSource`.
- **Fixture DRY.** Refactored four DB-backed tests onto a shared
  `seedModFixture` helper after the first draft duplicated ~100 lines.

## Test plan

- [ ] `go test -short ./internal/marketplace/...` (state-machine unit tests)
- [ ] CI runs `go test ./migrations/...` and the full
      `internal/marketplace` suite under testcontainers
- [ ] `golangci-lint run --new-from-rev=origin/main ./...` clean locally