### PR TITLE
feat(m14): pin SuperTokens core to 11.4.4 + add WebAuthn RP config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,15 @@ VALKEY_URL=redis://valkey:6379/0
 # ─── SuperTokens ─────────────────────────────────────────────────────────────
 SUPERTOKENS_API_KEY=supertokens-dev-key-replace-me
 
+# ─── WebAuthn / Passkey Relying Party (M14 #775) ─────────────────────────────
+# RP_ID is the eTLD+1 the browser scopes generated credentials to. It MUST
+# match the domain the frontend is served from — credentials registered
+# against one RP_ID cannot be used from another. Use `localhost` for local
+# development; set the registered domain (e.g. `ravencloak.org`) in prod.
+# RP_NAME is the human-readable name shown in the browser's passkey prompt.
+RAVEN_WEBAUTHN_RP_ID=ravencloak.org
+RAVEN_WEBAUTHN_RP_NAME=Raven
+
 # Google OAuth (for SuperTokens social login)
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=

--- a/deploy/ec2/docker-compose.server.yml
+++ b/deploy/ec2/docker-compose.server.yml
@@ -32,6 +32,9 @@ services:
     environment:
       SUPERTOKENS_CONNECTION_URI: "http://supertokens:3567"
       SUPERTOKENS_API_KEY: "${SUPERTOKENS_API_KEY}"
+      # WebAuthn / Passkey Relying Party config (M14 #775).
+      RAVEN_WEBAUTHN_RP_ID: "${RAVEN_WEBAUTHN_RP_ID:-localhost}"
+      RAVEN_WEBAUTHN_RP_NAME: "${RAVEN_WEBAUTHN_RP_NAME:-Raven}"
     depends_on:
       postgres:
         condition: service_healthy
@@ -62,6 +65,9 @@ services:
     environment:
       SUPERTOKENS_CONNECTION_URI: "http://supertokens:3567"
       SUPERTOKENS_API_KEY: "${SUPERTOKENS_API_KEY}"
+      # WebAuthn / Passkey Relying Party config (M14 #775).
+      RAVEN_WEBAUTHN_RP_ID: "${RAVEN_WEBAUTHN_RP_ID:-localhost}"
+      RAVEN_WEBAUTHN_RP_NAME: "${RAVEN_WEBAUTHN_RP_NAME:-Raven}"
     entrypoint: ["dotenvx", "run", "--", "/app/worker"]
     depends_on:
       postgres:
@@ -129,7 +135,10 @@ services:
 
   # ─── SuperTokens Auth Backend ─────────────────────────────────────────────
   supertokens:
-    image: registry.supertokens.io/supertokens/supertokens-postgresql
+    # Pinned to the latest stable tag with WebAuthn / passkey support (core
+    # v11.4.4 — see M14 #775). The `latest` tag is intentionally avoided so
+    # passkey behaviour stays reproducible across redeploys.
+    image: registry.supertokens.io/supertokens/supertokens-postgresql:11.4.4
     environment:
       POSTGRESQL_CONNECTION_URI: "postgresql://${POSTGRES_USER:-raven}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-raven}"
       API_KEYS: "${SUPERTOKENS_API_KEY}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,12 @@ services:
       RAVEN_OTEL_SERVICE_NAME: "raven-api"
       RAVEN_SUPERTOKENS_CONNECTION_URI: "http://supertokens:3567"
       RAVEN_SUPERTOKENS_API_KEY: "${SUPERTOKENS_API_KEY:-supertokens-dev-key-replace-me}"
+      # WebAuthn / Passkey Relying Party config (M14 #775). Default `localhost`
+      # so local dev works out of the box; production must set the registered
+      # domain (e.g. `ravencloak.org`) so generated credentials are scoped
+      # correctly.
+      RAVEN_WEBAUTHN_RP_ID: "${RAVEN_WEBAUTHN_RP_ID:-localhost}"
+      RAVEN_WEBAUTHN_RP_NAME: "${RAVEN_WEBAUTHN_RP_NAME:-Raven}"
       GOOGLE_CLIENT_ID: "${GOOGLE_CLIENT_ID}"
       GOOGLE_CLIENT_SECRET: "${GOOGLE_CLIENT_SECRET}"
       TMDB_API_KEY: "${TMDB_API_KEY:-}"
