### PR TITLE
fix(worker): skip Anthropic when picking the embed provider

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -22,6 +22,7 @@ import (
 	rpcClient "github.com/ravencloak-org/Raven/internal/grpc"
 	pb "github.com/ravencloak-org/Raven/internal/grpc/pb"
 	"github.com/ravencloak-org/Raven/internal/jobs"
+	"github.com/ravencloak-org/Raven/internal/model"
 	"github.com/ravencloak-org/Raven/internal/posthog"
 	"github.com/ravencloak-org/Raven/internal/queue"
 	"github.com/ravencloak-org/Raven/internal/repository"
@@ -135,18 +136,39 @@ func main() {
 		// GetEmbedding rejects empty `provider` with NotFound; chat
 		// already does this lookup in chat.go.
 		llmRepo := repository.NewLLMProviderRepository(pool)
+		// Anthropic does not publish a public embeddings API, so we must
+		// never route an embed call to it even when it's the org's default
+		// chat provider. Walk the active provider list and pick the first
+		// embedding-capable one — falling back to the broader-default
+		// resolution only when no provider in the list supports embeddings.
+		embeddingCapable := map[string]bool{
+			"openai": true,
+			"cohere": true,
+			"ollama": true,
+		}
 		resolveProvider := func(ctx context.Context, orgID string) string {
 			var providerType string
 			err := db.WithOrgID(ctx, pool, orgID, func(tx pgx.Tx) error {
+				// Prefer the explicit default if it's embedding-capable.
 				cfg, err := llmRepo.GetDefault(ctx, tx, orgID)
-				if err != nil {
-					if errors.Is(err, pgx.ErrNoRows) {
-						return nil
-					}
+				if err == nil && cfg != nil && embeddingCapable[string(cfg.Provider)] {
+					providerType = string(cfg.Provider)
+					return nil
+				}
+				if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 					return err
 				}
-				if cfg != nil {
-					providerType = string(cfg.Provider)
+				// Default is Anthropic, missing, or non-embedding — scan
+				// the active provider list for an embedding-capable one.
+				configs, listErr := llmRepo.List(ctx, tx, orgID)
+				if listErr != nil {
+					return listErr
+				}
+				for _, c := range configs {
+					if c.Status == model.ProviderStatusActive && embeddingCapable[string(c.Provider)] {
+						providerType = string(c.Provider)
+						return nil
+					}
 				}
 				return nil
 			})


### PR DESCRIPTION
## Summary

The worker's embed-time provider resolver returned the org's default LLM provider verbatim. When that default is Anthropic — which does not publish a public embeddings API — every chunk-time embed call to the Python worker failed with:

`rpc error: code = Internal desc = Anthropic does not publish a public embeddings API. Configure OpenAI, Cohere, or Ollama as the embedding provider for this org/workspace (chat can still route to Anthropic).`

This bit users on the add-URL flow (URL crawl → chunk → embed) once they had set Anthropic as their org default — and was reported in chat today.

## Fix

In `cmd/worker/main.go`'s `resolveProvider`, when the org's default isn't embedding-capable (Anthropic, missing, or unknown), walk `llmRepo.List(...)` and pick the first **active** OpenAI / Cohere / Ollama entry. Only if no embedding-capable provider exists for the org does the resolver fall through to the existing `ollama` literal fallback further down `embedFn`.

Embedding-capable set is a small map literal at the top of the closure: `{"openai": true, "cohere": true, "ollama": true}`. Anthropic remains valid for chat — only the embed path filters it out.

## Test plan

- [x] `go build ./cmd/worker` clean
- [x] `golangci-lint run --new-from-rev=origin/main` 0 issues
- [ ] Manual verification on the demo box after deploy: org with Anthropic-default + at least one OpenAI/Ollama provider can add a URL without the gRPC error
- [ ] Org with **only** Anthropic configured should still fall through to the `ollama` literal default (current behaviour preserved)