### PR TITLE
feat(frontend): Marketplace browse/detail/preview/import/re-import views (#732)

### DIFF
--- a/frontend/e2e/marketplace/marketplace.spec.ts
+++ b/frontend/e2e/marketplace/marketplace.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '../fixtures'
+
+// Marketplace happy-path: browse → preview → import → redirect to new KB.
+// The test relies on at least one seeded Public KB being available on the
+// target environment; on CI the seed step runs ahead of e2e (see
+// `scripts/seed-marketplace-fixtures.sql`). Locally without a seed the test
+// auto-skips by guarding on the empty-state element.
+
+test.describe('Marketplace', () => {
+  test('browse → preview → import flow', async ({ authenticatedPage: page }) => {
+    await page.goto('/marketplace')
+    await expect(page.getByTestId('marketplace-list-view')).toBeVisible()
+
+    // If the marketplace is empty in the test env, skip the rest. Avoids a
+    // brittle failure when seed data hasn't been provisioned.
+    const empty = page.getByTestId('marketplace-empty-state')
+    if (await empty.isVisible().catch(() => false)) {
+      test.skip(true, 'No seeded Public KBs on this environment')
+    }
+
+    const firstCard = page.getByTestId('marketplace-card').first()
+    await expect(firstCard).toBeVisible()
+    await firstCard.click()
+
+    await expect(page.getByTestId('marketplace-detail-view')).toBeVisible()
+    await page.getByTestId('marketplace-detail-preview').click()
+    await expect(page.getByTestId('marketplace-preview-dialog')).toBeVisible()
+
+    // Use the Import CTA inside the preview dialog to keep the flow tight.
+    await page.getByTestId('marketplace-preview-import-cta').click()
+    await expect(page.getByTestId('marketplace-import-dialog')).toBeVisible()
+    await page.getByTestId('marketplace-import-confirm').click()
+
+    // Successful import redirects to the local KB detail page.
+    await page.waitForURL(/\/orgs\/.+\/workspaces\/.+\/knowledge-bases\/.+/)
+  })
+
+  test('re-import button on an imported KB shows confirmation', async ({
+    authenticatedPage: page,
+  }) => {
+    // Re-uses the test above's residue — assumes the user has at least one
+    // imported KB. Soft-skips otherwise to avoid coupling.
+    await page.goto('/dashboard')
+    const importedKb = page.locator('[data-test="kb-re-import-button"]').first()
+    if (!(await importedKb.isVisible().catch(() => false))) {
+      test.skip(true, 'No imported KB available to exercise re-import')
+    }
+    await importedKb.click()
+    await expect(page.getByTestId('kb-re-import-dialog')).toBeVisible()
+    await page.getByTestId('kb-re-import-confirm').click()
+    await expect(page.getByTestId('kb-re-import-dialog')).toBeHidden({ timeout: 15_000 })
+  })
+})

--- a/frontend/src/api/marketplace.spec.ts
+++ b/frontend/src/api/marketplace.spec.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import {
+  listMarketplace,
+  getMarketplaceKb,
+  previewMarketplaceKb,
+  reImportKnowledgeBase,
+  MarketplaceApiError,
+  SPDX_LICENSES,
+} from './marketplace'
+
+// `buildQuery` is unexported; we re-test through the public list endpoint
+// by inspecting the fetched URL via the mocked global fetch.
+
+describe('marketplace api client', () => {
+  const originalFetch = globalThis.fetch
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn()
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+  })
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('serialises license[] as repeated query parameters', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ items: [] }), { status: 200 }),
+    )
+    await listMarketplace({
+      q: 'rag',
+      sort: 'most_imported',
+      license: ['MIT', 'Apache-2.0'],
+      limit: 50,
+      offset: 20,
+    })
+    const url = String(fetchMock.mock.calls[0][0])
+    expect(url).toContain('q=rag')
+    expect(url).toContain('sort=most_imported')
+    expect(url).toContain('limit=50')
+    expect(url).toContain('offset=20')
+    expect(url).toMatch(/license=MIT/)
+    expect(url).toMatch(/license=Apache-2\.0/)
+  })
+
+  it('throws MarketplaceApiError with status on 410 Gone', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: 'gone' }), { status: 410 }),
+    )
+    await expect(getMarketplaceKb('acme', 'docs')).rejects.toMatchObject({
+      name: 'MarketplaceApiError',
+      status: 410,
+    })
+  })
+
+  it('throws MarketplaceApiError with status on 403 forbidden preview', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: 'private' }), { status: 403 }),
+    )
+    let caught: unknown = null
+    try {
+      await previewMarketplaceKb('acme', 'docs')
+    } catch (err) {
+      caught = err
+    }
+    expect(caught).toBeInstanceOf(MarketplaceApiError)
+    expect((caught as MarketplaceApiError).status).toBe(403)
+  })
+
+  it('re-import POST sends confirm:true to the workspace-scoped endpoint', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ kb_id: 'k', imported_from_revision_at: '2026-06-01T00:00:00Z' }),
+        { status: 200 },
+      ),
+    )
+    await reImportKnowledgeBase('org-1', 'ws-1', 'kb-1')
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(String(url)).toMatch(
+      /\/orgs\/org-1\/workspaces\/ws-1\/knowledge-bases\/kb-1\/re-import$/,
+    )
+    expect(init?.method).toBe('POST')
+    expect(JSON.parse(String(init?.body))).toEqual({ confirm: true })
+  })
+
+  it('exposes the curated 7-entry SPDX allow-list (ADR-0006)', () => {
+    expect([...SPDX_LICENSES]).toEqual([
+      'CC0-1.0',
+      'CC-BY-4.0',
+      'CC-BY-SA-4.0',
+      'CC-BY-NC-4.0',
+      'MIT',
+      'Apache-2.0',
+      'GPL-3.0',
+    ])
+  })
+})
+

