### PR TITLE
fix(llm-providers): /test endpoint shouldn't require Create-side fields

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -805,7 +805,6 @@ func main() {
 			// row is written — limits how loud bad keys can get in the logs.
 			llm.POST("/test", middleware.RequireOrgRole("org_admin"), llmHandler.TestConnection)
 			llm.GET("", llmHandler.List)
-			llm.POST("/test", middleware.RequireOrgRole("org_admin"), llmHandler.Test)
 			// Default-provider health probe used by the SPA's polling cron.
 			// Open to any authenticated org member (not just admins) since
 			// the toast lives across every authenticated page.

--- a/frontend/src/api/llm-providers.ts
+++ b/frontend/src/api/llm-providers.ts
@@ -150,11 +150,18 @@ export async function testLlmProviderConnection(
 // failure (dead Cloudflare tunnel, revoked key, missing default) instead
 // of an HTTP error, so the polling cron can render a banner uniformly
 // without distinguishing 5xx from "configured but broken".
+//
+// The `_=<ts>` query param is a cache-buster. The Raven SPA registers a
+// PWA service worker at `/raven/` scope which intercepts same-origin
+// GETs and serves stale responses — Chrome's `cache: 'no-store'` fetch
+// option does not bypass SW interception (it only bypasses the HTTP
+// cache layer below the SW). A per-call unique URL forces the SW
+// strategy to fall through to the network on every probe.
 export async function fetchDefaultProviderHealth(
   orgId: string,
 ): Promise<TestConnectionResult> {
   return authFetch<TestConnectionResult>(
-    `/orgs/${orgId}/llm-providers/default/health`,
+    `/orgs/${orgId}/llm-providers/default/health?_=${Date.now()}`,
   )
 }
 

--- a/internal/handler/llm_provider.go
+++ b/internal/handler/llm_provider.go
@@ -69,7 +69,12 @@ func NewLLMProviderHandler(svc LLMProviderServicer) *LLMProviderHandler {
 // @Failure     422 {object} apierror.AppError
 // @Router      /orgs/{org_id}/llm-providers/test [post]
 func (h *LLMProviderHandler) TestConnection(c *gin.Context) {
-	var req model.CreateLLMProviderRequest
+	// The probe endpoint accepts a deliberately laxer body than Create —
+	// see model.TestInlineRequest. Asking the user to fill in display_name
+	// (and pass api_key:"required,min=1" for keyless Ollama) before they
+	// can probe an unreachable tunnel was the actual cause of the 422
+	// the demo kept hitting.
+	var req model.TestInlineRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		_ = c.Error(&apierror.AppError{
 			Code:    http.StatusUnprocessableEntity,
@@ -79,7 +84,7 @@ func (h *LLMProviderHandler) TestConnection(c *gin.Context) {
 		c.Abort()
 		return
 	}
-	result, err := service.TestConnection(c.Request.Context(), req)
+	result, err := service.TestConnection(c.Request.Context(), req.ToCreateRequest())
 	if err != nil {
 		_ = c.Error(apierror.NewInternal("provider probe failed: " + err.Error()))
 		c.Abort()

--- a/internal/model/llm_provider.go
+++ b/internal/model/llm_provider.go
@@ -112,6 +112,34 @@ type CreateLLMProviderRequest struct {
 	IsDefault   bool           `json:"is_default,omitempty"`
 }
 
+// TestInlineRequest is the body shape for POST .../llm-providers/test. It is
+// deliberately laxer than CreateLLMProviderRequest: the whole point of the
+// probe endpoint is "validate before commit" — gating it on Create-side
+// fields like display_name would force the user to fill in cosmetic copy
+// before they can find out whether their tunnel URL even resolves. Keep
+// only the fields the probe actually consumes; everything else (display
+// name, default flag, config) is ignored if sent.
+type TestInlineRequest struct {
+	Provider LLMProvider `json:"provider" binding:"required"`
+	APIKey   string      `json:"api_key"`
+	BaseURL  *string     `json:"base_url,omitempty"`
+}
+
+// ToCreateRequest adapts a TestInlineRequest into the CreateLLMProviderRequest
+// shape that service.TestConnection accepts, populating non-probe fields
+// with placeholder values so they don't fail downstream validation while
+// the probe itself runs. Useful while service.TestConnection still types
+// its arg as CreateLLMProviderRequest — once that's narrowed the adapter
+// can go.
+func (r TestInlineRequest) ToCreateRequest() CreateLLMProviderRequest {
+	return CreateLLMProviderRequest{
+		Provider:    r.Provider,
+		DisplayName: "probe", // placeholder; never persisted
+		APIKey:      r.APIKey,
+		BaseURL:     r.BaseURL,
+	}
+}
+
 // UpdateLLMProviderRequest is the payload for PUT .../llm-providers/:provider_id.
 type UpdateLLMProviderRequest struct {
 	DisplayName *string        `json:"display_name,omitempty" binding:"omitempty,min=1,max=255"`


### PR DESCRIPTION
## Why

POST `/api/v1/orgs/:org_id/llm-providers/test` binds to `CreateLLMProviderRequest` which marks `DisplayName` + `APIKey` as `binding:"required,min=1"`. Two failure modes that hit the public demo this afternoon:

1. **Can't probe a tunnel URL without first naming the provider.** The Add-Provider dialog's "Test now" button submits whatever's in the form — if the user hasn't typed a display_name yet, the probe 422s before the URL is even reached. Display name has nothing to do with whether the tunnel resolves.

2. **Keyless providers (Ollama) need a placeholder.** The SPA sends `api_key: 'not-required'` for Ollama; the moment that placeholder logic drifts you get 422s with "APIKey failed on the required tag" instead of a probe result.

## What

- New `model.TestInlineRequest` with only the fields the probe actually consumes (`provider` + optional `api_key` + optional `base_url`).
- `handler.TestConnection` binds to that shape. Service still takes `CreateLLMProviderRequest` so we adapt with `ToCreateRequest()` using a `"probe"` placeholder display_name that never gets persisted.

## Verified

Live on the demo box:
```
POST /llm-providers/test {provider:'ollama', base_url:'https://<tunnel>'}
  → 200 {ok:true, detail:'Connected — 5 model(s) installed locally'}
```