### PR TITLE
fix(db): VerifyMigrationsState uses set-based comparison

### DIFF
--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"fmt"
 	"io/fs"
+	"sort"
+	"strconv"
 	"strings"
 
 	_ "github.com/lib/pq" // postgres driver for the database/sql handle goose requires
@@ -46,8 +48,13 @@ func RunMigrations(ctx context.Context, databaseURL string) error {
 }
 
 // VerifyMigrationsState confirms the database has applied exactly the set of
-// migrations embedded in the binary. It is cheap (one COUNT(*) plus a directory
-// walk of migrations.FS) and runs at startup in both edge and cloud profiles.
+// migrations embedded in the binary. It compares the SET of version_ids
+// recorded in goose_db_version against the SET parsed from embedded migration
+// filenames. A simple COUNT(*) check is fragile against intentional or
+// accidental version gaps (e.g. a hot-deploy that runs the SQL by hand before
+// the file lands in main, or a renumbering that skips an id): equal counts
+// can mask a different SET on each side. The set-based comparison surfaces
+// exactly which versions are out of sync.
 //
 // In the edge profile this is a belt-and-braces check that RunMigrations did
 // what it claimed. In the cloud profile (AutoMigrate=false, Bytebase applies
@@ -56,7 +63,7 @@ func RunMigrations(ctx context.Context, databaseURL string) error {
 // silently serving traffic against a stale schema.
 //
 // Goose seeds the version table with version_id=0 on first use; that row is
-// excluded from the applied count.
+// excluded from the applied set.
 func VerifyMigrationsState(ctx context.Context, databaseURL string) error {
 	sqlDB, err := sql.Open("postgres", databaseURL)
 	if err != nil {
@@ -68,14 +75,68 @@ func VerifyMigrationsState(ctx context.Context, databaseURL string) error {
 		return fmt.Errorf("ping postgres for verify: %w", err)
 	}
 
-	// goose_db_version is append-only: every Up and Down appends a row, so a
-	// rollback+re-apply produces multiple is_applied=true rows for the same
-	// version_id. Count only the LATEST row per version_id (highest id) and
-	// keep it iff its is_applied=true. bool_and across the history would
-	// incorrectly drop versions that were rolled back and re-applied.
-	var appliedCount int
-	if err := sqlDB.QueryRowContext(ctx,
-		`SELECT COUNT(*)
+	applied, err := appliedVersionSet(ctx, sqlDB)
+	if err != nil {
+		return fmt.Errorf("read goose_db_version: %w", err)
+	}
+
+	embedded, err := embeddedVersionSet()
+	if err != nil {
+		return fmt.Errorf("read embedded migrations: %w", err)
+	}
+
+	// Symmetric difference. "orphan" = applied to DB but not present in the
+	// embedded set (usually a binary rollback to an older release; serious).
+	// "unapplied" = present in embedded set but not applied (deploy gap;
+	// `goose up` needed).
+	var orphan, unapplied []int64
+	for v := range applied {
+		if _, ok := embedded[v]; !ok {
+			orphan = append(orphan, v)
+		}
+	}
+	for v := range embedded {
+		if _, ok := applied[v]; !ok {
+			unapplied = append(unapplied, v)
+		}
+	}
+
+	if len(orphan) == 0 && len(unapplied) == 0 {
+		return nil
+	}
+
+	sort.Slice(orphan, func(i, j int) bool { return orphan[i] < orphan[j] })
+	sort.Slice(unapplied, func(i, j int) bool { return unapplied[i] < unapplied[j] })
+
+	switch {
+	case len(orphan) > 0 && len(unapplied) > 0:
+		return fmt.Errorf(
+			"migration state mismatch: orphan applied migrations not in embedded set: %v; unapplied migrations: %v",
+			orphan, unapplied,
+		)
+	case len(orphan) > 0:
+		return fmt.Errorf(
+			"migration state mismatch: orphan applied migrations not in embedded set: %v",
+			orphan,
+		)
+	default:
+		return fmt.Errorf(
+			"migration state mismatch: unapplied migrations: %v",
+			unapplied,
+		)
+	}
+}
+
+// appliedVersionSet returns the set of version_ids currently applied in
+// goose_db_version. goose_db_version is append-only: every Up and Down appends
+// a row, so a rollback+re-apply produces multiple is_applied=true rows for the
+// same version_id. We keep only the LATEST row per version_id (highest id)
+// and treat the version as applied iff that latest row has is_applied=true.
+// bool_and across the history would incorrectly drop versions that were
+// rolled back and re-applied.
+func appliedVersionSet(ctx context.Context, sqlDB *sql.DB) (map[int64]struct{}, error) {
+	rows, err := sqlDB.QueryContext(ctx,
+		`SELECT g.version_id
 		FROM goose_db_version g
 		WHERE g.version_id > 0
 		  AND g.is_applied = true
@@ -84,34 +145,50 @@ func VerifyMigrationsState(ctx context.Context, databaseURL string) error {
 		      FROM goose_db_version sub
 		      WHERE sub.version_id = g.version_id
 		  )`,
-	).Scan(&appliedCount); err != nil {
-		return fmt.Errorf("count goose_db_version: %w", err)
-	}
-
-	expectedCount, err := countEmbeddedMigrations()
+	)
 	if err != nil {
-		return fmt.Errorf("count embedded migrations: %w", err)
+		return nil, err
 	}
+	defer func() { _ = rows.Close() }()
 
-	if appliedCount != expectedCount {
-		return fmt.Errorf(
-			"migration state mismatch: %d applied in goose_db_version, %d expected from embedded migrations",
-			appliedCount, expectedCount,
-		)
+	set := make(map[int64]struct{})
+	for rows.Next() {
+		var v int64
+		if err := rows.Scan(&v); err != nil {
+			return nil, err
+		}
+		set[v] = struct{}{}
 	}
-	return nil
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return set, nil
 }
 
-func countEmbeddedMigrations() (int, error) {
+// embeddedVersionSet returns the set of version_ids parsed from the embedded
+// migrations FS. Filenames follow goose's NNNNN_description.sql convention;
+// the leading numeric prefix is the version_id.
+func embeddedVersionSet() (map[int64]struct{}, error) {
 	entries, err := fs.ReadDir(migrations.FS, ".")
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
-	count := 0
+	set := make(map[int64]struct{})
 	for _, e := range entries {
-		if !e.IsDir() && strings.HasSuffix(e.Name(), ".sql") {
-			count++
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".sql") {
+			continue
 		}
+		name := e.Name()
+		// Take everything up to the first underscore as the version id.
+		idx := strings.IndexByte(name, '_')
+		if idx <= 0 {
+			return nil, fmt.Errorf("migration filename %q has no version prefix", name)
+		}
+		v, err := strconv.ParseInt(name[:idx], 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("parse version from migration filename %q: %w", name, err)
+		}
+		set[v] = struct{}{}
 	}
-	return count, nil
+	return set, nil
 }

--- a/internal/db/migrate_test.go
+++ b/internal/db/migrate_test.go
@@ -20,25 +20,96 @@ func TestVerifyMigrationsState_AllAppliedPasses(t *testing.T) {
 	require.NoError(t, db.VerifyMigrationsState(ctx, dsn))
 }
 
-func TestVerifyMigrationsState_MismatchReturnsError(t *testing.T) {
+// When the DB is missing one of the embedded versions (a deploy that ran the
+// new binary but goose hasn't caught up yet), VerifyMigrationsState must name
+// the specific unapplied version_id, not just say "count mismatch".
+func TestVerifyMigrationsState_UnappliedReturnsError(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
 	pool := testutil.NewTestDB(t)
 	dsn := pool.Config().ConnString()
 
+	var latestVersion int64
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT MAX(version_id) FROM goose_db_version WHERE version_id > 0`,
+	).Scan(&latestVersion))
+
 	_, err := pool.Exec(ctx,
-		`DELETE FROM goose_db_version WHERE version_id = (
-			SELECT MAX(version_id) FROM goose_db_version WHERE is_applied = true
-		)`,
+		`DELETE FROM goose_db_version WHERE version_id = $1`, latestVersion,
 	)
 	require.NoError(t, err)
 
 	err = db.VerifyMigrationsState(ctx, dsn)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "migration state mismatch")
+	require.Contains(t, err.Error(), "unapplied migrations")
+	// The specific id must appear in the error so operators can act on it
+	// without re-reading the goose table by hand.
+	require.Contains(t, err.Error(), "[")
 }
 