--- a/frontend/src/api/marketplace.ts
+++ b/frontend/src/api/marketplace.ts
@@ -1,0 +1,196 @@
+// Marketplace API client (#732).
+//
+// Wraps the M2 Marketplace endpoints declared in contracts/openapi.yaml. The
+// repo has no OpenAPI -> TS codegen pipeline today (verified at PR time: no
+// openapi-typescript or @hey-api in package.json), so types are hand-mirrored
+// from the spec. When codegen lands, swap these for generated types — the
+// shapes were lifted verbatim from `MarketplaceListItem`, `MarketplaceListing`,
+// `MarketplacePreview`, `ImportResult`, and `MarketplaceReport` in openapi.yaml.
+//
+// `MarketplaceApiError` exposes the raw HTTP status so callers can branch on
+// 410 (slug-hold "Gone") and 403/404 without string-matching error messages.
+
+const API_BASE = () => import.meta.env.VITE_API_BASE_URL ?? '/api/v1'
+
+export class MarketplaceApiError extends Error {
+  status: number
+  body: unknown
+  constructor(status: number, message: string, body?: unknown) {
+    super(message)
+    this.name = 'MarketplaceApiError'
+    this.status = status
+    this.body = body
+  }
+}
+
+async function marketplaceFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(API_BASE() + path, {
+    ...init,
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      ...init?.headers,
+    },
+  })
+  if (res.status === 204) return undefined as T
+  const body = await res.json().catch(() => ({}))
+  if (!res.ok) {
+    const msg =
+      (body && typeof body === 'object' && 'message' in body && typeof body.message === 'string'
+        ? body.message
+        : undefined) ||
+      (body && typeof body === 'object' && 'error' in body && typeof body.error === 'string'
+        ? body.error
+        : undefined) ||
+      `Marketplace request failed (${res.status})`
+    throw new MarketplaceApiError(res.status, msg, body)
+  }
+  return body as T
+}
+
+// --- Types (mirrors of openapi.yaml; flag in PR body) ---
+
+export type MarketplaceSort = 'newest' | 'most_imported' | 'recently_updated' | 'alphabetic'
+
+/** Curated SPDX allow-list (ADR-0006). */
+export const SPDX_LICENSES = [
+  'CC0-1.0',
+  'CC-BY-4.0',
+  'CC-BY-SA-4.0',
+  'CC-BY-NC-4.0',
+  'MIT',
+  'Apache-2.0',
+  'GPL-3.0',
+] as const
+export type SpdxLicense = (typeof SPDX_LICENSES)[number]
+
+export interface MarketplaceListItem {
+  kb_id: string
+  org_slug: string
+  org_display_name: string
+  kb_slug: string
+  name: string
+  description?: string
+  last_modified_at: string
+  license_spdx_id: string
+  import_count: number
+  source_public_kb_id?: string | null
+  source_org_slug?: string | null
+  source_org_display_name?: string | null
+}
+
+export interface MarketplaceListing {
+  items: MarketplaceListItem[]
+  next_cursor?: string | null
+  total?: number
+}
+
+export interface MarketplaceListQuery {
+  q?: string
+  sort?: MarketplaceSort
+  license?: string[]
+  limit?: number
+  offset?: number
+}
+
+/** Detail row — shape matches `GET /marketplace/{org_slug}/{kb_slug}`, which
+ * the spec types as `KnowledgeBase` plus the marketplace lineage + counts.
+ * The card fields are included so the detail view can render the same chrome
+ * without a second request. */
+export interface MarketplaceKbDetail extends MarketplaceListItem {
+  source_count?: number
+  document_count?: number
+  chunk_count?: number
+}
+
+export interface PreviewChunk {
+  chunk_id: string
+  ordinal: number
+  text: string
+}
+
+export interface MarketplacePreview {
+  chunks: PreviewChunk[]
+}
+
+export interface ImportResult {
+  kb_id: string
+  imported_from_revision_at: string
+}
+
+export interface MarketplaceReport {
+  report_id: string
+  reported_kb_id: string
+  reporter_user_id?: string | null
+  reason: string
+  status: 'open' | 'reviewing' | 'resolved' | 'dismissed'
+  created_at: string
+}
+
+// --- Endpoints ---
+
+function buildQuery(params: MarketplaceListQuery): string {
+  const sp = new URLSearchParams()
+  if (params.q) sp.set('q', params.q)
+  if (params.sort) sp.set('sort', params.sort)
+  if (params.limit !== undefined) sp.set('limit', String(params.limit))
+  if (params.offset !== undefined) sp.set('offset', String(params.offset))
+  if (params.license) {
+    for (const lic of params.license) sp.append('license', lic)
+  }
+  const qs = sp.toString()
+  return qs ? `?${qs}` : ''
+}
+
+export function listMarketplace(params: MarketplaceListQuery = {}): Promise<MarketplaceListing> {
+  return marketplaceFetch<MarketplaceListing>(`/marketplace${buildQuery(params)}`)
+}
+
+export function getMarketplaceKb(
+  orgSlug: string,
+  kbSlug: string,
+): Promise<MarketplaceKbDetail> {
+  return marketplaceFetch<MarketplaceKbDetail>(
+    `/marketplace/${encodeURIComponent(orgSlug)}/${encodeURIComponent(kbSlug)}`,
+  )
+}
+
+export function previewMarketplaceKb(
+  orgSlug: string,
+  kbSlug: string,
+): Promise<MarketplacePreview> {
+  return marketplaceFetch<MarketplacePreview>(
+    `/marketplace/${encodeURIComponent(orgSlug)}/${encodeURIComponent(kbSlug)}/preview`,
+  )
+}
+
+export function importMarketplaceKb(
+  publicKbId: string,
+  workspaceId: string,
+): Promise<ImportResult> {
+  return marketplaceFetch<ImportResult>(
+    `/marketplace/import/${encodeURIComponent(publicKbId)}`,
+    { method: 'POST', body: JSON.stringify({ workspace_id: workspaceId }) },
+  )
+}
+
+export function reImportKnowledgeBase(
+  orgId: string,
+  wsId: string,
+  kbId: string,
+): Promise<ImportResult> {
+  return marketplaceFetch<ImportResult>(
+    `/orgs/${encodeURIComponent(orgId)}/workspaces/${encodeURIComponent(wsId)}/knowledge-bases/${encodeURIComponent(kbId)}/re-import`,
+    { method: 'POST', body: JSON.stringify({ confirm: true }) },
+  )
+}
+
+export function submitMarketplaceReport(
+  kbId: string,
+  reason: string,
+): Promise<MarketplaceReport> {
+  return marketplaceFetch<MarketplaceReport>('/marketplace/reports', {
+    method: 'POST',
+    body: JSON.stringify({ kb_id: kbId, reason }),
+  })
+}

--- a/frontend/src/components/marketplace/LicenseBadge.spec.ts
+++ b/frontend/src/components/marketplace/LicenseBadge.spec.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import LicenseBadge from './LicenseBadge.vue'
+
+describe('LicenseBadge', () => {
+  it('renders friendly label + tooltip for known SPDX ids', () => {
+    const wrapper = mount(LicenseBadge, { props: { license: 'CC-BY-SA-4.0' } })
+    expect(wrapper.text()).toBe('CC BY-SA 4.0')
+    expect(wrapper.attributes('title')).toContain('same license')
+  })
+
+  it('falls back to the raw id for unknown SPDX entries', () => {
+    const wrapper = mount(LicenseBadge, { props: { license: 'BSD-3-Clause' } })
+    expect(wrapper.text()).toBe('BSD-3-Clause')
+    expect(wrapper.attributes('title')).toContain('BSD-3-Clause')
+  })
+
+  it('renders "Unlicensed" when license is missing', () => {
+    const wrapper = mount(LicenseBadge, { props: { license: null } })
+    expect(wrapper.text()).toBe('Unlicensed')
+  })
+})

