### PR TITLE
fix(llm): SetDefault returns 200 + updated provider, not 204

### DIFF
--- a/internal/handler/llm_provider.go
+++ b/internal/handler/llm_provider.go
@@ -20,7 +20,7 @@ type LLMProviderServicer interface {
 	List(ctx context.Context, orgID string) ([]model.LLMProviderResponse, error)
 	Update(ctx context.Context, orgID, configID string, req model.UpdateLLMProviderRequest) (*model.LLMProviderResponse, error)
 	Delete(ctx context.Context, orgID, configID string) error
-	SetDefault(ctx context.Context, orgID, configID string) error
+	SetDefault(ctx context.Context, orgID, configID string) (*model.LLMProviderResponse, error)
 	TestConnection(ctx context.Context, orgID string, req model.TestProviderRequest) (*model.TestConnectionResult, error)
 }
 
@@ -277,12 +277,13 @@ func (h *LLMProviderHandler) Test(c *gin.Context) {
 // SetDefault handles PUT /api/v1/orgs/:org_id/llm-providers/:provider_id/default.
 //
 // @Summary     Set default LLM provider
-// @Description Mark a provider config as the default for the organisation
+// @Description Mark a provider config as the default for the organisation and return the updated row
 // @Tags        llm-providers
+// @Produce     json
 // @Security    BearerAuth
 // @Param       org_id      path string true "Organisation ID"
 // @Param       provider_id path string true "Provider config ID"
-// @Success     204
+// @Success     200 {object} model.LLMProviderResponse
 // @Failure     401 {object} apierror.AppError
 // @Failure     403 {object} apierror.AppError
 // @Failure     404 {object} apierror.AppError
@@ -290,10 +291,11 @@ func (h *LLMProviderHandler) Test(c *gin.Context) {
 func (h *LLMProviderHandler) SetDefault(c *gin.Context) {
 	orgID := c.Param("org_id")
 	providerID := c.Param("provider_id")
-	if err := h.svc.SetDefault(c.Request.Context(), orgID, providerID); err != nil {
+	resp, err := h.svc.SetDefault(c.Request.Context(), orgID, providerID)
+	if err != nil {
 		_ = c.Error(err)
 		c.Abort()
 		return
 	}
-	c.Status(http.StatusNoContent)
+	c.JSON(http.StatusOK, resp)
 }

--- a/internal/handler/llm_provider_test.go
+++ b/internal/handler/llm_provider_test.go
@@ -23,7 +23,7 @@ type mockLLMProviderService struct {
 	listFn       func(ctx context.Context, orgID string) ([]model.LLMProviderResponse, error)
 	updateFn     func(ctx context.Context, orgID, configID string, req model.UpdateLLMProviderRequest) (*model.LLMProviderResponse, error)
 	deleteFn     func(ctx context.Context, orgID, configID string) error
-	setDefaultFn func(ctx context.Context, orgID, configID string) error
+	setDefaultFn func(ctx context.Context, orgID, configID string) (*model.LLMProviderResponse, error)
 	testFn       func(ctx context.Context, orgID string, req model.TestProviderRequest) (*model.TestConnectionResult, error)
 }
 
@@ -42,7 +42,7 @@ func (m *mockLLMProviderService) Update(ctx context.Context, orgID, configID str
 func (m *mockLLMProviderService) Delete(ctx context.Context, orgID, configID string) error {
 	return m.deleteFn(ctx, orgID, configID)
 }
-func (m *mockLLMProviderService) SetDefault(ctx context.Context, orgID, configID string) error {
+func (m *mockLLMProviderService) SetDefault(ctx context.Context, orgID, configID string) (*model.LLMProviderResponse, error) {
 	return m.setDefaultFn(ctx, orgID, configID)
 }
 func (m *mockLLMProviderService) TestConnection(ctx context.Context, orgID string, req model.TestProviderRequest) (*model.TestConnectionResult, error) {
@@ -223,15 +223,34 @@ func TestDeleteLLMProvider_Success(t *testing.T) {
 
 func TestSetDefaultLLMProvider_Success(t *testing.T) {
 	svc := &mockLLMProviderService{
-		setDefaultFn: func(_ context.Context, _, _ string) error { return nil },
+		setDefaultFn: func(_ context.Context, orgID, configID string) (*model.LLMProviderResponse, error) {
+			return &model.LLMProviderResponse{
+				ID:          configID,
+				OrgID:       orgID,
+				Provider:    model.LLMProviderOpenAI,
+				DisplayName: "Default Test",
+				IsDefault:   true,
+				Status:      model.ProviderStatusActive,
+			}, nil
+		},
 	}
 	r := newLLMProviderRouter(svc)
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest(http.MethodPut, "/api/v1/orgs/org-abc/llm-providers/prov-1/default", nil)
 	r.ServeHTTP(w, req)
 
-	if w.Code != http.StatusNoContent {
-		t.Errorf("expected 204, got %d", w.Code)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var got model.LLMProviderResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("failed to decode response: %v: %s", err, w.Body.String())
+	}
+	if !got.IsDefault {
+		t.Errorf("expected IsDefault=true, got false: %s", w.Body.String())
+	}
+	if got.ID != "prov-1" {
+		t.Errorf("expected ID=prov-1, got %q", got.ID)
 	}
 }
 

--- a/internal/service/llm_provider.go
+++ b/internal/service/llm_provider.go
@@ -188,18 +188,28 @@ func (s *LLMProviderService) Delete(ctx context.Context, orgID, configID string)
 	return nil
 }
 
-// SetDefault marks a provider config as the default for an org.
-func (s *LLMProviderService) SetDefault(ctx context.Context, orgID, configID string) error {
+// SetDefault marks a provider config as the default for an org and returns the
+// updated row so the caller can refresh state without a follow-up GET.
+func (s *LLMProviderService) SetDefault(ctx context.Context, orgID, configID string) (*model.LLMProviderResponse, error) {
+	var cfg *model.LLMProviderConfig
 	err := db.WithOrgID(ctx, s.pool, orgID, func(tx pgx.Tx) error {
-		return s.repo.SetDefault(ctx, tx, orgID, configID)
+		if setErr := s.repo.SetDefault(ctx, tx, orgID, configID); setErr != nil {
+			return setErr
+		}
+		fetched, getErr := s.repo.GetByID(ctx, tx, orgID, configID)
+		if getErr != nil {
+			return getErr
+		}
+		cfg = fetched
+		return nil
 	})
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
-			return apierror.NewNotFound("LLM provider config not found")
+		if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "no rows") {
+			return nil, apierror.NewNotFound("LLM provider config not found")
 		}
-		return apierror.NewInternal("failed to set default provider: " + err.Error())
+		return nil, apierror.NewInternal("failed to set default provider: " + err.Error())
 	}
-	return nil
+	return cfg.ToResponse(), nil
 }
 
 // TestConnection probes a vendor either with inline credentials or with the


### PR DESCRIPTION
## Summary

The frontend on `/llm-providers` reports

> Could not switch default: Failed to execute 'json' on 'Response': Unexpected end of JSON input

when a user clicks **Make default** on a non-default LLM provider card.

### Root cause

- Backend `internal/handler/llm_provider.go` `SetDefault` returned `c.Status(http.StatusNoContent)` (204, empty body).
- Frontend `frontend/src/api/llm-providers.ts` `setDefaultLlmProvider` is typed `Promise<LlmProvider>` and uses the generic `authFetch<LlmProvider>(...)`, which unconditionally calls `res.json()` — that throws on an empty body.
- The Pinia store `frontend/src/stores/llm-providers.ts` already consumes the returned provider to refresh local state, so the contract should be **200 + JSON** like every other CRUD endpoint on this resource.

### Fix (backend-only, smallest diff)

- `service.SetDefault` now returns `(*model.LLMProviderResponse, error)`. It flips `is_default` via the existing repository call, then fetches the fresh row via `repo.GetByID` inside the same transaction and returns its `ToResponse()`.
- `handler.SetDefault` now responds with `c.JSON(http.StatusOK, resp)`, mirroring `Update` / `Get`. Swagger annotation updated to `@Success 200 {object} model.LLMProviderResponse` and `@Produce json`.
- Handler test `TestSetDefaultLLMProvider_Success` now asserts `200`, decodes the body, and checks `IsDefault == true`.

No frontend changes are required — the existing call site is already shaped for this contract.

## Test plan

- [x] `go test ./internal/handler/... ./internal/service/...` passes
- [x] `golangci-lint run --new-from-rev=origin/main ./...` reports 0 issues
- [ ] Manual: click **Make default** on a non-default provider card on `/llm-providers`; toast should switch silently and the card list updates without the JSON parse error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* The "set default" LLM provider endpoint now returns the complete updated provider configuration in the response, including the provider ID and default status indicator. This allows immediate confirmation of configuration updates without requiring a separate API call to retrieve the details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->