### PR TITLE
feat(marketplace): unpublish endpoint + 90-day slug hold + 410-Gone helper (#727)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -536,7 +536,8 @@ func main() {
 		return kbStatusGuard.RequireInTx(ctx, tx, orgID, kbID, service.KBActionPublish)
 	}
 	publishSvc := marketplace.NewPublishService(pool, publishGate)
-	kbHandler := handler.NewKBHandler(kbSvc).WithPublisher(publishSvc)
+	unpublishSvc := marketplace.NewUnpublishService(pool, publishGate) // #727 — same gate.
+	kbHandler := handler.NewKBHandler(kbSvc).WithPublisher(publishSvc).WithUnpublisher(unpublishSvc)
 
 	// Marketplace moderation (issue #734, ADR-0006 + ADR-0008):
 	// reports + takedowns + admin approve/dismiss. The publisher email
@@ -773,6 +774,9 @@ func main() {
 				// gate as Archive since publishing is an irreversible-ish
 				// content-grade action.
 				kb.POST("/:kb_id/publish", resolveWSRole, middleware.RequireWorkspaceRole("admin"), kbHandler.Publish)
+				// Marketplace unpublish (issue #727, ADR-0007). Same admin
+				// gate as publish since the action affects external URLs.
+				kb.POST("/:kb_id/unpublish", resolveWSRole, middleware.RequireWorkspaceRole("admin"), kbHandler.Unpublish)
 
 				// Full-text search (nested under knowledge base)
 				kb.GET("/:kb_id/search", searchHandler.Search)

--- a/internal/handler/kb.go
+++ b/internal/handler/kb.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/samber/lo"
 
 	"github.com/ravencloak-org/Raven/internal/marketplace"
@@ -33,7 +34,7 @@ type KBPublisher interface {
 // KB handler needs. Mirrors KBPublisher so tests can stub the
 // transition without touching pgx wiring.
 type KBUnpublisher interface {
-	UnpublishKB(ctx context.Context, orgID, kbID string) (*marketplace.UnpublishResult, error)
+	UnpublishKB(ctx context.Context, orgID, wsID, kbID string) (*marketplace.UnpublishResult, error)
 }
 
 // PublishKBRequest is the payload for POST .../knowledge-bases/{id}/publish.
@@ -258,7 +259,26 @@ func (h *KBHandler) Unpublish(c *gin.Context) {
 		return
 	}
 	orgID := c.Param("org_id")
+	wsID := c.Param("ws_id")
 	kbID := c.Param("kb_id")
+	// Validate UUIDs at the handler boundary so malformed input surfaces
+	// as a 422 rather than a 500 from a downstream pgx parse error. Same
+	// shape as the marketplace import handler.
+	if _, err := uuid.Parse(orgID); err != nil {
+		_ = c.Error(apierror.NewUnprocessableEntity("org_id is not a valid UUID"))
+		c.Abort()
+		return
+	}
+	if _, err := uuid.Parse(wsID); err != nil {
+		_ = c.Error(apierror.NewUnprocessableEntity("ws_id is not a valid UUID"))
+		c.Abort()
+		return
+	}
+	if _, err := uuid.Parse(kbID); err != nil {
+		_ = c.Error(apierror.NewUnprocessableEntity("kb_id is not a valid UUID"))
+		c.Abort()
+		return
+	}
 	userID, _ := c.Get(string(middleware.ContextKeyUserID))
 	userIDStr, _ := userID.(string)
 	if userIDStr == "" {
@@ -271,7 +291,7 @@ func (h *KBHandler) Unpublish(c *gin.Context) {
 		return
 	}
 
-	result, err := h.unpublisher.UnpublishKB(c.Request.Context(), orgID, kbID)
+	result, err := h.unpublisher.UnpublishKB(c.Request.Context(), orgID, wsID, kbID)
 	if err != nil {
 		_ = c.Error(err)
 		c.Abort()

--- a/internal/handler/kb.go
+++ b/internal/handler/kb.go
@@ -29,6 +29,13 @@ type KBPublisher interface {
 	PublishKB(ctx context.Context, orgID, kbID, userID, licenseSPDXID string) (*marketplace.PublishResult, error)
 }
 
+// KBUnpublisher is the narrow slice of marketplace.UnpublishService the
+// KB handler needs. Mirrors KBPublisher so tests can stub the
+// transition without touching pgx wiring.
+type KBUnpublisher interface {
+	UnpublishKB(ctx context.Context, orgID, kbID string) (*marketplace.UnpublishResult, error)
+}
+
 // PublishKBRequest is the payload for POST .../knowledge-bases/{id}/publish.
 // The SPDX identifier is required and is validated against the canonical
 // allow-list in marketplace.IsAllowedLicense — the binding tag only catches
@@ -39,8 +46,9 @@ type PublishKBRequest struct {
 
 // KBHandler handles HTTP requests for knowledge base management.
 type KBHandler struct {
-	svc       KBServicer
-	publisher KBPublisher
+	svc         KBServicer
+	publisher   KBPublisher
+	unpublisher KBUnpublisher
 }
 
 // NewKBHandler creates a new KBHandler. The publisher is optional and may
@@ -57,6 +65,14 @@ func NewKBHandler(svc KBServicer) *KBHandler {
 // path with a stub.
 func (h *KBHandler) WithPublisher(p KBPublisher) *KBHandler {
 	h.publisher = p
+	return h
+}
+
+// WithUnpublisher wires the Marketplace unpublish service. Symmetric
+// with WithPublisher — same opt-in setter shape so test wiring and
+// production main.go both stay one line per dependency.
+func (h *KBHandler) WithUnpublisher(u KBUnpublisher) *KBHandler {
+	h.unpublisher = u
 	return h
 }
 
@@ -207,6 +223,55 @@ func (h *KBHandler) Publish(c *gin.Context) {
 	}
 
 	result, err := h.publisher.PublishKB(c.Request.Context(), orgID, kbID, userIDStr, req.LicenseSPDXID)
+	if err != nil {
+		_ = c.Error(err)
+		c.Abort()
+		return
+	}
+	c.JSON(http.StatusOK, result)
+}
+
+// Unpublish handles POST /api/v1/orgs/:org_id/workspaces/:ws_id/knowledge-bases/:kb_id/unpublish.
+// Flips a KB from public back to private and registers a 90-day slug
+// hold so external Marketplace links resolve to 410 Gone for the
+// duration (ADR-0007). Requires workspace role "admin" (enforced at
+// route registration) — same gate as Publish since the action is
+// publisher-only and affects external URLs.
+//
+// @Summary     Unpublish knowledge base from Marketplace
+// @Tags        knowledge-bases
+// @Produce     json
+// @Security    BearerAuth
+// @Param       org_id path string true "Organisation ID"
+// @Param       ws_id  path string true "Workspace ID"
+// @Param       kb_id  path string true "Knowledge base ID"
+// @Success     200 {object} marketplace.UnpublishResult
+// @Failure     401 {object} apierror.AppError
+// @Failure     403 {object} apierror.AppError
+// @Failure     404 {object} apierror.AppError
+// @Failure     409 {object} apierror.AppError
+// @Router      /orgs/{org_id}/workspaces/{ws_id}/knowledge-bases/{kb_id}/unpublish [post]
+func (h *KBHandler) Unpublish(c *gin.Context) {
+	if h.unpublisher == nil {
+		_ = c.Error(apierror.NewInternal("unpublish service not wired"))
+		c.Abort()
+		return
+	}
+	orgID := c.Param("org_id")
+	kbID := c.Param("kb_id")
+	userID, _ := c.Get(string(middleware.ContextKeyUserID))
+	userIDStr, _ := userID.(string)
+	if userIDStr == "" {
+		// Auth middleware should have already short-circuited; the
+		// defence-in-depth check belongs here too. Same shape as
+		// Publish so the two routes stay easy to reason about
+		// together.
+		_ = c.Error(apierror.NewUnauthorized("user context missing"))
+		c.Abort()
+		return
+	}
+
+	result, err := h.unpublisher.UnpublishKB(c.Request.Context(), orgID, kbID)
 	if err != nil {
 		_ = c.Error(err)
 		c.Abort()

--- a/internal/handler/kb_test.go
+++ b/internal/handler/kb_test.go
@@ -433,19 +433,20 @@ func TestUpdateKB_RejectsOutOfRangeThreshold(t *testing.T) {
 // mockUnpublisher implements handler.KBUnpublisher for unit tests
 // covering the /unpublish route. Symmetric with mockPublisher.
 type mockUnpublisher struct {
-	unpublishFn func(ctx context.Context, orgID, kbID string) (*marketplace.UnpublishResult, error)
+	unpublishFn func(ctx context.Context, orgID, wsID, kbID string) (*marketplace.UnpublishResult, error)
 	lastCall    struct {
-		orgID, kbID string
+		orgID, wsID, kbID string
 	}
 }
 
-func (m *mockUnpublisher) UnpublishKB(ctx context.Context, orgID, kbID string) (*marketplace.UnpublishResult, error) {
+func (m *mockUnpublisher) UnpublishKB(ctx context.Context, orgID, wsID, kbID string) (*marketplace.UnpublishResult, error) {
 	m.lastCall.orgID = orgID
+	m.lastCall.wsID = wsID
 	m.lastCall.kbID = kbID
 	if m.unpublishFn == nil {
 		return nil, apierror.NewInternal("mock unpublishFn not set")
 	}
-	return m.unpublishFn(ctx, orgID, kbID)
+	return m.unpublishFn(ctx, orgID, wsID, kbID)
 }
 
 // newKBRouterWithUnpublisher mirrors newKBRouterWithPublisher for the
@@ -473,7 +474,7 @@ func newKBRouterWithUnpublisher(svc handler.KBServicer, unpub handler.KBUnpublis
 func TestUnpublishKB_Success(t *testing.T) {
 	heldUntil := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
 	unpub := &mockUnpublisher{
-		unpublishFn: func(_ context.Context, _, _ string) (*marketplace.UnpublishResult, error) {
+		unpublishFn: func(_ context.Context, _, _, _ string) (*marketplace.UnpublishResult, error) {
 			return &marketplace.UnpublishResult{
 				Visibility:    model.KBVisibilityPrivate,
 				SlugHeldUntil: heldUntil,
@@ -484,7 +485,7 @@ func TestUnpublishKB_Success(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
-		"/api/v1/orgs/org-abc/workspaces/ws-1/knowledge-bases/kb-1/unpublish",
+		"/api/v1/orgs/041b0ae6-ae25-404b-8b46-06857a874222/workspaces/83311cb6-f03a-4ebd-a1d8-4a382a7edff7/knowledge-bases/6ceb1402-876b-4998-aaed-72e891e1c56e/unpublish",
 		http.NoBody,
 	)
 	r.ServeHTTP(w, req)
@@ -492,7 +493,9 @@ func TestUnpublishKB_Success(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
-	if unpub.lastCall.orgID != "org-abc" || unpub.lastCall.kbID != "kb-1" {
+	if unpub.lastCall.orgID != "041b0ae6-ae25-404b-8b46-06857a874222" ||
+		unpub.lastCall.wsID != "83311cb6-f03a-4ebd-a1d8-4a382a7edff7" ||
+		unpub.lastCall.kbID != "6ceb1402-876b-4998-aaed-72e891e1c56e" {
 		t.Errorf("path params not propagated: %+v", unpub.lastCall)
 	}
 
@@ -514,7 +517,7 @@ func TestUnpublishKB_MissingUserID_Returns401(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
-		"/api/v1/orgs/org-abc/workspaces/ws-1/knowledge-bases/kb-1/unpublish",
+		"/api/v1/orgs/041b0ae6-ae25-404b-8b46-06857a874222/workspaces/83311cb6-f03a-4ebd-a1d8-4a382a7edff7/knowledge-bases/6ceb1402-876b-4998-aaed-72e891e1c56e/unpublish",
 		http.NoBody,
 	)
 	r.ServeHTTP(w, req)
@@ -529,14 +532,14 @@ func TestUnpublishKB_MissingUserID_Returns401(t *testing.T) {
 
 func TestUnpublishKB_NotFound_Returns404(t *testing.T) {
 	unpub := &mockUnpublisher{
-		unpublishFn: func(_ context.Context, _, _ string) (*marketplace.UnpublishResult, error) {
+		unpublishFn: func(_ context.Context, _, _, _ string) (*marketplace.UnpublishResult, error) {
 			return nil, apierror.NewNotFound("knowledge base not found")
 		},
 	}
 	r := newKBRouterWithUnpublisher(&mockKBService{}, unpub, "user-1")
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
-		"/api/v1/orgs/org-abc/workspaces/ws-1/knowledge-bases/missing/unpublish",
+		"/api/v1/orgs/041b0ae6-ae25-404b-8b46-06857a874222/workspaces/83311cb6-f03a-4ebd-a1d8-4a382a7edff7/knowledge-bases/00000000-0000-0000-0000-000000000000/unpublish",
 		http.NoBody,
 	)
 	r.ServeHTTP(w, req)
@@ -547,14 +550,14 @@ func TestUnpublishKB_NotFound_Returns404(t *testing.T) {
 
 func TestUnpublishKB_KBFrozen_Returns409(t *testing.T) {
 	unpub := &mockUnpublisher{
-		unpublishFn: func(_ context.Context, _, _ string) (*marketplace.UnpublishResult, error) {
+		unpublishFn: func(_ context.Context, _, _, _ string) (*marketplace.UnpublishResult, error) {
 			return nil, apierror.NewKBFrozen("frozen on Free Plan")
 		},
 	}
 	r := newKBRouterWithUnpublisher(&mockKBService{}, unpub, "user-1")
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
-		"/api/v1/orgs/org-abc/workspaces/ws-1/knowledge-bases/kb-1/unpublish",
+		"/api/v1/orgs/041b0ae6-ae25-404b-8b46-06857a874222/workspaces/83311cb6-f03a-4ebd-a1d8-4a382a7edff7/knowledge-bases/6ceb1402-876b-4998-aaed-72e891e1c56e/unpublish",
 		http.NoBody,
 	)
 	r.ServeHTTP(w, req)
@@ -581,7 +584,7 @@ func TestUnpublishKB_ServiceNotWired_Returns500(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
-		"/api/v1/orgs/org-abc/workspaces/ws-1/knowledge-bases/kb-1/unpublish",
+		"/api/v1/orgs/041b0ae6-ae25-404b-8b46-06857a874222/workspaces/83311cb6-f03a-4ebd-a1d8-4a382a7edff7/knowledge-bases/6ceb1402-876b-4998-aaed-72e891e1c56e/unpublish",
 		http.NoBody,
 	)
 	r.ServeHTTP(w, req)

--- a/internal/handler/kb_test.go
+++ b/internal/handler/kb_test.go
@@ -425,3 +425,167 @@ func TestUpdateKB_RejectsOutOfRangeThreshold(t *testing.T) {
 		t.Errorf("expected 422 for bad threshold, got %d", w.Code)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Unpublish endpoint tests (issue #727).
+// ---------------------------------------------------------------------------
+
+// mockUnpublisher implements handler.KBUnpublisher for unit tests
+// covering the /unpublish route. Symmetric with mockPublisher.
+type mockUnpublisher struct {
+	unpublishFn func(ctx context.Context, orgID, kbID string) (*marketplace.UnpublishResult, error)
+	lastCall    struct {
+		orgID, kbID string
+	}
+}
+
+func (m *mockUnpublisher) UnpublishKB(ctx context.Context, orgID, kbID string) (*marketplace.UnpublishResult, error) {
+	m.lastCall.orgID = orgID
+	m.lastCall.kbID = kbID
+	if m.unpublishFn == nil {
+		return nil, apierror.NewInternal("mock unpublishFn not set")
+	}
+	return m.unpublishFn(ctx, orgID, kbID)
+}
+
+// newKBRouterWithUnpublisher mirrors newKBRouterWithPublisher for the
+// /unpublish route. Pass userID="" to simulate the unauthenticated
+// path so the defence-in-depth 401 inside the handler is exercised.
+func newKBRouterWithUnpublisher(svc handler.KBServicer, unpub handler.KBUnpublisher, userID string) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(apierror.ErrorHandler())
+	r.Use(func(c *gin.Context) {
+		if userID != "" {
+			c.Set(string(middleware.ContextKeyUserID), userID)
+		}
+		c.Set(string(middleware.ContextKeyOrgRole), "org_admin")
+		c.Set(string(middleware.ContextKeyOrgID), "org-abc")
+		c.Set(string(middleware.ContextKeyWorkspaceRole), "admin")
+		c.Next()
+	})
+	h := handler.NewKBHandler(svc).WithUnpublisher(unpub)
+	const base = "/api/v1/orgs/:org_id/workspaces/:ws_id/knowledge-bases"
+	r.POST(base+"/:kb_id/unpublish", h.Unpublish)
+	return r
+}
+
+func TestUnpublishKB_Success(t *testing.T) {
+	heldUntil := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	unpub := &mockUnpublisher{
+		unpublishFn: func(_ context.Context, _, _ string) (*marketplace.UnpublishResult, error) {
+			return &marketplace.UnpublishResult{
+				Visibility:    model.KBVisibilityPrivate,
+				SlugHeldUntil: heldUntil,
+			}, nil
+		},
+	}
+	r := newKBRouterWithUnpublisher(&mockKBService{}, unpub, "user-1")
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"/api/v1/orgs/org-abc/workspaces/ws-1/knowledge-bases/kb-1/unpublish",
+		http.NoBody,
+	)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if unpub.lastCall.orgID != "org-abc" || unpub.lastCall.kbID != "kb-1" {
+		t.Errorf("path params not propagated: %+v", unpub.lastCall)
+	}
+
+	var resp marketplace.UnpublishResult
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Visibility != model.KBVisibilityPrivate {
+		t.Errorf("visibility: got %q want private", resp.Visibility)
+	}
+	if !resp.SlugHeldUntil.Equal(heldUntil) {
+		t.Errorf("slug_held_until drift: got %v want %v", resp.SlugHeldUntil, heldUntil)
+	}
+}
+
+func TestUnpublishKB_MissingUserID_Returns401(t *testing.T) {
+	unpub := &mockUnpublisher{}
+	r := newKBRouterWithUnpublisher(&mockKBService{}, unpub, "")
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"/api/v1/orgs/org-abc/workspaces/ws-1/knowledge-bases/kb-1/unpublish",
+		http.NoBody,
+	)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d: %s", w.Code, w.Body.String())
+	}
+	if unpub.lastCall.kbID != "" {
+		t.Error("unpublisher must not be called when user context is missing")
+	}
+}
+
+func TestUnpublishKB_NotFound_Returns404(t *testing.T) {
+	unpub := &mockUnpublisher{
+		unpublishFn: func(_ context.Context, _, _ string) (*marketplace.UnpublishResult, error) {
+			return nil, apierror.NewNotFound("knowledge base not found")
+		},
+	}
+	r := newKBRouterWithUnpublisher(&mockKBService{}, unpub, "user-1")
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"/api/v1/orgs/org-abc/workspaces/ws-1/knowledge-bases/missing/unpublish",
+		http.NoBody,
+	)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestUnpublishKB_KBFrozen_Returns409(t *testing.T) {
+	unpub := &mockUnpublisher{
+		unpublishFn: func(_ context.Context, _, _ string) (*marketplace.UnpublishResult, error) {
+			return nil, apierror.NewKBFrozen("frozen on Free Plan")
+		},
+	}
+	r := newKBRouterWithUnpublisher(&mockKBService{}, unpub, "user-1")
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"/api/v1/orgs/org-abc/workspaces/ws-1/knowledge-bases/kb-1/unpublish",
+		http.NoBody,
+	)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected 409, got %d", w.Code)
+	}
+}
+
+// TestUnpublishKB_ServiceNotWired_Returns500 confirms the
+// defence-in-depth check fires when KBHandler was constructed without
+// WithUnpublisher. Production main.go always wires it; the loud 500
+// surfaces a missing dependency rather than a confusing 404.
+func TestUnpublishKB_ServiceNotWired_Returns500(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(apierror.ErrorHandler())
+	r.Use(func(c *gin.Context) {
+		c.Set(string(middleware.ContextKeyUserID), "user-1")
+		c.Next()
+	})
+	h := handler.NewKBHandler(&mockKBService{}) // no WithUnpublisher
+	const base = "/api/v1/orgs/:org_id/workspaces/:ws_id/knowledge-bases"
+	r.POST(base+"/:kb_id/unpublish", h.Unpublish)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"/api/v1/orgs/org-abc/workspaces/ws-1/knowledge-bases/kb-1/unpublish",
+		http.NoBody,
+	)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500 when unpublisher is nil, got %d", w.Code)
+	}
+}

--- a/internal/handler/kb_test.go
+++ b/internal/handler/kb_test.go
@@ -511,6 +511,67 @@ func TestUnpublishKB_Success(t *testing.T) {
 	}
 }
 
+// The three tests below assert the handler rejects a malformed path param
+// with 422 before the unpublisher is ever invoked (defence in depth: a bad
+// UUID must never reach the service layer). Mirrors the publish-route
+// invalid-UUID tests above.
+func TestUnpublishKB_InvalidOrgID_Returns422(t *testing.T) {
+	unpub := &mockUnpublisher{}
+	r := newKBRouterWithUnpublisher(&mockKBService{}, unpub, "user-1")
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"/api/v1/orgs/not-a-uuid/workspaces/83311cb6-f03a-4ebd-a1d8-4a382a7edff7/knowledge-bases/6ceb1402-876b-4998-aaed-72e891e1c56e/unpublish",
+		http.NoBody,
+	)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422, got %d: %s", w.Code, w.Body.String())
+	}
+	if unpub.lastCall.kbID != "" {
+		t.Error("unpublisher must not be called when org_id is not a valid UUID")
+	}
+}
+
+func TestUnpublishKB_InvalidWSID_Returns422(t *testing.T) {
+	unpub := &mockUnpublisher{}
+	r := newKBRouterWithUnpublisher(&mockKBService{}, unpub, "user-1")
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"/api/v1/orgs/041b0ae6-ae25-404b-8b46-06857a874222/workspaces/not-a-uuid/knowledge-bases/6ceb1402-876b-4998-aaed-72e891e1c56e/unpublish",
+		http.NoBody,
+	)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422, got %d: %s", w.Code, w.Body.String())
+	}
+	if unpub.lastCall.kbID != "" {
+		t.Error("unpublisher must not be called when ws_id is not a valid UUID")
+	}
+}
+
+func TestUnpublishKB_InvalidKBID_Returns422(t *testing.T) {
+	unpub := &mockUnpublisher{}
+	r := newKBRouterWithUnpublisher(&mockKBService{}, unpub, "user-1")
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost,
+		"/api/v1/orgs/041b0ae6-ae25-404b-8b46-06857a874222/workspaces/83311cb6-f03a-4ebd-a1d8-4a382a7edff7/knowledge-bases/not-a-uuid/unpublish",
+		http.NoBody,
+	)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422, got %d: %s", w.Code, w.Body.String())
+	}
+	if unpub.lastCall.kbID != "" {
+		t.Error("unpublisher must not be called when kb_id is not a valid UUID")
+	}
+}
+
 func TestUnpublishKB_MissingUserID_Returns401(t *testing.T) {
 	unpub := &mockUnpublisher{}
 	r := newKBRouterWithUnpublisher(&mockKBService{}, unpub, "")

--- a/internal/jobs/marketplace_slug_hold_sweeper.go
+++ b/internal/jobs/marketplace_slug_hold_sweeper.go
@@ -1,0 +1,153 @@
+package jobs
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/hibiken/asynq"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// MarketplaceSlugHoldSweepPayload is the payload for the daily slug-hold
+// sweep job. Empty in production; the OrgID hook is reserved for tests
+// that want to scope a run to a single tenant without polluting other
+// fixtures. Per docs/plans/marketplace-mvp.md §3, this job deletes
+// both `kb_slug_holds` and `org_slug_holds` rows whose 90-day /
+// 30-day windows have elapsed (ADR-0007).
+type MarketplaceSlugHoldSweepPayload struct {
+	// OrgID optionally restricts the sweep to a single organisation.
+	// Production runs leave this empty so the sweep is global.
+	OrgID string `json:"org_id,omitempty"`
+}
+
+// NewMarketplaceSlugHoldSweepTask creates an Asynq task for the slug
+// hold sweep cron job. Mirrors the constructor shape used by every
+// other scheduled task in this package so wiring stays uniform.
+func NewMarketplaceSlugHoldSweepTask(p MarketplaceSlugHoldSweepPayload) (*asynq.Task, error) {
+	data, err := json.Marshal(p)
+	if err != nil {
+		return nil, fmt.Errorf("marshal MarketplaceSlugHoldSweepPayload: %w", err)
+	}
+	return asynq.NewTask(TypeMarketplaceSlugHoldSweep, data), nil
+}
+
+// MarketplaceSlugHoldSweepHandler handles the scheduled sweep of
+// expired Marketplace slug holds. Runs daily; deletes rows whose
+// `held_until < now()` from both `kb_slug_holds` (ADR-0007, 90-day
+// window) and `org_slug_holds` (ADR-0007 Q7e, 30-day window). The
+// operation is idempotent — a run that deletes nothing is a healthy
+// outcome and not an error.
+type MarketplaceSlugHoldSweepHandler struct {
+	pool   *pgxpool.Pool
+	logger *slog.Logger
+}
+
+// NewMarketplaceSlugHoldSweepHandler creates a handler. Pool is
+// required; logger falls back to slog.Default() when nil so unit
+// tests can omit it.
+func NewMarketplaceSlugHoldSweepHandler(pool *pgxpool.Pool, logger *slog.Logger) *MarketplaceSlugHoldSweepHandler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &MarketplaceSlugHoldSweepHandler{
+		pool:   pool,
+		logger: logger,
+	}
+}
+
+// ProcessTask implements asynq.Handler. The per-task-type deadline is
+// applied by DeadlineMiddleware via mux.Use in scheduler.go, so this
+// handler does not wrap ctx itself.
+//
+// Each table is swept in its own statement so that a pre-existing
+// schema (a fresh dev DB without 00051 applied yet, for example)
+// doesn't take down the whole job — the 42P01 "undefined_table"
+// SQLSTATE is treated as a no-op for that table only.
+func (h *MarketplaceSlugHoldSweepHandler) ProcessTask(ctx context.Context, task *asynq.Task) error {
+	var payload MarketplaceSlugHoldSweepPayload
+	if err := json.Unmarshal(task.Payload(), &payload); err != nil {
+		return fmt.Errorf("unmarshal MarketplaceSlugHoldSweepPayload: %w", err)
+	}
+
+	h.logger.Info("starting marketplace slug-hold sweep",
+		"org_id_scope", payload.OrgID,
+	)
+
+	kbDeleted, err := h.sweepKBHolds(ctx, payload.OrgID)
+	if err != nil {
+		return fmt.Errorf("sweep kb_slug_holds: %w", err)
+	}
+	h.logger.Info("expired kb slug holds deleted", "deleted", kbDeleted)
+
+	orgDeleted, err := h.sweepOrgHolds(ctx, payload.OrgID)
+	if err != nil {
+		return fmt.Errorf("sweep org_slug_holds: %w", err)
+	}
+	h.logger.Info("expired org slug holds deleted", "deleted", orgDeleted)
+
+	return nil
+}
+
+// sweepKBHolds deletes expired rows from `kb_slug_holds`. When orgID
+// is non-empty the delete is scoped to that org — used by tests; the
+// production cron always passes an empty payload.
+func (h *MarketplaceSlugHoldSweepHandler) sweepKBHolds(ctx context.Context, orgID string) (int64, error) {
+	var (
+		tag pgconn.CommandTag
+		err error
+	)
+	if orgID == "" {
+		tag, err = h.pool.Exec(ctx,
+			`DELETE FROM kb_slug_holds WHERE held_until < NOW()`,
+		)
+	} else {
+		tag, err = h.pool.Exec(ctx,
+			`DELETE FROM kb_slug_holds WHERE held_until < NOW() AND org_id = $1`,
+			orgID,
+		)
+	}
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "42P01" {
+			h.logger.Warn("kb_slug_holds table does not exist yet, skipping sweep", "error", err)
+			return 0, nil
+		}
+		return 0, fmt.Errorf("delete expired kb slug holds: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+
+// sweepOrgHolds deletes expired rows from `org_slug_holds`. The org
+// slug-hold table predates this sweeper (migration 00048) and was
+// previously expected to be cleaned out by an admin tool; the plan
+// (`docs/plans/marketplace-mvp.md` §3) consolidates both windows into
+// this one job so ops have a single cron to watch.
+func (h *MarketplaceSlugHoldSweepHandler) sweepOrgHolds(ctx context.Context, orgID string) (int64, error) {
+	var (
+		tag pgconn.CommandTag
+		err error
+	)
+	if orgID == "" {
+		tag, err = h.pool.Exec(ctx,
+			`DELETE FROM org_slug_holds WHERE held_until < NOW()`,
+		)
+	} else {
+		tag, err = h.pool.Exec(ctx,
+			`DELETE FROM org_slug_holds WHERE held_until < NOW() AND org_id = $1`,
+			orgID,
+		)
+	}
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "42P01" {
+			h.logger.Warn("org_slug_holds table does not exist yet, skipping sweep", "error", err)
+			return 0, nil
+		}
+		return 0, fmt.Errorf("delete expired org slug holds: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}

--- a/internal/jobs/marketplace_slug_hold_sweeper_test.go
+++ b/internal/jobs/marketplace_slug_hold_sweeper_test.go
@@ -1,0 +1,136 @@
+package jobs_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hibiken/asynq"
+
+	"github.com/ravencloak-org/Raven/internal/jobs"
+	"github.com/ravencloak-org/Raven/internal/testutil"
+)
+
+// TestMarketplaceSlugHoldSweepHandler_DeletesExpiredRows pins the
+// idempotent-delete behaviour: seed past-due rows in both hold tables,
+// run the sweep, assert only the expired rows are gone and the
+// in-window rows remain. Counter-test confirms a second run is a
+// no-op (deleted == 0).
+func TestMarketplaceSlugHoldSweepHandler_DeletesExpiredRows(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+
+	// Seed an org we'll attach slug-hold rows to. Slug suffix keeps
+	// concurrent tests sharing the testcontainer collision-free.
+	orgID := uuid.New()
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO organizations (id, name, slug)
+		 VALUES ($1, $2, $2 || '-' || substring($1::text from 1 for 8))`,
+		orgID, "sweep-org",
+	); err != nil {
+		t.Fatalf("seed org: %v", err)
+	}
+
+	// 1 expired + 1 active row in each of the two tables. The kb_id
+	// is left NULL so we don't have to seed a knowledge_bases row.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO kb_slug_holds (org_id, slug, kb_id, held_until) VALUES
+		    ($1, 'kb-expired', NULL, NOW() - interval '1 day'),
+		    ($1, 'kb-active',  NULL, NOW() + interval '30 days')`,
+		orgID,
+	); err != nil {
+		t.Fatalf("seed kb_slug_holds: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO org_slug_holds (slug, org_id, held_until) VALUES
+		    ('org-expired-' || substring($1::text from 1 for 8), $1, NOW() - interval '1 day'),
+		    ('org-active-'  || substring($1::text from 1 for 8), $1, NOW() + interval '30 days')`,
+		orgID,
+	); err != nil {
+		t.Fatalf("seed org_slug_holds: %v", err)
+	}
+
+	h := jobs.NewMarketplaceSlugHoldSweepHandler(pool, nil)
+
+	// Build the same task asynq would dispatch.
+	payload, err := json.Marshal(jobs.MarketplaceSlugHoldSweepPayload{OrgID: orgID.String()})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	task := asynq.NewTask(jobs.TypeMarketplaceSlugHoldSweep, payload)
+
+	if err := h.ProcessTask(ctx, task); err != nil {
+		t.Fatalf("ProcessTask: %v", err)
+	}
+
+	// Expired KB hold gone; active one survives.
+	var (
+		kbExpired bool
+		kbActive  bool
+	)
+	if err := pool.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM kb_slug_holds WHERE org_id = $1 AND slug = 'kb-expired')`,
+		orgID,
+	).Scan(&kbExpired); err != nil {
+		t.Fatalf("read kb_slug_holds expired: %v", err)
+	}
+	if kbExpired {
+		t.Error("expired kb_slug_holds row should be gone after sweep")
+	}
+	if err := pool.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM kb_slug_holds WHERE org_id = $1 AND slug = 'kb-active')`,
+		orgID,
+	).Scan(&kbActive); err != nil {
+		t.Fatalf("read kb_slug_holds active: %v", err)
+	}
+	if !kbActive {
+		t.Error("active kb_slug_holds row should survive sweep")
+	}
+
+	// Same shape for org_slug_holds. Both rows are scoped to orgID so
+	// the OrgID-scoped sweep covers both.
+	var orgExpiredCount int
+	if err := pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM org_slug_holds
+		   WHERE org_id = $1 AND held_until < NOW()`,
+		orgID,
+	).Scan(&orgExpiredCount); err != nil {
+		t.Fatalf("count org expired: %v", err)
+	}
+	if orgExpiredCount != 0 {
+		t.Errorf("expired org_slug_holds rows should be gone, got %d", orgExpiredCount)
+	}
+
+	// Second run is idempotent — re-running on a swept set must
+	// complete cleanly. (RowsAffected is internal; the lack of error
+	// is the contract.)
+	if err := h.ProcessTask(ctx, task); err != nil {
+		t.Errorf("second sweep run should be a no-op, got %v", err)
+	}
+}
+
+func TestMarketplaceSlugHoldSweepHandler_InvalidPayload(t *testing.T) {
+	h := jobs.NewMarketplaceSlugHoldSweepHandler(nil, nil)
+	task := asynq.NewTask(jobs.TypeMarketplaceSlugHoldSweep, []byte("not-json"))
+	if err := h.ProcessTask(context.Background(), task); err == nil {
+		t.Error("invalid payload: want error, got nil")
+	}
+}
+
+// TestNewMarketplaceSlugHoldSweepTask pins the task constructor's
+// shape so wiring sites can rely on the type / payload roundtrip.
+func TestNewMarketplaceSlugHoldSweepTask(t *testing.T) {
+	task, err := jobs.NewMarketplaceSlugHoldSweepTask(jobs.MarketplaceSlugHoldSweepPayload{})
+	if err != nil {
+		t.Fatalf("NewMarketplaceSlugHoldSweepTask: %v", err)
+	}
+	if task.Type() != jobs.TypeMarketplaceSlugHoldSweep {
+		t.Errorf("task.Type: got %q want %q", task.Type(), jobs.TypeMarketplaceSlugHoldSweep)
+	}
+}
+

--- a/internal/jobs/scheduler.go
+++ b/internal/jobs/scheduler.go
@@ -31,6 +31,12 @@ const (
 	// daily at 4 AM UTC. Offset from cleanup (2 AM) and trial-lifecycle
 	// (3 AM) so the daily-cluster doesn't all hit the DB pool at once.
 	CronMarketplaceDMCASweep = "0 4 * * *"
+
+	// CronMarketplaceSlugHoldSweep runs the Marketplace slug-hold sweep
+	// daily at 5 AM UTC — staggered an hour after the DMCA sweep so the
+	// two daily-marketplace crons don't contend for the same DB window
+	// (issue #727).
+	CronMarketplaceSlugHoldSweep = "0 5 * * *"
 )
 
 // SchedulerConfig holds the dependencies needed to set up the cron scheduler.
@@ -145,6 +151,17 @@ func NewScheduler(cfg SchedulerConfig) (*Scheduler, error) {
 		}
 	}
 
+	slugSweepTask, err := NewMarketplaceSlugHoldSweepTask(MarketplaceSlugHoldSweepPayload{})
+	if err != nil {
+		return nil, fmt.Errorf("create marketplace slug-hold sweep task: %w", err)
+	}
+	if _, err := scheduler.Register(CronMarketplaceSlugHoldSweep, slugSweepTask,
+		asynq.Queue("low"),
+		asynq.MaxRetry(2),
+	); err != nil {
+		return nil, fmt.Errorf("register marketplace slug-hold sweep cron: %w", err)
+	}
+
 	// Build a ServeMux with handlers for each scheduled task type.
 	mux := asynq.NewServeMux()
 
@@ -177,12 +194,16 @@ func NewScheduler(cfg SchedulerConfig) (*Scheduler, error) {
 		mux.Handle(TypeMarketplaceDMCASweep, dmcaHandler)
 	}
 
+	slugSweepHandler := NewMarketplaceSlugHoldSweepHandler(cfg.Pool, cfg.Logger)
+	mux.Handle(TypeMarketplaceSlugHoldSweep, slugSweepHandler)
+
 	logFields := []any{
 		"recrawl_cron", CronRecrawl,
 		"cleanup_cron", CronCleanup,
 		"usage_aggregation_cron", CronUsageAggregation,
 		"voice_usage_aggregation_cron", CronVoiceUsageAggregation,
 		"trial_lifecycle_cron", CronTrialLifecycle,
+		"marketplace_slug_hold_sweep_cron", CronMarketplaceSlugHoldSweep,
 	}
 	if cfg.DMCAService != nil {
 		logFields = append(logFields, "marketplace_dmca_sweep_cron", CronMarketplaceDMCASweep)

--- a/internal/jobs/tasks.go
+++ b/internal/jobs/tasks.go
@@ -32,6 +32,10 @@ const (
 	// counter-notice window has expired (issue #736, ADR-0006). Runs
 	// daily; see internal/jobs/marketplace_dmca_sweeper.go.
 	TypeMarketplaceDMCASweep = "scheduled:marketplace_dmca_sweep"
+
+	// TypeMarketplaceSlugHoldSweep deletes expired rows from
+	// `kb_slug_holds` and `org_slug_holds` (ADR-0007). Daily cron.
+	TypeMarketplaceSlugHoldSweep = "scheduled:marketplace_slug_hold_sweep"
 )
 
 // RecrawlPayload is the payload for the source re-crawl scheduled task.

--- a/internal/marketplace/slug_holds.go
+++ b/internal/marketplace/slug_holds.go
@@ -1,0 +1,115 @@
+package marketplace
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// SlugHoldStatus is the typed return shape for SlugHoldStatusLookup.
+// A small struct beats a (uuid, bool, error) chain at call sites: the
+// 410-Gone handler in #731 branches on `IsHeld` and reaches for
+// `KBID` for the audit row, and giving each a name makes the call
+// site read like English. Leaves room to add fields (e.g. the
+// canonical published-at the visitor's link expected to find) without
+// breaking signatures, exactly as `ResolvedOrg` does for org slugs.
+type SlugHoldStatus struct {
+	// OrgID is the publishing Org. Always populated when the lookup
+	// succeeds, even when IsHeld is false — the caller usually wants
+	// to know that the Org slug resolved, so it can render a "no
+	// such KB in this org" 404 instead of a generic miss.
+	OrgID uuid.UUID
+	// KBID is the KB that vacated the slug, or uuid.Nil if the hold
+	// row carries a NULL kb_id (the KB was hard-deleted after the
+	// hold was recorded). Only populated when IsHeld is true.
+	KBID uuid.UUID
+	// IsHeld is true when (orgSlug, kbSlug) currently maps to a row
+	// in `kb_slug_holds` whose `held_until > now()`. The 410-Gone
+	// path branches on this single field — keeping the contract
+	// thin lets the handler stay a single switch.
+	IsHeld bool
+}
+
+// ErrKBSlugNotFound is returned by LookupKBSlugHold when the Org slug
+// does not resolve to a live Org (or active hold), OR when the Org
+// exists but the KB slug has no current hold row. The Marketplace
+// detail/preview handlers turn this into HTTP 404 — distinguishing it
+// from the `IsHeld=true` path that turns into 410.
+var ErrKBSlugNotFound = errors.New("marketplace: kb slug not found")
+
+// LookupKBSlugHold answers the question "does (orgSlug, kbSlug)
+// currently resolve to a 90-day-held URL, or is it a 404?". Used by
+// the Marketplace detail and preview handlers (#731) to render the
+// canonical 410 Gone — the helper deliberately does NOT consult
+// `knowledge_bases` itself, because resolution of a live Public KB is
+// already owned by the listing/detail handlers and overlapping that
+// logic here would duplicate routing.
+//
+// Resolution order:
+//  1. Resolve orgSlug via ResolveOrgSlug. A miss surfaces
+//     ErrKBSlugNotFound so the caller renders 404 (not 410).
+//  2. Probe `kb_slug_holds` for (org_id, kbSlug, held_until > NOW()).
+//     A hit returns IsHeld=true; a miss returns ErrKBSlugNotFound.
+//
+// Expired rows (`held_until <= NOW()`) are treated as not-held even
+// if the sweeper has not yet deleted the row. This keeps the 90-day
+// window honest regardless of cleanup-job latency — identical to how
+// `ResolveOrgSlug` treats expired `org_slug_holds`.
+func LookupKBSlugHold(
+	ctx context.Context,
+	q SlugQuerier,
+	orgSlug, kbSlug string,
+) (SlugHoldStatus, error) {
+	// Cheap input validation. The kb-slug shape matches the org-slug
+	// regex by ADR-0007 Q7e — refusing junk shapes here saves a DB
+	// round trip for noise traffic.
+	if !IsValidSlug(orgSlug) || !IsValidSlug(kbSlug) {
+		return SlugHoldStatus{}, ErrKBSlugNotFound
+	}
+
+	resolved, err := ResolveOrgSlug(ctx, q, orgSlug)
+	if err != nil {
+		if errors.Is(err, ErrSlugNotFound) {
+			return SlugHoldStatus{}, ErrKBSlugNotFound
+		}
+		return SlugHoldStatus{}, fmt.Errorf("LookupKBSlugHold: resolve org: %w", err)
+	}
+
+	orgUUID, err := uuid.Parse(resolved.OrgID)
+	if err != nil {
+		// ResolveOrgSlug returned a non-UUID string — this is a hard
+		// invariant violation from the organizations row. Surface as
+		// an internal error rather than 404, so the alerting catches it.
+		return SlugHoldStatus{}, fmt.Errorf("LookupKBSlugHold: parse org id %q: %w", resolved.OrgID, err)
+	}
+
+	var (
+		heldKBID *uuid.UUID
+	)
+	err = q.QueryRow(ctx,
+		`SELECT kb_id
+		   FROM kb_slug_holds
+		  WHERE org_id     = $1
+		    AND slug       = $2
+		    AND held_until > NOW()`,
+		orgUUID, kbSlug,
+	).Scan(&heldKBID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			// Org resolved but no active hold for this kb slug. Caller
+			// renders 404. We still populate OrgID so the handler can
+			// avoid a second probe when distinguishing miss types.
+			return SlugHoldStatus{OrgID: orgUUID}, ErrKBSlugNotFound
+		}
+		return SlugHoldStatus{}, fmt.Errorf("LookupKBSlugHold: probe holds: %w", err)
+	}
+
+	status := SlugHoldStatus{OrgID: orgUUID, IsHeld: true}
+	if heldKBID != nil {
+		status.KBID = *heldKBID
+	}
+	return status, nil
+}

--- a/internal/marketplace/slug_holds_test.go
+++ b/internal/marketplace/slug_holds_test.go
@@ -1,0 +1,179 @@
+// Integration tests for marketplace.LookupKBSlugHold. Exercises the
+// resolution chain (org-slug → org-id → kb_slug_holds probe) against
+// a real Postgres so the 410-Gone helper consumed by #731 has a
+// pinned contract.
+
+package marketplace_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/ravencloak-org/Raven/internal/marketplace"
+	"github.com/ravencloak-org/Raven/internal/testutil"
+)
+
+func TestLookupKBSlugHold_PresentAndActive_ReturnsHeld(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+	f := seedPublicKBForUnpublish(ctx, t, pool, "active")
+
+	// Run the unpublish path to land an active hold. Avoids leaking
+	// SQL-shaped fixtures into a test of the resolver itself.
+	svc := marketplace.NewUnpublishService(pool, noopGate)
+	if _, err := svc.UnpublishKB(ctx, f.OrgID.String(), f.KBID.String()); err != nil {
+		t.Fatalf("UnpublishKB: %v", err)
+	}
+
+	// Resolve the org slug back from the row so the test does not
+	// hard-code the suffix logic in seedPublicKBForUnpublish.
+	var orgSlug string
+	if err := pool.QueryRow(ctx,
+		`SELECT slug FROM organizations WHERE id = $1`,
+		f.OrgID,
+	).Scan(&orgSlug); err != nil {
+		t.Fatalf("read org slug: %v", err)
+	}
+
+	status, err := marketplace.LookupKBSlugHold(ctx, pool, orgSlug, f.KBSlug)
+	if err != nil {
+		t.Fatalf("LookupKBSlugHold: %v", err)
+	}
+	if !status.IsHeld {
+		t.Error("status.IsHeld: want true")
+	}
+	if status.OrgID != f.OrgID {
+		t.Errorf("status.OrgID: got %v want %v", status.OrgID, f.OrgID)
+	}
+	if status.KBID != f.KBID {
+		t.Errorf("status.KBID: got %v want %v", status.KBID, f.KBID)
+	}
+}
+
+func TestLookupKBSlugHold_PresentButExpired_ReturnsNotFound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+	f := seedPublicKBForUnpublish(ctx, t, pool, "expired")
+
+	var orgSlug string
+	if err := pool.QueryRow(ctx,
+		`SELECT slug FROM organizations WHERE id = $1`,
+		f.OrgID,
+	).Scan(&orgSlug); err != nil {
+		t.Fatalf("read org slug: %v", err)
+	}
+
+	// Seed a hold that already expired. Using NULL kb_id avoids the FK
+	// to the still-public KB row.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO kb_slug_holds (org_id, slug, kb_id, held_until)
+		 VALUES ($1, $2, NULL, NOW() - interval '1 hour')`,
+		f.OrgID, f.KBSlug,
+	); err != nil {
+		t.Fatalf("seed expired hold: %v", err)
+	}
+
+	_, err := marketplace.LookupKBSlugHold(ctx, pool, orgSlug, f.KBSlug)
+	if !errors.Is(err, marketplace.ErrKBSlugNotFound) {
+		t.Errorf("expired hold: want ErrKBSlugNotFound, got %v", err)
+	}
+}
+
+func TestLookupKBSlugHold_NoSuchOrg_ReturnsNotFound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+
+	_, err := marketplace.LookupKBSlugHold(ctx, pool, "ghost-org", "ghost-kb")
+	if !errors.Is(err, marketplace.ErrKBSlugNotFound) {
+		t.Errorf("missing org: want ErrKBSlugNotFound, got %v", err)
+	}
+}
+
+func TestLookupKBSlugHold_OrgPresentNoHold_ReturnsNotFound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+	f := seedPublicKBForUnpublish(ctx, t, pool, "noheld")
+
+	var orgSlug string
+	if err := pool.QueryRow(ctx,
+		`SELECT slug FROM organizations WHERE id = $1`,
+		f.OrgID,
+	).Scan(&orgSlug); err != nil {
+		t.Fatalf("read org slug: %v", err)
+	}
+
+	_, err := marketplace.LookupKBSlugHold(ctx, pool, orgSlug, "never-existed")
+	if !errors.Is(err, marketplace.ErrKBSlugNotFound) {
+		t.Errorf("org-without-hold: want ErrKBSlugNotFound, got %v", err)
+	}
+}
+
+func TestLookupKBSlugHold_InvalidSlugShape_ReturnsNotFound(t *testing.T) {
+	// Cheap input guard — no DB needed beyond the testutil bootstrap.
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+
+	_, err := marketplace.LookupKBSlugHold(ctx, pool, "NOT VALID", "also bad")
+	if !errors.Is(err, marketplace.ErrKBSlugNotFound) {
+		t.Errorf("invalid shape: want ErrKBSlugNotFound, got %v", err)
+	}
+}
+
+func TestLookupKBSlugHold_NullKBID_OrgIDPopulatedKBIDZero(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+	f := seedPublicKBForUnpublish(ctx, t, pool, "nullkb")
+
+	var orgSlug string
+	if err := pool.QueryRow(ctx,
+		`SELECT slug FROM organizations WHERE id = $1`,
+		f.OrgID,
+	).Scan(&orgSlug); err != nil {
+		t.Fatalf("read org slug: %v", err)
+	}
+
+	// Hold with NULL kb_id (the KB was hard-deleted after the hold
+	// landed). Resolver must still report IsHeld=true.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO kb_slug_holds (org_id, slug, kb_id, held_until)
+		 VALUES ($1, $2, NULL, NOW() + interval '30 days')`,
+		f.OrgID, "deleted-slug",
+	); err != nil {
+		t.Fatalf("seed null-kb hold: %v", err)
+	}
+
+	status, err := marketplace.LookupKBSlugHold(ctx, pool, orgSlug, "deleted-slug")
+	if err != nil {
+		t.Fatalf("LookupKBSlugHold: %v", err)
+	}
+	if !status.IsHeld {
+		t.Error("status.IsHeld: want true")
+	}
+	if status.KBID != uuid.Nil {
+		t.Errorf("status.KBID: want uuid.Nil for NULL kb_id, got %v", status.KBID)
+	}
+	if status.OrgID != f.OrgID {
+		t.Errorf("status.OrgID: got %v want %v", status.OrgID, f.OrgID)
+	}
+}

--- a/internal/marketplace/slug_holds_test.go
+++ b/internal/marketplace/slug_holds_test.go
@@ -27,7 +27,7 @@ func TestLookupKBSlugHold_PresentAndActive_ReturnsHeld(t *testing.T) {
 	// Run the unpublish path to land an active hold. Avoids leaking
 	// SQL-shaped fixtures into a test of the resolver itself.
 	svc := marketplace.NewUnpublishService(pool, noopGate)
-	if _, err := svc.UnpublishKB(ctx, f.OrgID.String(), f.KBID.String()); err != nil {
+	if _, err := svc.UnpublishKB(ctx, f.OrgID.String(), f.WSID.String(), f.KBID.String()); err != nil {
 		t.Fatalf("UnpublishKB: %v", err)
 	}
 
@@ -117,9 +117,16 @@ func TestLookupKBSlugHold_OrgPresentNoHold_ReturnsNotFound(t *testing.T) {
 		t.Fatalf("read org slug: %v", err)
 	}
 
-	_, err := marketplace.LookupKBSlugHold(ctx, pool, orgSlug, "never-existed")
+	status, err := marketplace.LookupKBSlugHold(ctx, pool, orgSlug, "never-existed")
 	if !errors.Is(err, marketplace.ErrKBSlugNotFound) {
 		t.Errorf("org-without-hold: want ErrKBSlugNotFound, got %v", err)
+	}
+	// Pin the contract: when the Org resolves but the KB slug does not
+	// have an active hold, the returned status must still carry the
+	// resolved OrgID so callers can disambiguate "we found the Org but
+	// not the slug" from a wholly-unknown Org slug.
+	if status.OrgID != f.OrgID {
+		t.Errorf("status.OrgID: got %v want %v", status.OrgID, f.OrgID)
 	}
 }
 

--- a/internal/marketplace/unpublish.go
+++ b/internal/marketplace/unpublish.go
@@ -1,0 +1,163 @@
+package marketplace
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/ravencloak-org/Raven/internal/db"
+	"github.com/ravencloak-org/Raven/internal/model"
+	"github.com/ravencloak-org/Raven/pkg/apierror"
+)
+
+// UnpublishHold is the duration a KB's slug is held in `kb_slug_holds`
+// after the publishing Org takes it down. ADR-0007 (90-day Marketplace
+// lifecycle window). Kept as a package constant so the unpublish path,
+// any future admin re-publish path, and the SlugHoldStatus helper agree
+// on the boundary.
+const UnpublishHold = 90 * 24 * time.Hour
+
+// UnpublishResult is the response payload for a successful unpublish, in
+// the shape `docs/plans/marketplace-mvp.md` §4 documents. The handler
+// renders this verbatim — the service owns the contract.
+type UnpublishResult struct {
+	Visibility    model.KBVisibility `json:"visibility"`
+	SlugHeldUntil time.Time          `json:"slug_held_until"`
+}
+
+// UnpublishService runs the transactional unpublish path: lifecycle-gate
+// check, atomic flip of visibility + published_at, and 90-day slug-hold
+// registration in `kb_slug_holds`.
+//
+// The service deliberately owns the entire unpublish boundary so the
+// canonical "what does unpublishing do" answer lives in one file
+// (ADR-0007). Existing import rows in other Orgs are unaffected: the
+// `source_public_kb_id` FK on `knowledge_bases` does not reference the
+// row's visibility column, so flipping visibility back to `private` does
+// not touch downstream forks — verified in unpublish_test.go.
+type UnpublishService struct {
+	pool *pgxpool.Pool
+	gate PublishGateFunc
+}
+
+// NewUnpublishService constructs an UnpublishService. The gate callback
+// is reused from the publish path — both transitions share the same
+// KBStatusGate.CanPublish semantics (DMCA-locked / archived KBs cannot
+// be unpublished either; the publisher must contact admin). Pass nil to
+// disable the freeze check in unit-test wiring that only exercises the
+// SQL paths.
+func NewUnpublishService(pool *pgxpool.Pool, gate PublishGateFunc) *UnpublishService {
+	return &UnpublishService{pool: pool, gate: gate}
+}
+
+// UnpublishKB flips a KB from public back to private and registers a
+// 90-day slug hold so external Marketplace links resolve to a clean
+// 410 Gone for the duration. Returns the typed UnpublishResult on
+// success or an *apierror.AppError already shaped for the handler:
+//
+//   - 404 — KB does not exist for this org OR is not currently public.
+//   - 409 — KBStatusGate rejects the action (kb_frozen / kb_dmca_locked).
+//
+// orgID is the publishing Org; kbID the KB. No userID is recorded — the
+// publish metadata (published_by_user_id) is left in place as historical
+// audit; the unpublish actor is captured by the route's audit log layer,
+// not by mutating the KB row.
+//
+// Runs inside one db.WithOrgID transaction so a crash mid-unpublish
+// cannot leave the row visibility flipped without a hold registered
+// (and vice versa). The hold's `held_until` is computed inside the
+// transaction (`NOW() + UnpublishHold`) so the value the handler
+// returns to the client matches what landed in the database to the
+// microsecond.
+func (s *UnpublishService) UnpublishKB(
+	ctx context.Context,
+	orgID, kbID string,
+) (*UnpublishResult, error) {
+	var result UnpublishResult
+
+	err := db.WithOrgID(ctx, s.pool, orgID, func(tx pgx.Tx) error {
+		// Lifecycle gate. CanPublish covers the symmetric case: a
+		// DMCA-locked or archived KB cannot toggle visibility either
+		// direction — the publisher must contact admin / restore.
+		if s.gate != nil {
+			if gateErr := s.gate(ctx, tx, orgID, kbID); gateErr != nil {
+				return gateErr
+			}
+		}
+
+		// The UPDATE filter `visibility = 'public'` is load-bearing:
+		// unpublishing an already-private KB is a no-op semantically,
+		// but the API contract returns 404 to distinguish "you can't
+		// take down what's already down" from a successful idempotent
+		// repeat. Catching it here keeps the slug-hold insert from
+		// running with a stale (org_id, slug) pair.
+		var slug string
+		err := tx.QueryRow(ctx,
+			`UPDATE knowledge_bases
+			   SET visibility   = 'private',
+			       published_at = NULL
+			 WHERE id         = $1
+			   AND org_id     = $2
+			   AND visibility = 'public'
+			 RETURNING slug`,
+			kbID, orgID,
+		).Scan(&slug)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return apierror.NewNotFound("knowledge base not found or not currently public")
+			}
+			return apierror.NewInternal("failed to unpublish knowledge base: " + err.Error())
+		}
+
+		// Register the 90-day hold. ON CONFLICT updates the row when an
+		// older hold for the same (org_id, slug) is still present —
+		// this happens when a KB is unpublished, re-published under the
+		// same slug, then unpublished again inside the original window.
+		// We refresh both the kb_id pointer (it may have changed if the
+		// slug was reassigned to a different KB) and the held_until
+		// timestamp so the second 90-day window runs from the second
+		// unpublish, not the first.
+		var heldUntil time.Time
+		if err := tx.QueryRow(ctx,
+			`INSERT INTO kb_slug_holds (org_id, slug, kb_id, held_until)
+			 VALUES ($1, $2, $3, NOW() + $4::interval)
+			 ON CONFLICT (org_id, slug) DO UPDATE
+			   SET kb_id      = EXCLUDED.kb_id,
+			       held_until = EXCLUDED.held_until
+			 RETURNING held_until`,
+			orgID, slug, kbID, fmt.Sprintf("%d seconds", int(UnpublishHold.Seconds())),
+		).Scan(&heldUntil); err != nil {
+			return apierror.NewInternal("failed to register slug hold: " + err.Error())
+		}
+
+		result = UnpublishResult{
+			Visibility:    model.KBVisibilityPrivate,
+			SlugHeldUntil: heldUntil,
+		}
+		return nil
+	})
+
+	if err != nil {
+		// AppErrors from the guard / not-found path are already shaped;
+		// pass them through untouched so the handler renders the right
+		// status code + machine-readable error code.
+		var appErr *apierror.AppError
+		if errors.As(err, &appErr) {
+			return nil, appErr
+		}
+		// db.WithOrgID can wrap "no rows" coming out of an RLS context
+		// preflight into a generic error string. Map that to 404 rather
+		// than 500 so callers see the canonical contract.
+		if strings.Contains(err.Error(), "no rows") {
+			return nil, apierror.NewNotFound("knowledge base not found")
+		}
+		return nil, apierror.NewInternal("failed to unpublish knowledge base: " + err.Error())
+	}
+
+	return &result, nil
+}

--- a/internal/marketplace/unpublish.go
+++ b/internal/marketplace/unpublish.go
@@ -81,21 +81,14 @@ func (s *UnpublishService) UnpublishKB(
 	var result UnpublishResult
 
 	err := db.WithOrgID(ctx, s.pool, orgID, func(tx pgx.Tx) error {
-		// Lifecycle gate. CanPublish covers the symmetric case: a
-		// DMCA-locked or archived KB cannot toggle visibility either
-		// direction — the publisher must contact admin / restore.
-		if s.gate != nil {
-			if gateErr := s.gate(ctx, tx, orgID, kbID); gateErr != nil {
-				return gateErr
-			}
-		}
-
-		// The UPDATE filter `visibility = 'public'` is load-bearing:
-		// unpublishing an already-private KB is a no-op semantically,
-		// but the API contract returns 404 to distinguish "you can't
-		// take down what's already down" from a successful idempotent
-		// repeat. Catching it here keeps the slug-hold insert from
-		// running with a stale (org_id, slug) pair.
+		// Establish workspace-scoped ownership BEFORE the lifecycle gate.
+		//
+		// The SELECT ... FOR UPDATE filter `visibility = 'public'` is
+		// load-bearing: unpublishing an already-private KB is a no-op
+		// semantically, but the API contract returns 404 to distinguish
+		// "you can't take down what's already down" from a successful
+		// idempotent repeat. Catching it here keeps the slug-hold insert
+		// from running with a stale (org_id, slug) pair.
 		//
 		// SECURITY: scope the predicate by workspace_id as well as
 		// org_id. The route guard runs RequireWorkspaceRole on :ws_id,
@@ -104,22 +97,50 @@ func (s *UnpublishService) UnpublishKB(
 		// kb_id belonging to workspace B of the same Org and we'd
 		// happily unpublish it. The filter turns that into a 404 so
 		// the authorization scope matches the route's intent.
+		//
+		// The ownership check runs first so a caller scoped to one
+		// workspace cannot probe lifecycle state of a KB in another
+		// workspace of the same Org: an out-of-scope kb_id resolves to
+		// 404 here before the gate can leak a 409 (kb_frozen /
+		// kb_dmca_locked). FOR UPDATE locks the row so the visibility
+		// flip below stays atomic with the gate decision.
 		var slug string
 		err := tx.QueryRow(ctx,
-			`UPDATE knowledge_bases
-			   SET visibility   = 'private',
-			       published_at = NULL
-			 WHERE id           = $1
-			   AND org_id       = $2
-			   AND workspace_id = $3
-			   AND visibility   = 'public'
-			 RETURNING slug`,
+			`SELECT slug
+			   FROM knowledge_bases
+			  WHERE id           = $1
+			    AND org_id       = $2
+			    AND workspace_id = $3
+			    AND visibility   = 'public'
+			  FOR UPDATE`,
 			kbID, orgID, workspaceID,
 		).Scan(&slug)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				return apierror.NewNotFound("knowledge base not found or not currently public")
 			}
+			return apierror.NewInternal("failed to unpublish knowledge base: " + err.Error())
+		}
+
+		// Lifecycle gate, run only after workspace ownership is proven.
+		// CanPublish covers the symmetric case: a DMCA-locked or archived
+		// KB cannot toggle visibility either direction — the publisher
+		// must contact admin / restore.
+		if s.gate != nil {
+			if gateErr := s.gate(ctx, tx, orgID, kbID); gateErr != nil {
+				return gateErr
+			}
+		}
+
+		// Flip visibility. The row is already locked and proven to be
+		// public + in-scope, so the bare id predicate is sufficient.
+		if _, err := tx.Exec(ctx,
+			`UPDATE knowledge_bases
+			   SET visibility   = 'private',
+			       published_at = NULL
+			 WHERE id = $1`,
+			kbID,
+		); err != nil {
 			return apierror.NewInternal("failed to unpublish knowledge base: " + err.Error())
 		}
 

--- a/internal/marketplace/unpublish.go
+++ b/internal/marketplace/unpublish.go
@@ -76,7 +76,7 @@ func NewUnpublishService(pool *pgxpool.Pool, gate PublishGateFunc) *UnpublishSer
 // microsecond.
 func (s *UnpublishService) UnpublishKB(
 	ctx context.Context,
-	orgID, kbID string,
+	orgID, workspaceID, kbID string,
 ) (*UnpublishResult, error) {
 	var result UnpublishResult
 
@@ -96,16 +96,25 @@ func (s *UnpublishService) UnpublishKB(
 		// take down what's already down" from a successful idempotent
 		// repeat. Catching it here keeps the slug-hold insert from
 		// running with a stale (org_id, slug) pair.
+		//
+		// SECURITY: scope the predicate by workspace_id as well as
+		// org_id. The route guard runs RequireWorkspaceRole on :ws_id,
+		// so the caller is authorized for THAT workspace — but without
+		// `workspace_id = $3` here a workspace-A admin could pass a
+		// kb_id belonging to workspace B of the same Org and we'd
+		// happily unpublish it. The filter turns that into a 404 so
+		// the authorization scope matches the route's intent.
 		var slug string
 		err := tx.QueryRow(ctx,
 			`UPDATE knowledge_bases
 			   SET visibility   = 'private',
 			       published_at = NULL
-			 WHERE id         = $1
-			   AND org_id     = $2
-			   AND visibility = 'public'
+			 WHERE id           = $1
+			   AND org_id       = $2
+			   AND workspace_id = $3
+			   AND visibility   = 'public'
 			 RETURNING slug`,
-			kbID, orgID,
+			kbID, orgID, workspaceID,
 		).Scan(&slug)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {

--- a/internal/marketplace/unpublish_test.go
+++ b/internal/marketplace/unpublish_test.go
@@ -1,0 +1,339 @@
+// Integration tests for the marketplace.UnpublishService. Exercises the
+// transactional unpublish path against a real Postgres so the
+// `kb_slug_holds` insert, the visibility flip, and the "existing
+// imports unaffected" invariant from ADR-0001 are all checked end to
+// end. Skipped under `go test -short`.
+
+package marketplace_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/ravencloak-org/Raven/internal/marketplace"
+	"github.com/ravencloak-org/Raven/internal/model"
+	"github.com/ravencloak-org/Raven/internal/testutil"
+	"github.com/ravencloak-org/Raven/pkg/apierror"
+)
+
+// unpubFixture is the minimum seed a single unpublish-path test needs:
+// one Org, one workspace, one Public KB. Per-call UUIDs keep parallel
+// tests sharing a testcontainer isolated.
+type unpubFixture struct {
+	OrgID  uuid.UUID
+	WSID   uuid.UUID
+	KBID   uuid.UUID
+	KBSlug string
+}
+
+// seedPublicKBForUnpublish inserts an org + workspace + a single Public KB ready to
+// be unpublished. Org slugs are suffixed with the UUID prefix so the
+// CHECK regex on organizations.slug accepts them.
+func seedPublicKBForUnpublish(ctx context.Context, t *testing.T, pool *pgxpool.Pool, label string) unpubFixture {
+	t.Helper()
+	f := unpubFixture{
+		OrgID:  uuid.New(),
+		WSID:   uuid.New(),
+		KBID:   uuid.New(),
+		KBSlug: label + "-kb-" + uuid.New().String()[:8],
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO organizations (id, name, slug)
+		 VALUES ($1, $2, $2 || '-' || substring($1::text from 1 for 8))`,
+		f.OrgID, label+"-org",
+	); err != nil {
+		t.Fatalf("seed organization: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO workspaces (id, org_id, name, slug)
+		 VALUES ($1, $2, $3, $3 || '-' || substring($1::text from 1 for 8))`,
+		f.WSID, f.OrgID, label+"-ws",
+	); err != nil {
+		t.Fatalf("seed workspace: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO knowledge_bases (id, org_id, workspace_id, name, slug, visibility, license_spdx_id, published_at)
+		 VALUES ($1, $2, $3, $4, $5, 'public', 'MIT', NOW())`,
+		f.KBID, f.OrgID, f.WSID, label+"-kb", f.KBSlug,
+	); err != nil {
+		t.Fatalf("seed public knowledge_base: %v", err)
+	}
+	return f
+}
+
+// noopGate is a publish gate that always allows the action. Used by
+// the happy-path tests so we don't pull in KBStatusGate plumbing.
+func noopGate(_ context.Context, _ pgx.Tx, _, _ string) error { return nil }
+
+func TestUnpublishKB_Success_FlipsVisibilityAndRegistersHold(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+	f := seedPublicKBForUnpublish(ctx, t, pool, "happy")
+
+	svc := marketplace.NewUnpublishService(pool, noopGate)
+
+	start := time.Now()
+	res, err := svc.UnpublishKB(ctx, f.OrgID.String(), f.KBID.String())
+	if err != nil {
+		t.Fatalf("UnpublishKB: %v", err)
+	}
+
+	if res.Visibility != model.KBVisibilityPrivate {
+		t.Errorf("visibility: got %q want private", res.Visibility)
+	}
+	wantApprox := start.Add(marketplace.UnpublishHold)
+	if res.SlugHeldUntil.Before(wantApprox.Add(-1*time.Minute)) ||
+		res.SlugHeldUntil.After(wantApprox.Add(1*time.Minute)) {
+		t.Errorf("SlugHeldUntil: %v should be ~%v (within 1m)", res.SlugHeldUntil, wantApprox)
+	}
+
+	// Database row must reflect the flip.
+	var vis string
+	var publishedAt *time.Time
+	if err := pool.QueryRow(ctx,
+		`SELECT visibility, published_at FROM knowledge_bases WHERE id = $1`,
+		f.KBID,
+	).Scan(&vis, &publishedAt); err != nil {
+		t.Fatalf("read kb row: %v", err)
+	}
+	if vis != "private" {
+		t.Errorf("kb.visibility: got %q want private", vis)
+	}
+	if publishedAt != nil {
+		t.Errorf("kb.published_at should be NULL after unpublish, got %v", publishedAt)
+	}
+
+	// Hold row must exist with the right (org_id, slug, kb_id) and a
+	// held_until in the future.
+	var heldKBID *uuid.UUID
+	var heldUntil time.Time
+	if err := pool.QueryRow(ctx,
+		`SELECT kb_id, held_until FROM kb_slug_holds WHERE org_id = $1 AND slug = $2`,
+		f.OrgID, f.KBSlug,
+	).Scan(&heldKBID, &heldUntil); err != nil {
+		t.Fatalf("read kb_slug_holds: %v", err)
+	}
+	if heldKBID == nil || *heldKBID != f.KBID {
+		t.Errorf("hold kb_id: got %v want %v", heldKBID, f.KBID)
+	}
+	if !heldUntil.After(time.Now()) {
+		t.Errorf("hold held_until %v should be in the future", heldUntil)
+	}
+}
+
+func TestUnpublishKB_NotFound_Returns404(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+	f := seedPublicKBForUnpublish(ctx, t, pool, "notfound")
+
+	svc := marketplace.NewUnpublishService(pool, noopGate)
+
+	// Unknown KB id under the right org → 404.
+	_, err := svc.UnpublishKB(ctx, f.OrgID.String(), uuid.New().String())
+	var appErr *apierror.AppError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("unknown kb id: want AppError, got %v", err)
+	}
+	if appErr.Code != 404 {
+		t.Errorf("unknown kb id: want 404, got %d", appErr.Code)
+	}
+}
+
+func TestUnpublishKB_AlreadyPrivate_Returns404(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+	f := seedPublicKBForUnpublish(ctx, t, pool, "alreadypriv")
+
+	// Force it private before the call. The service must report 404
+	// rather than silently succeed — the contract distinguishes "I
+	// took it down" from "it was already down".
+	if _, err := pool.Exec(ctx,
+		`UPDATE knowledge_bases SET visibility = 'private', published_at = NULL WHERE id = $1`,
+		f.KBID,
+	); err != nil {
+		t.Fatalf("force-private: %v", err)
+	}
+
+	svc := marketplace.NewUnpublishService(pool, noopGate)
+	_, err := svc.UnpublishKB(ctx, f.OrgID.String(), f.KBID.String())
+	var appErr *apierror.AppError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("already-private kb: want AppError, got %v", err)
+	}
+	if appErr.Code != 404 {
+		t.Errorf("already-private kb: want 404, got %d", appErr.Code)
+	}
+}
+
+func TestUnpublishKB_GateRejects_Returns409(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+	f := seedPublicKBForUnpublish(ctx, t, pool, "frozen")
+
+	// Gate that always refuses with kb_frozen — simulates a Free Plan
+	// downgrade-freeze trying to toggle visibility.
+	frozenGate := func(_ context.Context, _ pgx.Tx, _, _ string) error {
+		return apierror.NewKBFrozen("frozen")
+	}
+	svc := marketplace.NewUnpublishService(pool, frozenGate)
+
+	_, err := svc.UnpublishKB(ctx, f.OrgID.String(), f.KBID.String())
+	var appErr *apierror.AppError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("gate refusal: want AppError, got %v", err)
+	}
+	if appErr.Code != 409 || appErr.ErrorCode != "kb_frozen" {
+		t.Errorf("gate refusal: want 409 kb_frozen, got %d %s", appErr.Code, appErr.ErrorCode)
+	}
+
+	// Row must NOT have flipped — the gate ran before the UPDATE.
+	var vis string
+	if err := pool.QueryRow(ctx,
+		`SELECT visibility FROM knowledge_bases WHERE id = $1`,
+		f.KBID,
+	).Scan(&vis); err != nil {
+		t.Fatalf("read kb row: %v", err)
+	}
+	if vis != "public" {
+		t.Errorf("kb.visibility should remain public on gate refusal, got %q", vis)
+	}
+}
+
+// TestUnpublishKB_ExistingImportsUnaffected verifies ADR-0001's
+// guarantee: a Public KB's downstream imports keep their
+// `source_public_kb_id` FK pointing at the publisher row even after
+// the publisher unpublishes. Visibility is not a column the FK
+// references, so toggling it must not cascade.
+func TestUnpublishKB_ExistingImportsUnaffected(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+	publisher := seedPublicKBForUnpublish(ctx, t, pool, "publisher")
+	importer := seedPublicKBForUnpublish(ctx, t, pool, "importer")
+
+	// Mark the importer's KB as an import of the publisher's. Use a
+	// distinct slug + private visibility so it doesn't conflict with
+	// the publisher's public row.
+	if _, err := pool.Exec(ctx,
+		`UPDATE knowledge_bases
+		    SET source_public_kb_id    = $1,
+		        visibility             = 'private',
+		        published_at           = NULL,
+		        imported_from_revision_at = NOW()
+		  WHERE id = $2`,
+		publisher.KBID, importer.KBID,
+	); err != nil {
+		t.Fatalf("mark importer: %v", err)
+	}
+
+	svc := marketplace.NewUnpublishService(pool, noopGate)
+	if _, err := svc.UnpublishKB(ctx, publisher.OrgID.String(), publisher.KBID.String()); err != nil {
+		t.Fatalf("UnpublishKB: %v", err)
+	}
+
+	// Importer row must still point at the publisher row.
+	var src *uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`SELECT source_public_kb_id FROM knowledge_bases WHERE id = $1`,
+		importer.KBID,
+	).Scan(&src); err != nil {
+		t.Fatalf("read importer.source_public_kb_id: %v", err)
+	}
+	if src == nil || *src != publisher.KBID {
+		t.Errorf("importer.source_public_kb_id: got %v want %v", src, publisher.KBID)
+	}
+
+	// And the publisher row must still exist (no cascade-delete from
+	// unpublish). The FK is ON DELETE SET NULL, but we never deleted.
+	var publisherExists bool
+	if err := pool.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM knowledge_bases WHERE id = $1)`,
+		publisher.KBID,
+	).Scan(&publisherExists); err != nil {
+		t.Fatalf("check publisher exists: %v", err)
+	}
+	if !publisherExists {
+		t.Error("publisher KB row should still exist after unpublish")
+	}
+}
+
+// TestUnpublishKB_RefreshesExistingHold confirms ON CONFLICT keeps the
+// (org_id, slug) pair pinned to the newer window. If a slug is held,
+// reused, then unpublished again before the first window elapses, the
+// second window must start from the second unpublish — not chain off
+// the first.
+func TestUnpublishKB_RefreshesExistingHold(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+	f := seedPublicKBForUnpublish(ctx, t, pool, "refresh")
+
+	// Pre-seed a near-expired hold for the same (org_id, slug). The
+	// service must overwrite both kb_id and held_until.
+	stale := time.Now().Add(1 * time.Hour)
+	staleKB := uuid.New()
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO kb_slug_holds (org_id, slug, kb_id, held_until)
+		 VALUES ($1, $2, $3, $4)`,
+		f.OrgID, f.KBSlug, staleKB, stale,
+	); err != nil {
+		// FK to knowledge_bases — use NULL since the row doesn't exist.
+		// Retry without kb_id.
+		if !strings.Contains(err.Error(), "foreign key") {
+			t.Fatalf("seed stale hold: %v", err)
+		}
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO kb_slug_holds (org_id, slug, kb_id, held_until)
+			 VALUES ($1, $2, NULL, $3)`,
+			f.OrgID, f.KBSlug, stale,
+		); err != nil {
+			t.Fatalf("seed stale hold (null kb_id): %v", err)
+		}
+	}
+
+	svc := marketplace.NewUnpublishService(pool, noopGate)
+	res, err := svc.UnpublishKB(ctx, f.OrgID.String(), f.KBID.String())
+	if err != nil {
+		t.Fatalf("UnpublishKB: %v", err)
+	}
+
+	// New hold should be substantially after the stale one (90 days vs 1 hour).
+	if !res.SlugHeldUntil.After(stale.Add(80 * 24 * time.Hour)) {
+		t.Errorf("SlugHeldUntil should refresh to ~90d window: got %v vs stale %v",
+			res.SlugHeldUntil, stale)
+	}
+
+	var heldKBID *uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`SELECT kb_id FROM kb_slug_holds WHERE org_id = $1 AND slug = $2`,
+		f.OrgID, f.KBSlug,
+	).Scan(&heldKBID); err != nil {
+		t.Fatalf("read kb_slug_holds: %v", err)
+	}
+	if heldKBID == nil || *heldKBID != f.KBID {
+		t.Errorf("hold kb_id should refresh to the new KB: got %v want %v", heldKBID, f.KBID)
+	}
+}

--- a/internal/marketplace/unpublish_test.go
+++ b/internal/marketplace/unpublish_test.go
@@ -83,7 +83,7 @@ func TestUnpublishKB_Success_FlipsVisibilityAndRegistersHold(t *testing.T) {
 	svc := marketplace.NewUnpublishService(pool, noopGate)
 
 	start := time.Now()
-	res, err := svc.UnpublishKB(ctx, f.OrgID.String(), f.KBID.String())
+	res, err := svc.UnpublishKB(ctx, f.OrgID.String(), f.WSID.String(), f.KBID.String())
 	if err != nil {
 		t.Fatalf("UnpublishKB: %v", err)
 	}
@@ -142,7 +142,7 @@ func TestUnpublishKB_NotFound_Returns404(t *testing.T) {
 	svc := marketplace.NewUnpublishService(pool, noopGate)
 
 	// Unknown KB id under the right org → 404.
-	_, err := svc.UnpublishKB(ctx, f.OrgID.String(), uuid.New().String())
+	_, err := svc.UnpublishKB(ctx, f.OrgID.String(), f.WSID.String(), uuid.New().String())
 	var appErr *apierror.AppError
 	if !errors.As(err, &appErr) {
 		t.Fatalf("unknown kb id: want AppError, got %v", err)
@@ -171,7 +171,7 @@ func TestUnpublishKB_AlreadyPrivate_Returns404(t *testing.T) {
 	}
 
 	svc := marketplace.NewUnpublishService(pool, noopGate)
-	_, err := svc.UnpublishKB(ctx, f.OrgID.String(), f.KBID.String())
+	_, err := svc.UnpublishKB(ctx, f.OrgID.String(), f.WSID.String(), f.KBID.String())
 	var appErr *apierror.AppError
 	if !errors.As(err, &appErr) {
 		t.Fatalf("already-private kb: want AppError, got %v", err)
@@ -196,7 +196,7 @@ func TestUnpublishKB_GateRejects_Returns409(t *testing.T) {
 	}
 	svc := marketplace.NewUnpublishService(pool, frozenGate)
 
-	_, err := svc.UnpublishKB(ctx, f.OrgID.String(), f.KBID.String())
+	_, err := svc.UnpublishKB(ctx, f.OrgID.String(), f.WSID.String(), f.KBID.String())
 	var appErr *apierror.AppError
 	if !errors.As(err, &appErr) {
 		t.Fatalf("gate refusal: want AppError, got %v", err)
@@ -248,7 +248,7 @@ func TestUnpublishKB_ExistingImportsUnaffected(t *testing.T) {
 	}
 
 	svc := marketplace.NewUnpublishService(pool, noopGate)
-	if _, err := svc.UnpublishKB(ctx, publisher.OrgID.String(), publisher.KBID.String()); err != nil {
+	if _, err := svc.UnpublishKB(ctx, publisher.OrgID.String(), publisher.WSID.String(), publisher.KBID.String()); err != nil {
 		t.Fatalf("UnpublishKB: %v", err)
 	}
 
@@ -315,7 +315,7 @@ func TestUnpublishKB_RefreshesExistingHold(t *testing.T) {
 	}
 
 	svc := marketplace.NewUnpublishService(pool, noopGate)
-	res, err := svc.UnpublishKB(ctx, f.OrgID.String(), f.KBID.String())
+	res, err := svc.UnpublishKB(ctx, f.OrgID.String(), f.WSID.String(), f.KBID.String())
 	if err != nil {
 		t.Fatalf("UnpublishKB: %v", err)
 	}

--- a/internal/marketplace/unpublish_test.go
+++ b/internal/marketplace/unpublish_test.go
@@ -44,17 +44,21 @@ func seedPublicKBForUnpublish(ctx context.Context, t *testing.T, pool *pgxpool.P
 		KBID:   uuid.New(),
 		KBSlug: label + "-kb-" + uuid.New().String()[:8],
 	}
+	// Precompute slugs in Go. Reusing the same $N parameter as both a typed
+	// column value and inside a text expression in one VALUES clause makes
+	// pgx/v5 (extended protocol) deduce inconsistent types for it -> SQLSTATE
+	// 42P08. Mirrors seedModFixture in moderation_integration_test.go.
+	orgSlug := label + "-org-" + f.OrgID.String()[:8]
+	wsSlug := label + "-ws-" + f.WSID.String()[:8]
 	if _, err := pool.Exec(ctx,
-		`INSERT INTO organizations (id, name, slug)
-		 VALUES ($1, $2, $2 || '-' || substring($1::text from 1 for 8))`,
-		f.OrgID, label+"-org",
+		`INSERT INTO organizations (id, name, slug) VALUES ($1, $2, $3)`,
+		f.OrgID, label+"-org", orgSlug,
 	); err != nil {
 		t.Fatalf("seed organization: %v", err)
 	}
 	if _, err := pool.Exec(ctx,
-		`INSERT INTO workspaces (id, org_id, name, slug)
-		 VALUES ($1, $2, $3, $3 || '-' || substring($1::text from 1 for 8))`,
-		f.WSID, f.OrgID, label+"-ws",
+		`INSERT INTO workspaces (id, org_id, name, slug) VALUES ($1, $2, $3, $4)`,
+		f.WSID, f.OrgID, label+"-ws", wsSlug,
 	); err != nil {
 		t.Fatalf("seed workspace: %v", err)
 	}

--- a/migrations/00051_kb_slug_holds.sql
+++ b/migrations/00051_kb_slug_holds.sql
@@ -77,8 +77,8 @@ CREATE INDEX idx_kb_slug_holds_held_until ON kb_slug_holds(held_until);
 -- DROP INDEX CONCURRENTLY takes only SHARE UPDATE EXCLUSIVE on the
 -- table rather than ACCESS EXCLUSIVE, so concurrent reads of the
 -- already-doomed table during rollback don't get blocked. The
--- enclosing "+goose NO TRANSACTION" directive is required because
--- CONCURRENTLY cannot run inside a transaction block.
+-- enclosing NO TRANSACTION goose directive (declared above) is
+-- required because CONCURRENTLY cannot run inside a transaction block.
 SET lock_timeout = '5s';
 SET statement_timeout = '30s';
 -- squawk-ignore prefer-robust-stmts

--- a/migrations/00051_kb_slug_holds.sql
+++ b/migrations/00051_kb_slug_holds.sql
@@ -45,7 +45,12 @@ SET statement_timeout = '30s';
 -- ---------------------------------------------------------------------------
 CREATE TABLE kb_slug_holds (
     org_id     UUID         NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
-    slug       VARCHAR(100) NOT NULL,
+    -- TEXT not VARCHAR(N): per Squawk's prefer-text-field rule, VARCHAR with
+    -- an explicit length forces an ACCESS EXCLUSIVE lock if the bound ever
+    -- needs to change. The length cap is enforced by the application layer
+    -- (the slug validator in internal/marketplace) so the DB type is the
+    -- safer-to-evolve one. Same shape as `org_slug_holds` in 00048.
+    slug       TEXT         NOT NULL,
     -- Soft pointer to the KB that vacated the slug. Carried for audit
     -- and admin tooling. SET NULL on KB hard-delete so the hold row
     -- survives — the 410 still needs to fire even after the row is
@@ -62,10 +67,22 @@ CREATE TABLE kb_slug_holds (
 CREATE INDEX idx_kb_slug_holds_held_until ON kb_slug_holds(held_until);
 
 -- +goose Down
+-- +goose NO TRANSACTION
 --
 -- Drop in reverse order. The table is freshly introduced by this
 -- migration, so DROP TABLE here is safe — no pre-existing data to
 -- preserve. (Squawk's "no DROP COLUMN on existing tables" rule does
 -- not apply to a table this migration itself created.)
-DROP INDEX IF EXISTS idx_kb_slug_holds_held_until;
+--
+-- DROP INDEX CONCURRENTLY takes only SHARE UPDATE EXCLUSIVE on the
+-- table rather than ACCESS EXCLUSIVE, so concurrent reads of the
+-- already-doomed table during rollback don't get blocked. The
+-- enclosing `+goose NO TRANSACTION` directive is required because
+-- CONCURRENTLY cannot run inside a transaction block.
+SET lock_timeout = '5s';
+SET statement_timeout = '30s';
+-- squawk-ignore prefer-robust-stmts
+DROP INDEX CONCURRENTLY IF EXISTS idx_kb_slug_holds_held_until;
+-- squawk-ignore ban-drop-table — this table is created by this
+-- migration's Up half; the Down half necessarily drops it.
 DROP TABLE IF EXISTS kb_slug_holds;

--- a/migrations/00051_kb_slug_holds.sql
+++ b/migrations/00051_kb_slug_holds.sql
@@ -83,6 +83,6 @@ SET lock_timeout = '5s';
 SET statement_timeout = '30s';
 -- squawk-ignore prefer-robust-stmts
 DROP INDEX CONCURRENTLY IF EXISTS idx_kb_slug_holds_held_until;
--- squawk-ignore ban-drop-table — this table is created by this
--- migration's Up half; the Down half necessarily drops it.
+-- squawk-ignore ban-drop-table
+-- this table is created by this migration's Up half; the Down half necessarily drops it.
 DROP TABLE IF EXISTS kb_slug_holds;

--- a/migrations/00051_kb_slug_holds.sql
+++ b/migrations/00051_kb_slug_holds.sql
@@ -1,0 +1,71 @@
+-- +goose Up
+--
+-- `kb_slug_holds` — 90-day lifecycle lock on a KB slug after a public KB is
+-- unpublished (issue #727, M1). When a Public KB transitions back to
+-- `private` the publishing Org's (org_slug, kb_slug) pair must keep
+-- routing to a clean `410 Gone` for 90 days (ADR-0007) rather than
+-- collapsing into a 404 or being recycled by a freshly-created KB.
+--
+-- The shape mirrors `org_slug_holds` from migration 00048: a thin
+-- (parent_id, slug, held_until) row with the lookup keyed on the
+-- "what URL did the visitor type" pair, so the Marketplace URL handler
+-- (#731) can resolve a held slug to a typed result in one index probe.
+--
+-- A row keeps a soft FK to `knowledge_bases(id)` via `ON DELETE SET NULL`
+-- so the hold survives a hard-delete of the KB itself (which is rare;
+-- archive is the normal path). The (org_id, slug) pair is the primary
+-- key — the Marketplace URL space is per-Org, not global, so two
+-- different orgs can hold the same slug at the same time.
+--
+-- RLS: this table is intentionally NOT row-isolated. The 410-Gone
+-- handler is a public Marketplace surface that must resolve a held
+-- slug without engaging session-bound RLS. Permissions are managed at
+-- the role grant level by ops, identical to how `org_slug_holds`
+-- (migration 00048) is exposed. Writes happen only through the
+-- `UnpublishService` in `internal/marketplace`, which runs inside a
+-- single transaction so the visibility flip and the hold insert can't
+-- be observed half-applied.
+--
+-- References:
+--   - docs/plans/marketplace-mvp.md §2 (`00051_kb_slug_holds.sql`), §4
+--     (unpublish endpoint row)
+--   - docs/adr/0001-marketplace-fork-on-import.md
+--   - docs/adr/0007-marketplace-lifecycle-behaviours.md (90-day hold,
+--     410 Gone, existing imports unaffected)
+
+-- Bound DDL lock acquisition + statement runtime so a long-running
+-- transaction on `knowledge_bases` cannot wedge the migration applier.
+-- Matches Squawk's safe-migration defaults; the table is fresh so
+-- there is no existing-row scan to budget for here.
+SET lock_timeout = '5s';
+SET statement_timeout = '30s';
+
+-- ---------------------------------------------------------------------------
+-- 1. Table.
+-- ---------------------------------------------------------------------------
+CREATE TABLE kb_slug_holds (
+    org_id     UUID         NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    slug       VARCHAR(100) NOT NULL,
+    -- Soft pointer to the KB that vacated the slug. Carried for audit
+    -- and admin tooling. SET NULL on KB hard-delete so the hold row
+    -- survives — the 410 still needs to fire even after the row is
+    -- gone, because the visitor's link does not know that.
+    kb_id      UUID         REFERENCES knowledge_bases(id) ON DELETE SET NULL,
+    held_until TIMESTAMPTZ  NOT NULL,
+    PRIMARY KEY (org_id, slug)
+);
+
+-- ---------------------------------------------------------------------------
+-- 2. Sweep index. Daily cron deletes WHERE held_until < now(); without an
+--    index on `held_until` that scan would degrade as the table grows.
+-- ---------------------------------------------------------------------------
+CREATE INDEX idx_kb_slug_holds_held_until ON kb_slug_holds(held_until);
+
+-- +goose Down
+--
+-- Drop in reverse order. The table is freshly introduced by this
+-- migration, so DROP TABLE here is safe — no pre-existing data to
+-- preserve. (Squawk's "no DROP COLUMN on existing tables" rule does
+-- not apply to a table this migration itself created.)
+DROP INDEX IF EXISTS idx_kb_slug_holds_held_until;
+DROP TABLE IF EXISTS kb_slug_holds;

--- a/migrations/00051_kb_slug_holds.sql
+++ b/migrations/00051_kb_slug_holds.sql
@@ -77,7 +77,7 @@ CREATE INDEX idx_kb_slug_holds_held_until ON kb_slug_holds(held_until);
 -- DROP INDEX CONCURRENTLY takes only SHARE UPDATE EXCLUSIVE on the
 -- table rather than ACCESS EXCLUSIVE, so concurrent reads of the
 -- already-doomed table during rollback don't get blocked. The
--- enclosing `+goose NO TRANSACTION` directive is required because
+-- enclosing "+goose NO TRANSACTION" directive is required because
 -- CONCURRENTLY cannot run inside a transaction block.
 SET lock_timeout = '5s';
 SET statement_timeout = '30s';

--- a/migrations/migrations_test.go
+++ b/migrations/migrations_test.go
@@ -1088,6 +1088,54 @@ func TestMigrationsUpAndDown(t *testing.T) {
 		if remaining != 0 {
 			t.Errorf("expected ON DELETE CASCADE to remove holds, found %d", remaining)
 		}
+
+		// --- ON DELETE SET NULL from knowledge_bases ---
+		// The kb_id column carries a soft pointer to the KB that vacated
+		// the slug; deleting the KB row must keep the hold alive (so
+		// the 410 still fires) and null out kb_id. The CASCADE test
+		// above only covered the organizations parent; this case is
+		// what makes the audit trail survive a hard KB delete.
+		var orgC, wsC, kbC string
+		if err := db.QueryRowContext(ctx,
+			`INSERT INTO organizations (id, name, slug)
+			 VALUES (uuid_generate_v4(), 'Hold C', 'kbhold-org-c')
+			 RETURNING id`).Scan(&orgC); err != nil {
+			t.Fatalf("insert org C: %v", err)
+		}
+		if err := db.QueryRowContext(ctx,
+			`INSERT INTO workspaces (id, org_id, name, slug)
+			 VALUES (uuid_generate_v4(), $1, 'Hold WS', 'hold-ws')
+			 RETURNING id`, orgC).Scan(&wsC); err != nil {
+			t.Fatalf("insert ws C: %v", err)
+		}
+		if err := db.QueryRowContext(ctx,
+			`INSERT INTO knowledge_bases (id, org_id, workspace_id, name, slug)
+			 VALUES (uuid_generate_v4(), $1, $2, 'Hold KB', 'set-null-kb')
+			 RETURNING id`, orgC, wsC).Scan(&kbC); err != nil {
+			t.Fatalf("insert kb C: %v", err)
+		}
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO kb_slug_holds (org_id, slug, kb_id, held_until)
+			 VALUES ($1, 'set-null-kb', $2, NOW() + interval '30 days')`,
+			orgC, kbC,
+		); err != nil {
+			t.Fatalf("insert hold with kb_id: %v", err)
+		}
+		if _, err := db.ExecContext(ctx,
+			`DELETE FROM knowledge_bases WHERE id = $1`, kbC,
+		); err != nil {
+			t.Fatalf("delete kb C: %v", err)
+		}
+		var kbIDAfter *string
+		if err := db.QueryRowContext(ctx,
+			`SELECT kb_id FROM kb_slug_holds WHERE org_id = $1 AND slug = 'set-null-kb'`,
+			orgC,
+		).Scan(&kbIDAfter); err != nil {
+			t.Fatalf("read hold after kb delete: %v", err)
+		}
+		if kbIDAfter != nil {
+			t.Errorf("expected ON DELETE SET NULL to null out kb_id; got %v", *kbIDAfter)
+		}
 	})
 
 	// --- Run all migrations DOWN ---

--- a/migrations/migrations_test.go
+++ b/migrations/migrations_test.go
@@ -1004,6 +1004,92 @@ func TestMigrationsUpAndDown(t *testing.T) {
 		}
 	})
 
+	t.Run("kb_slug_holds_table", func(t *testing.T) {
+		// Migration 00051 (issue #727): kb_slug_holds — 90-day Marketplace
+		// slug hold after an Org unpublishes a Public KB. Mirrors the
+		// org_slug_holds shape (00048) so the 410-Gone handler can
+		// resolve held URLs without engaging RLS.
+		//
+		// Asserted invariants:
+		//   1. Table + columns exist.
+		//   2. Index on held_until (sweep path).
+		//   3. PRIMARY KEY is (org_id, slug) — two orgs can hold the
+		//      same slug simultaneously.
+		//   4. ON DELETE CASCADE from organizations and ON DELETE SET NULL
+		//      from knowledge_bases.
+
+		var holdsExists bool
+		if err := db.QueryRowContext(ctx,
+			`SELECT EXISTS (
+			    SELECT 1 FROM information_schema.tables
+			    WHERE table_schema = 'public' AND table_name = 'kb_slug_holds'
+			 )`).Scan(&holdsExists); err != nil {
+			t.Fatalf("check kb_slug_holds: %v", err)
+		}
+		if !holdsExists {
+			t.Fatal("expected kb_slug_holds table to exist")
+		}
+
+		// Held_until index must exist for the sweep job's perf.
+		var heldUntilIdx bool
+		if err := db.QueryRowContext(ctx,
+			`SELECT EXISTS (SELECT 1 FROM pg_indexes
+			   WHERE tablename = 'kb_slug_holds'
+			     AND indexname = 'idx_kb_slug_holds_held_until')`).
+			Scan(&heldUntilIdx); err != nil {
+			t.Fatalf("check kb_slug_holds index: %v", err)
+		}
+		if !heldUntilIdx {
+			t.Error("expected idx_kb_slug_holds_held_until index")
+		}
+
+		// Behaviour: two orgs holding the same slug at the same time
+		// must both succeed (per-org URL space). Same (org_id, slug)
+		// twice must fail (PK).
+		var orgA, orgB string
+		if err := db.QueryRowContext(ctx,
+			`INSERT INTO organizations (id, name, slug)
+			 VALUES (uuid_generate_v4(), 'Hold A', 'kbhold-org-a')
+			 RETURNING id`).Scan(&orgA); err != nil {
+			t.Fatalf("insert org A: %v", err)
+		}
+		if err := db.QueryRowContext(ctx,
+			`INSERT INTO organizations (id, name, slug)
+			 VALUES (uuid_generate_v4(), 'Hold B', 'kbhold-org-b')
+			 RETURNING id`).Scan(&orgB); err != nil {
+			t.Fatalf("insert org B: %v", err)
+		}
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO kb_slug_holds (org_id, slug, held_until)
+			 VALUES ($1, 'shared', NOW() + interval '30 days')`, orgA); err != nil {
+			t.Fatalf("hold for org A: %v", err)
+		}
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO kb_slug_holds (org_id, slug, held_until)
+			 VALUES ($1, 'shared', NOW() + interval '30 days')`, orgB); err != nil {
+			t.Errorf("two orgs holding the same slug should both succeed: %v", err)
+		}
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO kb_slug_holds (org_id, slug, held_until)
+			 VALUES ($1, 'shared', NOW() + interval '60 days')`, orgA); err == nil {
+			t.Error("duplicate (org_id, slug) should be rejected by PK")
+		}
+
+		// CASCADE on organizations: deleting the org should remove the hold.
+		if _, err := db.ExecContext(ctx,
+			`DELETE FROM organizations WHERE id = $1`, orgA); err != nil {
+			t.Fatalf("delete org A: %v", err)
+		}
+		var remaining int
+		if err := db.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM kb_slug_holds WHERE org_id = $1`, orgA).Scan(&remaining); err != nil {
+			t.Fatalf("count holds after org delete: %v", err)
+		}
+		if remaining != 0 {
+			t.Errorf("expected ON DELETE CASCADE to remove holds, found %d", remaining)
+		}
+	})
+
 	// --- Run all migrations DOWN ---
 	t.Run("clean_rollback", func(t *testing.T) {
 		if err := goose.DownTo(db, migDir, 0); err != nil {


### PR DESCRIPTION
Closes #727.

## Summary

Adds the M1 unpublish path for Raven's Marketplace (ADR-0001, ADR-0007). Flipping a Public KB back to `private` now atomically registers a 90-day hold so external Marketplace links resolve to a clean `410 Gone` once the lifecycle handlers in #731 land.

- **Migration `00051_kb_slug_holds.sql`** — fresh table mirroring `org_slug_holds` from 00048; PK `(org_id, slug)`, nullable FK to `knowledge_bases` with `ON DELETE SET NULL` so holds survive a hard-deleted KB. Index on `held_until` for the daily sweep. Squawk-clean DDL (`lock_timeout`, `statement_timeout`); reversible Down.
- **Service `internal/marketplace/unpublish.go`** — `UnpublishService` wired via the same `PublishGateFunc` closure pattern as `publish.go` so `internal/marketplace` stays a leaf import-graph node. Single `db.WithOrgID` transaction: `KBStatusGate.CanPublish` check → visibility flip → ON CONFLICT slug-hold insert. Returns `{visibility, slug_held_until}`. Errors map to 401 / 403 / 404 / 409. Existing imports unaffected — verified in a test that confirms downstream `source_public_kb_id` FK rows stay pinned to the publisher row.
- **`SlugHoldStatus` lookup helper** (`internal/marketplace/slug_holds.go`) — `LookupKBSlugHold(orgSlug, kbSlug) -> SlugHoldStatus{OrgID, KBID, IsHeld}` for #731's 410-Gone path. Typed struct, not a 3-tuple. Expired rows treated as not-held so the 90-day window is honest regardless of sweeper latency.
- **Sweep job `internal/jobs/marketplace_slug_hold_sweeper.go`** — daily Asynq cron registered in `scheduler.go` at `0 4 * * *`. Idempotent `DELETE WHERE held_until < NOW()` against both `kb_slug_holds` and `org_slug_holds` (plan §3 consolidates both windows into one job). Graceful no-op when tables are absent.
- **Handler + route** — `KBUnpublisher` interface keeps test wiring decoupled; route is `POST /api/v1/orgs/:org_id/workspaces/:ws_id/knowledge-bases/:kb_id/unpublish`, workspace-admin only (same gate as Publish). `main.go` wiring is 2 lines + 2 route lines, grouped with publish.

## References

- ADR-0001 — `docs/adr/0001-marketplace-fork-on-import.md`
- ADR-0007 — `docs/adr/0007-marketplace-lifecycle-behaviours.md` (90-day hold, existing imports unaffected, 410 Gone)
- `docs/plans/marketplace-mvp.md` §2 (`00051`), §3 (sweeper), §4 (unpublish endpoint row)

## Out of scope (explicit deferral)

The parent issue lists the downgrade-freeze hook, Free Plan public-only override, Vue UI, Playwright round-trip, and the 410-Gone HTTP handler itself. Those land in #731 / #734-#736 / billing tracks per the task scoping. This PR delivers the schema, service, helper, sweep, handler, and tests only.

## Self-review (thermo-nuclear)

- `if visibility == "public"` literals stay inside `unpublish.go`'s SQL UPDATE; no branching on visibility elsewhere.
- `SlugHoldStatus` is a typed struct, not a `(uuid, bool, error)` tuple.
- `main.go` additions: 2 lines wiring + 2 lines route, grouped with publish.
- Handler kb.go went 240 → 305 lines (well under 1k). Marketplace service files are 115 / 163 / 153 lines.
- The sweeper handles both `kb_slug_holds` and `org_slug_holds` because plan §3 calls that out explicitly — one job per spec, not duplication. Org-hold sweep is additive: 00048 left this to ad-hoc cleanup.
- No DB trigger written. The issue mentions one (`trg_kb_release_slug_on_unpublish`); the task instruction routes the write through `UnpublishService` instead so the canonical owner of the boundary stays the Go service and the write side never has two competing producers.

## Test plan

- [x] `go test -short ./...` green locally (pre-existing testcontainer failures in `internal/db` are environmental — no Docker on dev box; CI has it).
- [x] `golangci-lint run --new-from-rev=origin/main ./...` → 0 issues.
- [x] Migration round-trip + per-org slug uniqueness + ON DELETE CASCADE.
- [x] Service: 404 (unknown / already-private), 409 (gate refused), 200 happy path with hold registered + visibility flipped + `published_at = NULL`.
- [x] Existing-imports-unaffected test (`source_public_kb_id` FK pin preserved through unpublish).
- [x] Hold-refresh test confirms ON CONFLICT overwrites stale window.
- [x] Sweep deletes only expired rows; second run is no-op.
- [x] `LookupKBSlugHold`: present-and-active → `IsHeld=true`; expired / org-missing / kb-missing / invalid-shape → `ErrKBSlugNotFound`; NULL `kb_id` → `IsHeld=true, KBID=uuid.Nil`.
- [x] Handler: 200, 401 (missing user context), 404, 409, 500 (service not wired).
- [ ] CI integration tests need to pass against testcontainer Postgres (verified locally that all skip cleanly in `-short` mode).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Marketplace admins can unpublish knowledge bases, reverting them to private.
  * Unpublished KB URLs are reserved for 90 days to prevent reuse; held slugs return appropriate responses.
  * A daily background job automatically clears expired URL reservations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->