### PR TITLE
feat(marketplace): listing, detail, and preview HTTP endpoints with 410-Gone (#731)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -549,6 +549,16 @@ func main() {
 		pool, reportsRepo, takedownsRepo, marketplace.NewNoopPublisherNotifier(),
 	)
 	adminMarketplaceHandler := handler.NewAdminMarketplaceHandler(adminModerationSvc)
+
+	// Marketplace discovery handler (issue #731). Reads-only across
+	// tenants via the SECURITY DEFINER functions from #728; the slug
+	// resolver is the stub that #727 will supersede with a direct
+	// kb_slug_holds-aware lookup.
+	marketplaceQueries := marketplace.NewQueries(pool)
+	marketplaceResolver := func(ctx context.Context, orgSlug, kbSlug string) (marketplace.SlugStatus, error) {
+		return marketplace.MarketplaceSlugStatus(ctx, pool, orgSlug, kbSlug)
+	}
+	marketplaceHandler := handler.NewMarketplaceHandler(marketplaceQueries, marketplaceResolver)
 	sourceHandler := handler.NewSourceHandler(sourceSvc)
 	docHandler := handler.NewDocumentHandler(docSvc)
 	searchHandler := handler.NewSearchHandler(searchSvc)
@@ -1094,6 +1104,20 @@ func main() {
 			adminMarket.GET("/dmca", adminDMCAHandler.List)
 			adminMarket.POST("/dmca", adminDMCAHandler.Submit)
 			adminMarket.POST("/dmca/:id/counter-notice", adminDMCAHandler.SubmitCounterNotice)
+		}
+
+		// --- Marketplace discovery routes (issue #731) ---
+		// Authenticated-only — per CONTEXT.md the Marketplace is walled;
+		// the standard session middleware on `api` is the gate. No admin
+		// role required: cross-tenant reads are scoped by the SECURITY
+		// DEFINER functions in migration 00052. The 410-Gone path for an
+		// unpublished slug is enforced inside the handler via the shared
+		// marketplaceLookupOr410 helper so detail + preview can't drift.
+		marketplaceGrp := api.Group("/marketplace")
+		{
+			marketplaceGrp.GET("", marketplaceHandler.List)
+			marketplaceGrp.GET("/:org_slug/:kb_slug", marketplaceHandler.Detail)
+			marketplaceGrp.GET("/:org_slug/:kb_slug/preview", marketplaceHandler.Preview)
 		}
 	}
 