+// When the DB has a goose row for a version_id that isn't in the embedded
+// migrations FS (a binary rollback to an older release leaves "orphan"
+// applied rows), the error must label them as orphans and list the id.
+func TestVerifyMigrationsState_OrphanReturnsError(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	pool := testutil.NewTestDB(t)
+	dsn := pool.Config().ConnString()
+
+	// Pick a version_id far above anything in the embedded set so it's
+	// unambiguously an orphan from this binary's point of view.
+	const orphanVersion = 999999
+	_, err := pool.Exec(ctx,
+		`INSERT INTO goose_db_version (version_id, is_applied, tstamp)
+		 VALUES ($1, true, now())`,
+		orphanVersion,
+	)
+	require.NoError(t, err)
+
+	err = db.VerifyMigrationsState(ctx, dsn)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "migration state mismatch")
+	require.Contains(t, err.Error(), "orphan applied migrations not in embedded set")
+	require.Contains(t, err.Error(), "999999")
+}
+
+// A version that was rolled back (latest row is_applied=false) must be
+// treated as not-applied for verification purposes — it will then either
+// match the embedded set (no error) or appear in the unapplied list.
+func TestVerifyMigrationsState_RollbackLatestRowNotApplied(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	pool := testutil.NewTestDB(t)
+	dsn := pool.Config().ConnString()
+
+	var latestVersion int64
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT MAX(version_id) FROM goose_db_version WHERE version_id > 0`,
+	).Scan(&latestVersion))
+
+	// Append a rollback row for the latest version. The version is in the
+	// embedded set but the latest row says is_applied=false, so it must be
+	// reported as unapplied.
+	_, err := pool.Exec(ctx,
+		`INSERT INTO goose_db_version (version_id, is_applied, tstamp)
+		 VALUES ($1, false, now())`,
+		latestVersion,
+	)
+	require.NoError(t, err)
+
+	err = db.VerifyMigrationsState(ctx, dsn)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unapplied migrations")
+}
+
+// A rollback followed by a re-apply leaves the LATEST row as is_applied=true,
+// even though earlier rows exist for the same version. VerifyMigrationsState
+// must look at the latest row per version_id and treat the version as
+// applied — bool_and across history would false-positive here.
 func TestVerifyMigrationsState_RollbackThenReapplyPasses(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -46,11 +117,6 @@ func TestVerifyMigrationsState_RollbackThenReapplyPasses(t *testing.T) {
 	pool := testutil.NewTestDB(t)
 	dsn := pool.Config().ConnString()
 
-	// Simulate a rollback then re-apply of the latest migration by appending
-	// two extra rows for its version_id — one with is_applied=false (the
-	// rollback event), one with is_applied=true (the re-apply). Goose's table
-	// is append-only; VerifyMigrationsState must look at the LATEST row per
-	// version_id, not COUNT(*) of is_applied=true rows.
 	var latestVersion int64
 	err := pool.QueryRow(ctx,
 		`SELECT MAX(version_id) FROM goose_db_version WHERE version_id > 0`,
@@ -65,4 +131,37 @@ func TestVerifyMigrationsState_RollbackThenReapplyPasses(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, db.VerifyMigrationsState(ctx, dsn))
+}
+
+// Both orphan and unapplied at once: the error must mention both lists so
+// operators see the full picture rather than fix one and rediscover the
+// other on the next boot.
+func TestVerifyMigrationsState_OrphanAndUnappliedReturnsBoth(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	pool := testutil.NewTestDB(t)
+	dsn := pool.Config().ConnString()
+
+	var latestVersion int64
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT MAX(version_id) FROM goose_db_version WHERE version_id > 0`,
+	).Scan(&latestVersion))
+
+	// Delete the highest applied row → unapplied.
+	_, err := pool.Exec(ctx,
+		`DELETE FROM goose_db_version WHERE version_id = $1`, latestVersion,
+	)
+	require.NoError(t, err)
+	// Insert a far-future version → orphan.
+	_, err = pool.Exec(ctx,
+		`INSERT INTO goose_db_version (version_id, is_applied, tstamp)
+		 VALUES (999999, true, now())`,
+	)
+	require.NoError(t, err)
+
+	err = db.VerifyMigrationsState(ctx, dsn)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "orphan applied migrations not in embedded set")
+	require.Contains(t, err.Error(), "unapplied migrations")
 }


