### PR TITLE
fix(llm-providers): coalesce undefined detail in test-connection handlers

### DIFF
--- a/frontend/src/pages/llm-providers/LlmProviderListPage.vue
+++ b/frontend/src/pages/llm-providers/LlmProviderListPage.vue
@@ -596,7 +596,7 @@ async function runTestConnection() {
       api_key,
     })
     createTestStatus.value = result.ok ? 'pass' : 'fail'
-    createTestDetail.value = result.detail
+    createTestDetail.value = result.detail ?? ''
   } catch (e: unknown) {
     createTestStatus.value = 'fail'
     createTestDetail.value = e instanceof Error ? e.message : 'Test failed'


### PR DESCRIPTION
Hotfix for the Cloudflare Pages build failure on main.

```
src/pages/llm-providers/LlmProviderListPage.vue(599,5): error TS2322:
Type 'string | undefined' is not assignable to type 'string'.
```

`TestConnectionResult.detail` is optional but `createTestDetail` is typed `ref<string>`. Added `?? ''` to every assignment from `result.detail`.

Verified locally: `pnpm exec vue-tsc -b` clean, `pnpm build` succeeds.