--- a/internal/handler/marketplace.go
+++ b/internal/handler/marketplace.go
@@ -1,0 +1,400 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/ravencloak-org/Raven/internal/marketplace"
+	"github.com/ravencloak-org/Raven/pkg/apierror"
+)
+
+// Marketplace listing defaults. The HTTP-side ceiling is 50; the SECURITY
+// DEFINER function in migration 00052 also clamps to 50, so the two
+// numbers are deliberately equal — every layer rejects over-large pages
+// instead of one silently shrinking what the other accepted.
+const (
+	marketplaceDefaultLimit = 25
+	marketplaceMaxLimit     = 50
+)
+
+// validSortValues mirrors the four-entry whitelist enforced by the SQL
+// function. We validate Go-side so a malformed query string returns 400
+// before any database round trip and so we surface a stable
+// error_code clients can branch on; the SQL function's
+// invalid_parameter_value path is the backstop.
+var validSortValues = map[string]marketplace.ListSort{
+	string(marketplace.SortNewest):          marketplace.SortNewest,
+	string(marketplace.SortMostImported):    marketplace.SortMostImported,
+	string(marketplace.SortRecentlyUpdated): marketplace.SortRecentlyUpdated,
+	string(marketplace.SortAlphabetic):      marketplace.SortAlphabetic,
+}
+
+// MarketplaceLister is the narrow slice of marketplace.Queries the
+// Marketplace handler needs for the listing endpoint. Defined here so
+// handler tests can pass a stub without standing up a real pgxpool.
+type MarketplaceLister interface {
+	ListPublicKBs(ctx context.Context, f marketplace.ListFilters) ([]marketplace.ListItem, error)
+	PreviewKB(ctx context.Context, publicKBID uuid.UUID) ([]marketplace.PreviewChunk, error)
+}
+
+// SlugResolver wraps marketplace.MarketplaceSlugStatus so the handler can
+// be unit-tested with a stub that returns canned (404 / 410 / detail)
+// outcomes without standing up the database.
+type SlugResolver func(ctx context.Context, orgSlug, kbSlug string) (marketplace.SlugStatus, error)
+
+// MarketplaceHandler serves the cross-tenant Marketplace discovery
+// surface: listing, detail, and ≤3-chunk preview. All three are
+// authenticated (per CONTEXT.md the Marketplace is "walled" — only
+// logged-in users see it) but carry no admin gate; the route group in
+// main.go applies the standard SessionMiddleware + UserLookup chain
+// shared by every other /api/v1 handler.
+type MarketplaceHandler struct {
+	queries  MarketplaceLister
+	resolver SlugResolver
+}
+
+// NewMarketplaceHandler wires the handler to a Queries instance and a
+// slug resolver. The resolver is a function (not a method on Queries)
+// because the stub MarketplaceSlugStatus lives at the package level
+// rather than on Queries — this lets tests inject a deterministic
+// resolver without dragging a partial Queries mock through every case.
+func NewMarketplaceHandler(q MarketplaceLister, resolver SlugResolver) *MarketplaceHandler {
+	return &MarketplaceHandler{queries: q, resolver: resolver}
+}
+
+// MarketplaceListResponse is the envelope returned by the listing
+// endpoint. The `items` field carries one row per ADR-0005's listing
+// row shape (also surfaced as marketplace.ListItem). `next_offset` is
+// the offset to pass for the next page, or null when no further pages
+// exist.
+type MarketplaceListResponse struct {
+	Items      []MarketplaceListItem `json:"items"`
+	NextOffset *int                  `json:"next_offset"`
+}
+
+// MarketplaceListItem is the JSON projection of marketplace.ListItem.
+// Defined here (not on the marketplace package) because the JSON shape
+// is an HTTP-surface concern; the marketplace package owns the Go
+// types, the handler owns the wire format.
+type MarketplaceListItem struct {
+	KBID                 uuid.UUID  `json:"kb_id"`
+	OrgSlug              string     `json:"org_slug"`
+	OrgDisplayName       string     `json:"org_display_name"`
+	KBSlug               string     `json:"kb_slug"`
+	KBName               string     `json:"kb_name"`
+	Description          *string    `json:"description,omitempty"`
+	LicenseSPDXID        *string    `json:"license_spdx_id,omitempty"`
+	LastModifiedAt       string     `json:"last_modified_at"`
+	ImportCount          int        `json:"import_count"`
+	SourcePublicKBID     *uuid.UUID `json:"source_public_kb_id,omitempty"`
+	SourceOrgSlug        *string    `json:"source_org_slug,omitempty"`
+	SourceOrgDisplayName *string    `json:"source_org_display_name,omitempty"`
+}
+
+// MarketplacePreviewResponse is the JSON envelope for the preview
+// endpoint. The `chunks` field is always present and may be empty when
+// the KB has no chunks yet; an empty slice (not null) keeps the wire
+// shape stable for clients.
+type MarketplacePreviewResponse struct {
+	Chunks []MarketplacePreviewChunk `json:"chunks"`
+}
+
+// MarketplacePreviewChunk is the JSON projection of
+// marketplace.PreviewChunk.
+type MarketplacePreviewChunk struct {
+	ChunkID uuid.UUID `json:"chunk_id"`
+	Ordinal int       `json:"ordinal"`
+	Text    string    `json:"text"`
+}
+
+// List handles GET /api/v1/marketplace.
+//
+// Query string:
+//   - q         — free-form search (FTS); empty means no filter.
+//   - sort      — one of newest|most_imported|recently_updated|alphabetic
+//     (default: newest).
+//   - license[] — repeated SPDX identifier; each must be in the 7-item
+//     allow-list.
+//   - limit     — page size, default 25, hard cap 50.
+//   - offset    — page start, default 0.
+//
+// @Summary     List public Marketplace KBs
+// @Tags        marketplace
+// @Produce     json
+// @Security    BearerAuth
+// @Param       q       query string  false "Free-form FTS search"
+// @Param       sort    query string  false "newest|most_imported|recently_updated|alphabetic"
+// @Param       license query []string false "SPDX identifier(s) to filter by" collectionFormat(multi)
+// @Param       limit   query int     false "Page size, max 50"
+// @Param       offset  query int     false "Page start"
+// @Success     200 {object} MarketplaceListResponse
+// @Failure     400 {object} apierror.AppError
+// @Failure     401 {object} apierror.AppError
+// @Router      /marketplace [get]
+func (h *MarketplaceHandler) List(c *gin.Context) {
+	filters, appErr := parseListFilters(c)
+	if appErr != nil {
+		_ = c.Error(appErr)
+		c.Abort()
+		return
+	}
+
+	items, err := h.queries.ListPublicKBs(c.Request.Context(), filters)
+	if err != nil {
+		// The SQL function raises invalid_parameter_value on a bad sort,
+		// which the Queries layer maps to ErrUnknownSort. We already
+		// rejected those Go-side above so reaching this branch is a
+		// drift signal — surface 400 with the same error_code rather
+		// than 500, so the cause is obvious in logs.
+		if errors.Is(err, marketplace.ErrUnknownSort) {
+			_ = c.Error(&apierror.AppError{
+				Code:      http.StatusBadRequest,
+				Message:   "Bad Request",
+				Detail:    err.Error(),
+				ErrorCode: "invalid_sort",
+			})
+			c.Abort()
+			return
+		}
+		_ = c.Error(err)
+		c.Abort()
+		return
+	}
+
+	resp := MarketplaceListResponse{
+		Items: make([]MarketplaceListItem, 0, len(items)),
+	}
+	for i := range items {
+		resp.Items = append(resp.Items, toMarketplaceListItem(items[i]))
+	}
+	// `next_offset` is set when the page came back full. The SQL
+	// function may have clamped Limit, but we mirror what we asked for
+	// (filters.Limit), so the client's next request will pass the same
+	// effective page size.
+	if len(items) == filters.Limit {
+		next := filters.Offset + filters.Limit
+		resp.NextOffset = &next
+	}
+	c.JSON(http.StatusOK, resp)
+}
+
+// Detail handles GET /api/v1/marketplace/:org_slug/:kb_slug.
+//
+// Resolves the slug pair via marketplaceLookupOr410 — a 410 hold
+// short-circuits the listing row lookup. A missing pair returns 404; an
+// active hold returns 410 with error_code "slug_held".
+//
+// @Summary     Public KB detail
+// @Tags        marketplace
+// @Produce     json
+// @Security    BearerAuth
+// @Param       org_slug path string true "Publisher Org slug"
+// @Param       kb_slug  path string true "Public KB slug"
+// @Success     200 {object} MarketplaceListItem
+// @Failure     401 {object} apierror.AppError
+// @Failure     404 {object} apierror.AppError
+// @Failure     410 {object} apierror.AppError
+// @Router      /marketplace/{org_slug}/{kb_slug} [get]
+func (h *MarketplaceHandler) Detail(c *gin.Context) {
+	orgSlug := c.Param("org_slug")
+	kbSlug := c.Param("kb_slug")
+
+	status, appErr := h.marketplaceLookupOr410(c.Request.Context(), orgSlug, kbSlug)
+	if appErr != nil {
+		_ = c.Error(appErr)
+		c.Abort()
+		return
+	}
+	c.JSON(http.StatusOK, toMarketplaceListItem(*status.Detail))
+}
+
+// Preview handles GET /api/v1/marketplace/:org_slug/:kb_slug/preview.
+//
+// Identical 410 / 404 contract to Detail, plus 403 when the underlying
+// KB is private — the SECURITY DEFINER function in migration 00052
+// raises insufficient_privilege which the Queries layer maps to
+// ErrKBNotPublic. Server-side preview-count increment happens inside
+// the function regardless of how this handler reads the result.
+//
+// @Summary     Preview ≤3 sample chunks from a Public KB
+// @Tags        marketplace
+// @Produce     json
+// @Security    BearerAuth
+// @Param       org_slug path string true "Publisher Org slug"
+// @Param       kb_slug  path string true "Public KB slug"
+// @Success     200 {object} MarketplacePreviewResponse
+// @Failure     401 {object} apierror.AppError
+// @Failure     403 {object} apierror.AppError
+// @Failure     404 {object} apierror.AppError
+// @Failure     410 {object} apierror.AppError
+// @Router      /marketplace/{org_slug}/{kb_slug}/preview [get]
+func (h *MarketplaceHandler) Preview(c *gin.Context) {
+	orgSlug := c.Param("org_slug")
+	kbSlug := c.Param("kb_slug")
+
+	status, appErr := h.marketplaceLookupOr410(c.Request.Context(), orgSlug, kbSlug)
+	if appErr != nil {
+		_ = c.Error(appErr)
+		c.Abort()
+		return
+	}
+
+	chunks, err := h.queries.PreviewKB(c.Request.Context(), status.KBID)
+	if err != nil {
+		if errors.Is(err, marketplace.ErrKBNotPublic) {
+			_ = c.Error(&apierror.AppError{
+				Code:    http.StatusForbidden,
+				Message: "Forbidden",
+				Detail:  "knowledge base is not public",
+			})
+			c.Abort()
+			return
+		}
+		_ = c.Error(err)
+		c.Abort()
+		return
+	}
+
+	resp := MarketplacePreviewResponse{
+		Chunks: make([]MarketplacePreviewChunk, 0, len(chunks)),
+	}
+	for _, ch := range chunks {
+		resp.Chunks = append(resp.Chunks, MarketplacePreviewChunk{
+			ChunkID: ch.ChunkID,
+			Ordinal: ch.Ordinal,
+			Text:    ch.Text,
+		})
+	}
+	c.JSON(http.StatusOK, resp)
+}
+
+// marketplaceLookupOr410 is the shared resolver for Detail and Preview.
+// Returns the resolved SlugStatus on success, or an *apierror.AppError
+// the caller can hand straight to `c.Error`. Extracted so the two
+// handlers can't drift on the 410 / 404 boundary — one rule, one
+// implementation, surfaced as a single code path.
+func (h *MarketplaceHandler) marketplaceLookupOr410(ctx context.Context, orgSlug, kbSlug string) (marketplace.SlugStatus, *apierror.AppError) {
+	status, err := h.resolver(ctx, orgSlug, kbSlug)
+	if err != nil {
+		return marketplace.SlugStatus{}, apierror.NewInternal(err.Error())
+	}
+	if status.IsHeld {
+		return marketplace.SlugStatus{}, apierror.NewGone(
+			"this knowledge base has been unpublished",
+			"slug_held",
+		)
+	}
+	if status.Detail == nil {
+		return marketplace.SlugStatus{}, apierror.NewNotFound("knowledge base not found")
+	}
+	return status, nil
+}
+
+// parseListFilters reads the listing query string into a
+// marketplace.ListFilters, validating sort + license values against the
+// enums in marketplace.ListSort and marketplace.AllowedSPDXLicenses
+// respectively. Returns an *apierror.AppError on the first failure so
+// the handler can stop on a single drop point.
+func parseListFilters(c *gin.Context) (marketplace.ListFilters, *apierror.AppError) {
+	filters := marketplace.ListFilters{
+		Query:  strings.TrimSpace(c.Query("q")),
+		Limit:  marketplaceDefaultLimit,
+		Offset: 0,
+	}
+
+	// Sort. Empty string defaults to SortNewest — the Marketplace
+	// homepage call must work without an explicit sort. Unknown values
+	// are rejected here (400) rather than at the SQL boundary so the
+	// error_code is stable and the database is not consulted.
+	sortRaw := c.Query("sort")
+	if sortRaw == "" {
+		filters.Sort = marketplace.SortNewest
+	} else {
+		sort, ok := validSortValues[sortRaw]
+		if !ok {
+			return marketplace.ListFilters{}, &apierror.AppError{
+				Code:      http.StatusBadRequest,
+				Message:   "Bad Request",
+				Detail:    fmt.Sprintf("sort %q is not one of newest, most_imported, recently_updated, alphabetic", sortRaw),
+				ErrorCode: "invalid_sort",
+			}
+		}
+		filters.Sort = sort
+	}
+
+	// License filter. Gin's QueryArray returns every value of a
+	// repeated parameter, supporting both `?license=MIT&license=Apache-2.0`
+	// and `?license[]=MIT&license[]=Apache-2.0` shapes. We validate
+	// each against the canonical allow-list — a typo would otherwise
+	// silently return zero rows, which is a bad failure mode for
+	// callers (no result vs. a 400 they can fix).
+	for _, lic := range c.QueryArray("license") {
+		if lic == "" {
+			continue
+		}
+		if !marketplace.IsAllowedLicense(lic) {
+			return marketplace.ListFilters{}, &apierror.AppError{
+				Code:      http.StatusBadRequest,
+				Message:   "Bad Request",
+				Detail:    fmt.Sprintf("license %q is not in the SPDX allow-list", lic),
+				ErrorCode: "invalid_license",
+			}
+		}
+		filters.Licenses = append(filters.Licenses, lic)
+	}
+
+	// Limit. A non-numeric value is treated as "use the default"
+	// rather than 400; this matches how the rest of the API handles
+	// optional pagination knobs. The hard cap mirrors the SQL function
+	// clamp at 50 — defence in depth.
+	if raw := c.Query("limit"); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil {
+			if n < 1 {
+				n = marketplaceDefaultLimit
+			} else if n > marketplaceMaxLimit {
+				n = marketplaceMaxLimit
+			}
+			filters.Limit = n
+		}
+	}
+
+	// Offset. Negative or non-numeric becomes 0 (the SQL function
+	// already clamps to >= 0; we mirror that so the response envelope's
+	// next_offset arithmetic stays positive).
+	if raw := c.Query("offset"); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+			filters.Offset = n
+		}
+	}
+
+	return filters, nil
+}
+
+// toMarketplaceListItem projects the Go-side marketplace.ListItem into
+// its JSON wire shape. We format LastModifiedAt as RFC3339 so the
+// frontend can pass it back through Date.parse without parsing pgx's
+// time precision quirks; the marketplace.ListItem field is a Go
+// time.Time so we don't need to keep two clock representations in sync.
+func toMarketplaceListItem(it marketplace.ListItem) MarketplaceListItem {
+	return MarketplaceListItem{
+		KBID:                 it.KBID,
+		OrgSlug:              it.OrgSlug,
+		OrgDisplayName:       it.OrgDisplayName,
+		KBSlug:               it.KBSlug,
+		KBName:               it.KBName,
+		Description:          it.Description,
+		LicenseSPDXID:        it.LicenseSPDXID,
+		LastModifiedAt:       it.LastModifiedAt.UTC().Format("2006-01-02T15:04:05.999999999Z07:00"),
+		ImportCount:          it.ImportCount,
+		SourcePublicKBID:     it.SourcePublicKBID,
+		SourceOrgSlug:        it.SourceOrgSlug,
+		SourceOrgDisplayName: it.SourceOrgDisplayName,
+	}
+}