### PR DESCRIPTION
Closes #755.

## What was broken

`internal/db/migrate.go` `VerifyMigrationsState` compared a `COUNT(*)` of applied versions in `goose_db_version` against a count of `.sql` files in the embedded migrations FS. Equal counts can mask a different SET on each side, and any version gap (intentional renumbering, or a hot-deploy that ran SQL by hand before the file landed in `main`) makes the count-based check false-positive both ways.

Demo hit this concretely on a fresh API deploy from `main`: 51 rows applied (versions 1-45, 47-50, 52-53 — missing 46) vs 52 embedded files. The API crash-looped on boot with the generic "migration state mismatch" message until the binary was hand-patched. The 00046 migration (`embeddings_resize_to_768`) had been run manually in May and only landed on `main` via PR #689 afterwards.

## Fix shape

- `appliedVersionSet` reads the SET of `version_id`s whose latest `goose_db_version` row has `is_applied=true`. Keeps the existing latest-row-per-version_id logic so a rollback-then-reapply (which appends multiple rows for the same version_id) doesn't false-positive.
- `embeddedVersionSet` parses the leading numeric prefix from each `.sql` filename in `migrations.FS`.
- Symmetric difference. Error names the specific ids:
  - `"unapplied migrations: [46]"` — deploy gap, `goose up` needed.
  - `"orphan applied migrations not in embedded set: [99]"` — binary rolled back to an older release; serious.
  - Both lists are emitted when both kinds are present.