--- a/frontend/src/components/marketplace/LicenseBadge.vue
+++ b/frontend/src/components/marketplace/LicenseBadge.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+// LicenseBadge — SPDX license chip with a tooltip explaining the license.
+// Per ADR-0006, only the 7 curated SPDX ids appear on Public KBs; unknown
+// ids still render but fall through to a generic description so we never
+// blank-render an unfamiliar identifier (defensive — a backend that lands
+// a new allow-list entry should still be displayable).
+import { computed } from 'vue'
+
+const props = defineProps<{
+  /** SPDX identifier (e.g. "CC-BY-4.0"). May be empty when the row is mid-publish. */
+  license: string | null | undefined
+  /** Optional override — default sm for cards, md for the detail header. */
+  size?: 'sm' | 'md'
+}>()
+
+const SPDX_INFO: Record<string, { label: string; description: string }> = {
+  'CC0-1.0': {
+    label: 'CC0 1.0',
+    description: 'No rights reserved. Use freely without attribution.',
+  },
+  'CC-BY-4.0': {
+    label: 'CC BY 4.0',
+    description: 'Free to use with attribution to the publisher.',
+  },
+  'CC-BY-SA-4.0': {
+    label: 'CC BY-SA 4.0',
+    description: 'Free to use with attribution; derivatives must use the same license.',
+  },
+  'CC-BY-NC-4.0': {
+    label: 'CC BY-NC 4.0',
+    description: 'Free for non-commercial use with attribution.',
+  },
+  MIT: {
+    label: 'MIT',
+    description: 'Permissive open-source license — minimal restrictions, attribution required.',
+  },
+  'Apache-2.0': {
+    label: 'Apache 2.0',
+    description: 'Permissive open-source license with explicit patent grant.',
+  },
+  'GPL-3.0': {
+    label: 'GPL 3.0',
+    description: 'Copyleft — derivatives must also be GPL-3.0 licensed.',
+  },
+}
+
+const info = computed(() => {
+  const id = props.license ?? ''
+  return (
+    SPDX_INFO[id] ?? {
+      label: id || 'Unlicensed',
+      description: id
+        ? `SPDX identifier ${id}. See the publisher for terms.`
+        : 'No license metadata available.',
+    }
+  )
+})
+
+const sizeClass = computed(() =>
+  (props.size ?? 'sm') === 'md'
+    ? 'text-xs px-2.5 py-1'
+    : 'text-[11px] px-2 py-0.5',
+)
+</script>
+
+<template>
+  <span
+    class="inline-flex items-center rounded-full border border-indigo-200 bg-indigo-50 font-medium text-indigo-700"
+    :class="sizeClass"
+    :title="info.description"
+    data-test="license-badge"
+  >
+    {{ info.label }}
+  </span>
+</template>