--- a/internal/handler/marketplace_test.go
+++ b/internal/handler/marketplace_test.go
@@ -1,0 +1,397 @@
+package handler_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/ravencloak-org/Raven/internal/handler"
+	"github.com/ravencloak-org/Raven/internal/marketplace"
+	"github.com/ravencloak-org/Raven/pkg/apierror"
+)
+
+// mockMarketplaceLister implements handler.MarketplaceLister for unit
+// tests. Each function is settable so a test can target one path
+// (List vs. Preview) without dragging in stubs for the other.
+type mockMarketplaceLister struct {
+	listFn    func(ctx context.Context, f marketplace.ListFilters) ([]marketplace.ListItem, error)
+	previewFn func(ctx context.Context, kbID uuid.UUID) ([]marketplace.PreviewChunk, error)
+}
+
+func (m *mockMarketplaceLister) ListPublicKBs(ctx context.Context, f marketplace.ListFilters) ([]marketplace.ListItem, error) {
+	return m.listFn(ctx, f)
+}
+
+func (m *mockMarketplaceLister) PreviewKB(ctx context.Context, kbID uuid.UUID) ([]marketplace.PreviewChunk, error) {
+	return m.previewFn(ctx, kbID)
+}
+
+func newMarketplaceRouter(q handler.MarketplaceLister, resolver handler.SlugResolver) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(apierror.ErrorHandler())
+	h := handler.NewMarketplaceHandler(q, resolver)
+	r.GET("/api/v1/marketplace", h.List)
+	r.GET("/api/v1/marketplace/:org_slug/:kb_slug", h.Detail)
+	r.GET("/api/v1/marketplace/:org_slug/:kb_slug/preview", h.Preview)
+	return r
+}
+
+// fakeListItem returns a ListItem with a deterministic UUID derived from
+// `name` so tests can compare across calls without flakiness.
+func fakeListItem(t *testing.T, name string) marketplace.ListItem {
+	t.Helper()
+	id := uuid.NewSHA1(uuid.NameSpaceOID, []byte(name))
+	return marketplace.ListItem{
+		KBID:           id,
+		OrgSlug:        "acme",
+		OrgDisplayName: "Acme",
+		KBSlug:         name,
+		KBName:         name,
+		LastModifiedAt: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+		ImportCount:    0,
+	}
+}
+
+// ----------------------------------------------------------------------
+// Listing endpoint
+// ----------------------------------------------------------------------
+
+func TestMarketplaceList_HappyPath_DefaultsToNewest(t *testing.T) {
+	var seen marketplace.ListFilters
+	svc := &mockMarketplaceLister{
+		listFn: func(_ context.Context, f marketplace.ListFilters) ([]marketplace.ListItem, error) {
+			seen = f
+			return []marketplace.ListItem{fakeListItem(t, "alpha")}, nil
+		},
+	}
+	r := newMarketplaceRouter(svc, nil)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/marketplace", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if seen.Sort != marketplace.SortNewest {
+		t.Errorf("expected default sort=newest, got %q", seen.Sort)
+	}
+	if seen.Limit != 25 {
+		t.Errorf("expected default limit=25, got %d", seen.Limit)
+	}
+	var resp handler.MarketplaceListResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Items) != 1 || resp.Items[0].KBSlug != "alpha" {
+		t.Errorf("unexpected items: %+v", resp.Items)
+	}
+	if resp.NextOffset != nil {
+		t.Errorf("expected next_offset nil for partial page, got %v", *resp.NextOffset)
+	}
+}
+
+func TestMarketplaceList_InvalidSort_Returns400WithCode(t *testing.T) {
+	svc := &mockMarketplaceLister{
+		listFn: func(_ context.Context, _ marketplace.ListFilters) ([]marketplace.ListItem, error) {
+			t.Fatal("Queries should not be called for invalid sort")
+			return nil, nil
+		},
+	}
+	r := newMarketplaceRouter(svc, nil)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/marketplace?sort=bogus", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	var body apierror.AppError
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.ErrorCode != "invalid_sort" {
+		t.Errorf("expected error_code=invalid_sort, got %q", body.ErrorCode)
+	}
+}
+
+func TestMarketplaceList_InvalidLicense_Returns400WithCode(t *testing.T) {
+	svc := &mockMarketplaceLister{
+		listFn: func(_ context.Context, _ marketplace.ListFilters) ([]marketplace.ListItem, error) {
+			t.Fatal("Queries should not be called for invalid license")
+			return nil, nil
+		},
+	}
+	r := newMarketplaceRouter(svc, nil)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/marketplace?license=BAD-LICENSE-9.0", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	var body apierror.AppError
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.ErrorCode != "invalid_license" {
+		t.Errorf("expected error_code=invalid_license, got %q", body.ErrorCode)
+	}
+}
+
+func TestMarketplaceList_LimitClampedAt50(t *testing.T) {
+	var seen marketplace.ListFilters
+	svc := &mockMarketplaceLister{
+		listFn: func(_ context.Context, f marketplace.ListFilters) ([]marketplace.ListItem, error) {
+			seen = f
+			return nil, nil
+		},
+	}
+	r := newMarketplaceRouter(svc, nil)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/marketplace?limit=999", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if seen.Limit != 50 {
+		t.Errorf("expected limit clamped to 50, got %d", seen.Limit)
+	}
+}
+
+func TestMarketplaceList_Pagination_DistinctPages(t *testing.T) {
+	pages := [][]marketplace.ListItem{
+		{fakeListItem(t, "a"), fakeListItem(t, "b")},
+		{fakeListItem(t, "c"), fakeListItem(t, "d")},
+	}
+	svc := &mockMarketplaceLister{
+		listFn: func(_ context.Context, f marketplace.ListFilters) ([]marketplace.ListItem, error) {
+			pageIdx := f.Offset / 2
+			if pageIdx >= len(pages) {
+				return nil, nil
+			}
+			return pages[pageIdx], nil
+		},
+	}
+	r := newMarketplaceRouter(svc, nil)
+
+	w1 := httptest.NewRecorder()
+	req1 := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/marketplace?limit=2&offset=0", nil)
+	r.ServeHTTP(w1, req1)
+	var p1 handler.MarketplaceListResponse
+	if err := json.Unmarshal(w1.Body.Bytes(), &p1); err != nil {
+		t.Fatalf("decode p1: %v", err)
+	}
+	if len(p1.Items) != 2 {
+		t.Fatalf("expected 2 items on page 1, got %d", len(p1.Items))
+	}
+	if p1.NextOffset == nil || *p1.NextOffset != 2 {
+		t.Errorf("expected next_offset=2 on full page, got %v", p1.NextOffset)
+	}
+
+	w2 := httptest.NewRecorder()
+	req2 := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/marketplace?limit=2&offset=2", nil)
+	r.ServeHTTP(w2, req2)
+	var p2 handler.MarketplaceListResponse
+	if err := json.Unmarshal(w2.Body.Bytes(), &p2); err != nil {
+		t.Fatalf("decode p2: %v", err)
+	}
+	if len(p2.Items) != 2 {
+		t.Fatalf("expected 2 items on page 2, got %d", len(p2.Items))
+	}
+
+	// Pages must not overlap — every slug from page 1 must be absent
+	// from page 2.
+	page1Slugs := map[string]bool{}
+	for _, it := range p1.Items {
+		page1Slugs[it.KBSlug] = true
+	}
+	for _, it := range p2.Items {
+		if page1Slugs[it.KBSlug] {
+			t.Errorf("page 2 leaked item %q from page 1", it.KBSlug)
+		}
+	}
+}
+
+// ----------------------------------------------------------------------
+// Detail endpoint
+// ----------------------------------------------------------------------
+
+func TestMarketplaceDetail_HappyPath(t *testing.T) {
+	item := fakeListItem(t, "alpha")
+	svc := &mockMarketplaceLister{}
+	resolver := func(_ context.Context, orgSlug, kbSlug string) (marketplace.SlugStatus, error) {
+		if orgSlug != "acme" || kbSlug != "alpha" {
+			t.Errorf("unexpected resolver args (%q,%q)", orgSlug, kbSlug)
+		}
+		return marketplace.SlugStatus{KBID: item.KBID, Detail: &item}, nil
+	}
+	r := newMarketplaceRouter(svc, resolver)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/marketplace/acme/alpha", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var out handler.MarketplaceListItem
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.KBID != item.KBID {
+		t.Errorf("expected kb id %s, got %s", item.KBID, out.KBID)
+	}
+}
+
+func TestMarketplaceDetail_NotFound_Returns404(t *testing.T) {
+	svc := &mockMarketplaceLister{}
+	resolver := func(_ context.Context, _, _ string) (marketplace.SlugStatus, error) {
+		return marketplace.SlugStatus{}, nil // Detail nil + IsHeld false → 404
+	}
+	r := newMarketplaceRouter(svc, resolver)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/marketplace/unknown/missing", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestMarketplaceDetail_Held_Returns410WithCode(t *testing.T) {
+	svc := &mockMarketplaceLister{}
+	resolver := func(_ context.Context, _, _ string) (marketplace.SlugStatus, error) {
+		return marketplace.SlugStatus{IsHeld: true}, nil
+	}
+	r := newMarketplaceRouter(svc, resolver)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/marketplace/acme/old", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusGone {
+		t.Fatalf("expected 410, got %d: %s", w.Code, w.Body.String())
+	}
+	var body apierror.AppError
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.ErrorCode != "slug_held" {
+		t.Errorf("expected error_code=slug_held, got %q", body.ErrorCode)
+	}
+}
+
+func TestMarketplaceDetail_ResolverError_Returns500(t *testing.T) {
+	svc := &mockMarketplaceLister{}
+	resolver := func(_ context.Context, _, _ string) (marketplace.SlugStatus, error) {
+		return marketplace.SlugStatus{}, errors.New("boom")
+	}
+	r := newMarketplaceRouter(svc, resolver)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/marketplace/acme/alpha", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+}
+
+// ----------------------------------------------------------------------
+// Preview endpoint
+// ----------------------------------------------------------------------
+
+func TestMarketplacePreview_HappyPath_ReturnsChunks(t *testing.T) {
+	item := fakeListItem(t, "alpha")
+	chunks := []marketplace.PreviewChunk{
+		{ChunkID: uuid.New(), Ordinal: 0, Text: "first"},
+		{ChunkID: uuid.New(), Ordinal: 1, Text: "second"},
+	}
+	svc := &mockMarketplaceLister{
+		previewFn: func(_ context.Context, kbID uuid.UUID) ([]marketplace.PreviewChunk, error) {
+			if kbID != item.KBID {
+				t.Errorf("expected kb id %s, got %s", item.KBID, kbID)
+			}
+			return chunks, nil
+		},
+	}
+	resolver := func(_ context.Context, _, _ string) (marketplace.SlugStatus, error) {
+		return marketplace.SlugStatus{KBID: item.KBID, Detail: &item}, nil
+	}
+	r := newMarketplaceRouter(svc, resolver)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/marketplace/acme/alpha/preview", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var out handler.MarketplacePreviewResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(out.Chunks) != 2 {
+		t.Errorf("expected 2 chunks, got %d", len(out.Chunks))
+	}
+}
+
+func TestMarketplacePreview_NotPublic_Returns403(t *testing.T) {
+	item := fakeListItem(t, "alpha")
+	svc := &mockMarketplaceLister{
+		previewFn: func(_ context.Context, _ uuid.UUID) ([]marketplace.PreviewChunk, error) {
+			return nil, marketplace.ErrKBNotPublic
+		},
+	}
+	resolver := func(_ context.Context, _, _ string) (marketplace.SlugStatus, error) {
+		return marketplace.SlugStatus{KBID: item.KBID, Detail: &item}, nil
+	}
+	r := newMarketplaceRouter(svc, resolver)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/marketplace/acme/alpha/preview", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestMarketplacePreview_NotFound_Returns404(t *testing.T) {
+	svc := &mockMarketplaceLister{
+		previewFn: func(_ context.Context, _ uuid.UUID) ([]marketplace.PreviewChunk, error) {
+			t.Fatal("PreviewKB should not be called when slug resolution misses")
+			return nil, nil
+		},
+	}
+	resolver := func(_ context.Context, _, _ string) (marketplace.SlugStatus, error) {
+		return marketplace.SlugStatus{}, nil
+	}
+	r := newMarketplaceRouter(svc, resolver)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/marketplace/unknown/missing/preview", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestMarketplacePreview_Held_Returns410(t *testing.T) {
+	svc := &mockMarketplaceLister{
+		previewFn: func(_ context.Context, _ uuid.UUID) ([]marketplace.PreviewChunk, error) {
+			t.Fatal("PreviewKB should not be called when slug is held")
+			return nil, nil
+		},
+	}
+	resolver := func(_ context.Context, _, _ string) (marketplace.SlugStatus, error) {
+		return marketplace.SlugStatus{IsHeld: true}, nil
+	}
+	r := newMarketplaceRouter(svc, resolver)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/marketplace/acme/old/preview", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusGone {
+		t.Fatalf("expected 410, got %d: %s", w.Code, w.Body.String())
+	}
+	var body apierror.AppError
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.ErrorCode != "slug_held" {
+		t.Errorf("expected error_code=slug_held, got %q", body.ErrorCode)
+	}
+}