`RunMigrations` is unchanged: it delegates to `goose.UpContext`, which has no count-based check, so the same bug pattern doesn't apply.

## Tests (`internal/db/migrate_test.go`)

- `_AllAppliedPasses` — set equality → no error.
- `_UnappliedReturnsError` — DB missing the highest version → error names "unapplied migrations".
- `_OrphanReturnsError` — DB has version_id=999999 not in embedded set → error names "orphan applied migrations not in embedded set" and the id.
- `_OrphanAndUnappliedReturnsBoth` — both kinds at once → error mentions both lists.
- `_RollbackLatestRowNotApplied` — latest row `is_applied=false` → version treated as not-applied (reported as unapplied).
- `_RollbackThenReapplyPasses` — multiple rows for the same version_id, latest is `is_applied=true` → version treated as applied (regression guard on the latest-row logic).

`golangci-lint run --new-from-rev=origin/main ./...` → 0 issues. CI runs the testcontainer tests in a clean Docker env; local Colima socket-mount issue prevents running them on my machine.

## One-time demo backfill (performed alongside this PR)

```
docker exec ec2-postgres-1 psql -U raven -d raven -c "
  INSERT INTO goose_db_version (version_id, is_applied, tstamp)
  VALUES (46, true, NOW());"
# verified: SELECT version_id FROM goose_db_version WHERE version_id=46 AND is_applied=true; → 46
```

The 00046 migration is a no-op against the demo schema (embeddings table is already `vector(768)` with the HNSW index from the May hot-deploy). Backfilling the goose row is the documented recovery path for "manual SQL ran before goose got the file". After the next deploy of this branch, the demo will boot cleanly without the DEMO-VERIFY-PATCH.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced database migration state verification with more reliable comparison logic, providing clearer error messages that specifically identify unapplied or orphaned migrations when inconsistencies are detected.

* **Tests**
  * Expanded test coverage for migration state verification scenarios, including orphaned migrations, unapplied migrations, and rollback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->