@@ -280,7 +286,10 @@ services:
 
   # ─── SuperTokens Auth Backend ─────────────────────────────────────────────
   supertokens:
-    image: registry.supertokens.io/supertokens/supertokens-postgresql
+    # Pinned to the latest stable tag with WebAuthn / passkey support (core
+    # v11.4.4 — see M14 #775). The `latest` tag is intentionally avoided so
+    # passkey behaviour stays reproducible across redeploys.
+    image: registry.supertokens.io/supertokens/supertokens-postgresql:11.4.4
     # Hardening: SuperTokens Core boots a JVM that listens on a high port and
     # drops to the `supertokens` user via its entrypoint.
     security_opt:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	GRPC         GRPCConfig
 	OTel         OTelConfig
 	SuperTokens  SuperTokensConfig
+	Webauthn     WebauthnConfig
 	GoogleOAuth  GoogleOAuthConfig
 	CORS         CORSConfig
 	RateLimit    RateLimitConfig
@@ -273,6 +274,21 @@ type SuperTokensConfig struct {
 	WebsiteDomain string `mapstructure:"website_domain"` // e.g. https://app.ravencloak.org
 }
 
+// WebauthnConfig holds the Relying Party identity surfaced to clients during
+// passkey registration and authentication ceremonies (M14 #775). The values
+// flow into SuperTokens' WebAuthn recipe at init time; mismatched values
+// across deploy targets will silently invalidate previously-registered
+// credentials, so keep them stable per environment.
+type WebauthnConfig struct {
+	// RPID is the eTLD+1 the browser scopes generated credentials to. MUST
+	// match the domain the frontend is served from. Use `localhost` for
+	// local dev; set the registered domain in prod (e.g. `ravencloak.org`).
+	RPID string `mapstructure:"rp_id"`
+	// RPName is the human-readable name shown in the browser's passkey
+	// prompt (e.g. "Raven").
+	RPName string `mapstructure:"rp_name"`
+}
+
 // GoogleOAuthConfig holds Google OAuth credentials for social login via SuperTokens.
 type GoogleOAuthConfig struct {
 	ClientID     string `mapstructure:"client_id"`
@@ -393,6 +409,8 @@ func Load() (*Config, error) {
 	v.SetDefault("supertokens.api_key", "")
 	v.SetDefault("supertokens.api_domain", "http://localhost:8081")
 	v.SetDefault("supertokens.website_domain", "http://localhost:5173")
+	v.SetDefault("webauthn.rp_id", "localhost")
+	v.SetDefault("webauthn.rp_name", "Raven")
 	v.SetDefault("googleoauth.client_id", "")
 	v.SetDefault("googleoauth.client_secret", "")
 	// CORS allowed origins can be overridden via the RAVEN_CORS_ALLOWED_ORIGINS
@@ -530,6 +548,8 @@ func Load() (*Config, error) {
 	_ = v.BindEnv("supertokens.api_key", "RAVEN_SUPERTOKENS_API_KEY")
 	_ = v.BindEnv("supertokens.api_domain", "RAVEN_SUPERTOKENS_API_DOMAIN")
 	_ = v.BindEnv("supertokens.website_domain", "RAVEN_SUPERTOKENS_WEBSITE_DOMAIN")
+	_ = v.BindEnv("webauthn.rp_id", "RAVEN_WEBAUTHN_RP_ID")
+	_ = v.BindEnv("webauthn.rp_name", "RAVEN_WEBAUTHN_RP_NAME")
 	_ = v.BindEnv("googleoauth.client_id", "GOOGLE_CLIENT_ID")
 	_ = v.BindEnv("googleoauth.client_secret", "GOOGLE_CLIENT_SECRET")
 	_ = v.BindEnv("server.port", "RAVEN_SERVER_PORT")


### PR DESCRIPTION
## Summary

Pins the SuperTokens postgresql image at the latest stable tag with WebAuthn / passkey support so passkey behaviour stays reproducible across redeploys, and introduces `RAVEN_WEBAUTHN_RP_ID` / `RAVEN_WEBAUTHN_RP_NAME` env vars wired through Go config and both compose files.

- `registry.supertokens.io/supertokens/supertokens-postgresql:11.4.4` pinned in `docker-compose.yml` and `deploy/ec2/docker-compose.server.yml` (replacing implicit `:latest`).
- New `RAVEN_WEBAUTHN_RP_ID` (default `localhost`) and `RAVEN_WEBAUTHN_RP_NAME` (default `Raven`) env vars surfaced to the `api` and `worker` services.
- New `WebauthnConfig` (RPID, RPName) added to `internal/config/config.go` using the codebase's existing viper `SetDefault` + `BindEnv` pattern (this file uses `mapstructure` tags + viper, not `envconfig`; the spec's `envconfig` reference doesn't match the actual pattern so I followed the convention already in the file).
- `.env.example` gets a dedicated `WebAuthn / Passkey Relying Party` section documenting both vars.

Closes #775

## Step 1 — probe results on the demo box (Vultr `64.176.97.248`)

```text
$ docker ps --format '{{.Names}}\t{{.Image}}' | grep -i supertokens
ec2-supertokens-1   registry.supertokens.io/supertokens/supertokens-postgresql

$ docker exec ec2-supertokens-1 cat /usr/lib/supertokens/version.yaml
core_version: 11.4.4
plugin_interface_version: 8.5.0
plugin_version: 9.4.2
plugin_name: postgresql

$ docker exec ec2-supertokens-1 curl -s -H 'api-key: ...' http://localhost:3567/apiversion
{"versions":["2.14","2.13","2.12","2.11","2.10","2.21","2.20","2.19","2.18","2.17","3.0","2.16","3.1","4.0","2.15","5.0","5.1","5.2","5.3","2.7","5.4","2.8","2.9"]}

# WebAuthn recipe probe (CDI 5.3 + rid: webauthn):
$ curl -s -o /tmp/r.txt -w 'HTTP %{http_code}\n' \
    -H 'rid: webauthn' -H 'cdi-version: 5.3' -H 'api-key: ...' \
    http://localhost:3567/recipe/webauthn/options
HTTP 400
Field name 'webauthnGeneratedOptionsId' is missing in GET request
```

**Verdict:** the current core (11.4.4) already supports WebAuthn — the `HTTP 400` with a webauthn-specific field-name error proves the recipe is registered; a missing recipe would be `HTTP 404 / "recipe not initialized"`. The image was running floating `:latest`; this PR pins it to `:11.4.4` (currently the latest stable tag on Docker Hub, last updated 2026-04-24).

## RP ID propagation note

`supertokens-golang` does not yet ship a WebAuthn recipe, so the new `RAVEN_WEBAUTHN_RP_ID` / `RAVEN_WEBAUTHN_RP_NAME` values are not wired into a recipe init call from Go in this PR. They are surfaced through `cfg.Webauthn.RPID` / `cfg.Webauthn.RPName` for the upcoming passkey API + frontend stack (PR #777 is the foundation). The SuperTokens core currently derives RP_ID from the frontend's origin during ceremony; the env-side knob is the contract we want once a Go recipe (or tenant-level init call) lands.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/config/... ./internal/handler/... ./internal/service/...` passes (incl. existing passkey handler/service tests added by #777)
- [x] `golangci-lint run --new-from-rev=origin/main ./...` -> 0 issues
- [x] Verified the demo box core (11.4.4) responds to a webauthn recipe probe with a recipe-aware error (not a 404)
- [ ] CI green