--- a/internal/marketplace/slug_status.go
+++ b/internal/marketplace/slug_status.go
@@ -118,7 +118,7 @@ func MarketplaceSlugStatus(ctx context.Context, pool *pgxpool.Pool, orgSlug, kbS
 		 FROM kb_slug_holds h
 		 JOIN organizations o ON o.id = h.org_id
 		 WHERE o.slug = $1
-		   AND h.kb_slug = $2
+		   AND h.slug = $2
 		   AND h.held_until > NOW()
 		   AND o.status != 'deactivated'`,
 		orgSlug, kbSlug,

--- a/internal/marketplace/slug_status.go
+++ b/internal/marketplace/slug_status.go
@@ -1,0 +1,169 @@
+// Marketplace KB slug-status resolution (issue #731 stub for #727).
+//
+// MarketplaceSlugStatus is the seam the Marketplace HTTP handlers
+// (#731) use to translate a URL slug pair `(org_slug, kb_slug)` into one
+// of three outcomes:
+//
+//   - HTTP 410 — slug is in `kb_slug_holds` (the publisher unpublished
+//     within the hold window). ADR-0007 §"Slug hold semantics".
+//   - HTTP 404 — slug pair does not resolve to any Public KB and is not
+//     held. Includes "private KB exists at this org slug but no public
+//     KB at this kb slug" — by design we can't distinguish that without
+//     leaking existence.
+//   - HTTP 200/403 — slug resolves to a Public KB; caller proceeds.
+//
+// Issue #727 will replace the resolution body with a direct join against
+// `knowledge_bases` (via the unpublish-aware SECURITY DEFINER it
+// introduces). Until then this file holds the stub:
+//
+//   - The hold check is a plain JOIN to `organizations` because
+//     `kb_slug_holds` has no RLS (cross-tenant by design) and the orgs
+//     table is publicly readable for this kind of lookup (mirrors the
+//     pattern in ResolveOrgSlug).
+//   - The KB detail lookup walks `marketplace_list_public_kbs` (the
+//     existing SECURITY DEFINER from #728) page-by-page, filtering for
+//     matching org_slug + kb_slug Go-side. Inefficient but correct, and
+//     bounded by stubWalkPageCap pages so a pathological query cannot
+//     stall a request indefinitely. The TODO below documents the
+//     intended replacement.
+
+package marketplace
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// stubWalkPageLimit and stubWalkPageCap bound the paginated walk in the
+// stub MarketplaceSlugStatus. The defaults (50 × 10 = 500 KBs) cover the
+// MVP Marketplace size with margin. Increase only if you understand the
+// quadratic cost and have a measured reason — #727 removes the walk
+// entirely.
+const (
+	stubWalkPageLimit = 50
+	stubWalkPageCap   = 10
+)
+
+// SlugStatus is the resolved view of a `(org_slug, kb_slug)` Marketplace
+// URL pair. Exactly one of `Detail` and `IsHeld` is meaningful at a time:
+// when `IsHeld` is true the slug is in `kb_slug_holds` and the handler
+// must return 410; otherwise `Detail` carries the public listing row
+// (nil if neither lookup matched, which the handler maps to 404).
+//
+// We return the full ListItem here (not just the KBID) so the detail
+// handler does not have to re-query the same row through a second
+// SECURITY DEFINER call: the slug resolution and the detail body share
+// one round trip in the common (200) case.
+type SlugStatus struct {
+	// KBID is the resolved KB's id when either the listing matched or
+	// the hold row records a non-NULL kb_id. uuid.Nil otherwise.
+	KBID uuid.UUID
+	// IsHeld is true when an active row exists in `kb_slug_holds` for
+	// the requested slug pair (`held_until > NOW()`). The handler maps
+	// this to HTTP 410 with `error_code: "slug_held"`.
+	IsHeld bool
+	// Detail is the Public KB listing row matching the slug pair, or
+	// nil when no Public KB matches (either because the slug is held,
+	// or because the pair never resolved at all). When IsHeld is true,
+	// callers must NOT inspect Detail — there is no live row to show.
+	Detail *ListItem
+}
+
+// MarketplaceSlugStatus resolves a `(org_slug, kb_slug)` URL pair to a
+// SlugStatus.
+//
+// Order of operations:
+//  1. Probe `kb_slug_holds` for an active hold; if found, return
+//     IsHeld=true immediately so the 410 fast-path doesn't pay for a
+//     listing walk.
+//  2. Walk `marketplace_list_public_kbs` for a matching Public KB.
+//     Returns SlugStatus{Detail: nil} when no row matches (handler →
+//     404).
+//
+// TODO(#727): replace the listing walk with a direct SECURITY DEFINER
+// lookup (`marketplace_resolve_public_kb(org_slug, kb_slug)` or
+// equivalent) once the unpublish path lands. The current implementation
+// is O(rows / page) per call and exists only so the #731 handlers can
+// ship before #727 merges.
+//
+// The exported name `MarketplaceSlugStatus` is fixed by the issue #731
+// brief — #727 replaces this implementation in place. The revive
+// stutter (marketplace.MarketplaceSlugStatus) is intentional and
+// scoped to this transitional helper.
+//
+//nolint:revive // name fixed by #731 brief; replaced by #727.
+func MarketplaceSlugStatus(ctx context.Context, pool *pgxpool.Pool, orgSlug, kbSlug string) (SlugStatus, error) {
+	// Cheap input validation — refuse to touch the database for a slug
+	// we know cannot exist. Matches the guard in ResolveOrgSlug; KB
+	// slugs do not yet share the org slug regex (VARCHAR(100) in
+	// migration 00007), so we only reject the obvious empty cases here
+	// and let the listing function return zero rows for malformed
+	// kb_slug values.
+	if orgSlug == "" || kbSlug == "" {
+		return SlugStatus{}, nil
+	}
+
+	// 1. Hold lookup. We join to `organizations` so a hold whose owning
+	//    org has been deactivated is treated as a miss — mirrors the
+	//    same defence in ResolveOrgSlug for org_slug_holds. Held rows
+	//    short-circuit before we pay for the listing walk.
+	var heldKBID *uuid.UUID
+	err := pool.QueryRow(ctx,
+		`SELECT h.kb_id
+		 FROM kb_slug_holds h
+		 JOIN organizations o ON o.id = h.org_id
+		 WHERE o.slug = $1
+		   AND h.kb_slug = $2
+		   AND h.held_until > NOW()
+		   AND o.status != 'deactivated'`,
+		orgSlug, kbSlug,
+	).Scan(&heldKBID)
+	switch {
+	case err == nil:
+		status := SlugStatus{IsHeld: true}
+		if heldKBID != nil {
+			status.KBID = *heldKBID
+		}
+		return status, nil
+	case errors.Is(err, pgx.ErrNoRows):
+		// Fall through to listing walk.
+	default:
+		return SlugStatus{}, fmt.Errorf("MarketplaceSlugStatus: hold lookup: %w", err)
+	}
+
+	// 2. Listing walk. We use SortAlphabetic for a stable order across
+	//    pages so a row inserted between two `Query` calls cannot cause
+	//    a duplicate or a skip in the matching probe. Each page is
+	//    capped at stubWalkPageLimit, and we bail after stubWalkPageCap
+	//    pages so a pathological large Marketplace does not stall a
+	//    request indefinitely.
+	q := NewQueries(pool)
+	for page := 0; page < stubWalkPageCap; page++ {
+		rows, err := q.ListPublicKBs(ctx, ListFilters{
+			Sort:   SortAlphabetic,
+			Limit:  stubWalkPageLimit,
+			Offset: page * stubWalkPageLimit,
+		})
+		if err != nil {
+			return SlugStatus{}, fmt.Errorf("MarketplaceSlugStatus: list walk page %d: %w", page, err)
+		}
+		for i := range rows {
+			it := rows[i]
+			if it.OrgSlug == orgSlug && it.KBSlug == kbSlug {
+				return SlugStatus{KBID: it.KBID, Detail: &it}, nil
+			}
+		}
+		if len(rows) < stubWalkPageLimit {
+			// Reached the end of the listing — no further pages exist,
+			// so the slug pair definitively does not resolve to a
+			// Public KB. Map to 404 in the handler.
+			break
+		}
+	}
+	return SlugStatus{}, nil
+}

--- a/internal/marketplace/slug_status_test.go
+++ b/internal/marketplace/slug_status_test.go
@@ -128,7 +128,7 @@ func TestMarketplaceSlugStatus_HeldShortCircuits(t *testing.T) {
 		t.Fatalf("seed public kb: %v", err)
 	}
 	if _, err := pool.Exec(ctx,
-		`INSERT INTO kb_slug_holds (org_id, kb_slug, kb_id, held_until)
+		`INSERT INTO kb_slug_holds (org_id, slug, kb_id, held_until)
 		 VALUES ($1, $2, NULL, $3)`,
 		orgID, "withdrawn", time.Now().Add(7*24*time.Hour),
 	); err != nil {
@@ -156,7 +156,7 @@ func TestMarketplaceSlugStatus_ExpiredHoldIsMiss(t *testing.T) {
 
 	orgID, _ := seedSlugStatusOrg(ctx, t, pool, "ss-exp-org", "SS Exp")
 	if _, err := pool.Exec(ctx,
-		`INSERT INTO kb_slug_holds (org_id, kb_slug, kb_id, held_until)
+		`INSERT INTO kb_slug_holds (org_id, slug, kb_id, held_until)
 		 VALUES ($1, $2, NULL, $3)`,
 		orgID, "expired", time.Now().Add(-24*time.Hour),
 	); err != nil {

--- a/internal/marketplace/slug_status_test.go
+++ b/internal/marketplace/slug_status_test.go
@@ -1,0 +1,176 @@
+package marketplace_test
+
+import (
+	"context"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/ravencloak-org/Raven/internal/marketplace"
+	"github.com/ravencloak-org/Raven/internal/testutil"
+)
+
+func slugStatusMigrationsDir(t *testing.T) string {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Join(filepath.Dir(filename), "..", "..", "migrations")
+}
+
+func seedSlugStatusOrg(ctx context.Context, t *testing.T, pool *pgxpool.Pool, slug, name string) (uuid.UUID, uuid.UUID) {
+	t.Helper()
+	var orgID, wsID uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO organizations (id, name, slug)
+		 VALUES (uuid_generate_v4(), $1, $2)
+		 RETURNING id`, name, slug,
+	).Scan(&orgID); err != nil {
+		t.Fatalf("seed org: %v", err)
+	}
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO workspaces (id, org_id, name, slug)
+		 VALUES (uuid_generate_v4(), $1, $2, $3)
+		 RETURNING id`, orgID, name+" WS", slug+"-ws",
+	).Scan(&wsID); err != nil {
+		t.Fatalf("seed workspace: %v", err)
+	}
+	return orgID, wsID
+}
+
+func TestMarketplaceSlugStatus_ResolvesPublicKB(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	pool := testutil.NewTestDB(t, testutil.WithMigrationsDir(slugStatusMigrationsDir(t)))
+
+	orgID, wsID := seedSlugStatusOrg(ctx, t, pool, "ss-acme", "SS Acme")
+	var kbID uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO knowledge_bases
+		   (org_id, workspace_id, name, slug, visibility, license_spdx_id, published_at)
+		 VALUES ($1, $2, 'Alpha', 'alpha', 'public', 'MIT', NOW())
+		 RETURNING id`, orgID, wsID,
+	).Scan(&kbID); err != nil {
+		t.Fatalf("seed public kb: %v", err)
+	}
+
+	status, err := marketplace.MarketplaceSlugStatus(ctx, pool, "ss-acme", "alpha")
+	if err != nil {
+		t.Fatalf("MarketplaceSlugStatus: %v", err)
+	}
+	if status.IsHeld {
+		t.Errorf("expected IsHeld=false for live public KB")
+	}
+	if status.Detail == nil {
+		t.Fatalf("expected non-nil Detail")
+	}
+	if status.KBID != kbID {
+		t.Errorf("expected kb id %s, got %s", kbID, status.KBID)
+	}
+	if status.Detail.OrgSlug != "ss-acme" || status.Detail.KBSlug != "alpha" {
+		t.Errorf("unexpected detail row: %+v", status.Detail)
+	}
+}
+
+func TestMarketplaceSlugStatus_MissReturnsZero(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	pool := testutil.NewTestDB(t, testutil.WithMigrationsDir(slugStatusMigrationsDir(t)))
+
+	// Seed a public KB so the listing is non-empty; the resolver
+	// should still miss on a wrong slug pair.
+	orgID, wsID := seedSlugStatusOrg(ctx, t, pool, "ss-miss-org", "SS Miss")
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO knowledge_bases
+		   (org_id, workspace_id, name, slug, visibility, license_spdx_id, published_at)
+		 VALUES ($1, $2, 'Beta', 'beta', 'public', 'MIT', NOW())`,
+		orgID, wsID); err != nil {
+		t.Fatalf("seed public kb: %v", err)
+	}
+
+	status, err := marketplace.MarketplaceSlugStatus(ctx, pool, "ss-miss-org", "nonexistent")
+	if err != nil {
+		t.Fatalf("MarketplaceSlugStatus: %v", err)
+	}
+	if status.IsHeld {
+		t.Errorf("expected IsHeld=false on miss")
+	}
+	if status.Detail != nil {
+		t.Errorf("expected Detail nil on miss, got %+v", status.Detail)
+	}
+}
+
+func TestMarketplaceSlugStatus_HeldShortCircuits(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	pool := testutil.NewTestDB(t, testutil.WithMigrationsDir(slugStatusMigrationsDir(t)))
+
+	orgID, wsID := seedSlugStatusOrg(ctx, t, pool, "ss-held-org", "SS Held")
+	// Seed a Public KB under a different slug; the held lookup must
+	// return IsHeld=true for the held slug irrespective of any live
+	// KB row for that org.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO knowledge_bases
+		   (org_id, workspace_id, name, slug, visibility, license_spdx_id, published_at)
+		 VALUES ($1, $2, 'Live', 'live', 'public', 'MIT', NOW())`,
+		orgID, wsID); err != nil {
+		t.Fatalf("seed public kb: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO kb_slug_holds (org_id, kb_slug, kb_id, held_until)
+		 VALUES ($1, $2, NULL, $3)`,
+		orgID, "withdrawn", time.Now().Add(7*24*time.Hour),
+	); err != nil {
+		t.Fatalf("seed slug hold: %v", err)
+	}
+
+	status, err := marketplace.MarketplaceSlugStatus(ctx, pool, "ss-held-org", "withdrawn")
+	if err != nil {
+		t.Fatalf("MarketplaceSlugStatus: %v", err)
+	}
+	if !status.IsHeld {
+		t.Errorf("expected IsHeld=true for active hold")
+	}
+	if status.Detail != nil {
+		t.Errorf("expected Detail nil when held, got %+v", status.Detail)
+	}
+}
+
+func TestMarketplaceSlugStatus_ExpiredHoldIsMiss(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	pool := testutil.NewTestDB(t, testutil.WithMigrationsDir(slugStatusMigrationsDir(t)))
+
+	orgID, _ := seedSlugStatusOrg(ctx, t, pool, "ss-exp-org", "SS Exp")
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO kb_slug_holds (org_id, kb_slug, kb_id, held_until)
+		 VALUES ($1, $2, NULL, $3)`,
+		orgID, "expired", time.Now().Add(-24*time.Hour),
+	); err != nil {
+		t.Fatalf("seed slug hold: %v", err)
+	}
+
+	status, err := marketplace.MarketplaceSlugStatus(ctx, pool, "ss-exp-org", "expired")
+	if err != nil {
+		t.Fatalf("MarketplaceSlugStatus: %v", err)
+	}
+	if status.IsHeld {
+		t.Errorf("expected IsHeld=false for expired hold, got true")
+	}
+	if status.Detail != nil {
+		t.Errorf("expected Detail nil for expired hold (and no live KB), got %+v", status.Detail)
+	}
+}

