### PR TITLE
feat(marketplace): publish endpoint with SPDX license allow-list (#726)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -51,6 +51,7 @@ import (
 	"github.com/ravencloak-org/Raven/internal/resilience"
 	"github.com/ravencloak-org/Raven/internal/hyperswitch"
 	"github.com/ravencloak-org/Raven/internal/mail"
+	"github.com/ravencloak-org/Raven/internal/marketplace"
 	"github.com/ravencloak-org/Raven/internal/middleware"
 	"github.com/ravencloak-org/Raven/internal/model"
 	"github.com/ravencloak-org/Raven/internal/posthog"
@@ -518,7 +519,18 @@ func main() {
 	orgHandler := handler.NewOrgHandler(orgSvc, userRepo)
 	wsHandler := handler.NewWorkspaceHandler(wsSvc)
 	userHandler := handler.NewUserHandler(userSvc)
-	kbHandler := handler.NewKBHandler(kbSvc)
+	// Marketplace publish service (issue #726): owns the canonical
+	// publish boundary — license allow-list, status-gate freeze, atomic
+	// flip of visibility + publish metadata. Shares kbStatusGuard so the
+	// freeze policy used here matches every other write surface. The
+	// gate is wired via a closure so internal/marketplace does not pull
+	// in internal/service (which would create an import cycle through
+	// internal/repository → internal/marketplace).
+	publishGate := func(ctx context.Context, tx pgx.Tx, orgID, kbID string) error {
+		return kbStatusGuard.RequireInTx(ctx, tx, orgID, kbID, service.KBActionPublish)
+	}
+	publishSvc := marketplace.NewPublishService(pool, publishGate)
+	kbHandler := handler.NewKBHandler(kbSvc).WithPublisher(publishSvc)
 	sourceHandler := handler.NewSourceHandler(sourceSvc)
 	docHandler := handler.NewDocumentHandler(docSvc)
 	searchHandler := handler.NewSearchHandler(searchSvc)
@@ -702,6 +714,11 @@ func main() {
 				kb.GET("/:kb_id", kbHandler.Get)
 				kb.PUT("/:kb_id", resolveWSRole, middleware.RequireWorkspaceRole("member"), kbHandler.Update)
 				kb.DELETE("/:kb_id", resolveWSRole, middleware.RequireWorkspaceRole("admin"), kbHandler.Archive)
+				// Marketplace publish (issue #726, ADR-0002). Admin role is
+				// Raven's equivalent of the kb:publish permission — same
+				// gate as Archive since publishing is an irreversible-ish
+				// content-grade action.
+				kb.POST("/:kb_id/publish", resolveWSRole, middleware.RequireWorkspaceRole("admin"), kbHandler.Publish)
 
 				// Full-text search (nested under knowledge base)
 				kb.GET("/:kb_id/search", searchHandler.Search)

--- a/internal/handler/kb.go
+++ b/internal/handler/kb.go
@@ -7,6 +7,8 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/samber/lo"
 
+	"github.com/ravencloak-org/Raven/internal/marketplace"
+	"github.com/ravencloak-org/Raven/internal/middleware"
 	"github.com/ravencloak-org/Raven/internal/model"
 	"github.com/ravencloak-org/Raven/pkg/apierror"
 )
@@ -20,14 +22,42 @@ type KBServicer interface {
 	Archive(ctx context.Context, orgID, kbID string) error
 }
 
-// KBHandler handles HTTP requests for knowledge base management.
-type KBHandler struct {
-	svc KBServicer
+// KBPublisher is the narrow slice of marketplace.PublishService the KB
+// handler needs. Defined here so handler unit tests can pass a stub
+// without dragging the full pgxpool wiring into the test harness.
+type KBPublisher interface {
+	PublishKB(ctx context.Context, orgID, kbID, userID, licenseSPDXID string) (*marketplace.PublishResult, error)
 }
 
-// NewKBHandler creates a new KBHandler.
+// PublishKBRequest is the payload for POST .../knowledge-bases/{id}/publish.
+// The SPDX identifier is required and is validated against the canonical
+// allow-list in marketplace.IsAllowedLicense — the binding tag only catches
+// the empty-string case.
+type PublishKBRequest struct {
+	LicenseSPDXID string `json:"license_spdx_id" binding:"required"`
+}
+
+// KBHandler handles HTTP requests for knowledge base management.
+type KBHandler struct {
+	svc       KBServicer
+	publisher KBPublisher
+}
+
+// NewKBHandler creates a new KBHandler. The publisher is optional and may
+// be left nil in test wiring that does not exercise the publish path; the
+// Publish handler short-circuits with 500 when it is nil so the missing
+// dependency surfaces loudly rather than as a confusing 404.
 func NewKBHandler(svc KBServicer) *KBHandler {
 	return &KBHandler{svc: svc}
+}
+
+// WithPublisher wires the Marketplace publish service. Kept as an
+// after-construction setter so existing callers of NewKBHandler don't
+// have to be touched and so the handler tests can opt in to the publish
+// path with a stub.
+func (h *KBHandler) WithPublisher(p KBPublisher) *KBHandler {
+	h.publisher = p
+	return h
 }
 
 // Create handles POST /api/v1/orgs/:org_id/workspaces/:ws_id/knowledge-bases.
@@ -125,6 +155,64 @@ func (h *KBHandler) Update(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, kb)
+}
+
+// Publish handles POST /api/v1/orgs/:org_id/workspaces/:ws_id/knowledge-bases/:kb_id/publish.
+// Flips a KB from private to public, validates the chosen SPDX license
+// against marketplace.AllowedSPDXLicenses, and stamps the publish
+// metadata. Requires workspace role "admin" (enforced at route
+// registration), which is Raven's equivalent of the kb:publish
+// permission until per-action ACLs land.
+//
+// @Summary     Publish knowledge base to Marketplace
+// @Tags        knowledge-bases
+// @Accept      json
+// @Produce     json
+// @Security    BearerAuth
+// @Param       org_id  path string true "Organisation ID"
+// @Param       ws_id   path string true "Workspace ID"
+// @Param       kb_id   path string true "Knowledge base ID"
+// @Param       request body PublishKBRequest true "Publish payload"
+// @Success     200 {object} marketplace.PublishResult
+// @Failure     401 {object} apierror.AppError
+// @Failure     403 {object} apierror.AppError
+// @Failure     404 {object} apierror.AppError
+// @Failure     409 {object} apierror.AppError
+// @Failure     422 {object} apierror.AppError
+// @Router      /orgs/{org_id}/workspaces/{ws_id}/knowledge-bases/{kb_id}/publish [post]
+func (h *KBHandler) Publish(c *gin.Context) {
+	if h.publisher == nil {
+		_ = c.Error(apierror.NewInternal("publish service not wired"))
+		c.Abort()
+		return
+	}
+	orgID := c.Param("org_id")
+	kbID := c.Param("kb_id")
+	userID, _ := c.Get(string(middleware.ContextKeyUserID))
+	userIDStr, _ := userID.(string)
+	if userIDStr == "" {
+		// Auth middleware should have already short-circuited; if we ever
+		// land here the request is unauthenticated. Surface 401 instead
+		// of writing a NULL user id to the audit column.
+		_ = c.Error(apierror.NewUnauthorized("user context missing"))
+		c.Abort()
+		return
+	}
+
+	var req PublishKBRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		_ = c.Error(apierror.NewUnprocessableEntity(err.Error()))
+		c.Abort()
+		return
+	}
+
+	result, err := h.publisher.PublishKB(c.Request.Context(), orgID, kbID, userIDStr, req.LicenseSPDXID)
+	if err != nil {
+		_ = c.Error(err)
+		c.Abort()
+		return
+	}
+	c.JSON(http.StatusOK, result)
 }
 
 // Archive handles DELETE /api/v1/orgs/:org_id/workspaces/:ws_id/knowledge-bases/:kb_id.

--- a/internal/handler/kb_test.go
+++ b/internal/handler/kb_test.go
@@ -7,9 +7,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/ravencloak-org/Raven/internal/handler"
+	"github.com/ravencloak-org/Raven/internal/marketplace"
 	"github.com/ravencloak-org/Raven/internal/middleware"
 	"github.com/ravencloak-org/Raven/internal/model"
 	"github.com/ravencloak-org/Raven/pkg/apierror"
@@ -187,6 +189,222 @@ func TestUpdateKB_AcceptsCacheKnobs(t *testing.T) {
 	}
 	if received.CacheSimilarityThreshold == nil || *received.CacheSimilarityThreshold != threshold {
 		t.Errorf("cache_similarity_threshold not propagated: %+v", received.CacheSimilarityThreshold)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Publish endpoint tests (issue #726).
+// ---------------------------------------------------------------------------
+
+// mockPublisher implements handler.KBPublisher for unit tests covering the
+// /publish route. The publishFn lets each test inject the exact result
+// or *apierror.AppError it wants the handler to render.
+type mockPublisher struct {
+	publishFn func(ctx context.Context, orgID, kbID, userID, licenseSPDXID string) (*marketplace.PublishResult, error)
+	// lastCall records the most recent invocation so assertions can verify
+	// the handler propagated path params and the user id from the auth
+	// context.
+	lastCall struct {
+		orgID, kbID, userID, license string
+	}
+}
+
+func (m *mockPublisher) PublishKB(ctx context.Context, orgID, kbID, userID, licenseSPDXID string) (*marketplace.PublishResult, error) {
+	m.lastCall.orgID = orgID
+	m.lastCall.kbID = kbID
+	m.lastCall.userID = userID
+	m.lastCall.license = licenseSPDXID
+	if m.publishFn == nil {
+		return nil, apierror.NewInternal("mock publishFn not set")
+	}
+	return m.publishFn(ctx, orgID, kbID, userID, licenseSPDXID)
+}
+
+// newKBRouterWithPublisher wires the same harness as newKBRouter and
+// additionally registers the publish route with a stub publisher and
+// optional userID override. Pass userID="" to simulate the unauthenticated
+// case (the handler must still surface 401 — the auth middleware would
+// normally have short-circuited, but the defence-in-depth check belongs
+// to the handler).
+func newKBRouterWithPublisher(svc handler.KBServicer, pub handler.KBPublisher, userID string) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(apierror.ErrorHandler())
+	r.Use(func(c *gin.Context) {
+		if userID != "" {
+			c.Set(string(middleware.ContextKeyUserID), userID)
+		}
+		c.Set(string(middleware.ContextKeyOrgRole), "org_admin")
+		c.Set(string(middleware.ContextKeyOrgID), "org-abc")
+		c.Set(string(middleware.ContextKeyWorkspaceRole), "admin")
+		c.Next()
+	})
+	h := handler.NewKBHandler(svc).WithPublisher(pub)
+	const base = "/api/v1/orgs/:org_id/workspaces/:ws_id/knowledge-bases"
+	r.POST(base+"/:kb_id/publish", h.Publish)
+	return r
+}
+
+func TestPublishKB_Success(t *testing.T) {
+	publishedAt := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	pub := &mockPublisher{
+		publishFn: func(_ context.Context, _, _, _, license string) (*marketplace.PublishResult, error) {
+			return &marketplace.PublishResult{
+				Visibility:     model.KBVisibilityPublic,
+				PublishedAt:    publishedAt,
+				MarketplaceURL: marketplace.URL("acme", "support-docs"),
+			}, nil
+		},
+	}
+	r := newKBRouterWithPublisher(&mockKBService{}, pub, "user-1")
+
+	body, _ := json.Marshal(map[string]string{"license_spdx_id": "MIT"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"/api/v1/orgs/org-abc/workspaces/ws-1/knowledge-bases/kb-1/publish",
+		bytes.NewBuffer(body),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if pub.lastCall.orgID != "org-abc" || pub.lastCall.kbID != "kb-1" {
+		t.Errorf("path params not propagated: %+v", pub.lastCall)
+	}
+	if pub.lastCall.userID != "user-1" {
+		t.Errorf("expected user id from context, got %q", pub.lastCall.userID)
+	}
+	if pub.lastCall.license != "MIT" {
+		t.Errorf("license not propagated: %q", pub.lastCall.license)
+	}
+
+	var resp marketplace.PublishResult
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Visibility != model.KBVisibilityPublic {
+		t.Errorf("visibility: got %q want public", resp.Visibility)
+	}
+	if resp.MarketplaceURL != "https://raven.ravencloak.org/marketplace/acme/support-docs" {
+		t.Errorf("marketplace_url drift: %q", resp.MarketplaceURL)
+	}
+}
+
+// TestPublishKB_MissingUserID_Returns401 exercises the defence-in-depth
+// check inside the handler: a request that somehow reached us without the
+// auth middleware setting a user id must be refused with 401 rather than
+// writing a NULL into published_by_user_id.
+func TestPublishKB_MissingUserID_Returns401(t *testing.T) {
+	pub := &mockPublisher{}
+	r := newKBRouterWithPublisher(&mockKBService{}, pub, "")
+
+	body, _ := json.Marshal(map[string]string{"license_spdx_id": "MIT"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"/api/v1/orgs/org-abc/workspaces/ws-1/knowledge-bases/kb-1/publish",
+		bytes.NewBuffer(body),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d: %s", w.Code, w.Body.String())
+	}
+	if pub.lastCall.userID != "" {
+		t.Error("publisher must not be called when user context is missing")
+	}
+}
+
+// TestPublishKB_KBFrozen_Returns409 covers the path where the publish
+// service returns the canonical kb_frozen 409 — surfaced when the KB sits
+// in read_only_private (Free Plan freeze, ADR-0004). The handler must
+// pass it through with the correct status code.
+func TestPublishKB_KBFrozen_Returns409(t *testing.T) {
+	pub := &mockPublisher{
+		publishFn: func(_ context.Context, _, _, _, _ string) (*marketplace.PublishResult, error) {
+			return nil, apierror.NewKBFrozen("frozen on Free Plan")
+		},
+	}
+	r := newKBRouterWithPublisher(&mockKBService{}, pub, "user-1")
+	body, _ := json.Marshal(map[string]string{"license_spdx_id": "MIT"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"/api/v1/orgs/org-abc/workspaces/ws-1/knowledge-bases/kb-1/publish",
+		bytes.NewBuffer(body),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestPublishKB_NotFound_Returns404(t *testing.T) {
+	pub := &mockPublisher{
+		publishFn: func(_ context.Context, _, _, _, _ string) (*marketplace.PublishResult, error) {
+			return nil, apierror.NewNotFound("knowledge base not found")
+		},
+	}
+	r := newKBRouterWithPublisher(&mockKBService{}, pub, "user-1")
+	body, _ := json.Marshal(map[string]string{"license_spdx_id": "MIT"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"/api/v1/orgs/org-abc/workspaces/ws-1/knowledge-bases/missing/publish",
+		bytes.NewBuffer(body),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+// TestPublishKB_BadLicense_Returns422 confirms the handler renders the
+// allow-list rejection from the service as 422 (not 400). The license is
+// shape-valid but semantically rejected — exactly what 422 is for.
+func TestPublishKB_BadLicense_Returns422(t *testing.T) {
+	pub := &mockPublisher{
+		publishFn: func(_ context.Context, _, _, _, _ string) (*marketplace.PublishResult, error) {
+			return nil, apierror.NewUnprocessableEntity("license_spdx_id \"BSD-3-Clause\" is not in the allow-list")
+		},
+	}
+	r := newKBRouterWithPublisher(&mockKBService{}, pub, "user-1")
+	body, _ := json.Marshal(map[string]string{"license_spdx_id": "BSD-3-Clause"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"/api/v1/orgs/org-abc/workspaces/ws-1/knowledge-bases/kb-1/publish",
+		bytes.NewBuffer(body),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422, got %d", w.Code)
+	}
+}
+
+// TestPublishKB_EmptyLicensePayload_Returns422 covers the request-binding
+// level: the JSON parses cleanly but license_spdx_id is missing /
+// empty-string, which the `binding:"required"` tag rejects with 422
+// before the service is ever consulted.
+func TestPublishKB_EmptyLicensePayload_Returns422(t *testing.T) {
+	pub := &mockPublisher{
+		publishFn: func(_ context.Context, _, _, _, _ string) (*marketplace.PublishResult, error) {
+			t.Fatal("service must not be called when payload is invalid")
+			return nil, nil
+		},
+	}
+	r := newKBRouterWithPublisher(&mockKBService{}, pub, "user-1")
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"/api/v1/orgs/org-abc/workspaces/ws-1/knowledge-bases/kb-1/publish",
+		bytes.NewBufferString(`{}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422, got %d", w.Code)
 	}
 }
 

--- a/internal/marketplace/license.go
+++ b/internal/marketplace/license.go
@@ -1,0 +1,45 @@
+package marketplace
+
+// SPDX license allow-list for the Marketplace publish path (ADR-0006).
+//
+// The seven entries below are the entire universe of licenses a publisher
+// may attach to a Public KB. The list is a code constant — NOT a config
+// knob — so changing it requires a PR, code review, and the CI test
+// TestAllowedSPDXLicensesExact (which pins the exact set). The review gate
+// is intentional: adding a license has product, legal, and UX (badge
+// rendering) consequences and must not be flippable at runtime.
+//
+// Order matches docs/adr/0006-licence-and-moderation.md so a side-by-side
+// diff against the ADR is trivial. Do NOT alphabetise or otherwise
+// re-order; the order is part of the documented contract surfaced to
+// reviewers and to TestAllowedSPDXLicensesExact.
+
+// AllowedSPDXLicenses is the canonical, ordered set of SPDX identifiers a
+// publisher may attach to a Public KB. Adding or removing an entry MUST
+// also update docs/adr/0006-licence-and-moderation.md and the assertion
+// in TestAllowedSPDXLicensesExact.
+var AllowedSPDXLicenses = []string{
+	"CC0-1.0",
+	"CC-BY-4.0",
+	"CC-BY-SA-4.0",
+	"CC-BY-NC-4.0",
+	"MIT",
+	"Apache-2.0",
+	"GPL-3.0",
+}
+
+// IsAllowedLicense reports whether id is exactly one of the canonical SPDX
+// identifiers in AllowedSPDXLicenses. The match is case-sensitive — SPDX
+// identifiers are themselves case-sensitive, and we don't want
+// "cc-by-4.0" or "Mit" sneaking past a typo and landing in the database
+// where the badge renderer would silently miss it.
+//
+// O(n) linear scan over 7 entries — a map would only obfuscate this.
+func IsAllowedLicense(id string) bool {
+	for _, allowed := range AllowedSPDXLicenses {
+		if id == allowed {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/marketplace/license_test.go
+++ b/internal/marketplace/license_test.go
@@ -1,0 +1,69 @@
+package marketplace_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ravencloak-org/Raven/internal/marketplace"
+)
+
+// TestAllowedSPDXLicensesExact is the CI guard required by ADR-0002 / ADR-0006.
+// It pins the exact ordered set of SPDX identifiers the Marketplace publish
+// path will accept. Adding or removing a license is a deliberate decision
+// with product, legal, and UX (badge rendering) implications — this test
+// is the trip-wire that fails a PR which changes the list without also
+// updating the ADRs.
+//
+// If you are here because this test failed:
+//  1. Confirm docs/adr/0006-licence-and-moderation.md has been updated to
+//     reflect the new allow-list.
+//  2. Update `want` below to match the new canonical list, preserving the
+//     ADR's documented order.
+//  3. Re-run the test.
+func TestAllowedSPDXLicensesExact(t *testing.T) {
+	want := []string{
+		"CC0-1.0",
+		"CC-BY-4.0",
+		"CC-BY-SA-4.0",
+		"CC-BY-NC-4.0",
+		"MIT",
+		"Apache-2.0",
+		"GPL-3.0",
+	}
+
+	if got := marketplace.AllowedSPDXLicenses; !reflect.DeepEqual(got, want) {
+		t.Errorf("AllowedSPDXLicenses drift detected.\n got:  %v\n want: %v\n"+
+			"If this change is intentional, update docs/adr/0006-licence-and-moderation.md and this test in the same PR.",
+			got, want)
+	}
+}
+
+// TestIsAllowedLicense covers the helper's three interesting branches:
+// exact match, empty string, and a near-miss that exercises the
+// case-sensitive comparison guard.
+func TestIsAllowedLicense(t *testing.T) {
+	cases := []struct {
+		name string
+		id   string
+		want bool
+	}{
+		{name: "exact_match_first", id: "CC0-1.0", want: true},
+		{name: "exact_match_last", id: "GPL-3.0", want: true},
+		{name: "exact_match_middle", id: "MIT", want: true},
+		{name: "empty_string", id: "", want: false},
+		{name: "unknown_identifier", id: "BSD-3-Clause", want: false},
+		{name: "case_sensitive_lower", id: "mit", want: false},
+		{name: "case_sensitive_mixed", id: "Cc-By-4.0", want: false},
+		// SPDX identifiers do not have leading / trailing whitespace; the
+		// helper must reject these rather than silently trim.
+		{name: "leading_space", id: " MIT", want: false},
+		{name: "trailing_space", id: "MIT ", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := marketplace.IsAllowedLicense(tc.id); got != tc.want {
+				t.Errorf("IsAllowedLicense(%q) = %v, want %v", tc.id, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/marketplace/publish.go
+++ b/internal/marketplace/publish.go
@@ -1,0 +1,195 @@
+package marketplace
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/ravencloak-org/Raven/internal/db"
+	"github.com/ravencloak-org/Raven/internal/model"
+	"github.com/ravencloak-org/Raven/pkg/apierror"
+)
+
+// PublishGateFunc is the callback shape the publish service uses to ask
+// the lifecycle freeze gate "may this KB transition private → public
+// right now?". Defined as a function (rather than an interface that
+// references internal/service.KBAction) so this package stays a leaf
+// import-graph node: internal/repository already imports
+// internal/marketplace for org-slug helpers, and internal/service imports
+// internal/repository, so a direct dependency on internal/service from
+// this package would create an import cycle.
+//
+// The callback returns nil when the KB may publish, an *apierror.AppError
+// when the gate refuses, and any other error type for unexpected failures.
+// The wiring site in cmd/api/main.go closes over service.KBStatusGuard
+// and service.KBActionPublish to satisfy this shape with one line.
+type PublishGateFunc func(ctx context.Context, tx pgx.Tx, orgID, kbID string) error
+
+// marketplaceURLHost is the canonical host segment of the public Marketplace
+// URL contract per ADR-0005. Kept as a code constant — the host is part of
+// the documented user-facing surface and must not drift between deployments.
+const marketplaceURLHost = "https://raven.ravencloak.org/marketplace"
+
+// URL builds the public Marketplace URL for a Public KB given the
+// publishing Org's slug and the KB's slug. Single source of truth so the
+// handler response, future emails, and any audit log row produce
+// byte-identical URLs. Named URL rather than MarketplaceURL because
+// marketplace.MarketplaceURL would stutter at call sites; the package
+// name already conveys the domain.
+func URL(orgSlug, kbSlug string) string {
+	return fmt.Sprintf("%s/%s/%s", marketplaceURLHost, orgSlug, kbSlug)
+}
+
+// PublishResult is the response payload for a successful publish, in the
+// exact shape ADR-0002 / docs/plans/marketplace-mvp.md §4 require the API
+// to return. Kept as a typed struct so the handler stays a thin renderer
+// and the service owns the contract.
+type PublishResult struct {
+	Visibility     model.KBVisibility `json:"visibility"`
+	PublishedAt    time.Time          `json:"published_at"`
+	MarketplaceURL string             `json:"marketplace_url"`
+}
+
+// PublishService runs the transactional publish path: status-gate check,
+// license allow-list check, atomic flip of visibility + published_at +
+// published_by_user_id + license_spdx_id, and assembly of the typed
+// response.
+//
+// The service deliberately owns the entire publish boundary — handler
+// validates payload shape, then defers every business rule to here. That
+// keeps the canonical "what does it mean to publish a KB" answer in one
+// file (ADR-0002).
+type PublishService struct {
+	pool *pgxpool.Pool
+	gate PublishGateFunc
+}
+
+// NewPublishService constructs a PublishService. The gate callback is
+// invoked inside the publish transaction before any UPDATE; pass nil to
+// disable the freeze check in unit-test wiring that only exercises the
+// license-validation / SQL paths.
+func NewPublishService(pool *pgxpool.Pool, gate PublishGateFunc) *PublishService {
+	return &PublishService{pool: pool, gate: gate}
+}
+
+// PublishKB flips a KB from private to public and stamps the publish
+// metadata. Returns the typed PublishResult on success or an *apierror.AppError
+// already shaped for the handler:
+//
+//   - 404 — KB does not exist for this org.
+//   - 409 — KBStatusGate rejects the action (kb_frozen / kb_dmca_locked).
+//   - 422 — license_spdx_id is not in AllowedSPDXLicenses.
+//
+// userID is the actor's internal user UUID (set by the JWT middleware on
+// the handler context). It is recorded on published_by_user_id for audit.
+//
+// The whole thing runs inside one db.WithOrgID transaction so the row read
+// for org-slug resolution, the status check, and the UPDATE all share the
+// same snapshot — no chance of a concurrent rename racing the URL we
+// return.
+func (s *PublishService) PublishKB(
+	ctx context.Context,
+	orgID, kbID, userID, licenseSPDXID string,
+) (*PublishResult, error) {
+	// License validation runs before we touch the database. There is no
+	// reason to pay a round trip for a payload the allow-list will
+	// reject anyway.
+	if !IsAllowedLicense(licenseSPDXID) {
+		return nil, apierror.NewUnprocessableEntity(
+			fmt.Sprintf("license_spdx_id %q is not in the allow-list", licenseSPDXID),
+		)
+	}
+
+	var result PublishResult
+
+	err := db.WithOrgID(ctx, s.pool, orgID, func(tx pgx.Tx) error {
+		// Lifecycle gate (ADR-0004 / issue #725). Catches archived, frozen,
+		// and DMCA-locked KBs with the canonical machine-readable error
+		// codes the SPA already branches on. Runs before any UPDATE so a
+		// frozen KB never sees its row touched.
+		if s.gate != nil {
+			if gateErr := s.gate(ctx, tx, orgID, kbID); gateErr != nil {
+				return gateErr
+			}
+		}
+
+		// The UPDATE + RETURNING does double duty:
+		//   1. Verifies the KB exists for this org (RowsAffected == 0 →
+		//      404). Bypassing GetByID keeps the path one round trip.
+		//   2. Reads back the Org slug via JOIN in a CTE so the response
+		//      URL is computed inside the same transaction.
+		//
+		// Status filter on the UPDATE keeps the freeze check (above) and
+		// the SQL write defence-in-depth: even if the guard were ever
+		// disabled, an archived row would be untouched.
+		var publishedAt time.Time
+		var orgSlug, kbSlug string
+		err := tx.QueryRow(ctx,
+			`WITH updated AS (
+				UPDATE knowledge_bases
+				   SET visibility           = 'public',
+				       published_at         = NOW(),
+				       published_by_user_id = $3,
+				       license_spdx_id      = $4
+				 WHERE id     = $1
+				   AND org_id = $2
+				   AND status = 'active'
+				 RETURNING published_at, slug, org_id
+			 )
+			 SELECT u.published_at, o.slug, u.slug
+			   FROM updated u
+			   JOIN organizations o ON o.id = u.org_id`,
+			kbID, orgID, userID, licenseSPDXID,
+		).Scan(&publishedAt, &orgSlug, &kbSlug)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return apierror.NewNotFound("knowledge base not found")
+			}
+			// The CHECK constraint knowledge_bases_public_requires_license
+			// or the partial UNIQUE idx_kb_public_org_slug_uniq are the
+			// only realistic write-time failures here. The former should
+			// be unreachable (we always set license_spdx_id), so a
+			// constraint hit means a slug collision against another
+			// already-public KB in this org — surface 409 so the SPA can
+			// prompt for a rename.
+			var pgErr *pgconn.PgError
+			if errors.As(err, &pgErr) && pgErr.Code == pgUniqueViolation {
+				return apierror.NewConflict(
+					"slug collision: another public knowledge base in this org already owns this slug",
+				)
+			}
+			return apierror.NewInternal("failed to publish knowledge base: " + err.Error())
+		}
+
+		result = PublishResult{
+			Visibility:     model.KBVisibilityPublic,
+			PublishedAt:    publishedAt,
+			MarketplaceURL: URL(orgSlug, kbSlug),
+		}
+		return nil
+	})
+
+	if err != nil {
+		// AppErrors from the guard / CHECK paths are already shaped; pass
+		// them through untouched so the handler renders the right status
+		// code + machine-readable error code.
+		var appErr *apierror.AppError
+		if errors.As(err, &appErr) {
+			return nil, appErr
+		}
+		// db.WithOrgID can wrap "no rows" coming out of LoadStatus into a
+		// generic error string. Map that to a 404 rather than a 500.
+		if strings.Contains(err.Error(), "no rows") {
+			return nil, apierror.NewNotFound("knowledge base not found")
+		}
+		return nil, apierror.NewInternal("failed to publish knowledge base: " + err.Error())
+	}
+
+	return &result, nil
+}

--- a/internal/marketplace/publish_test.go
+++ b/internal/marketplace/publish_test.go
@@ -1,0 +1,41 @@
+package marketplace_test
+
+import (
+	"testing"
+
+	"github.com/ravencloak-org/Raven/internal/marketplace"
+)
+
+// TestURL pins the public Marketplace URL format documented in ADR-0005
+// so the SPA, future email templates, and any audit trail row produce
+// byte-identical strings. Drift here would silently break stored links
+// out in the wild.
+func TestURL(t *testing.T) {
+	cases := []struct {
+		name     string
+		orgSlug  string
+		kbSlug   string
+		expected string
+	}{
+		{
+			name:     "simple_slugs",
+			orgSlug:  "acme",
+			kbSlug:   "support-docs",
+			expected: "https://raven.ravencloak.org/marketplace/acme/support-docs",
+		},
+		{
+			name:     "numeric_slugs",
+			orgSlug:  "org-42",
+			kbSlug:   "kb-1",
+			expected: "https://raven.ravencloak.org/marketplace/org-42/kb-1",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := marketplace.URL(tc.orgSlug, tc.kbSlug); got != tc.expected {
+				t.Errorf("URL(%q,%q) = %q, want %q",
+					tc.orgSlug, tc.kbSlug, got, tc.expected)
+			}
+		})
+	}
+}

--- a/migrations/00050_kb_license_and_strikes.sql
+++ b/migrations/00050_kb_license_and_strikes.sql
@@ -1,0 +1,78 @@
+-- +goose Up
+--
+-- Marketplace MVP (issue #726, M1).
+--
+-- License + moderation schema groundwork (ADR-0006).
+--
+-- 1. Partial CHECK on knowledge_bases enforcing the publish-time invariant
+--    "every Public KB carries an SPDX license". The license_spdx_id column
+--    itself was added in migration 00047 (issue #723); this migration only
+--    constrains its nullability for visibility='public' rows so existing
+--    private rows stay valid and an attempt to publish without selecting a
+--    license is rejected at the database layer as the last line of defence
+--    behind the application-level allow-list check in
+--    internal/marketplace/license.go.
+--
+-- 2. organizations.takedown_strikes — running tally of confirmed copyright /
+--    DMCA strikes against the publishing Org per ADR-0006. The MVP increment
+--    path is the admin "approve report" handler (issue #730); the column
+--    lands here so the publish lifecycle work and the moderation work can
+--    proceed independently against the same schema.
+--
+-- References:
+--   - docs/plans/marketplace-mvp.md §2 (00050_kb_license_and_strikes.sql)
+--   - docs/adr/0002-content-grade-publish-boundary.md (publish boundary)
+--   - docs/adr/0006-licence-and-moderation.md (SPDX allow-list + strikes)
+
+-- Bound the locks taken by the DDL below so a long-running query cannot
+-- block production indefinitely. 5s is enough for the operations here
+-- (NOT VALID add-constraint + small column add with constant default).
+SET lock_timeout = '5s';
+SET statement_timeout = '30s';
+
+-- ---------------------------------------------------------------------------
+-- 1. Partial CHECK: public KBs must carry a license.
+-- ---------------------------------------------------------------------------
+-- Phrased as "private OR licensed" rather than "public IMPLIES licensed"
+-- so every pre-existing private row (license_spdx_id IS NULL) passes
+-- without backfill. The expression is partial in spirit but unconditional
+-- in SQL — the predicate evaluates true for any private row regardless of
+-- license_spdx_id.
+--
+-- NOT VALID skips the full-table scan at add time; the immediately-following
+-- VALIDATE CONSTRAINT runs the check without blocking concurrent writes
+-- (it only takes SHARE UPDATE EXCLUSIVE, not ACCESS EXCLUSIVE).
+ALTER TABLE knowledge_bases
+    ADD CONSTRAINT knowledge_bases_public_requires_license
+    CHECK (visibility = 'private' OR license_spdx_id IS NOT NULL)
+    NOT VALID;
+
+ALTER TABLE knowledge_bases
+    VALIDATE CONSTRAINT knowledge_bases_public_requires_license;
+
+-- ---------------------------------------------------------------------------
+-- 2. organizations.takedown_strikes.
+-- ---------------------------------------------------------------------------
+-- BIGINT (not INTEGER) so we never have to widen later if abuse-volume
+-- analytics start incrementing a per-Org counter at unexpected rates.
+-- Default 0 so the moderation handler can assume the column is non-null on
+-- every row.
+ALTER TABLE organizations
+    ADD COLUMN takedown_strikes BIGINT NOT NULL DEFAULT 0;
+
+-- +goose Down
+--
+-- Reverse in dependency order: organizations column first, then the
+-- knowledge_bases CHECK. Neither has dependent objects (no triggers,
+-- views, or RLS policies reference them yet) so straight DROP works.
+-- The DROP COLUMN below is destructive in production but the Down half
+-- only ever runs in development / test rollback flows; the trade-off is
+-- accepted in exchange for a clean reversible migration.
+SET lock_timeout = '5s';
+SET statement_timeout = '30s';
+
+ALTER TABLE organizations
+    DROP COLUMN IF EXISTS takedown_strikes;
+
+ALTER TABLE knowledge_bases
+    DROP CONSTRAINT IF EXISTS knowledge_bases_public_requires_license;

--- a/migrations/migrations_test.go
+++ b/migrations/migrations_test.go
@@ -569,13 +569,13 @@ func TestMigrationsUpAndDown(t *testing.T) {
 			t.Fatalf("insert workspace: %v", err)
 		}
 		if _, err := db.ExecContext(ctx,
-			`INSERT INTO knowledge_bases (org_id, workspace_id, name, slug, visibility)
-			 VALUES ($1, $2, 'A', 'duplicate-slug', 'public')`, orgID2, wsID2); err != nil {
+			`INSERT INTO knowledge_bases (org_id, workspace_id, name, slug, visibility, license_spdx_id)
+			 VALUES ($1, $2, 'A', 'duplicate-slug', 'public', 'MIT')`, orgID2, wsID2); err != nil {
 			t.Fatalf("insert first public kb: %v", err)
 		}
 		if _, err := db.ExecContext(ctx,
-			`INSERT INTO knowledge_bases (org_id, workspace_id, name, slug, visibility)
-			 VALUES ($1, $2, 'B', 'duplicate-slug', 'public')`, orgID2, wsID2); err == nil {
+			`INSERT INTO knowledge_bases (org_id, workspace_id, name, slug, visibility, license_spdx_id)
+			 VALUES ($1, $2, 'B', 'duplicate-slug', 'public', 'MIT')`, orgID2, wsID2); err == nil {
 			t.Error("expected partial UNIQUE to reject second public KB with same (org_id, slug)")
 		}
 		// Two private KBs with the same (org_id, slug) — allowed by the
@@ -926,6 +926,78 @@ func TestMigrationsUpAndDown(t *testing.T) {
 					}
 				}
 			})
+		}
+	})
+
+	t.Run("kb_license_check_and_takedown_strikes", func(t *testing.T) {
+		// Migration 00050 (issue #726): partial CHECK on knowledge_bases
+		// enforcing license_spdx_id NOT NULL when visibility='public',
+		// plus organizations.takedown_strikes BIGINT NOT NULL DEFAULT 0.
+		//
+		// Asserted invariants:
+		//   1. takedown_strikes exists with the right type and default 0.
+		//   2. The CHECK constraint rejects an attempt to publish a KB
+		//      with NULL license_spdx_id.
+		//   3. Publishing with an SPDX id present succeeds.
+		//   4. Private KBs continue to permit NULL license_spdx_id —
+		//      the constraint must not regress existing rows.
+
+		// takedown_strikes column shape.
+		var dataType string
+		var defaultExpr *string
+		if err := db.QueryRowContext(ctx,
+			`SELECT data_type, column_default
+			 FROM information_schema.columns
+			 WHERE table_schema = 'public' AND table_name = 'organizations'
+			   AND column_name = 'takedown_strikes'`).
+			Scan(&dataType, &defaultExpr); err != nil {
+			t.Fatalf("read takedown_strikes column: %v", err)
+		}
+		if dataType != "bigint" {
+			t.Errorf("takedown_strikes data_type: want bigint, got %s", dataType)
+		}
+		if defaultExpr == nil || *defaultExpr != "0" {
+			got := "<nil>"
+			if defaultExpr != nil {
+				got = *defaultExpr
+			}
+			t.Errorf("takedown_strikes default: want 0, got %s", got)
+		}
+
+		// Bootstrap an org + workspace for the CHECK behaviour assertions.
+		var orgID3, wsID3 string
+		if err := db.QueryRowContext(ctx,
+			`INSERT INTO organizations (id, name, slug)
+			 VALUES (uuid_generate_v4(), 'License Test Org', 'license-test-org')
+			 RETURNING id`).Scan(&orgID3); err != nil {
+			t.Fatalf("insert organization: %v", err)
+		}
+		if err := db.QueryRowContext(ctx,
+			`INSERT INTO workspaces (id, org_id, name, slug)
+			 VALUES (uuid_generate_v4(), $1, 'License WS', 'license-ws')
+			 RETURNING id`, orgID3).Scan(&wsID3); err != nil {
+			t.Fatalf("insert workspace: %v", err)
+		}
+
+		// Private KB with NULL license must still be allowed.
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO knowledge_bases (org_id, workspace_id, name, slug)
+			 VALUES ($1, $2, 'Private OK', 'private-ok')`, orgID3, wsID3); err != nil {
+			t.Errorf("private KB with NULL license must be allowed: %v", err)
+		}
+
+		// Public KB with NULL license must be rejected by the CHECK.
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO knowledge_bases (org_id, workspace_id, name, slug, visibility)
+			 VALUES ($1, $2, 'Bad Public', 'bad-public', 'public')`, orgID3, wsID3); err == nil {
+			t.Error("expected CHECK to reject public KB with NULL license_spdx_id")
+		}
+
+		// Public KB with a license must succeed.
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO knowledge_bases (org_id, workspace_id, name, slug, visibility, license_spdx_id)
+			 VALUES ($1, $2, 'Good Public', 'good-public', 'public', 'MIT')`, orgID3, wsID3); err != nil {
+			t.Errorf("public KB with license must succeed: %v", err)
 		}
 	})
 

--- a/pkg/apierror/apierror.go
+++ b/pkg/apierror/apierror.go
@@ -71,6 +71,19 @@ func NewConflict(detail string) *AppError {
 	}
 }
 
+// NewUnprocessableEntity creates a 422 Unprocessable Entity error. Use this
+// for payloads whose shape parsed cleanly but whose semantic content was
+// rejected by a domain rule — e.g. an SPDX license that is not in the
+// Marketplace publish allow-list (ADR-0006). 400 is reserved for malformed
+// requests; 422 says "I understood you, the answer is still no".
+func NewUnprocessableEntity(detail string) *AppError {
+	return &AppError{
+		Code:    http.StatusUnprocessableEntity,
+		Message: "Unprocessable Entity",
+		Detail:  detail,
+	}
+}
+
 // NewTooManyRequests creates a 429 Too Many Requests error.
 func NewTooManyRequests(detail string) *AppError {
 	return &AppError{


### PR DESCRIPTION
## Summary

Implements the Marketplace publish path for issue #726:

- **Migration `00050_kb_license_and_strikes.sql`** — adds the partial CHECK `(visibility = 'private' OR license_spdx_id IS NOT NULL)` so every Public KB carries a license at the database layer (ADR-0006). The `license_spdx_id` column itself was already added by migration `00047` (issue #723), so only the CHECK is new. Adds `organizations.takedown_strikes INTEGER NOT NULL DEFAULT 0` for the moderation work (ADR-0006).
- **`internal/marketplace/license.go`** — `AllowedSPDXLicenses` code constant (the 7 entries from ADR-0006) plus `IsAllowedLicense` helper. Order matches the ADR.
- **`internal/marketplace/publish.go`** — transactional `PublishService`: license validation → `KBStatusGate.CanPublish` freeze gate → atomic `UPDATE` of `visibility` + `published_at` + `published_by_user_id` + `license_spdx_id`, with the org slug joined back inside the same CTE to assemble the response URL in one round trip.
- **`POST /api/v1/orgs/:org_id/workspaces/:ws_id/knowledge-bases/:kb_id/publish`** — grouped with the other KB routes, gated by workspace admin role (Raven's equivalent of `kb:publish` until per-action ACLs land). Returns `{ visibility, published_at, marketplace_url }`.
- **`pkg/apierror.NewUnprocessableEntity`** — 422 helper for the license rejection path.

## Self-review (thermo-nuclear)

| Check | Result |
|---|---|
| `main.go` past 1000 lines? | Was already 1081; addition is +17 lines (closure + route + wiring). |
| License allow-list a code constant, not config? | Yes — `var AllowedSPDXLicenses = []string{...}` with a CI test (`TestAllowedSPDXLicensesExact`) that fails on silent drift. |
| Publish service has one canonical path? | One method, `PublishKB`. License check → guard → UPDATE → response — no branches per KB type. |
| Handler doing service work? | No. Handler binds JSON, pulls `userID` from gin context, delegates everything else to `publisher.PublishKB`. |

### Notable design decisions
- **Avoiding the import cycle.** `internal/repository` already imports `internal/marketplace` (for org-slug helpers), and `internal/service` imports `internal/repository`. To let `marketplace.PublishService` use the `KBStatusGuard` without creating a cycle, the gate is wired via a `PublishGateFunc` closure constructed in `cmd/api/main.go`. The closure pattern keeps the guard's typed `KBAction` enum on the service side and the marketplace package as a leaf node.
- **Scope is narrower than the full issue.** Per the task brief, this PR ships the publish endpoint + schema + license allow-list. The projection module (`projection.go`, `projection_settings_allowlist.go`) and the `kb_slug_holds` collision check land in follow-up PRs once #727 introduces `kb_slug_holds` (migration 00051).
- **SECURITY DEFINER functions (#728) and import path (#729) are untouched.**

## Test plan

- [ ] `go test -short ./...` — passes locally (only failure is a Colima/Docker socket environmental issue unrelated to this PR; CI's Docker-in-CI step will run the full `migrations` integration test).
- [ ] `golangci-lint --new-from-rev=origin/main` — 0 issues.
- [ ] Migration round-trip + CHECK behaviour asserted in `migrations/migrations_test.go::kb_license_check_and_takedown_strikes`.
- [ ] Handler unit tests cover 200, 401 (missing user context), 404, 409 (`kb_frozen` from the guard), 422 (license rejected), and 422 (empty payload).
- [ ] `TestAllowedSPDXLicensesExact` pins the 7-entry allow-list per ADR-0002.

## References

- Closes #726
- ADR-0002 — content-grade publish boundary
- ADR-0005 — org as Marketplace publisher
- ADR-0006 — licence and moderation
- `docs/plans/marketplace-mvp.md` §2 (migration 00050), §3 (`license.go`, `publish.go`), §4 (publish row)