### PR TITLE
feat(m14): frontend foundation for passkey support

### DIFF
--- a/frontend/src/api/passkeys.ts
+++ b/frontend/src/api/passkeys.ts
@@ -1,0 +1,66 @@
+// Passkey API — thin wrapper around the Raven backend's per-user
+// passkey label endpoints. Credential storage itself lives in the
+// SuperTokens core and is proxied via /auth/webauthn/*; this module
+// only deals with the metadata Raven owns (label, timestamps).
+//
+// Endpoints mirror the design in
+// docs/superpowers/specs/2026-06-04-passkey-auth-design.md (Issue B):
+//   GET    /api/v1/me/passkeys
+//   PATCH  /api/v1/me/passkeys/:credential_id
+//   DELETE /api/v1/me/passkeys/:credential_id
+
+export interface Passkey {
+  credential_id: string
+  label: string
+  created_at: string
+  last_used_at: string | null
+}
+
+const API_BASE = () => import.meta.env.VITE_API_BASE_URL ?? '/api/v1'
+
+async function authFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(API_BASE() + path, {
+    ...init,
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      ...init?.headers,
+    },
+  })
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}))
+    throw new Error(data.message || data.error || `Request failed (${res.status})`)
+  }
+  // DELETE may return 204 No Content with no body; guard JSON parsing.
+  if (res.status === 204) {
+    return undefined as T
+  }
+  const text = await res.text()
+  if (!text) {
+    return undefined as T
+  }
+  return JSON.parse(text) as T
+}
+
+export async function listPasskeys(): Promise<Passkey[]> {
+  const data = await authFetch<Passkey[] | { items: Passkey[] }>(`/me/passkeys`)
+  return Array.isArray(data) ? data : (data?.items ?? [])
+}
+
+export async function relabelPasskey(
+  credentialId: string,
+  label: string,
+): Promise<Passkey> {
+  return authFetch<Passkey>(`/me/passkeys/${encodeURIComponent(credentialId)}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ label }),
+  })
+}
+
+export async function removePasskey(credentialId: string): Promise<void> {
+  await authFetch<void>(`/me/passkeys/${encodeURIComponent(credentialId)}`, {
+    method: 'DELETE',
+  })
+}
+
+export { authFetch as _authFetch }

--- a/frontend/src/plugins/supertokens.ts
+++ b/frontend/src/plugins/supertokens.ts
@@ -1,6 +1,7 @@
 import SuperTokens from "supertokens-web-js"
 import Session from "supertokens-web-js/recipe/session"
 import ThirdParty from "supertokens-web-js/recipe/thirdparty"
+import Webauthn from "supertokens-web-js/recipe/webauthn"
 
 // Shared with components/TurnstileWidget.vue. The widget writes the
 // solved token here; the preAPIHook reads it back when SuperTokens
@@ -53,6 +54,12 @@ export function initSuperTokens() {
       ThirdParty.init({
         preAPIHook: async (context) => attachTurnstileTokenOnSignup(context),
       }),
+      // Webauthn (passkey) recipe — proxied through the Go API's
+      // existing SuperTokensMiddleware to the SuperTokens core. No
+      // recipe-specific options needed for the SDK side: the enrolment
+      // and sign-in flows are triggered explicitly from the
+      // passkey store and login page.
+      Webauthn.init(),
     ],
   })
 }

--- a/frontend/src/stores/passkeys.spec.ts
+++ b/frontend/src/stores/passkeys.spec.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { usePasskeysStore } from './passkeys'
+import * as passkeysApi from '../api/passkeys'
+import Webauthn from 'supertokens-web-js/recipe/webauthn'
+import type { Passkey } from '../api/passkeys'
+
+vi.mock('../api/passkeys')
+vi.mock('supertokens-web-js/recipe/webauthn', () => ({
+  default: {
+    getRegisterOptions: vi.fn(),
+    createCredential: vi.fn(),
+    registerCredential: vi.fn(),
+  },
+}))
+
+const passkeyA: Passkey = {
+  credential_id: 'cred-aaaa',
+  label: 'MacBook Touch ID',
+  created_at: '2026-06-01T10:00:00Z',
+  last_used_at: null,
+}
+
+const passkeyB: Passkey = {
+  credential_id: 'cred-bbbb',
+  label: 'iPhone',
+  created_at: '2026-06-02T10:00:00Z',
+  last_used_at: '2026-06-03T11:00:00Z',
+}
+
+function okGetRegisterOptions() {
+  return {
+    status: 'OK' as const,
+    registerOptions: { challenge: 'chal', timeout: 60000 },
+  }
+}
+
+function okCreateCredential(credentialId: string) {
+  return {
+    status: 'OK' as const,
+    registrationResponse: { id: credentialId, type: 'public-key' },
+  }
+}
+
+function okRegisterCredential() {
+  return { status: 'OK' as const }
+}
+
+describe('usePasskeysStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  describe('fetchPasskeys', () => {
+    it('populates passkeys on success', async () => {
+      vi.mocked(passkeysApi.listPasskeys).mockResolvedValue([passkeyA, passkeyB])
+      const store = usePasskeysStore()
+      await store.fetchPasskeys()
+      expect(store.passkeys).toHaveLength(2)
+      expect(store.passkeys[0].credential_id).toBe('cred-aaaa')
+      expect(store.loading).toBe(false)
+      expect(store.error).toBeNull()
+    })
+
+    it('sets error and leaves passkeys empty on failure', async () => {
+      vi.mocked(passkeysApi.listPasskeys).mockRejectedValue(new Error('Network down'))
+      const store = usePasskeysStore()
+      await store.fetchPasskeys()
+      expect(store.error).toBe('Network down')
+      expect(store.passkeys).toHaveLength(0)
+      expect(store.loading).toBe(false)
+    })
+  })
+
+  describe('addPasskey', () => {
+    it('runs the full WebAuthn ceremony and appends the labeled passkey', async () => {
+      vi.mocked(Webauthn.getRegisterOptions).mockResolvedValue(
+        okGetRegisterOptions() as never,
+      )
+      vi.mocked(Webauthn.createCredential).mockResolvedValue(
+        okCreateCredential('cred-new') as never,
+      )
+      vi.mocked(Webauthn.registerCredential).mockResolvedValue(
+        okRegisterCredential() as never,
+      )
+      const persisted: Passkey = {
+        credential_id: 'cred-new',
+        label: 'Work Laptop',
+        created_at: '2026-06-04T09:00:00Z',
+        last_used_at: null,
+      }
+      vi.mocked(passkeysApi.relabelPasskey).mockResolvedValue(persisted)
+
+      const store = usePasskeysStore()
+      const result = await store.addPasskey('Work Laptop')
+
+      expect(Webauthn.getRegisterOptions).toHaveBeenCalledOnce()
+      expect(Webauthn.createCredential).toHaveBeenCalledOnce()
+      expect(Webauthn.registerCredential).toHaveBeenCalledOnce()
+      expect(passkeysApi.relabelPasskey).toHaveBeenCalledWith('cred-new', 'Work Laptop')
+      expect(result).toEqual(persisted)
+      expect(store.passkeys).toHaveLength(1)
+      expect(store.passkeys[0]).toEqual(persisted)
+      expect(store.error).toBeNull()
+    })
+
+    it('rolls back on getRegisterOptions failure (no API call)', async () => {
+      vi.mocked(passkeysApi.listPasskeys).mockResolvedValue([passkeyA])
+      vi.mocked(Webauthn.getRegisterOptions).mockRejectedValue(
+        new Error('Core unreachable'),
+      )
+
+      const store = usePasskeysStore()
+      await store.fetchPasskeys()
+      const before = store.passkeys.slice()
+
+      await expect(store.addPasskey('Phone')).rejects.toThrow('Core unreachable')
+      expect(store.passkeys).toEqual(before)
+      expect(passkeysApi.relabelPasskey).not.toHaveBeenCalled()
+      expect(store.error).toBe('Core unreachable')
+    })
+
+    it('rolls back when the authenticator declines (createCredential non-OK)', async () => {
+      vi.mocked(passkeysApi.listPasskeys).mockResolvedValue([passkeyA])
+      vi.mocked(Webauthn.getRegisterOptions).mockResolvedValue(
+        okGetRegisterOptions() as never,
+      )
+      vi.mocked(Webauthn.createCredential).mockResolvedValue({
+        status: 'AUTHENTICATOR_ALREADY_REGISTERED',
+      } as never)
+
+      const store = usePasskeysStore()
+      await store.fetchPasskeys()
+      const before = store.passkeys.slice()
+
+      await expect(store.addPasskey('Phone')).rejects.toThrow(
+        /Authenticator declined enrolment/,
+      )
+      expect(store.passkeys).toEqual(before)
+      expect(passkeysApi.relabelPasskey).not.toHaveBeenCalled()
+      expect(store.error).toMatch(/Authenticator declined enrolment/)
+    })
+
+    it('rolls back when the label PATCH API fails after registration', async () => {
+      vi.mocked(passkeysApi.listPasskeys).mockResolvedValue([passkeyA])
+      vi.mocked(Webauthn.getRegisterOptions).mockResolvedValue(
+        okGetRegisterOptions() as never,
+      )
+      vi.mocked(Webauthn.createCredential).mockResolvedValue(
+        okCreateCredential('cred-zzz') as never,
+      )
+      vi.mocked(Webauthn.registerCredential).mockResolvedValue(
+        okRegisterCredential() as never,
+      )
+      vi.mocked(passkeysApi.relabelPasskey).mockRejectedValue(
+        new Error('Label save failed'),
+      )
+
+      const store = usePasskeysStore()
+      await store.fetchPasskeys()
+      const before = store.passkeys.slice()
+
+      await expect(store.addPasskey('Tablet')).rejects.toThrow('Label save failed')
+      expect(store.passkeys).toEqual(before)
+      expect(store.error).toBe('Label save failed')
+    })
+  })
+
+  describe('removePasskey', () => {
+    it('removes the passkey on success', async () => {
+      vi.mocked(passkeysApi.listPasskeys).mockResolvedValue([passkeyA, passkeyB])
+      vi.mocked(passkeysApi.removePasskey).mockResolvedValue(undefined)
+
+      const store = usePasskeysStore()
+      await store.fetchPasskeys()
+      await store.removePasskey('cred-aaaa')
+
+      expect(store.passkeys).toHaveLength(1)
+      expect(store.passkeys[0].credential_id).toBe('cred-bbbb')
+      expect(passkeysApi.removePasskey).toHaveBeenCalledWith('cred-aaaa')
+    })
+
+    it('rolls back on API failure', async () => {
+      vi.mocked(passkeysApi.listPasskeys).mockResolvedValue([passkeyA, passkeyB])
+      vi.mocked(passkeysApi.removePasskey).mockRejectedValue(new Error('500 Server'))
+
+      const store = usePasskeysStore()
+      await store.fetchPasskeys()
+      const before = store.passkeys.slice()
+
+      await expect(store.removePasskey('cred-aaaa')).rejects.toThrow('500 Server')
+      expect(store.passkeys).toEqual(before)
+      expect(store.error).toBe('500 Server')
+    })
+  })
+
+  describe('relabelPasskey', () => {
+    it('updates the label in place on success', async () => {
+      vi.mocked(passkeysApi.listPasskeys).mockResolvedValue([passkeyA, passkeyB])
+      vi.mocked(passkeysApi.relabelPasskey).mockResolvedValue({
+        ...passkeyA,
+        label: 'Renamed Mac',
+      })
+
+      const store = usePasskeysStore()
+      await store.fetchPasskeys()
+      await store.relabelPasskey('cred-aaaa', 'Renamed Mac')
+
+      expect(store.passkeys[0].label).toBe('Renamed Mac')
+      // The other passkey is untouched.
+      expect(store.passkeys[1]).toEqual(passkeyB)
+    })
+
+    it('rolls back on API failure', async () => {
+      vi.mocked(passkeysApi.listPasskeys).mockResolvedValue([passkeyA, passkeyB])
+      vi.mocked(passkeysApi.relabelPasskey).mockRejectedValue(
+        new Error('Conflict'),
+      )
+
+      const store = usePasskeysStore()
+      await store.fetchPasskeys()
+      const before = store.passkeys.map((p) => ({ ...p }))
+
+      await expect(
+        store.relabelPasskey('cred-aaaa', 'Renamed Mac'),
+      ).rejects.toThrow('Conflict')
+      expect(store.passkeys).toEqual(before)
+      expect(store.error).toBe('Conflict')
+    })
+
+    it('throws when the credential is not in local state', async () => {
+      const store = usePasskeysStore()
+      await expect(
+        store.relabelPasskey('cred-missing', 'X'),
+      ).rejects.toThrow(/not found in local state/)
+      expect(passkeysApi.relabelPasskey).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/frontend/src/stores/passkeys.ts
+++ b/frontend/src/stores/passkeys.ts
@@ -1,0 +1,175 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { findIndex } from 'remeda'
+import WebauthnRecipe from 'supertokens-web-js/recipe/webauthn'
+import {
+  listPasskeys,
+  relabelPasskey as relabelPasskeyApi,
+  removePasskey as removePasskeyApi,
+  type Passkey,
+} from '../api/passkeys'
+
+// The SuperTokens v0.16 webauthn recipe ships overloaded static
+// methods with many error variants (see
+// supertokens-web-js/recipe/webauthn types). For the enrolment flow we
+// only need a narrow contract: each call returns `{ status, ... }`,
+// failure surfaces a non-OK status. Cast through a local minimal shape
+// so the store doesn't have to thread every error union through the
+// optimistic-update code, and so the tests can mock the same surface
+// without re-declaring every SDK type.
+type PasskeyEnrolment = {
+  getRegisterOptions: (input: {
+    userContext: Record<string, unknown>
+  }) => Promise<{ status: string; registerOptions?: unknown }>
+  createCredential: (input: {
+    registrationOptions: unknown
+    userContext: Record<string, unknown>
+  }) => Promise<{ status: string; registrationResponse?: { id: string } }>
+  registerCredential: (input: {
+    response: unknown
+    userContext: Record<string, unknown>
+  }) => Promise<{ status: string }>
+}
+
+const Webauthn = WebauthnRecipe as unknown as PasskeyEnrolment
+
+/**
+ * usePasskeysStore — manages the current user's enrolled passkeys.
+ *
+ * The store keeps its `passkeys` array in lockstep with the backend.
+ * Mutations are optimistic: the local state is updated immediately so
+ * the UI feels instant, and the action rolls the state back to the
+ * previous snapshot if the API call (or the WebAuthn browser ceremony)
+ * fails. This matches the design in
+ * docs/superpowers/specs/2026-06-04-passkey-auth-design.md (Issue B).
+ */
+export const usePasskeysStore = defineStore('passkeys', () => {
+  const passkeys = ref<Passkey[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+
+  async function fetchPasskeys(): Promise<void> {
+    loading.value = true
+    error.value = null
+    try {
+      passkeys.value = await listPasskeys()
+    } catch (e) {
+      error.value = (e as Error).message
+    } finally {
+      loading.value = false
+    }
+  }
+
+  /**
+   * Run the WebAuthn enrolment ceremony and persist the user-supplied
+   * label.
+   *
+   * Flow (per spec Issue B):
+   *   1. SuperTokens core returns challenge + RP info via
+   *      `Webauthn.getRegisterOptions()`.
+   *   2. The browser opens the authenticator
+   *      (`Webauthn.createCredential`) — biometric / PIN gate.
+   *   3. The signed attestation is posted back to the core via
+   *      `Webauthn.registerCredential`.
+   *   4. The Raven backend stores the user-friendly label against the
+   *      new credential ID.
+   *
+   * Optimistic: a placeholder row is pushed to local state as soon as
+   * the credential ID is known. Any failure rolls back to the snapshot
+   * taken before the ceremony started.
+   */
+  async function addPasskey(label: string): Promise<Passkey> {
+    error.value = null
+    const snapshot = passkeys.value.slice()
+    try {
+      const options = await Webauthn.getRegisterOptions({ userContext: {} })
+      if (options.status !== 'OK' || options.registerOptions === undefined) {
+        throw new Error(`Failed to start passkey enrolment: ${options.status}`)
+      }
+      const created = await Webauthn.createCredential({
+        registrationOptions: options.registerOptions,
+        userContext: {},
+      })
+      if (created.status !== 'OK' || !created.registrationResponse) {
+        throw new Error(`Authenticator declined enrolment: ${created.status}`)
+      }
+      const registered = await Webauthn.registerCredential({
+        response: created.registrationResponse,
+        userContext: {},
+      })
+      if (registered.status !== 'OK') {
+        throw new Error(`Passkey registration rejected: ${registered.status}`)
+      }
+      const credentialId = created.registrationResponse.id
+
+      // Optimistic: render the new row immediately while the label
+      // PATCH is in flight so the Settings UI doesn't flicker.
+      const optimistic: Passkey = {
+        credential_id: credentialId,
+        label,
+        created_at: new Date().toISOString(),
+        last_used_at: null,
+      }
+      passkeys.value = [...snapshot, optimistic]
+
+      const persisted = await relabelPasskeyApi(credentialId, label)
+      const idx = findIndex(passkeys.value, (p) => p.credential_id === credentialId)
+      if (idx !== -1) {
+        passkeys.value[idx] = persisted
+      }
+      return persisted
+    } catch (e) {
+      passkeys.value = snapshot
+      error.value = (e as Error).message
+      throw e
+    }
+  }
+
+  async function removePasskey(credentialId: string): Promise<void> {
+    error.value = null
+    const snapshot = passkeys.value.slice()
+    passkeys.value = passkeys.value.filter(
+      (p) => p.credential_id !== credentialId,
+    )
+    try {
+      await removePasskeyApi(credentialId)
+    } catch (e) {
+      passkeys.value = snapshot
+      error.value = (e as Error).message
+      throw e
+    }
+  }
+
+  async function relabelPasskey(
+    credentialId: string,
+    label: string,
+  ): Promise<void> {
+    error.value = null
+    const snapshot = passkeys.value.slice()
+    const idx = findIndex(passkeys.value, (p) => p.credential_id === credentialId)
+    if (idx === -1) {
+      // Nothing to update — surface a no-op error so the caller can
+      // refetch instead of silently ignoring the request.
+      throw new Error(`Passkey ${credentialId} not found in local state`)
+    }
+    passkeys.value[idx] = { ...passkeys.value[idx], label }
+    try {
+      const updated = await relabelPasskeyApi(credentialId, label)
+      passkeys.value[idx] = updated
+    } catch (e) {
+      passkeys.value = snapshot
+      error.value = (e as Error).message
+      throw e
+    }
+  }
+
+  return {
+    passkeys,
+    loading,
+    error,
+    fetchPasskeys,
+    addPasskey,
+    removePasskey,
+    relabelPasskey,
+  }
+})


### PR DESCRIPTION
## Summary

Frontend foundation for M14 passkey auth (issue #772). Wires up the SuperTokens `webauthn` recipe and adds the Raven-side API wrapper, Pinia store, and Vitest spec that future UI work (Settings → Authentication, Login → "Sign in with Passkey") will sit on top of.

No user-visible UI yet — that lands in the follow-up PR against #773 once the backend handler (issue B) is merged.

## Changes

- `frontend/src/plugins/supertokens.ts` — register `Webauthn.init()` in the recipe list alongside `Session.init()` and `ThirdParty.init()`.
- `frontend/src/api/passkeys.ts` (new) — `Passkey` type plus thin `authFetch` wrappers for `GET /me/passkeys`, `PATCH /me/passkeys/:id`, `DELETE /me/passkeys/:id`.
- `frontend/src/stores/passkeys.ts` (new) — Pinia store with optimistic updates and rollback for `fetchPasskeys`, `addPasskey` (full WebAuthn ceremony → label persist), `removePasskey`, `relabelPasskey`.
- `frontend/src/stores/passkeys.spec.ts` (new) — 11 Vitest cases: fetch happy + error, add happy + 3 rollback branches (options failure, authenticator decline, label PATCH failure), remove happy + rollback, relabel happy + rollback + missing-credential guard.

## Test plan

- [x] `cd frontend && npm install` succeeds
- [x] `cd frontend && npm run lint` — 0 errors (pre-existing warnings only)
- [x] `cd frontend && npm run test:unit` — 149/149 passing (11 new cases for `usePasskeysStore`)
- [x] `vue-tsc -b` — no new errors introduced (one pre-existing `LlmProviderListPage.vue` error unrelated to this PR)
- [ ] Manual smoke once backend handler (issue #773) lands

## Spec

`docs/superpowers/specs/2026-06-04-passkey-auth-design.md` (Issue B) — landing alongside the backend PR.

Closes #772

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added passkey management functionality allowing users to enroll, manage, and use passkeys for secure authentication.
  * Integrated WebAuthn support enabling passkey-based sign-in and enrollment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->