--- a/pkg/apierror/apierror.go
+++ b/pkg/apierror/apierror.go
@@ -127,6 +127,20 @@ func NewKBDMCALocked(detail string) *AppError {
 	}
 }
 
+// NewGone creates a 410 Gone with a machine-readable code. Used by the
+// Marketplace detail/preview paths to distinguish an unpublished slug
+// sitting in `kb_slug_holds` from a never-existed 404, per ADR-0007 §"Slug
+// hold semantics". `errorCode` is the stable client-facing identifier
+// (e.g. "slug_held"); pass "" to omit it.
+func NewGone(detail, errorCode string) *AppError {
+	return &AppError{
+		Code:      http.StatusGone,
+		Message:   "Gone",
+		Detail:    detail,
+		ErrorCode: errorCode,
+	}
+}
+
 // QuotaError extends AppError with billing-specific fields for 402 responses.
 type QuotaError struct {
 	AppError


### PR DESCRIPTION
## Summary

Wraps the SECURITY DEFINER functions from #728 in three authenticated HTTP handlers under `/api/v1/marketplace`:

- **`GET /marketplace`** — paginated listing with sort (`newest|most_imported|recently_updated|alphabetic`), repeated `license[]` SPDX filter, free-form `q`, `limit` (default 25, hard cap 50), `offset`.
- **`GET /marketplace/:org_slug/:kb_slug`** — detail. 404 on miss, **410 Gone** with `error_code: "slug_held"` when the slug pair is in `kb_slug_holds`.
- **`GET /marketplace/:org_slug/:kb_slug/preview`** — ≤3 sample chunks via the existing `PreviewKB` SECURITY DEFINER (which also bumps `preview_count`). Inherits 410/404 from detail; 403 when the underlying KB is private.

The 410 check is extracted into a single `marketplaceLookupOr410` helper so detail and preview cannot drift on the slug-hold boundary.

Validation is done Go-side with stable `error_code` values:
- `invalid_sort` (unknown sort enum)
- `invalid_license` (license not in the 7-item SPDX allow-list)
- `slug_held` (410 Gone)

Both layers cap `limit` at 50 (defence in depth).

Closes #731.

## What's stubbed

- `migrations/00051_kb_slug_holds.sql` — minimal table so the 410 path is testable. #727 owns the full unpublish write path / sweeper / policy and may extend the schema.
- `internal/marketplace/slug_status.go::MarketplaceSlugStatus` — walks the existing `marketplace_list_public_kbs` SECURITY DEFINER paginated, plus a direct hold lookup. #727 will replace the listing walk with a direct join. TODO comment is explicit.

## References

- ADR-0001 (`docs/adr/0001-marketplace-fork-on-import.md`)
- ADR-0005 (`docs/adr/0005-org-as-marketplace-publisher.md`)
- ADR-0007 (`docs/adr/0007-marketplace-lifecycle-behaviours.md`) — 410 Gone on slug hold
- ADR-0008 (`docs/adr/0008-marketplace-discovery-and-operations.md`) — sort / license filter
- `docs/plans/marketplace-mvp.md` §4

## Self-review notes (thermo-nuclear)

- File sizes — all new files <350 lines; `cmd/api/main.go` grows by ~15 lines.
- Boundary clean — handler does parsing+auth, `Queries` does retrieval, `MarketplaceSlugStatus` does slug resolution. No retrieval-shape branching in the handler.
- Shared `marketplaceLookupOr410` extracted to prevent detail/preview drift on the 410 contract.
- `SlugResolver` is a function type so unit tests can inject canned outcomes (404 / 410 / detail) without a partial `Queries` mock.
- Combined `SlugStatus.Detail` with slug resolution to avoid a second round trip in the common (200) case.
- `apierror.NewGone` added as a reusable helper rather than constructing 410 inline.
- One intentional `nolint:revive` on `MarketplaceSlugStatus` (name fixed by issue brief, replaced by #727).

## Test plan

- [x] `go test -short -count=1 ./internal/handler/ ./internal/marketplace/ ./pkg/apierror/` green (13 new tests pass).
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues.
- [x] Full short-mode test suite — only pre-existing `TestVerifyMigrationsState_*` failures (Docker socket / colima, unrelated to this change).
- [ ] CI confirms integration tests (`internal/marketplace/slug_status_test.go`, `internal/marketplace/queries_test.go`) green when testcontainers run.