--- a/frontend/src/components/marketplace/MarketplaceImportDialog.vue
+++ b/frontend/src/components/marketplace/MarketplaceImportDialog.vue
@@ -1,0 +1,160 @@
+<script setup lang="ts">
+// MarketplaceImportDialog — workspace picker + POST to import endpoint.
+// On success emits `imported` with the new KB id so the parent route can
+// navigate. We require an authStore.orgId (no marketplace flow without an
+// Org); the dialog defensively shows an empty-state when workspaces are
+// missing rather than rendering an empty <select>.
+import { onMounted, ref, watch } from 'vue'
+import { listWorkspaces, type Workspace } from '../../api/workspaces'
+import { importMarketplaceKb, MarketplaceApiError } from '../../api/marketplace'
+import { useAuthStore } from '../../stores/auth'
+
+const props = defineProps<{
+  open: boolean
+  publicKbId: string
+}>()
+
+const emit = defineEmits<{
+  close: []
+  imported: [payload: { orgId: string; workspaceId: string; kbId: string }]
+}>()
+
+const auth = useAuthStore()
+
+const workspaces = ref<Workspace[]>([])
+const selected = ref<string>('')
+const loadingWorkspaces = ref(false)
+const submitting = ref(false)
+const errorMessage = ref('')
+
+async function loadWorkspaces() {
+  if (!props.open) return
+  errorMessage.value = ''
+  if (!auth.orgId) {
+    errorMessage.value = 'You must belong to an organization to import a KB.'
+    return
+  }
+  loadingWorkspaces.value = true
+  try {
+    const res = await listWorkspaces(auth.orgId, 0, 100)
+    workspaces.value = res.items
+    if (!selected.value && workspaces.value.length > 0) {
+      selected.value = workspaces.value[0].id
+    }
+  } catch (err) {
+    errorMessage.value = err instanceof Error ? err.message : 'Failed to load workspaces.'
+  } finally {
+    loadingWorkspaces.value = false
+  }
+}
+
+onMounted(loadWorkspaces)
+watch(() => props.open, (open) => { if (open) loadWorkspaces() })
+
+async function submit() {
+  if (!selected.value || !auth.orgId) return
+  submitting.value = true
+  errorMessage.value = ''
+  try {
+    const result = await importMarketplaceKb(props.publicKbId, selected.value)
+    emit('imported', {
+      orgId: auth.orgId,
+      workspaceId: selected.value,
+      kbId: result.kb_id,
+    })
+  } catch (err) {
+    if (err instanceof MarketplaceApiError) {
+      if (err.status === 403) {
+        errorMessage.value = 'You do not have permission to import into this workspace.'
+      } else if (err.status === 422) {
+        errorMessage.value = 'Your plan does not allow this import.'
+      } else {
+        errorMessage.value = err.message
+      }
+    } else {
+      errorMessage.value = err instanceof Error ? err.message : 'Import failed.'
+    }
+  } finally {
+    submitting.value = false
+  }
+}
+</script>
+
+<template>
+  <div
+    v-if="open"
+    class="fixed inset-0 z-40 flex items-center justify-center bg-black/40 p-4"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="import-title"
+    data-test="marketplace-import-dialog"
+    @click.self="emit('close')"
+  >
+    <div class="w-full max-w-md rounded-xl bg-white p-6 shadow-xl">
+      <header class="mb-4 flex items-start justify-between">
+        <div>
+          <h2 id="import-title" class="text-lg font-semibold text-gray-900">
+            Import to workspace
+          </h2>
+          <p class="text-xs text-gray-500">
+            A new Knowledge Base will be created as a fork of the source.
+          </p>
+        </div>
+        <button
+          type="button"
+          class="rounded-md p-1 text-gray-500 hover:bg-gray-100"
+          aria-label="Close import dialog"
+          @click="emit('close')"
+        >
+          ×
+        </button>
+      </header>
+
+      <div v-if="loadingWorkspaces" class="py-6 text-center text-sm text-gray-500">
+        Loading workspaces…
+      </div>
+      <div
+        v-else-if="workspaces.length === 0 && !errorMessage"
+        class="rounded-md bg-yellow-50 border border-yellow-200 px-3 py-2 text-sm text-yellow-800"
+      >
+        You don't have any workspaces yet. Create one first.
+      </div>
+      <form v-else class="space-y-3" @submit.prevent="submit">
+        <label class="block text-sm font-medium text-gray-700" for="import-workspace">
+          Destination workspace
+        </label>
+        <select
+          id="import-workspace"
+          v-model="selected"
+          required
+          class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          data-test="marketplace-import-workspace"
+        >
+          <option v-for="ws in workspaces" :key="ws.id" :value="ws.id">
+            {{ ws.name }}
+          </option>
+        </select>
+        <p v-if="errorMessage" class="text-xs text-red-600" data-test="marketplace-import-error">
+          {{ errorMessage }}
+        </p>
+        <div class="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            class="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+            @click="emit('close')"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            :disabled="submitting || !selected"
+            class="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
+            data-test="marketplace-import-confirm"
+          >
+            {{ submitting ? 'Importing…' : 'Import' }}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/marketplace/MarketplaceKbCard.vue
+++ b/frontend/src/components/marketplace/MarketplaceKbCard.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+// MarketplaceKbCard — single Public KB tile rendered in the listing grid.
+// Self-contained (no API calls of its own) so the card can be re-used in
+// tests, the related-KB rail (future), and the detail page header.
+import { computed } from 'vue'
+import type { MarketplaceListItem } from '../../api/marketplace'
+import LicenseBadge from './LicenseBadge.vue'
+import ReportButton from './ReportButton.vue'
+
+const props = defineProps<{
+  item: MarketplaceListItem
+}>()
+
+const updatedLabel = computed(() => formatRelative(props.item.last_modified_at))
+
+function formatRelative(iso: string): string {
+  const then = new Date(iso).getTime()
+  if (Number.isNaN(then)) return ''
+  const seconds = Math.floor((Date.now() - then) / 1000)
+  if (seconds < 60) return 'Updated just now'
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `Updated ${minutes} minute${minutes === 1 ? '' : 's'} ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `Updated ${hours} hour${hours === 1 ? '' : 's'} ago`
+  const days = Math.floor(hours / 24)
+  if (days < 30) return `Updated ${days} day${days === 1 ? '' : 's'} ago`
+  const months = Math.floor(days / 30)
+  if (months < 12) return `Updated ${months} month${months === 1 ? '' : 's'} ago`
+  const years = Math.floor(days / 365)
+  return `Updated ${years} year${years === 1 ? '' : 's'} ago`
+}
+</script>
+
+<template>
+  <article
+    class="group flex h-full flex-col rounded-xl border border-gray-200 bg-white p-5 shadow-sm transition hover:border-indigo-300 hover:shadow-md"
+    data-test="marketplace-card"
+    :data-kb-id="item.kb_id"
+  >
+    <header class="flex items-start justify-between gap-3">
+      <RouterLink
+        :to="`/marketplace/${item.org_slug}/${item.kb_slug}`"
+        class="min-w-0 flex-1"
+      >
+        <h3 class="truncate text-base font-semibold text-gray-900 group-hover:text-indigo-700">
+          {{ item.name }}
+        </h3>
+        <p class="mt-0.5 truncate text-xs text-gray-500">
+          by
+          <span class="font-medium text-gray-700">{{ item.org_display_name }}</span>
+          <span class="text-gray-400"> · {{ item.org_slug }}</span>
+        </p>
+      </RouterLink>
+      <LicenseBadge :license="item.license_spdx_id" />
+    </header>
+
+    <p
+      v-if="item.description"
+      class="mt-3 line-clamp-3 text-sm text-gray-600"
+    >
+      {{ item.description }}
+    </p>
+
+    <footer class="mt-auto pt-4 flex items-center justify-between text-xs text-gray-500">
+      <div class="flex items-center gap-3">
+        <span data-test="marketplace-card-updated">{{ updatedLabel }}</span>
+        <span aria-hidden="true">·</span>
+        <span data-test="marketplace-card-imports">
+          {{ item.import_count }} import{{ item.import_count === 1 ? '' : 's' }}
+        </span>
+      </div>
+      <ReportButton :kb-id="item.kb_id" compact />
+    </footer>
+  </article>
+</template>

--- a/frontend/src/components/marketplace/MarketplaceListView.spec.ts
+++ b/frontend/src/components/marketplace/MarketplaceListView.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import MarketplaceListView from '../../pages/marketplace/MarketplaceListView.vue'
+
+// IntersectionObserver isn't available in happy-dom — stub before mount.
+class FakeIO {
+  observe = vi.fn()
+  disconnect = vi.fn()
+  unobserve = vi.fn()
+}
+;(globalThis as unknown as { IntersectionObserver: typeof FakeIO }).IntersectionObserver = FakeIO
+
+describe('MarketplaceListView filter behaviour', () => {
+  const originalFetch = globalThis.fetch
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    fetchMock = vi.fn().mockImplementation(
+      () =>
+        Promise.resolve(
+          new Response(JSON.stringify({ items: [] }), { status: 200 }),
+        ),
+    )
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+  })
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    vi.restoreAllMocks()
+  })
+
+  it('toggles a license filter and re-queries with the SPDX id', async () => {
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [{ path: '/', component: { template: '<div/>' } }],
+    })
+    const wrapper = mount(MarketplaceListView, {
+      global: { plugins: [router] },
+    })
+    await flushPromises()
+    fetchMock.mockClear()
+
+    const mitButton = wrapper.get('[data-test="marketplace-license-filter-MIT"]')
+    await mitButton.trigger('click')
+    await flushPromises()
+
+    expect(fetchMock).toHaveBeenCalled()
+    const url = String(fetchMock.mock.calls[0][0])
+    expect(url).toContain('license=MIT')
+
+    // Toggling again removes the filter
+    fetchMock.mockClear()
+    await mitButton.trigger('click')
+    await flushPromises()
+    const url2 = String(fetchMock.mock.calls[0][0])
+    expect(url2).not.toContain('license=MIT')
+  })
+
+  it('updates sort dropdown drives a refetch with the new sort param', async () => {
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [{ path: '/', component: { template: '<div/>' } }],
+    })
+    const wrapper = mount(MarketplaceListView, {
+      global: { plugins: [router] },
+    })
+    await flushPromises()
+    fetchMock.mockClear()
+
+    await wrapper.get('[data-test="marketplace-sort"]').setValue('most_imported')
+    await flushPromises()
+
+    const url = String(fetchMock.mock.calls[0][0])
+    expect(url).toContain('sort=most_imported')
+  })
+})

--- a/frontend/src/components/marketplace/MarketplacePreviewDialog.vue
+++ b/frontend/src/components/marketplace/MarketplacePreviewDialog.vue
@@ -1,0 +1,131 @@
+<script setup lang="ts">
+// MarketplacePreviewDialog — modal that renders up to 3 sample Chunks
+// from `/marketplace/{org}/{kb}/preview` (ADR-0007). No "load more"; the
+// cap is enforced server-side and we deliberately mirror that limit here.
+import { onMounted, ref, watch } from 'vue'
+import {
+  previewMarketplaceKb,
+  type PreviewChunk,
+  MarketplaceApiError,
+} from '../../api/marketplace'
+
+const props = defineProps<{
+  open: boolean
+  orgSlug: string
+  kbSlug: string
+}>()
+
+const emit = defineEmits<{
+  close: []
+  import: []
+}>()
+
+const chunks = ref<PreviewChunk[]>([])
+const loading = ref(false)
+const errorMessage = ref('')
+const errorStatus = ref<number | null>(null)
+
+async function load() {
+  if (!props.open) return
+  loading.value = true
+  errorMessage.value = ''
+  errorStatus.value = null
+  chunks.value = []
+  try {
+    const res = await previewMarketplaceKb(props.orgSlug, props.kbSlug)
+    chunks.value = res.chunks
+  } catch (err) {
+    if (err instanceof MarketplaceApiError) {
+      errorStatus.value = err.status
+      errorMessage.value =
+        err.status === 410
+          ? 'This KB has been unpublished.'
+          : err.message
+    } else {
+      errorMessage.value = err instanceof Error ? err.message : 'Failed to load preview.'
+    }
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(load)
+watch(() => [props.open, props.orgSlug, props.kbSlug], load)
+</script>
+
+<template>
+  <div
+    v-if="open"
+    class="fixed inset-0 z-40 flex items-center justify-center bg-black/40 p-4"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="preview-title"
+    data-test="marketplace-preview-dialog"
+    @click.self="emit('close')"
+  >
+    <div class="w-full max-w-2xl rounded-xl bg-white p-6 shadow-xl">
+      <header class="mb-4 flex items-start justify-between">
+        <div>
+          <h2 id="preview-title" class="text-lg font-semibold text-gray-900">
+            Preview
+          </h2>
+          <p class="text-xs text-gray-500">Up to 3 sample chunks from this KB.</p>
+        </div>
+        <button
+          type="button"
+          class="rounded-md p-1 text-gray-500 hover:bg-gray-100"
+          aria-label="Close preview"
+          data-test="marketplace-preview-close"
+          @click="emit('close')"
+        >
+          ×
+        </button>
+      </header>
+
+      <div v-if="loading" class="py-12 text-center text-sm text-gray-500">
+        Loading preview…
+      </div>
+      <div
+        v-else-if="errorMessage"
+        class="rounded-md bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700"
+        data-test="marketplace-preview-error"
+      >
+        {{ errorMessage }}
+      </div>
+      <div v-else-if="chunks.length === 0" class="py-12 text-center text-sm text-gray-500">
+        No preview chunks are available for this KB yet.
+      </div>
+      <ul v-else class="space-y-3" data-test="marketplace-preview-chunks">
+        <li
+          v-for="chunk in chunks"
+          :key="chunk.chunk_id"
+          class="rounded-md border border-gray-200 bg-gray-50 p-3"
+        >
+          <div class="mb-1 text-xs font-medium text-gray-500">
+            Chunk #{{ chunk.ordinal }}
+          </div>
+          <pre class="whitespace-pre-wrap text-sm text-gray-800">{{ chunk.text }}</pre>
+        </li>
+      </ul>
+
+      <footer class="mt-6 flex justify-end gap-2">
+        <button
+          type="button"
+          class="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+          @click="emit('close')"
+        >
+          Close
+        </button>
+        <button
+          type="button"
+          class="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
+          :disabled="!!errorMessage"
+          data-test="marketplace-preview-import-cta"
+          @click="emit('import')"
+        >
+          Import
+        </button>
+      </footer>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/marketplace/ReportButton.vue
+++ b/frontend/src/components/marketplace/ReportButton.vue
@@ -1,0 +1,112 @@
+<script setup lang="ts">
+// ReportButton — opens an inline form, POSTs to /marketplace/reports.
+// Inline confirmation (no toast system in repo). Used on both Marketplace
+// cards and the KB detail page.
+import { ref } from 'vue'
+import { submitMarketplaceReport, MarketplaceApiError } from '../../api/marketplace'
+
+const props = defineProps<{
+  kbId: string
+  /** Optional compact rendering for use inside cards. */
+  compact?: boolean
+}>()
+
+const open = ref(false)
+const reason = ref('')
+const submitting = ref(false)
+const errorMessage = ref('')
+const confirmation = ref('')
+
+function toggle(event: Event) {
+  // Cards wrap the whole row in a router-link; the report flow must not
+  // navigate. Stop propagation defensively at the button click.
+  event.stopPropagation()
+  event.preventDefault()
+  open.value = !open.value
+  if (!open.value) reset()
+}
+
+function reset() {
+  reason.value = ''
+  errorMessage.value = ''
+  confirmation.value = ''
+}
+
+async function submit(event: Event) {
+  event.preventDefault()
+  event.stopPropagation()
+  const trimmed = reason.value.trim()
+  if (!trimmed) return
+  submitting.value = true
+  errorMessage.value = ''
+  try {
+    await submitMarketplaceReport(props.kbId, trimmed)
+    confirmation.value = 'Report submitted. Our team will review it.'
+    reason.value = ''
+  } catch (err) {
+    if (err instanceof MarketplaceApiError && err.status === 429) {
+      errorMessage.value = 'Rate limit reached — try again later.'
+    } else {
+      errorMessage.value = err instanceof Error ? err.message : 'Failed to submit report.'
+    }
+  } finally {
+    submitting.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="relative inline-block" @click.stop>
+    <button
+      type="button"
+      class="rounded-md border border-gray-300 bg-white text-gray-700 hover:bg-gray-50"
+      :class="compact ? 'px-2 py-1 text-xs' : 'px-3 py-1.5 text-sm'"
+      data-test="marketplace-report-button"
+      @click="toggle"
+    >
+      Report
+    </button>
+
+    <div
+      v-if="open"
+      class="absolute right-0 z-10 mt-2 w-72 rounded-lg border border-gray-200 bg-white p-3 shadow-lg"
+      data-test="marketplace-report-form"
+    >
+      <p v-if="confirmation" class="text-sm text-green-700" data-test="marketplace-report-confirm">
+        {{ confirmation }}
+      </p>
+      <form v-else class="space-y-2" @submit="submit">
+        <label class="block text-xs font-medium text-gray-700" for="report-reason">
+          Why are you reporting this KB?
+        </label>
+        <textarea
+          id="report-reason"
+          v-model="reason"
+          rows="3"
+          maxlength="2000"
+          required
+          class="w-full resize-none rounded-md border border-gray-300 px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          data-test="marketplace-report-reason"
+        />
+        <p v-if="errorMessage" class="text-xs text-red-600">{{ errorMessage }}</p>
+        <div class="flex justify-end gap-2">
+          <button
+            type="button"
+            class="rounded-md px-2 py-1 text-xs text-gray-600 hover:bg-gray-100"
+            @click="toggle"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            :disabled="submitting || !reason.trim()"
+            class="rounded-md bg-indigo-600 px-3 py-1 text-xs font-medium text-white hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
+            data-test="marketplace-report-submit"
+          >
+            {{ submitting ? 'Submitting…' : 'Submit' }}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</template>

--- a/frontend/src/pages/knowledge-bases/KBDetailPage.vue
+++ b/frontend/src/pages/knowledge-bases/KBDetailPage.vue
@@ -1,10 +1,22 @@
 <script setup lang="ts">
-import { nextTick, onMounted, ref } from 'vue'
+import { computed, nextTick, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useKnowledgeBasesStore } from '../../stores/knowledge-bases'
 import CacheStatsCard from '../../components/cache/CacheStatsCard.vue'
 import RecentConversationsCard from '../../components/conversations/RecentConversationsCard.vue'
 import type { KnowledgeBase } from '../../api/knowledge-bases'
+import {
+  reImportKnowledgeBase,
+  MarketplaceApiError,
+} from '../../api/marketplace'
+
+// `source_public_kb_id` lives on the publish-lifecycle augmented KB row.
+// Until the OpenAPI codegen is wired up we read it loosely off the store's
+// `currentKB` (the backend always returns the field for Imported KBs).
+type AugmentedKB = KnowledgeBase & {
+  source_public_kb_id?: string | null
+  source_org_slug?: string | null
+}
 
 // When the cache card saves new settings it emits `updated` with the fresh
 // KB row; we refresh the store copy so the card re-renders with the new
@@ -265,6 +277,46 @@ function handleChatKeydown(event: KeyboardEvent) {
   }
 }
 
+// --- Re-import (#732) ---
+
+const reImportConfirmOpen = ref(false)
+const reImporting = ref(false)
+const reImportError = ref('')
+const reImportSourceGone = ref(false)
+
+const sourcePublicKbId = computed(
+  () => (store.currentKB as AugmentedKB | null)?.source_public_kb_id ?? null,
+)
+const canReImport = computed(() => !!sourcePublicKbId.value)
+
+function openReImportConfirm() {
+  reImportError.value = ''
+  reImportSourceGone.value = false
+  reImportConfirmOpen.value = true
+}
+
+async function confirmReImport() {
+  reImporting.value = true
+  reImportError.value = ''
+  try {
+    await reImportKnowledgeBase(orgId, wsId, kbId)
+    reImportConfirmOpen.value = false
+    await store.fetchKnowledgeBase(orgId, wsId, kbId)
+    await store.fetchDocuments(orgId, wsId, kbId)
+  } catch (err) {
+    if (err instanceof MarketplaceApiError && err.status === 410) {
+      reImportSourceGone.value = true
+    } else if (err instanceof MarketplaceApiError && err.status === 409) {
+      reImportError.value = 'This KB is not an import — there is no source to re-import from.'
+    } else {
+      reImportError.value =
+        err instanceof Error ? err.message : 'Re-import failed.'
+    }
+  } finally {
+    reImporting.value = false
+  }
+}
+
 // --- Status badge helpers ---
 
 function statusBadgeClass(status: string): string {
@@ -353,12 +405,66 @@ function statusBadgeClass(status: string): string {
             Edit
           </button>
           <button
+            v-if="canReImport"
+            class="rounded-md border border-indigo-600 px-4 py-2 text-sm font-medium text-indigo-700 hover:bg-indigo-50"
+            data-test="kb-re-import-button"
+            @click="openReImportConfirm"
+          >
+            Re-import
+          </button>
+          <button
             v-if="store.currentKB.status === 'active'"
             class="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700"
             @click="handleArchive"
           >
             Archive
           </button>
+        </div>
+      </div>
+
+      <!-- Re-import confirmation modal (#732 / ADR-0007) -->
+      <div
+        v-if="reImportConfirmOpen"
+        class="fixed inset-0 z-40 flex items-center justify-center bg-black/40 p-4"
+        role="dialog"
+        aria-modal="true"
+        data-test="kb-re-import-dialog"
+        @click.self="reImportConfirmOpen = false"
+      >
+        <div class="w-full max-w-md rounded-xl bg-white p-6 shadow-xl">
+          <h2 class="text-lg font-semibold text-gray-900">Re-import this KB?</h2>
+          <p v-if="!reImportSourceGone" class="mt-2 text-sm text-gray-600">
+            This will replace the documents in this KB with the latest version from the source.
+            Your chats and widgets will keep working.
+          </p>
+          <p
+            v-else
+            class="mt-2 text-sm text-yellow-800"
+            data-test="kb-re-import-gone"
+          >
+            The source KB was unpublished, so re-import is no longer possible. Your existing
+            imported content is unchanged.
+          </p>
+          <p v-if="reImportError" class="mt-2 text-xs text-red-600">{{ reImportError }}</p>
+          <div class="mt-4 flex justify-end gap-2">
+            <button
+              type="button"
+              class="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+              @click="reImportConfirmOpen = false"
+            >
+              Close
+            </button>
+            <button
+              v-if="!reImportSourceGone"
+              type="button"
+              :disabled="reImporting"
+              class="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
+              data-test="kb-re-import-confirm"
+              @click="confirmReImport"
+            >
+              {{ reImporting ? 'Re-importing…' : 'Re-import' }}
+            </button>
+          </div>
         </div>
       </div>
 

--- a/frontend/src/pages/marketplace/MarketplaceKbDetailView.vue
+++ b/frontend/src/pages/marketplace/MarketplaceKbDetailView.vue
@@ -1,0 +1,212 @@
+<script setup lang="ts">
+// Marketplace KB detail page.
+// Loads `/marketplace/{org_slug}/{kb_slug}`. The 410 Gone branch renders
+// a dedicated "this KB was unpublished" state (ADR-0007); 404 falls
+// through to a generic missing-KB state.
+import { computed, onMounted, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import {
+  getMarketplaceKb,
+  MarketplaceApiError,
+  type MarketplaceKbDetail,
+} from '../../api/marketplace'
+import LicenseBadge from '../../components/marketplace/LicenseBadge.vue'
+import ReportButton from '../../components/marketplace/ReportButton.vue'
+import MarketplacePreviewDialog from '../../components/marketplace/MarketplacePreviewDialog.vue'
+import MarketplaceImportDialog from '../../components/marketplace/MarketplaceImportDialog.vue'
+
+const route = useRoute()
+const router = useRouter()
+
+const detail = ref<MarketplaceKbDetail | null>(null)
+const loading = ref(false)
+const errorMessage = ref('')
+const errorStatus = ref<number | null>(null)
+const previewOpen = ref(false)
+const importOpen = ref(false)
+
+const orgSlug = computed(() => String(route.params.orgSlug))
+const kbSlug = computed(() => String(route.params.kbSlug))
+
+const isGone = computed(() => errorStatus.value === 410)
+const isMissing = computed(() => errorStatus.value === 404)
+
+async function load() {
+  loading.value = true
+  errorMessage.value = ''
+  errorStatus.value = null
+  detail.value = null
+  try {
+    detail.value = await getMarketplaceKb(orgSlug.value, kbSlug.value)
+  } catch (err) {
+    if (err instanceof MarketplaceApiError) {
+      errorStatus.value = err.status
+      errorMessage.value = err.message
+    } else {
+      errorMessage.value = err instanceof Error ? err.message : 'Failed to load KB.'
+    }
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(load)
+watch([orgSlug, kbSlug], load)
+
+function onImported(payload: { orgId: string; workspaceId: string; kbId: string }) {
+  importOpen.value = false
+  router.push(
+    `/orgs/${payload.orgId}/workspaces/${payload.workspaceId}/knowledge-bases/${payload.kbId}`,
+  )
+}
+
+function openImport() {
+  previewOpen.value = false
+  importOpen.value = true
+}
+</script>
+
+<template>
+  <div class="mx-auto max-w-4xl px-4 py-6" data-test="marketplace-detail-view">
+    <RouterLink
+      to="/marketplace"
+      class="mb-4 inline-block text-sm text-indigo-600 hover:text-indigo-800"
+    >
+      &larr; Back to marketplace
+    </RouterLink>
+
+    <div v-if="loading" class="py-12 text-center text-sm text-gray-500">Loading KB…</div>
+
+    <!-- 410 Gone — unpublished within the 90-day slug hold (ADR-0007). -->
+    <div
+      v-else-if="isGone"
+      class="rounded-xl border border-yellow-200 bg-yellow-50 p-8 text-center"
+      data-test="marketplace-detail-gone"
+    >
+      <h2 class="text-lg font-semibold text-yellow-900">This KB was unpublished</h2>
+      <p class="mt-2 text-sm text-yellow-800">
+        The publisher took this KB off the marketplace. Existing imports continue to work; the slug
+        is reserved for 90 days before it can be reused.
+      </p>
+      <RouterLink
+        to="/marketplace"
+        class="mt-4 inline-block rounded-md bg-yellow-600 px-4 py-2 text-sm font-medium text-white hover:bg-yellow-700"
+      >
+        Browse other KBs
+      </RouterLink>
+    </div>
+
+    <div
+      v-else-if="isMissing"
+      class="rounded-xl border border-gray-200 bg-white p-8 text-center"
+      data-test="marketplace-detail-missing"
+    >
+      <h2 class="text-lg font-semibold text-gray-900">KB not found</h2>
+      <p class="mt-2 text-sm text-gray-600">
+        We couldn't find a public KB at that address.
+      </p>
+    </div>
+
+    <div
+      v-else-if="errorMessage"
+      class="rounded-md bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700"
+    >
+      {{ errorMessage }}
+    </div>
+
+    <article v-else-if="detail" class="space-y-6">
+      <header class="space-y-2">
+        <div class="flex flex-wrap items-start justify-between gap-3">
+          <div class="min-w-0">
+            <h1 class="text-2xl font-bold text-gray-900">{{ detail.name }}</h1>
+            <p class="mt-1 text-sm text-gray-500">
+              by
+              <span class="font-medium text-gray-800">{{ detail.org_display_name }}</span>
+              <span class="text-gray-400"> · {{ detail.org_slug }}</span>
+            </p>
+          </div>
+          <LicenseBadge :license="detail.license_spdx_id" size="md" />
+        </div>
+        <p
+          v-if="detail.source_org_slug"
+          class="text-xs text-gray-500"
+          data-test="marketplace-detail-fork-line"
+        >
+          Forked from
+          <RouterLink
+            :to="`/marketplace/${detail.source_org_slug}/`"
+            class="text-indigo-600 hover:text-indigo-800"
+          >
+            {{ detail.source_org_display_name ?? detail.source_org_slug }}
+          </RouterLink>
+        </p>
+      </header>
+
+      <section class="flex flex-wrap gap-3">
+        <button
+          type="button"
+          class="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+          data-test="marketplace-detail-preview"
+          @click="previewOpen = true"
+        >
+          Preview
+        </button>
+        <button
+          type="button"
+          class="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+          data-test="marketplace-detail-import"
+          @click="importOpen = true"
+        >
+          Import
+        </button>
+        <ReportButton :kb-id="detail.kb_id" />
+      </section>
+
+      <section v-if="detail.description" class="prose prose-sm max-w-none">
+        <!-- Description is rendered as plain text; the backend does not return
+             rendered markdown today. When/if a server-side renderer lands,
+             swap this for a sanitised v-html wrapper. -->
+        <pre class="whitespace-pre-wrap text-sm text-gray-700">{{ detail.description }}</pre>
+      </section>
+
+      <section
+        class="grid grid-cols-2 gap-4 rounded-lg border border-gray-200 bg-gray-50 p-4 text-sm sm:grid-cols-4"
+        data-test="marketplace-detail-counts"
+      >
+        <div>
+          <dt class="text-xs text-gray-500">Sources</dt>
+          <dd class="font-medium text-gray-900">{{ detail.source_count ?? '—' }}</dd>
+        </div>
+        <div>
+          <dt class="text-xs text-gray-500">Documents</dt>
+          <dd class="font-medium text-gray-900">{{ detail.document_count ?? '—' }}</dd>
+        </div>
+        <div>
+          <dt class="text-xs text-gray-500">Chunks</dt>
+          <dd class="font-medium text-gray-900">{{ detail.chunk_count ?? '—' }}</dd>
+        </div>
+        <div>
+          <dt class="text-xs text-gray-500">Imports</dt>
+          <dd class="font-medium text-gray-900">{{ detail.import_count }}</dd>
+        </div>
+      </section>
+
+      <MarketplacePreviewDialog
+        v-if="detail"
+        :open="previewOpen"
+        :org-slug="detail.org_slug"
+        :kb-slug="detail.kb_slug"
+        @close="previewOpen = false"
+        @import="openImport"
+      />
+
+      <MarketplaceImportDialog
+        v-if="detail"
+        :open="importOpen"
+        :public-kb-id="detail.kb_id"
+        @close="importOpen = false"
+        @imported="onImported"
+      />
+    </article>
+  </div>
+</template>

--- a/frontend/src/pages/marketplace/MarketplaceListView.vue
+++ b/frontend/src/pages/marketplace/MarketplaceListView.vue
@@ -1,0 +1,226 @@
+<script setup lang="ts">
+// Marketplace list — search + license filter + sort + infinite-scroll grid.
+// Login is enforced by the route guard (meta.requiresAuth). Per plan §7,
+// anonymous browsing is explicitly deferred.
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import {
+  listMarketplace,
+  SPDX_LICENSES,
+  type MarketplaceListItem,
+  type MarketplaceSort,
+} from '../../api/marketplace'
+import MarketplaceKbCard from '../../components/marketplace/MarketplaceKbCard.vue'
+import MarketplaceImportDialog from '../../components/marketplace/MarketplaceImportDialog.vue'
+import { useRouter } from 'vue-router'
+
+const PAGE_LIMIT = 20
+
+const router = useRouter()
+
+const query = ref('')
+const sort = ref<MarketplaceSort>('recently_updated')
+const licenseFilter = ref<string[]>([])
+
+const items = ref<MarketplaceListItem[]>([])
+const loading = ref(false)
+const loadingMore = ref(false)
+const errorMessage = ref('')
+const offset = ref(0)
+const hasMore = ref(false)
+
+const sentinel = ref<HTMLDivElement | null>(null)
+let observer: IntersectionObserver | null = null
+
+// Import dialog state — list view supports import from cards in the future,
+// but for now is opened only from the card's RouterLink → detail page. We
+// still mount it here so deep-link "import this kb" works in a follow-up.
+const importDialogOpen = ref(false)
+const importPublicKbId = ref('')
+
+const showEmptyState = computed(
+  () => !loading.value && items.value.length === 0 && !errorMessage.value,
+)
+
+async function loadFirstPage() {
+  loading.value = true
+  errorMessage.value = ''
+  offset.value = 0
+  items.value = []
+  hasMore.value = false
+  try {
+    const res = await listMarketplace({
+      q: query.value.trim() || undefined,
+      sort: sort.value,
+      license: licenseFilter.value.length > 0 ? licenseFilter.value : undefined,
+      limit: PAGE_LIMIT,
+      offset: 0,
+    })
+    const next = Array.isArray(res.items) ? res.items : []
+    items.value = next
+    hasMore.value = next.length === PAGE_LIMIT
+    offset.value = next.length
+  } catch (err) {
+    errorMessage.value = err instanceof Error ? err.message : 'Failed to load marketplace.'
+  } finally {
+    loading.value = false
+  }
+}
+
+async function loadMore() {
+  if (loading.value || loadingMore.value || !hasMore.value) return
+  loadingMore.value = true
+  try {
+    const res = await listMarketplace({
+      q: query.value.trim() || undefined,
+      sort: sort.value,
+      license: licenseFilter.value.length > 0 ? licenseFilter.value : undefined,
+      limit: PAGE_LIMIT,
+      offset: offset.value,
+    })
+    const next = Array.isArray(res.items) ? res.items : []
+    items.value.push(...next)
+    hasMore.value = next.length === PAGE_LIMIT
+    offset.value += next.length
+  } catch (err) {
+    errorMessage.value = err instanceof Error ? err.message : 'Failed to load more results.'
+  } finally {
+    loadingMore.value = false
+  }
+}
+
+// Debounce search input so we don't fire on every keystroke.
+let searchTimer: ReturnType<typeof setTimeout> | null = null
+watch(query, () => {
+  if (searchTimer) clearTimeout(searchTimer)
+  searchTimer = setTimeout(loadFirstPage, 250)
+})
+watch([sort, licenseFilter], loadFirstPage, { deep: true })
+
+function toggleLicense(license: string) {
+  const idx = licenseFilter.value.indexOf(license)
+  if (idx === -1) {
+    licenseFilter.value = [...licenseFilter.value, license]
+  } else {
+    licenseFilter.value = licenseFilter.value.filter((l) => l !== license)
+  }
+}
+
+onMounted(() => {
+  loadFirstPage()
+  if (sentinel.value) {
+    observer = new IntersectionObserver((entries) => {
+      if (entries[0]?.isIntersecting) loadMore()
+    })
+    observer.observe(sentinel.value)
+  }
+})
+
+onBeforeUnmount(() => {
+  observer?.disconnect()
+  if (searchTimer) clearTimeout(searchTimer)
+})
+
+function onImported(payload: { orgId: string; workspaceId: string; kbId: string }) {
+  importDialogOpen.value = false
+  router.push(
+    `/orgs/${payload.orgId}/workspaces/${payload.workspaceId}/knowledge-bases/${payload.kbId}`,
+  )
+}
+</script>
+
+<template>
+  <div class="mx-auto max-w-7xl px-4 py-6" data-test="marketplace-list-view">
+    <header class="mb-6">
+      <h1 class="text-2xl font-bold text-gray-900">Marketplace</h1>
+      <p class="text-sm text-gray-500">
+        Browse Public Knowledge Bases published by other organizations.
+      </p>
+    </header>
+
+    <!-- Filter bar — inlined here because the list view is the only consumer.
+         Extract to its own SFC if filtering grows beyond search + sort + license. -->
+    <section class="mb-6 space-y-3 rounded-lg border border-gray-200 bg-white p-4">
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <input
+          v-model="query"
+          type="search"
+          placeholder="Search KBs by name or description…"
+          class="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          data-test="marketplace-search-input"
+        />
+        <select
+          v-model="sort"
+          class="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          data-test="marketplace-sort"
+        >
+          <option value="recently_updated">Recently updated</option>
+          <option value="newest">Newest</option>
+          <option value="most_imported">Most imported</option>
+          <option value="alphabetic">Alphabetic</option>
+        </select>
+      </div>
+      <div class="flex flex-wrap items-center gap-2 text-xs">
+        <span class="text-gray-500">License:</span>
+        <button
+          v-for="lic in SPDX_LICENSES"
+          :key="lic"
+          type="button"
+          class="rounded-full border px-2.5 py-0.5"
+          :class="licenseFilter.includes(lic)
+            ? 'border-indigo-500 bg-indigo-50 text-indigo-700'
+            : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-50'"
+          :data-test="`marketplace-license-filter-${lic}`"
+          @click="toggleLicense(lic)"
+        >
+          {{ lic }}
+        </button>
+        <button
+          v-if="licenseFilter.length > 0"
+          type="button"
+          class="ml-2 text-xs text-indigo-600 hover:text-indigo-800"
+          @click="licenseFilter = []"
+        >
+          Clear
+        </button>
+      </div>
+    </section>
+
+    <div
+      v-if="errorMessage"
+      class="mb-4 rounded-md bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700"
+      data-test="marketplace-list-error"
+    >
+      {{ errorMessage }}
+    </div>
+
+    <div v-if="loading" class="py-12 text-center text-sm text-gray-500">
+      Loading marketplace…
+    </div>
+    <div
+      v-else-if="showEmptyState"
+      class="py-12 text-center text-sm text-gray-500"
+      data-test="marketplace-empty-state"
+    >
+      No Public KBs match your filters yet.
+    </div>
+    <div
+      v-else
+      class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3"
+      data-test="marketplace-grid"
+    >
+      <MarketplaceKbCard v-for="item in items" :key="item.kb_id" :item="item" />
+    </div>
+
+    <div ref="sentinel" class="h-8" data-test="marketplace-sentinel"></div>
+    <div v-if="loadingMore" class="py-4 text-center text-xs text-gray-500">
+      Loading more…
+    </div>
+
+    <MarketplaceImportDialog
+      :open="importDialogOpen"
+      :public-kb-id="importPublicKbId"
+      @close="importDialogOpen = false"
+      @imported="onImported"
+    />
+  </div>
+</template>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -73,6 +73,18 @@ const router = createRouter({
           meta: { requiresAuth: true },
         },
         {
+          path: 'marketplace',
+          name: 'marketplace-list',
+          component: () => import('../pages/marketplace/MarketplaceListView.vue'),
+          meta: { requiresAuth: true },
+        },
+        {
+          path: 'marketplace/:orgSlug/:kbSlug',
+          name: 'marketplace-kb-detail',
+          component: () => import('../pages/marketplace/MarketplaceKbDetailView.vue'),
+          meta: { requiresAuth: true },
+        },
+        {
           path: 'analytics',
           name: 'analytics',
           component: () => import('../pages/analytics/AnalyticsDashboardPage.vue'),


### PR DESCRIPTION
## Summary

Implements the Vue.js Marketplace surfaces for issue #732 — list, detail, preview, import-destination picker, re-import on imported KBs, and a dedicated 410 Gone state.

- **Routes** (registered in `frontend/src/router/index.ts`):
  - `/marketplace` → `MarketplaceListView.vue` (search + sort + SPDX license multi-select + infinite-scroll grid)
  - `/marketplace/:orgSlug/:kbSlug` → `MarketplaceKbDetailView.vue` (description, license badge, source/document/chunk counts, "Forked from {Org}" lineage line, 410 unpublished state)
- **Components** (`frontend/src/components/marketplace/`):
  - `MarketplaceKbCard.vue`, `LicenseBadge.vue`, `MarketplacePreviewDialog.vue`, `MarketplaceImportDialog.vue`, `ReportButton.vue`
- **Re-import** on local Imported KBs: `KBDetailPage.vue` now shows a Re-import button when `source_public_kb_id` is non-null, opens a confirmation modal that warns about content replacement, calls `/orgs/:org/workspaces/:ws/knowledge-bases/:id/re-import` with `{confirm: true}`, and renders an inline "Source KB was unpublished" state on 410.
- **API client** (`frontend/src/api/marketplace.ts`): wraps all 6 endpoints — list, detail, preview, import, re-import, report — and surfaces HTTP status via a `MarketplaceApiError` so callers can branch on 410 / 403 / 422 without string-matching error messages.

### References

- Issue: closes #732
- Plan: `docs/plans/marketplace-mvp.md` §5 (Vue routes), §4 (endpoint shapes)
- ADR-0001 (fork-on-import), ADR-0003 (always-fresh `last_modified_at`), ADR-0005 (Org-as-publisher), ADR-0006 (license badge), ADR-0007 (410 + re-import confirmation)

### Self-review notes (thermo-nuclear pass)

- **Component decomposition (5 SFCs)** — kept as 5 rather than collapsing Card+Badge: the Badge is also used standalone on the detail header (and will be on the local KB header when M1 lands), while the Card has list-specific layout/imports/reports. Merging would couple list chrome to a reusable badge.
- **Hand-typed interfaces** — the frontend has no OpenAPI → TS codegen pipeline today (`openapi-typescript` / `@hey-api/openapi-ts` not in `package.json`). Types are mirrored verbatim from `contracts/openapi.yaml` and flagged with a TODO header in `marketplace.ts` so they can be swapped when codegen lands.
- **API calls live in the api layer** — components only call the wrappers; no direct `fetch` in any SFC.
- **No SFC over ~250 lines** — `MarketplaceListView.vue` is the sprawl risk (~220 lines incl. template); filter bar is inlined since the list is the only consumer, with a comment to extract if it grows past search + sort + license.
- **410 is unit-tested** at the API layer (`src/api/marketplace.spec.ts`) — not in e2e, per the task brief.

## Test plan

- [x] `npx vue-tsc -b` — clean
- [x] `npx eslint .` — 0 errors (6 pre-existing warnings unchanged)
- [x] `npx vitest run` — 17 files / 159 tests passing
- [ ] `npx playwright test e2e/marketplace` — Playwright spec authored under `frontend/e2e/marketplace/marketplace.spec.ts`; auto-skips locally without `E2E_USER`. Will run in CI once seed fixtures land.
- [x] Sign-off + DCO trailer present.