### PR TITLE
feat(marketplace): admin review queue + approve/dismiss endpoints (#734)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -524,7 +524,7 @@ func main() {
 	// --- Wire handlers ---
 	orgHandler := handler.NewOrgHandler(orgSvc, userRepo)
 	wsHandler := handler.NewWorkspaceHandler(wsSvc)
-	userHandler := handler.NewUserHandler(userSvc)
+	userHandler := handler.NewUserHandler(userSvc).WithAdminEmails(cfg.Admin.PlatformAdminEmails)
 	// Marketplace publish service (issue #726): owns the canonical
 	// publish boundary — license allow-list, status-gate freeze, atomic
 	// flip of visibility + publish metadata. Shares kbStatusGuard so the
@@ -537,6 +537,17 @@ func main() {
 	}
 	publishSvc := marketplace.NewPublishService(pool, publishGate)
 	kbHandler := handler.NewKBHandler(kbSvc).WithPublisher(publishSvc)
+
+	// Marketplace moderation (issue #734, ADR-0006 + ADR-0008):
+	// reports + takedowns + admin approve/dismiss. The publisher email
+	// is a no-op placeholder for now (logged-TODO) until the M9 SES
+	// pipeline is wired — productionising swaps in an Asynq enqueue.
+	reportsRepo := marketplace.NewReports(pool)
+	takedownsRepo := marketplace.NewTakedowns(pool)
+	adminModerationSvc := marketplace.NewAdminModeration(
+		pool, reportsRepo, takedownsRepo, marketplace.NewNoopPublisherNotifier(),
+	)
+	adminMarketplaceHandler := handler.NewAdminMarketplaceHandler(adminModerationSvc)
 	sourceHandler := handler.NewSourceHandler(sourceSvc)
 	docHandler := handler.NewDocumentHandler(docSvc)
 	searchHandler := handler.NewSearchHandler(searchSvc)
@@ -1015,6 +1026,20 @@ func main() {
 			r := c.Request.WithContext(ctx)
 			dsarHandler.Delete(c.Writer, r)
 		})
+
+		// --- Admin marketplace review queue (issue #734, ADR-0008) ---
+		// Session-authed, then gated by the RAVEN_ADMIN_EMAILS allow-list
+		// (the only admin tier in MVP — no granular admin roles). The
+		// gate runs after the session middleware that already mounted on
+		// `api`, so the caller's email is in context.
+		adminMarket := api.Group("/admin/marketplace",
+			middleware.RequirePlatformAdmin(cfg.Admin.PlatformAdminEmails),
+		)
+		{
+			adminMarket.GET("/reports", adminMarketplaceHandler.ListReports)
+			adminMarket.POST("/reports/:id/approve", adminMarketplaceHandler.Approve)
+			adminMarket.POST("/reports/:id/dismiss", adminMarketplaceHandler.Dismiss)
+		}
 	}
 
 	// Public chat routes — API key authentication (for embeddable chat widget).

--- a/frontend/e2e/admin/marketplace-reports.spec.ts
+++ b/frontend/e2e/admin/marketplace-reports.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '../fixtures'
+
+// E2E for the admin marketplace review queue (#734).
+//
+// Skipped unless E2E_ADMIN is configured — the gate is server-side
+// (RAVEN_ADMIN_EMAILS) so a non-admin user can't see the page. The
+// `adminPage` fixture signs in as the configured admin operator.
+//
+// Seeding a marketplace_report from the SPA isn't a primary user flow
+// (and the report-submission UI is a sibling deliverable). We
+// therefore exercise the navigate -> render -> action loop and trust
+// the backend integration test (TestAdminModeration_Approve_...) to
+// pin the atomic four-side-effect commitment.
+
+test.describe('Admin: Marketplace report queue', () => {
+  test('renders the queue and exposes status filter pills', async ({ adminPage: page }) => {
+    await page.goto('/admin/marketplace/reports')
+    await expect(page.getByRole('heading', { name: /report queue/i })).toBeVisible()
+    await expect(page.getByRole('tab', { name: 'Open' })).toBeVisible()
+    await expect(page.getByRole('tab', { name: 'Resolved' })).toBeVisible()
+  })
+
+  test('approve flow surfaces the confirm modal then closes on cancel', async ({
+    adminPage: page,
+  }, testInfo) => {
+    await page.goto('/admin/marketplace/reports')
+    const rowCount = await page.getByTestId('admin-reports-row').count()
+    testInfo.skip(
+      rowCount === 0,
+      'No open reports — seed one via POST /api/v1/marketplace/reports first',
+    )
+
+    const firstRow = page.getByTestId('admin-reports-row').first()
+    const reportId = await firstRow.getAttribute('data-report-id')
+    expect(reportId).toBeTruthy()
+
+    await firstRow.getByText('Approve').click()
+    await expect(page.getByText(/unpublish the KB/i)).toBeVisible()
+
+    // Cancel — row should still be present.
+    await page.getByRole('button', { name: 'Cancel' }).click()
+    await expect(firstRow).toBeVisible()
+  })
+
+  test('approve commits then the resolved row reappears under the Resolved tab', async ({
+    adminPage: page,
+  }, testInfo) => {
+    await page.goto('/admin/marketplace/reports')
+    const rowCount = await page.getByTestId('admin-reports-row').count()
+    testInfo.skip(
+      rowCount === 0,
+      'No open reports — seed one via POST /api/v1/marketplace/reports first',
+    )
+
+    const firstRow = page.getByTestId('admin-reports-row').first()
+    const reportId = await firstRow.getAttribute('data-report-id')
+    expect(reportId).toBeTruthy()
+
+    await firstRow.getByText('Approve').click()
+    await page.getByTestId('admin-reports-confirm').click()
+
+    // Toast surfaces the new strike count.
+    await expect(page.getByTestId('admin-reports-approve-toast')).toBeVisible()
+
+    // Switch to Resolved — the row should now appear there with the
+    // matching report id.
+    await page.getByRole('tab', { name: 'Resolved' }).click()
+    await expect(page.locator(`[data-report-id="${reportId}"]`)).toBeVisible()
+  })
+})

--- a/frontend/src/api/marketplace-admin.ts
+++ b/frontend/src/api/marketplace-admin.ts
@@ -1,0 +1,105 @@
+// API client for the admin marketplace review queue (issue #734).
+// Mirrors the per-endpoint shape in docs/plans/marketplace-mvp.md §4.
+//
+// The admin gate is enforced server-side by RequirePlatformAdmin
+// middleware against RAVEN_ADMIN_EMAILS. This client trusts the SPA
+// route guard to keep the unauthorised user away, but a tampered client
+// hitting these endpoints still gets a clean 403.
+
+export type ReportStatus = 'open' | 'reviewing' | 'resolved' | 'dismissed'
+
+export interface MarketplaceReport {
+  id: string
+  reported_kb_id: string
+  reporter_user_id: string | null
+  reason: string
+  status: ReportStatus
+  created_at: string
+}
+
+export interface ListReportsResponse {
+  reports: MarketplaceReport[]
+  limit: number
+  offset: number
+}
+
+export interface ApproveResult {
+  takedown_id: string
+  target_kb_id: string
+  strikes_after: number
+}
+
+export interface DismissResult {
+  report_id: string
+  status: 'dismissed'
+}
+
+async function authFetch(path: string, init?: RequestInit): Promise<Response> {
+  const base = import.meta.env.VITE_API_BASE_URL ?? '/api/v1'
+  return fetch(base + path, {
+    ...init,
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      ...init?.headers,
+    },
+  })
+}
+
+async function jsonOrThrow<T>(res: Response, op: string): Promise<T> {
+  if (res.ok) return (await res.json()) as T
+  const body = await res.json().catch(() => ({}) as Record<string, unknown>)
+  const detail =
+    typeof body.detail === 'string'
+      ? body.detail
+      : typeof body.message === 'string'
+        ? body.message
+        : res.statusText
+  const err = new Error(`${op}: ${res.status} ${detail}`) as Error & { status: number }
+  err.status = res.status
+  throw err
+}
+
+/**
+ * Fetches the admin review queue. Server-side default is `status=open`
+ * which matches the queue's live-work view; callers can pass any
+ * status to inspect history.
+ */
+export async function listReports(
+  status: ReportStatus = 'open',
+  limit = 50,
+  offset = 0,
+): Promise<ListReportsResponse> {
+  const qs = new URLSearchParams({
+    status,
+    limit: String(limit),
+    offset: String(offset),
+  })
+  const res = await authFetch(`/admin/marketplace/reports?${qs.toString()}`)
+  return jsonOrThrow<ListReportsResponse>(res, 'listReports')
+}
+
+/**
+ * Approves a report: unpublishes the KB, increments the publisher Org's
+ * `takedown_strikes`, writes a takedown audit row, and resolves the
+ * report — all atomically. Returns the strikes counter after the
+ * increment so the UI can show the "this is their N-th strike" banner.
+ */
+export async function approveReport(reportId: string): Promise<ApproveResult> {
+  const res = await authFetch(`/admin/marketplace/reports/${reportId}/approve`, {
+    method: 'POST',
+  })
+  return jsonOrThrow<ApproveResult>(res, 'approveReport')
+}
+
+/**
+ * Dismisses a report: closes the report without any takedown / strike /
+ * notification. The reporter is intentionally NOT notified
+ * (ADR-0008 §Why — report-confirms-takedown loop is a harassment vector).
+ */
+export async function dismissReport(reportId: string): Promise<DismissResult> {
+  const res = await authFetch(`/admin/marketplace/reports/${reportId}/dismiss`, {
+    method: 'POST',
+  })
+  return jsonOrThrow<DismissResult>(res, 'dismissReport')
+}

--- a/frontend/src/pages/admin/AdminReportsView.vue
+++ b/frontend/src/pages/admin/AdminReportsView.vue
@@ -1,0 +1,292 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import {
+  listReports,
+  approveReport,
+  dismissReport,
+  type MarketplaceReport,
+  type ReportStatus,
+} from '../../api/marketplace-admin'
+import ResponsiveModal from '../../components/ResponsiveModal.vue'
+
+// Admin review queue for marketplace reports (issue #734, ADR-0008).
+// Two binary admin actions per report: Approve (escalate to takedown)
+// and Dismiss (close without action). Status filter pill defaults to
+// the live work-list (`open`); operators can flip to any status to
+// inspect the queue's history.
+
+type StatusFilter = ReportStatus
+
+const STATUSES: { value: StatusFilter; label: string }[] = [
+  { value: 'open', label: 'Open' },
+  { value: 'reviewing', label: 'Reviewing' },
+  { value: 'resolved', label: 'Resolved' },
+  { value: 'dismissed', label: 'Dismissed' },
+]
+
+const reports = ref<MarketplaceReport[]>([])
+const status = ref<StatusFilter>('open')
+const loading = ref(false)
+const error = ref<string | null>(null)
+
+const confirmAction = ref<'approve' | 'dismiss' | null>(null)
+const targetReport = ref<MarketplaceReport | null>(null)
+const submitting = ref(false)
+
+const lastApproveResult = ref<{ kbId: string; strikes: number } | null>(null)
+
+async function refresh() {
+  loading.value = true
+  error.value = null
+  try {
+    const res = await listReports(status.value, 100, 0)
+    reports.value = res.reports
+  } catch (e) {
+    error.value = (e as Error).message
+  } finally {
+    loading.value = false
+  }
+}
+
+function openApprove(report: MarketplaceReport) {
+  targetReport.value = report
+  confirmAction.value = 'approve'
+}
+
+function openDismiss(report: MarketplaceReport) {
+  targetReport.value = report
+  confirmAction.value = 'dismiss'
+}
+
+function closeConfirm() {
+  if (submitting.value) return
+  confirmAction.value = null
+  targetReport.value = null
+}
+
+async function submitConfirm() {
+  if (!targetReport.value || !confirmAction.value) return
+  submitting.value = true
+  try {
+    if (confirmAction.value === 'approve') {
+      const result = await approveReport(targetReport.value.id)
+      lastApproveResult.value = {
+        kbId: result.target_kb_id,
+        strikes: result.strikes_after,
+      }
+    } else {
+      await dismissReport(targetReport.value.id)
+    }
+    closeConfirm()
+    await refresh()
+  } catch (e) {
+    error.value = (e as Error).message
+  } finally {
+    submitting.value = false
+  }
+}
+
+function formatAge(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime()
+  const hours = Math.floor(ms / 3_600_000)
+  if (hours < 1) return 'just now'
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  return `${days}d ago`
+}
+
+function formatReporter(report: MarketplaceReport): string {
+  // ADR-0006: reporter id may be NULL when the user was deleted (FK
+  // ON DELETE SET NULL). Surface that as anonymous in the UI rather
+  // than showing the empty string.
+  return report.reporter_user_id ? report.reporter_user_id.slice(0, 8) : 'anonymous'
+}
+
+const confirmTitle = computed(() => {
+  if (confirmAction.value === 'approve') return 'Approve report and unpublish KB?'
+  if (confirmAction.value === 'dismiss') return 'Dismiss report?'
+  return ''
+})
+
+onMounted(refresh)
+</script>
+
+<template>
+  <div class="p-4 sm:p-6">
+    <div class="mb-4 flex flex-wrap items-center justify-between gap-3">
+      <div>
+        <h1 class="text-xl font-semibold text-slate-100">Marketplace report queue</h1>
+        <p class="text-sm text-slate-400">
+          Reactive moderation queue (ADR-0006). Approve unpublishes the KB and
+          increments the publisher Org's strike counter.
+        </p>
+      </div>
+      <button
+        class="rounded border border-slate-600 px-3 py-1.5 text-sm text-slate-100 hover:bg-slate-700"
+        :disabled="loading"
+        @click="refresh"
+      >
+        Refresh
+      </button>
+    </div>
+
+    <!-- Status filter pills -->
+    <div class="mb-4 flex flex-wrap gap-2" role="tablist" aria-label="Report status filter">
+      <button
+        v-for="opt in STATUSES"
+        :key="opt.value"
+        role="tab"
+        :aria-selected="status === opt.value"
+        class="rounded-full border px-3 py-1 text-sm"
+        :class="
+          status === opt.value
+            ? 'border-indigo-400 bg-indigo-500/20 text-indigo-200'
+            : 'border-slate-600 text-slate-300 hover:bg-slate-700'
+        "
+        @click="status = opt.value; refresh()"
+      >
+        {{ opt.label }}
+      </button>
+    </div>
+
+    <div
+      v-if="lastApproveResult"
+      class="mb-4 rounded border border-emerald-500/40 bg-emerald-500/10 p-3 text-sm text-emerald-200"
+      data-testid="admin-reports-approve-toast"
+    >
+      KB <code class="font-mono">{{ lastApproveResult.kbId.slice(0, 8) }}</code> unpublished.
+      Publisher Org is now at <strong>{{ lastApproveResult.strikes }}</strong>
+      {{ lastApproveResult.strikes === 1 ? 'strike' : 'strikes' }}.
+      <button class="ml-2 text-emerald-100 underline" @click="lastApproveResult = null">
+        Dismiss
+      </button>
+    </div>
+
+    <div
+      v-if="error"
+      class="mb-4 rounded border border-red-500/40 bg-red-500/10 p-3 text-sm text-red-200"
+    >
+      {{ error }}
+    </div>
+
+    <div v-if="loading" class="text-sm text-slate-400">Loading…</div>
+
+    <div
+      v-else-if="reports.length === 0"
+      class="rounded border border-slate-700 p-6 text-center text-sm text-slate-400"
+      data-testid="admin-reports-empty"
+    >
+      No reports in <strong>{{ status }}</strong>.
+    </div>
+
+    <div v-else class="overflow-x-auto rounded border border-slate-700">
+      <table class="min-w-full text-left text-sm">
+        <thead class="bg-slate-800 text-xs uppercase text-slate-400">
+          <tr>
+            <th class="px-3 py-2">Report</th>
+            <th class="px-3 py-2">Target KB</th>
+            <th class="px-3 py-2">Reporter</th>
+            <th class="px-3 py-2">Reason</th>
+            <th class="px-3 py-2">Age</th>
+            <th class="px-3 py-2">Status</th>
+            <th class="px-3 py-2 text-right">Actions</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-700 bg-slate-900 text-slate-200">
+          <tr
+            v-for="r in reports"
+            :key="r.id"
+            data-testid="admin-reports-row"
+            :data-report-id="r.id"
+          >
+            <td class="px-3 py-2 font-mono text-xs">{{ r.id.slice(0, 8) }}</td>
+            <td class="px-3 py-2 font-mono text-xs">{{ r.reported_kb_id.slice(0, 8) }}</td>
+            <td class="px-3 py-2 font-mono text-xs">{{ formatReporter(r) }}</td>
+            <td class="max-w-md px-3 py-2 text-slate-300">
+              <span class="line-clamp-2">{{ r.reason }}</span>
+            </td>
+            <td class="px-3 py-2 text-slate-400">{{ formatAge(r.created_at) }}</td>
+            <td class="px-3 py-2">
+              <span
+                class="rounded-full px-2 py-0.5 text-xs"
+                :class="{
+                  'bg-amber-500/20 text-amber-200': r.status === 'open',
+                  'bg-sky-500/20 text-sky-200': r.status === 'reviewing',
+                  'bg-emerald-500/20 text-emerald-200': r.status === 'resolved',
+                  'bg-slate-500/20 text-slate-200': r.status === 'dismissed',
+                }"
+              >
+                {{ r.status }}
+              </span>
+            </td>
+            <td class="px-3 py-2 text-right">
+              <div class="flex justify-end gap-2">
+                <button
+                  v-if="r.status === 'open' || r.status === 'reviewing'"
+                  class="rounded border border-red-500/50 px-2 py-1 text-xs text-red-200 hover:bg-red-500/20"
+                  :data-testid="`admin-reports-approve-${r.id}`"
+                  @click="openApprove(r)"
+                >
+                  Approve
+                </button>
+                <button
+                  v-if="r.status === 'open' || r.status === 'reviewing'"
+                  class="rounded border border-slate-500/50 px-2 py-1 text-xs text-slate-300 hover:bg-slate-700"
+                  :data-testid="`admin-reports-dismiss-${r.id}`"
+                  @click="openDismiss(r)"
+                >
+                  Dismiss
+                </button>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <ResponsiveModal
+      :open="confirmAction !== null"
+      :title="confirmTitle"
+      @close="closeConfirm"
+    >
+      <div class="space-y-3 text-sm text-slate-200">
+        <p v-if="confirmAction === 'approve'">
+          This will unpublish the KB and increment the publisher Org's
+          <strong>takedown strikes</strong> by one. The action is auditable but
+          cannot be silently undone — recovery requires a manual republish.
+        </p>
+        <p v-if="confirmAction === 'dismiss'">
+          This will close the report without action. The reporter is not
+          notified (ADR-0006 — reporter-confirms-takedown loop is a known
+          harassment vector).
+        </p>
+        <p v-if="targetReport" class="rounded bg-slate-800/60 p-2 font-mono text-xs">
+          Report {{ targetReport.id.slice(0, 8) }} · KB
+          {{ targetReport.reported_kb_id.slice(0, 8) }}
+        </p>
+        <div class="flex justify-end gap-2 pt-2">
+          <button
+            class="rounded border border-slate-600 px-3 py-1.5 text-sm text-slate-200 hover:bg-slate-700"
+            :disabled="submitting"
+            @click="closeConfirm"
+          >
+            Cancel
+          </button>
+          <button
+            class="rounded px-3 py-1.5 text-sm text-white"
+            :class="
+              confirmAction === 'approve'
+                ? 'bg-red-600 hover:bg-red-500'
+                : 'bg-slate-600 hover:bg-slate-500'
+            "
+            :disabled="submitting"
+            data-testid="admin-reports-confirm"
+            @click="submitConfirm"
+          >
+            {{ submitting ? 'Submitting…' : 'Confirm' }}
+          </button>
+        </div>
+      </div>
+    </ResponsiveModal>
+  </div>
+</template>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -151,6 +151,16 @@ const router = createRouter({
           component: () => import('../pages/billing/PlansPage.vue'),
           meta: { requiresAuth: true },
         },
+        {
+          // Admin marketplace review queue (issue #734, ADR-0008).
+          // Server enforces the gate via RAVEN_ADMIN_EMAILS; the SPA's
+          // `requiresPlatformAdmin` meta hides the route from non-admins
+          // so they don't see a 403 in the network panel for nothing.
+          path: 'admin/marketplace/reports',
+          name: 'admin-marketplace-reports',
+          component: () => import('../pages/admin/AdminReportsView.vue'),
+          meta: { requiresAuth: true, requiresPlatformAdmin: true },
+        },
       ],
     },
     {
@@ -217,6 +227,13 @@ router.beforeEach(async (to) => {
 
   if (auth.isAuthenticated && !auth.hasOrg && to.path !== '/onboarding') {
     return '/onboarding'
+  }
+
+  // Platform-admin gate (issue #734). Authoritative gate is the
+  // backend middleware (RAVEN_ADMIN_EMAILS) — this is presentation-only
+  // so the UI doesn't render an admin nav for a regular user.
+  if (to.meta.requiresPlatformAdmin === true && !auth.isPlatformAdmin) {
+    return '/dashboard'
   }
 })
 

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -10,6 +10,10 @@ import { usePostHog } from '../plugins/posthog'
 export const useAuthStore = defineStore('auth', () => {
   const sessionExists = ref(false)
   const orgId = ref<string | null>(sessionStorage.getItem('raven_org_id'))
+  // Platform-admin flag — populated by /api/v1/me. Presentation-only;
+  // the backend enforces admin routes via middleware against
+  // RAVEN_ADMIN_EMAILS, so a tampered client cannot escalate.
+  const isPlatformAdmin = ref(false)
   const isAuthenticated = computed(() => sessionExists.value)
   const hasOrg = computed(() => !!orgId.value)
 
@@ -66,8 +70,9 @@ export const useAuthStore = defineStore('auth', () => {
           signal: controller.signal,
         })
         if (res.ok) {
-          const me = (await res.json()) as { org_id?: string }
+          const me = (await res.json()) as { org_id?: string; is_platform_admin?: boolean }
           if (me.org_id) setOrgId(me.org_id)
+          isPlatformAdmin.value = !!me.is_platform_admin
         }
       } catch {
         // Swallow (including AbortError) — if /me is unreachable the
@@ -167,6 +172,7 @@ export const useAuthStore = defineStore('auth', () => {
   return {
     sessionExists,
     orgId,
+    isPlatformAdmin,
     isAuthenticated,
     hasOrg,
     init,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,6 +41,22 @@ type Config struct {
 	EmailSummary EmailSummaryConfig
 	Retrieval    RetrievalConfig
 	Asynq        AsynqConfig
+	Admin        AdminConfig
+}
+
+// AdminConfig holds the platform-admin allow-list used by the marketplace
+// review queue and other internal-only operator endpoints.
+//
+// ADR-0008 §line 35: "no admin-role granularity beyond raven_admin". The
+// allow-list lives in config (not the DB) so a forgotten test seed cannot
+// silently grant admin privilege and so revoking admin requires a config
+// push (auditable) rather than a DB tweak.
+type AdminConfig struct {
+	// PlatformAdminEmails is the comma-separated allow-list of session
+	// email addresses that may hit /api/v1/admin/marketplace/*. Empty
+	// disables the endpoints (every request gets 403). Set via
+	// RAVEN_ADMIN_EMAILS=alice@ravencloak.org,bob@ravencloak.org.
+	PlatformAdminEmails []string `mapstructure:"platform_admin_emails"`
 }
 
 // RetrievalConfig holds tunables for the hybrid search / RRF pipeline used by
@@ -663,6 +679,12 @@ func Load() (*Config, error) {
 
 	_ = v.BindEnv("billing.slack_webhook_url", "RAVEN_SLACK_BILLING_WEBHOOK_URL")
 	v.SetDefault("billing.slack_webhook_url", "")
+
+	// Platform-admin allow-list (#734). Empty default — the admin
+	// marketplace endpoints respond 403 for every caller until an
+	// operator opts in by setting this env var.
+	v.SetDefault("admin.platform_admin_emails", []string{})
+	_ = v.BindEnv("admin.platform_admin_emails", "RAVEN_ADMIN_EMAILS")
 
 	// Try to read config file but don't fail if not found
 	_ = v.ReadInConfig()

--- a/internal/handler/admin_marketplace.go
+++ b/internal/handler/admin_marketplace.go
@@ -1,0 +1,185 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/ravencloak-org/Raven/internal/marketplace"
+	"github.com/ravencloak-org/Raven/pkg/apierror"
+)
+
+// AdminMarketplaceService is the slice of *marketplace.AdminModeration
+// this handler depends on. Declared as an interface so the unit tests
+// can pass a stub that returns canned errors (404, 409 mapping) without
+// standing up a Postgres testcontainer.
+type AdminMarketplaceService interface {
+	ListReports(ctx context.Context, status marketplace.ReportStatus, limit, offset int) ([]marketplace.Report, error)
+	Approve(ctx context.Context, reportID uuid.UUID) (marketplace.ApproveResult, error)
+	Dismiss(ctx context.Context, reportID uuid.UUID) error
+}
+
+// NewAdminMarketplaceHandler builds a handler ready to be wired into
+// the admin route group. The service argument may not be nil; main.go
+// constructs the service and passes it.
+func NewAdminMarketplaceHandler(svc AdminMarketplaceService) *AdminMarketplaceHandler {
+	return &AdminMarketplaceHandler{svc: svc}
+}
+
+// AdminMarketplaceHandler implements the three admin review-queue
+// endpoints described in plan §4.
+type AdminMarketplaceHandler struct {
+	svc AdminMarketplaceService
+}
+
+// ListReports handles GET /api/v1/admin/marketplace/reports.
+//
+// Query parameters:
+//   - status: one of open/reviewing/resolved/dismissed. Defaults to
+//     `open` since the queue's default view is the live work-list.
+//   - limit: max rows per page. Defaults to 50, capped at 200 (keeps
+//     a single response payload bounded for the SPA).
+//   - offset: zero-based offset for pagination. Defaults to 0. We do
+//     not yet support cursor-based pagination — created_at ASC + offset
+//     is sufficient for the MVP volumes.
+//
+// Returns 400 on invalid status / negative limit / non-numeric inputs.
+// The platform-admin gate runs upstream so 401/403 are already handled.
+func (h *AdminMarketplaceHandler) ListReports(c *gin.Context) {
+	statusStr := c.DefaultQuery("status", string(marketplace.ReportStatusOpen))
+	status := marketplace.ReportStatus(statusStr)
+	if !status.IsValid() {
+		_ = c.Error(apierror.NewBadRequest("invalid status query parameter"))
+		c.Abort()
+		return
+	}
+
+	limit, err := parsePageInt(c, "limit", 50, 200)
+	if err != nil {
+		_ = c.Error(err)
+		c.Abort()
+		return
+	}
+	offset, err := parsePageInt(c, "offset", 0, 1_000_000)
+	if err != nil {
+		_ = c.Error(err)
+		c.Abort()
+		return
+	}
+
+	reports, err := h.svc.ListReports(c.Request.Context(), status, limit, offset)
+	if err != nil {
+		_ = c.Error(err)
+		c.Abort()
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"reports": reports,
+		"limit":   limit,
+		"offset":  offset,
+	})
+}
+
+// Approve handles POST /api/v1/admin/marketplace/reports/:id/approve.
+//
+// Runs the four-side-effect atomic transaction described in ADR-0006.
+// On success returns {takedown_id, target_kb_id, strikes_after} so the
+// SPA can update the queue row + show a strike-count toast in one
+// round-trip.
+//
+// 404 when the report is missing; 409 on an illegal state-machine
+// transition (the row is already resolved/dismissed); 500 otherwise.
+func (h *AdminMarketplaceHandler) Approve(c *gin.Context) {
+	reportID, err := parseReportID(c)
+	if err != nil {
+		_ = c.Error(err)
+		c.Abort()
+		return
+	}
+
+	result, err := h.svc.Approve(c.Request.Context(), reportID)
+	if err != nil {
+		_ = c.Error(translateModerationError(err))
+		c.Abort()
+		return
+	}
+	c.JSON(http.StatusOK, result)
+}
+
+// Dismiss handles POST /api/v1/admin/marketplace/reports/:id/dismiss.
+//
+// 404 / 409 / 500 mapping identical to Approve. No body on success
+// beyond the canonical {report_id, status: 'dismissed'} echo so the SPA
+// can confirm the action without a follow-up GET.
+func (h *AdminMarketplaceHandler) Dismiss(c *gin.Context) {
+	reportID, err := parseReportID(c)
+	if err != nil {
+		_ = c.Error(err)
+		c.Abort()
+		return
+	}
+
+	if err := h.svc.Dismiss(c.Request.Context(), reportID); err != nil {
+		_ = c.Error(translateModerationError(err))
+		c.Abort()
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"report_id": reportID,
+		"status":    marketplace.ReportStatusDismissed,
+	})
+}
+
+// parseReportID pulls :id from the URL and validates it is a UUID.
+// Returns a 400 AppError on malformed input.
+func parseReportID(c *gin.Context) (uuid.UUID, error) {
+	raw := c.Param("id")
+	id, err := uuid.Parse(raw)
+	if err != nil {
+		return uuid.Nil, apierror.NewBadRequest("invalid report id")
+	}
+	return id, nil
+}
+
+// parsePageInt reads an optional integer query parameter. Returns the
+// default when missing, an error when present-but-malformed, and clamps
+// at the supplied max so a degenerate ?limit=2147483647 cannot blow up
+// a pgx prepared statement.
+func parsePageInt(c *gin.Context, name string, def, max int) (int, error) {
+	raw := c.Query(name)
+	if raw == "" {
+		return def, nil
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, apierror.NewBadRequest("invalid " + name + " query parameter")
+	}
+	if n < 0 {
+		return 0, apierror.NewBadRequest(name + " must be non-negative")
+	}
+	if n > max {
+		n = max
+	}
+	return n, nil
+}
+
+// translateModerationError maps marketplace sentinel errors to API
+// errors so the handler doesn't need a manual switch in every method.
+// Anything unknown becomes an opaque 500.
+func translateModerationError(err error) error {
+	switch {
+	case errors.Is(err, marketplace.ErrReportNotFound):
+		return apierror.NewNotFound("report not found")
+	case errors.Is(err, marketplace.ErrIllegalTransition):
+		return apierror.NewConflict("illegal report status transition")
+	case errors.Is(err, marketplace.ErrInvalidReportStatus):
+		return apierror.NewBadRequest("invalid report status")
+	default:
+		return err
+	}
+}

--- a/internal/handler/admin_marketplace_test.go
+++ b/internal/handler/admin_marketplace_test.go
@@ -1,0 +1,237 @@
+package handler_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/ravencloak-org/Raven/internal/handler"
+	"github.com/ravencloak-org/Raven/internal/marketplace"
+	"github.com/ravencloak-org/Raven/pkg/apierror"
+)
+
+// stubAdminSvc implements handler.AdminMarketplaceService with
+// programmable behaviour for unit tests. Replaces a real
+// *marketplace.AdminModeration so we don't need a Postgres testcontainer
+// for handler-layer error-mapping tests.
+type stubAdminSvc struct {
+	listResult []marketplace.Report
+	listErr    error
+
+	approveResult marketplace.ApproveResult
+	approveErr    error
+
+	dismissErr error
+
+	gotID uuid.UUID
+}
+
+func (s *stubAdminSvc) ListReports(_ context.Context, _ marketplace.ReportStatus, _, _ int) ([]marketplace.Report, error) {
+	return s.listResult, s.listErr
+}
+func (s *stubAdminSvc) Approve(_ context.Context, id uuid.UUID) (marketplace.ApproveResult, error) {
+	s.gotID = id
+	return s.approveResult, s.approveErr
+}
+func (s *stubAdminSvc) Dismiss(_ context.Context, id uuid.UUID) error {
+	s.gotID = id
+	return s.dismissErr
+}
+
+// newTestRouter wires the admin handler onto a minimal gin engine.
+// Skips auth middleware — the platform-admin gate is unit-tested
+// separately in internal/middleware. apierror.ErrorHandler is mounted
+// so c.Error -> AppError -> JSON response flows the same as production.
+func newTestRouter(t *testing.T, svc handler.AdminMarketplaceService) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(apierror.ErrorHandler())
+	h := handler.NewAdminMarketplaceHandler(svc)
+	r.GET("/admin/marketplace/reports", h.ListReports)
+	r.POST("/admin/marketplace/reports/:id/approve", h.Approve)
+	r.POST("/admin/marketplace/reports/:id/dismiss", h.Dismiss)
+	return r
+}
+
+func TestListReports_HappyPath(t *testing.T) {
+	t.Parallel()
+	rep := marketplace.Report{ID: uuid.New(), ReportedKBID: uuid.New(), Reason: "spam", Status: marketplace.ReportStatusOpen}
+	svc := &stubAdminSvc{listResult: []marketplace.Report{rep}}
+	r := newTestRouter(t, svc)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet,"/admin/marketplace/reports?status=open&limit=10", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d (body=%s)", w.Code, w.Body.String())
+	}
+	var got struct {
+		Reports []marketplace.Report `json:"reports"`
+		Limit   int                  `json:"limit"`
+		Offset  int                  `json:"offset"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Reports) != 1 || got.Reports[0].ID != rep.ID {
+		t.Errorf("unexpected reports payload: %+v", got)
+	}
+	if got.Limit != 10 || got.Offset != 0 {
+		t.Errorf("pagination echo: limit=%d offset=%d", got.Limit, got.Offset)
+	}
+}
+
+func TestListReports_InvalidStatus(t *testing.T) {
+	t.Parallel()
+	r := newTestRouter(t, &stubAdminSvc{})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet,"/admin/marketplace/reports?status=bogus", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status: want 400, got %d (body=%s)", w.Code, w.Body.String())
+	}
+}
+
+func TestListReports_InvalidLimit(t *testing.T) {
+	t.Parallel()
+	r := newTestRouter(t, &stubAdminSvc{})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet,"/admin/marketplace/reports?limit=abc", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status: want 400, got %d", w.Code)
+	}
+}
+
+func TestApprove_HappyPath(t *testing.T) {
+	t.Parallel()
+	want := marketplace.ApproveResult{
+		TakedownID:   uuid.New(),
+		TargetKBID:   uuid.New(),
+		StrikesAfter: 2,
+	}
+	svc := &stubAdminSvc{approveResult: want}
+	r := newTestRouter(t, svc)
+
+	reportID := uuid.New()
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost,"/admin/marketplace/reports/"+reportID.String()+"/approve", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d (body=%s)", w.Code, w.Body.String())
+	}
+	if svc.gotID != reportID {
+		t.Errorf("service called with wrong id: got %s, want %s", svc.gotID, reportID)
+	}
+	var got marketplace.ApproveResult
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got != want {
+		t.Errorf("body: got %+v, want %+v", got, want)
+	}
+}
+
+func TestApprove_BadUUID(t *testing.T) {
+	t.Parallel()
+	r := newTestRouter(t, &stubAdminSvc{})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost,"/admin/marketplace/reports/not-a-uuid/approve", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status: want 400, got %d", w.Code)
+	}
+}
+
+func TestApprove_NotFound(t *testing.T) {
+	t.Parallel()
+	svc := &stubAdminSvc{approveErr: marketplace.ErrReportNotFound}
+	r := newTestRouter(t, svc)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost,"/admin/marketplace/reports/"+uuid.NewString()+"/approve", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status: want 404, got %d (body=%s)", w.Code, w.Body.String())
+	}
+}
+
+func TestApprove_IllegalTransition_409(t *testing.T) {
+	t.Parallel()
+	svc := &stubAdminSvc{approveErr: errors.Join(marketplace.ErrIllegalTransition, errors.New("from=resolved to=resolved"))}
+	r := newTestRouter(t, svc)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost,"/admin/marketplace/reports/"+uuid.NewString()+"/approve", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("status: want 409, got %d (body=%s)", w.Code, w.Body.String())
+	}
+}
+
+func TestDismiss_HappyPath(t *testing.T) {
+	t.Parallel()
+	svc := &stubAdminSvc{}
+	r := newTestRouter(t, svc)
+
+	reportID := uuid.New()
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost,"/admin/marketplace/reports/"+reportID.String()+"/dismiss", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d", w.Code)
+	}
+	if svc.gotID != reportID {
+		t.Errorf("service called with wrong id: got %s", svc.gotID)
+	}
+	if !strings.Contains(w.Body.String(), `"status":"dismissed"`) {
+		t.Errorf("expected dismissed echo, got body=%s", w.Body.String())
+	}
+}
+
+func TestDismiss_NotFound(t *testing.T) {
+	t.Parallel()
+	svc := &stubAdminSvc{dismissErr: marketplace.ErrReportNotFound}
+	r := newTestRouter(t, svc)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost,"/admin/marketplace/reports/"+uuid.NewString()+"/dismiss", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status: want 404, got %d (body=%s)", w.Code, w.Body.String())
+	}
+}
+
+func TestDismiss_IllegalTransition_409(t *testing.T) {
+	t.Parallel()
+	svc := &stubAdminSvc{dismissErr: marketplace.ErrIllegalTransition}
+	r := newTestRouter(t, svc)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost,"/admin/marketplace/reports/"+uuid.NewString()+"/dismiss", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("status: want 409, got %d (body=%s)", w.Code, w.Body.String())
+	}
+}

--- a/internal/handler/user.go
+++ b/internal/handler/user.go
@@ -20,12 +20,22 @@ type UserServicer interface {
 
 // UserHandler handles HTTP requests for user management.
 type UserHandler struct {
-	svc UserServicer
+	svc          UserServicer
+	adminEmails  []string
 }
 
 // NewUserHandler creates a new UserHandler.
 func NewUserHandler(svc UserServicer) *UserHandler {
 	return &UserHandler{svc: svc}
+}
+
+// WithAdminEmails attaches the platform-admin allow-list so GET /me can
+// expose `is_platform_admin: true` for the SPA. Returns the receiver
+// so the wire-up in main.go stays a single chain. Optional — when not
+// called, GetMe still works but never reports admin (safe default).
+func (h *UserHandler) WithAdminEmails(emails []string) *UserHandler {
+	h.adminEmails = emails
+	return h
 }
 
 // GetMe handles GET /api/v1/me.
@@ -52,7 +62,24 @@ func (h *UserHandler) GetMe(c *gin.Context) {
 		c.Abort()
 		return
 	}
-	c.JSON(http.StatusOK, user)
+
+	// Echo platform-admin status so the SPA can decide whether to render
+	// the /admin/marketplace nav. The middleware enforcement on the
+	// admin endpoints is the authoritative gate; this flag is presentation
+	// only — a tampered client cannot escalate by setting it locally.
+	c.JSON(http.StatusOK, meResponse{
+		User:            user,
+		IsPlatformAdmin: middleware.IsPlatformAdmin(user.Email, h.adminEmails),
+	})
+}
+
+// meResponse is the wire shape for GET /api/v1/me. Embedding model.User
+// keeps the existing field set forward-compatible (any new column the
+// service exposes ships automatically) while adding the platform-admin
+// echo for the SPA's route guard.
+type meResponse struct {
+	*model.User
+	IsPlatformAdmin bool `json:"is_platform_admin"`
 }
 
 // UpdateMe handles PUT /api/v1/me.

--- a/internal/marketplace/admin_moderation.go
+++ b/internal/marketplace/admin_moderation.go
@@ -1,0 +1,309 @@
+// Package marketplace — admin_moderation: the report-driven approve/dismiss
+// service. Implements the four-side-effect atomic Approve and the trivial
+// Dismiss for the admin review queue (#734, ADR-0006, ADR-0008).
+//
+// Why a dedicated file:
+//
+//   - reports.go and takedowns.go are repository-shaped (one table each,
+//     one statement per method). The admin approve action crosses both
+//     tables PLUS knowledge_bases.visibility PLUS organizations
+//     .takedown_strikes. Putting that multi-table orchestration inside
+//     either repo blurs the layering.
+//   - The admin path uses SET LOCAL ROLE raven_admin to satisfy the
+//     admin-only RLS policies. Bundling that ceremony into the repo
+//     methods would force every other caller (reporter creating a
+//     report, etc.) to know about the role-switch.
+//
+// The handler layer (HTTP boundary) enforces who is allowed to call
+// these methods; this layer trusts the caller and focuses on atomicity.
+package marketplace
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// PublisherNotifier sends the "your KB was taken down" email per
+// ADR-0006. The default no-op implementation lets the admin endpoint
+// ship before the email pipeline is wired (M9 SES + summaries handles
+// general transactional mail).
+//
+// Notify is best-effort: the admin endpoint logs failures and returns
+// success because the takedown itself has already committed. Productionising
+// this should swap the no-op for an Asynq enqueue with the
+// marketplace_takedown_notifier handler (plan §3 / §M3) so the email
+// retries with dead-letter on persistent failure.
+type PublisherNotifier interface {
+	NotifyTakedown(ctx context.Context, kbID uuid.UUID, reason string) error
+}
+
+// noopPublisherNotifier is the safe default. Logs a TODO once so an
+// operator can see that the email side-effect isn't actually being sent.
+type noopPublisherNotifier struct{}
+
+// NotifyTakedown is a no-op that logs the would-be email at INFO. We
+// log at INFO not WARN because this is an expected state until the
+// email pipeline is wired — a WARN would fire on every approve and
+// drown legitimate alerts.
+func (noopPublisherNotifier) NotifyTakedown(ctx context.Context, kbID uuid.UUID, reason string) error {
+	slog.InfoContext(ctx, "marketplace: TODO wire publisher takedown email",
+		"kb_id", kbID, "reason_len", len(reason))
+	return nil
+}
+
+// NewNoopPublisherNotifier returns the default no-op notifier. Exported
+// so cmd/api/main.go can wire it explicitly (the explicit wire is
+// preferable to a nil-default that surprises a reader scanning main.go
+// for "what notifies the publisher?").
+func NewNoopPublisherNotifier() PublisherNotifier {
+	return noopPublisherNotifier{}
+}
+
+// AdminModeration handles the admin review-queue write paths: approve
+// (escalate to takedown) and dismiss (close without action).
+//
+// All methods assume the caller has already been gated by the HTTP-layer
+// platform-admin middleware. The service trusts that gate; double-gating
+// here would couple the service to the auth model.
+type AdminModeration struct {
+	pool      *pgxpool.Pool
+	reports   *Reports
+	takedowns *Takedowns
+	notifier  PublisherNotifier
+}
+
+// NewAdminModeration constructs an AdminModeration service. A nil notifier
+// is treated as the no-op notifier — callers that want a real notifier
+// must wire one explicitly.
+func NewAdminModeration(pool *pgxpool.Pool, reports *Reports, takedowns *Takedowns, notifier PublisherNotifier) *AdminModeration {
+	if notifier == nil {
+		notifier = noopPublisherNotifier{}
+	}
+	return &AdminModeration{
+		pool:      pool,
+		reports:   reports,
+		takedowns: takedowns,
+		notifier:  notifier,
+	}
+}
+
+// ApproveResult is what the admin endpoint returns on a successful
+// Approve. Fields match the response shape in plan §4.
+type ApproveResult struct {
+	// TakedownID is the primary key of the freshly inserted
+	// marketplace_takedowns row.
+	TakedownID uuid.UUID `json:"takedown_id"`
+	// TargetKBID is the KB that was unpublished.
+	TargetKBID uuid.UUID `json:"target_kb_id"`
+	// StrikesAfter is the publisher Org's takedown_strikes value after
+	// the increment. The frontend uses this to decide whether to surface
+	// a "third strike — suspension review required" banner per ADR-0006.
+	StrikesAfter int64 `json:"strikes_after"`
+}
+
+// Approve runs the four-side-effect atomic transaction described in
+// ADR-0006: drive the report through open -> reviewing -> resolved,
+// write a `source='admin'` takedown row, flip the target KB to
+// `visibility='private'`, and increment the publisher Org's
+// `takedown_strikes`. All four happen in a single transaction; if any
+// step fails the whole thing rolls back.
+//
+// The publisher email is sent OUTSIDE the transaction. The justification:
+//   - The DB transaction is the source of truth. Once committed, the
+//     takedown is real regardless of whether the email goes out.
+//   - SMTP latency under a held DB transaction would extend lock-hold
+//     time for no benefit.
+//   - Email failure must not roll back a confirmed takedown — the
+//     publisher is still entitled to know, just via a retry-able async
+//     path. Productionising swaps the inline call for an Asynq enqueue.
+//
+// Errors:
+//   - ErrReportNotFound: id does not exist.
+//   - ErrIllegalTransition: report has already been resolved/dismissed
+//     and cannot be approved again. HTTP layer surfaces this as 409.
+//   - Any pgx error from the underlying round-trips.
+func (s *AdminModeration) Approve(ctx context.Context, reportID uuid.UUID) (ApproveResult, error) {
+	var result ApproveResult
+	var reasonForEmail string
+
+	if err := s.runAdminTx(ctx, func(tx pgx.Tx) error {
+		// 1. Load the report so we have target_kb_id + reason for the
+		//    takedown row + email. Done first under FOR-UPDATE-equivalent
+		//    semantics in step 3 below — here we just need the body.
+		rep, err := s.reports.GetByID(ctx, tx, reportID)
+		if err != nil {
+			return err
+		}
+		reasonForEmail = rep.Reason
+
+		// 2. Move report through the state machine. open -> reviewing,
+		//    then reviewing -> resolved. Two transitions because the
+		//    state-machine table (moderation.go) enforces open is not
+		//    directly terminal-reachable — that invariant is shared with
+		//    the DB CHECK and we honour it here rather than special-casing
+		//    the admin path. FOR UPDATE inside TransitionInTx prevents a
+		//    concurrent Approve race.
+		if err := s.reports.TransitionInTx(ctx, tx, reportID, ReportStatusReviewing); err != nil {
+			return err
+		}
+		if err := s.reports.TransitionInTx(ctx, tx, reportID, ReportStatusResolved); err != nil {
+			return err
+		}
+
+		// 3. Flip the target KB to private. The UPDATE + RETURNING
+		//    pattern verifies the KB still exists (a concurrent hard-
+		//    delete during review would surface as ErrNoRows here and
+		//    roll the whole tx back) and gives us the org_id we need to
+		//    increment strikes against. RLS is bypassed because we are
+		//    under SET LOCAL ROLE raven_admin.
+		var publisherOrgID uuid.UUID
+		if err := tx.QueryRow(ctx,
+			`UPDATE knowledge_bases
+			    SET visibility = 'private'
+			  WHERE id = $1
+			  RETURNING org_id`,
+			rep.ReportedKBID,
+		).Scan(&publisherOrgID); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return fmt.Errorf("Approve: target KB %s missing: %w", rep.ReportedKBID, ErrReportNotFound)
+			}
+			return fmt.Errorf("Approve: unpublish KB: %w", err)
+		}
+
+		// 4. Increment the publisher Org's strike counter. RETURNING the
+		//    new value gives the handler something to display in the
+		//    "this was their N-th strike" banner.
+		if err := tx.QueryRow(ctx,
+			`UPDATE organizations
+			    SET takedown_strikes = takedown_strikes + 1
+			  WHERE id = $1
+			  RETURNING takedown_strikes`,
+			publisherOrgID,
+		).Scan(&result.StrikesAfter); err != nil {
+			return fmt.Errorf("Approve: increment strikes: %w", err)
+		}
+
+		// 5. Write the takedown audit-log row. Last in the chain so that
+		//    if any earlier step had rolled back, no orphan audit row
+		//    exists.
+		td, err := s.takedowns.CreateInTx(ctx, tx, rep.ReportedKBID, TakedownSourceAdmin, rep.Reason)
+		if err != nil {
+			return fmt.Errorf("Approve: takedown insert: %w", err)
+		}
+		result.TakedownID = td.ID
+		result.TargetKBID = td.TargetKBID
+		return nil
+	}); err != nil {
+		return ApproveResult{}, err
+	}
+
+	// Email is best-effort and runs OUTSIDE the transaction. A logged
+	// failure here is acceptable — the takedown has committed.
+	if err := s.notifier.NotifyTakedown(ctx, result.TargetKBID, reasonForEmail); err != nil {
+		slog.WarnContext(ctx, "marketplace: publisher takedown notification failed",
+			"kb_id", result.TargetKBID, "error", err)
+	}
+
+	return result, nil
+}
+
+// Dismiss drives the report through open -> reviewing -> dismissed.
+// No takedown, no strike, no email — ADR-0006 explicitly says the
+// reporter is NOT notified of dismissal (harassment-vector protection).
+//
+// Same error vocabulary as Approve.
+func (s *AdminModeration) Dismiss(ctx context.Context, reportID uuid.UUID) error {
+	return s.runAdminTx(ctx, func(tx pgx.Tx) error {
+		if err := s.reports.TransitionInTx(ctx, tx, reportID, ReportStatusReviewing); err != nil {
+			return err
+		}
+		return s.reports.TransitionInTx(ctx, tx, reportID, ReportStatusDismissed)
+	})
+}
+
+// runAdminTx opens a transaction, switches to the raven_admin role
+// (required for the admin-bypass RLS policies on marketplace_reports
+// and marketplace_takedowns), runs fn, and commits. Rolls back on any
+// returned error.
+//
+// SET LOCAL is used (not SET) so the role reverts to the pool
+// connection's default when the transaction ends — no leaked admin
+// privilege on the next caller to grab this connection.
+func (s *AdminModeration) runAdminTx(ctx context.Context, fn func(pgx.Tx) error) error {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("admin tx begin: %w", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	if _, err := tx.Exec(ctx, "SET LOCAL ROLE raven_admin"); err != nil {
+		return fmt.Errorf("admin tx set role: %w", err)
+	}
+
+	if err := fn(tx); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+// ListReports is the admin-only paginated review queue read. Wraps
+// Reports.List but runs the query under SET LOCAL ROLE raven_admin
+// so the admin_bypass RLS policy lets the SELECT see every reporter's
+// rows.
+//
+// The handler layer takes (status, limit, offset) from the query string
+// and forwards them. status validation is delegated to Reports.List.
+func (s *AdminModeration) ListReports(ctx context.Context, status ReportStatus, limit, offset int) ([]Report, error) {
+	if !status.IsValid() {
+		return nil, ErrInvalidReportStatus
+	}
+	if limit <= 0 {
+		return nil, fmt.Errorf("AdminModeration.ListReports: limit must be positive, got %d", limit)
+	}
+	if offset < 0 {
+		return nil, fmt.Errorf("AdminModeration.ListReports: offset must be non-negative, got %d", offset)
+	}
+
+	var out []Report
+	if err := s.runAdminTx(ctx, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx,
+			`SELECT id, reported_kb_id, reporter_user_id, reason, status, created_at
+			 FROM marketplace_reports
+			 WHERE status = $1
+			 ORDER BY created_at ASC
+			 LIMIT $2 OFFSET $3`,
+			status, limit, offset,
+		)
+		if err != nil {
+			return fmt.Errorf("AdminModeration.ListReports: query: %w", err)
+		}
+		defer rows.Close()
+
+		out = make([]Report, 0, limit)
+		for rows.Next() {
+			var rep Report
+			var reporter uuid.NullUUID
+			if err := rows.Scan(
+				&rep.ID, &rep.ReportedKBID, &reporter,
+				&rep.Reason, &rep.Status, &rep.CreatedAt,
+			); err != nil {
+				return fmt.Errorf("AdminModeration.ListReports: scan: %w", err)
+			}
+			if reporter.Valid {
+				uid := reporter.UUID
+				rep.ReporterUserID = &uid
+			}
+			out = append(out, rep)
+		}
+		return rows.Err()
+	}); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/internal/marketplace/admin_moderation_integration_test.go
+++ b/internal/marketplace/admin_moderation_integration_test.go
@@ -1,0 +1,260 @@
+// Integration tests for AdminModeration. Cover the four-side-effect
+// atomic approve, the dismiss path, and the failure-rollback guarantee
+// that makes the "transaction or nothing" promise testable.
+//
+// Skipped under `go test -short` so the fast unit loop stays free of
+// testcontainers (matches the convention used by moderation_integration_test.go).
+
+package marketplace_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/ravencloak-org/Raven/internal/marketplace"
+	"github.com/ravencloak-org/Raven/internal/testutil"
+)
+
+// kbVisibility reads the current visibility of the given KB row. Helper
+// for assertions across the integration tests below.
+func kbVisibility(ctx context.Context, t *testing.T, pool *pgxpool.Pool, kbID uuid.UUID) string {
+	t.Helper()
+	var v string
+	if err := pool.QueryRow(ctx, `SELECT visibility FROM knowledge_bases WHERE id = $1`, kbID).Scan(&v); err != nil {
+		t.Fatalf("read KB visibility: %v", err)
+	}
+	return v
+}
+
+// orgStrikes reads the publisher Org's takedown_strikes counter.
+func orgStrikes(ctx context.Context, t *testing.T, pool *pgxpool.Pool, orgID uuid.UUID) int64 {
+	t.Helper()
+	var n int64
+	if err := pool.QueryRow(ctx, `SELECT takedown_strikes FROM organizations WHERE id = $1`, orgID).Scan(&n); err != nil {
+		t.Fatalf("read strikes: %v", err)
+	}
+	return n
+}
+
+// countTakedowns returns the count of takedown rows for a KB.
+func countTakedowns(ctx context.Context, t *testing.T, pool *pgxpool.Pool, kbID uuid.UUID) int {
+	t.Helper()
+	var n int
+	if err := pool.QueryRow(ctx, `SELECT COUNT(*) FROM marketplace_takedowns WHERE target_kb_id = $1`, kbID).Scan(&n); err != nil {
+		t.Fatalf("count takedowns: %v", err)
+	}
+	return n
+}
+
+// reportStatus reads the current status of a report by id.
+func reportStatus(ctx context.Context, t *testing.T, pool *pgxpool.Pool, id uuid.UUID) marketplace.ReportStatus {
+	t.Helper()
+	var s string
+	if err := pool.QueryRow(ctx, `SELECT status FROM marketplace_reports WHERE id = $1`, id).Scan(&s); err != nil {
+		t.Fatalf("read report status: %v", err)
+	}
+	return marketplace.ReportStatus(s)
+}
+
+// TestAdminModeration_Approve_FourSideEffectsAtomic is the headline
+// integration test for #734. Asserts every one of the four side effects
+// described in ADR-0006 commits together: report→resolved, takedown row,
+// KB→private, strikes+1.
+func TestAdminModeration_Approve_FourSideEffectsAtomic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+	f := seedModFixture(ctx, t, pool, "approve")
+
+	// Seed a single report against the fixture KB.
+	reports := marketplace.NewReports(pool)
+	takedowns := marketplace.NewTakedowns(pool)
+	rep, err := reports.Create(ctx, f.KBID, f.UserID, "copyright violation")
+	if err != nil {
+		t.Fatalf("seed report: %v", err)
+	}
+
+	beforeStrikes := orgStrikes(ctx, t, pool, f.OrgID)
+	if v := kbVisibility(ctx, t, pool, f.KBID); v != "private" {
+		// fixture seeds without visibility, so default is 'private'.
+		// First, simulate it being published so the approve flip is observable.
+		if _, err := pool.Exec(ctx, `UPDATE knowledge_bases SET visibility='public' WHERE id=$1`, f.KBID); err != nil {
+			t.Fatalf("publish KB: %v", err)
+		}
+		_ = v
+	}
+
+	svc := marketplace.NewAdminModeration(pool, reports, takedowns, marketplace.NewNoopPublisherNotifier())
+	result, err := svc.Approve(ctx, rep.ID)
+	if err != nil {
+		t.Fatalf("Approve: %v", err)
+	}
+
+	// 1. Report -> resolved.
+	if got := reportStatus(ctx, t, pool, rep.ID); got != marketplace.ReportStatusResolved {
+		t.Errorf("report status: want %q, got %q", marketplace.ReportStatusResolved, got)
+	}
+
+	// 2. Takedown row exists for this KB.
+	if got := countTakedowns(ctx, t, pool, f.KBID); got != 1 {
+		t.Errorf("takedown rows: want 1, got %d", got)
+	}
+
+	// 3. KB visibility flipped to private.
+	if v := kbVisibility(ctx, t, pool, f.KBID); v != "private" {
+		t.Errorf("KB visibility: want private, got %q", v)
+	}
+
+	// 4. Strikes incremented by exactly 1.
+	if got, want := orgStrikes(ctx, t, pool, f.OrgID), beforeStrikes+1; got != want {
+		t.Errorf("strikes: want %d, got %d", want, got)
+	}
+
+	// 5. Result body fields match.
+	if result.TargetKBID != f.KBID {
+		t.Errorf("result.TargetKBID: want %s, got %s", f.KBID, result.TargetKBID)
+	}
+	if result.StrikesAfter != beforeStrikes+1 {
+		t.Errorf("result.StrikesAfter: want %d, got %d", beforeStrikes+1, result.StrikesAfter)
+	}
+	if result.TakedownID == uuid.Nil {
+		t.Errorf("result.TakedownID should be set")
+	}
+}
+
+// TestAdminModeration_Approve_AlreadyResolvedReturnsIllegalTransition
+// pins the 409 mapping at the service boundary — the second admin
+// click on the same report should not double-strike.
+func TestAdminModeration_Approve_AlreadyResolvedReturnsIllegalTransition(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+	f := seedModFixture(ctx, t, pool, "double")
+
+	if _, err := pool.Exec(ctx, `UPDATE knowledge_bases SET visibility='public' WHERE id=$1`, f.KBID); err != nil {
+		t.Fatalf("publish KB: %v", err)
+	}
+
+	reports := marketplace.NewReports(pool)
+	takedowns := marketplace.NewTakedowns(pool)
+	rep, err := reports.Create(ctx, f.KBID, f.UserID, "first")
+	if err != nil {
+		t.Fatalf("seed report: %v", err)
+	}
+
+	svc := marketplace.NewAdminModeration(pool, reports, takedowns, marketplace.NewNoopPublisherNotifier())
+	if _, err := svc.Approve(ctx, rep.ID); err != nil {
+		t.Fatalf("first Approve: %v", err)
+	}
+	strikesAfterFirst := orgStrikes(ctx, t, pool, f.OrgID)
+
+	// Second approve must be rejected and must NOT increment strikes.
+	_, err = svc.Approve(ctx, rep.ID)
+	if !errors.Is(err, marketplace.ErrIllegalTransition) {
+		t.Errorf("second Approve: want ErrIllegalTransition, got %v", err)
+	}
+	if got := orgStrikes(ctx, t, pool, f.OrgID); got != strikesAfterFirst {
+		t.Errorf("strikes after duplicate approve: want %d, got %d", strikesAfterFirst, got)
+	}
+}
+
+// TestAdminModeration_Approve_MissingReportReturns404 pins the not-found
+// error path so the HTTP handler can rely on the sentinel.
+func TestAdminModeration_Approve_MissingReportReturns404(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+
+	reports := marketplace.NewReports(pool)
+	takedowns := marketplace.NewTakedowns(pool)
+	svc := marketplace.NewAdminModeration(pool, reports, takedowns, marketplace.NewNoopPublisherNotifier())
+
+	_, err := svc.Approve(ctx, uuid.New())
+	if !errors.Is(err, marketplace.ErrReportNotFound) {
+		t.Errorf("missing report: want ErrReportNotFound, got %v", err)
+	}
+}
+
+// TestAdminModeration_Dismiss_HappyPath drives a report to dismissed
+// and asserts no side effects (no takedown, no strike, KB untouched).
+func TestAdminModeration_Dismiss_HappyPath(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+	f := seedModFixture(ctx, t, pool, "dismiss")
+
+	if _, err := pool.Exec(ctx, `UPDATE knowledge_bases SET visibility='public' WHERE id=$1`, f.KBID); err != nil {
+		t.Fatalf("publish KB: %v", err)
+	}
+
+	reports := marketplace.NewReports(pool)
+	takedowns := marketplace.NewTakedowns(pool)
+	rep, err := reports.Create(ctx, f.KBID, f.UserID, "false positive")
+	if err != nil {
+		t.Fatalf("seed report: %v", err)
+	}
+	beforeStrikes := orgStrikes(ctx, t, pool, f.OrgID)
+
+	svc := marketplace.NewAdminModeration(pool, reports, takedowns, marketplace.NewNoopPublisherNotifier())
+	if err := svc.Dismiss(ctx, rep.ID); err != nil {
+		t.Fatalf("Dismiss: %v", err)
+	}
+
+	if got := reportStatus(ctx, t, pool, rep.ID); got != marketplace.ReportStatusDismissed {
+		t.Errorf("report status: want dismissed, got %q", got)
+	}
+	if got := countTakedowns(ctx, t, pool, f.KBID); got != 0 {
+		t.Errorf("takedowns: want 0, got %d", got)
+	}
+	if v := kbVisibility(ctx, t, pool, f.KBID); v != "public" {
+		t.Errorf("KB visibility: want public (untouched), got %q", v)
+	}
+	if got := orgStrikes(ctx, t, pool, f.OrgID); got != beforeStrikes {
+		t.Errorf("strikes: want %d (unchanged), got %d", beforeStrikes, got)
+	}
+}
+
+// TestAdminModeration_ListReports filters by status and returns the
+// matching rows in created_at ASC order.
+func TestAdminModeration_ListReports(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+	f := seedModFixture(ctx, t, pool, "list")
+
+	reports := marketplace.NewReports(pool)
+	takedowns := marketplace.NewTakedowns(pool)
+	if _, err := reports.Create(ctx, f.KBID, f.UserID, "first"); err != nil {
+		t.Fatalf("seed report 1: %v", err)
+	}
+	if _, err := reports.Create(ctx, f.KBID, f.UserID, "second"); err != nil {
+		t.Fatalf("seed report 2: %v", err)
+	}
+
+	svc := marketplace.NewAdminModeration(pool, reports, takedowns, marketplace.NewNoopPublisherNotifier())
+	got, err := svc.ListReports(ctx, marketplace.ReportStatusOpen, 100, 0)
+	if err != nil {
+		t.Fatalf("ListReports: %v", err)
+	}
+	if len(got) < 2 {
+		t.Errorf("want >= 2 open reports, got %d", len(got))
+	}
+}

--- a/internal/marketplace/reports.go
+++ b/internal/marketplace/reports.go
@@ -210,6 +210,78 @@ func (r *Reports) Transition(ctx context.Context, id uuid.UUID, newStatus Report
 	return nil
 }
 
+// TransitionInTx is the in-transaction sibling of Transition. The admin
+// approve path (#734) needs to atomically (a) move a report through
+// open -> reviewing -> resolved, (b) write the takedown audit row, (c)
+// flip the target KB to private, and (d) bump the publisher Org's strike
+// counter. Doing those as four separate Transition + side-effect calls
+// would let a crash mid-way leave the system in an inconsistent state
+// (KB flipped but report still open, or strike incremented without a
+// takedown row). Callers pass their own transaction so all four happen
+// or none do.
+//
+// Same state-machine rules as Transition. Same error vocabulary.
+//
+// The caller is responsible for: opening the tx, switching role to
+// raven_admin if the row is admin-gated by RLS, and committing.
+func (r *Reports) TransitionInTx(ctx context.Context, tx pgx.Tx, id uuid.UUID, newStatus ReportStatus) error {
+	if !newStatus.IsValid() {
+		return ErrInvalidReportStatus
+	}
+
+	var current ReportStatus
+	if err := tx.QueryRow(ctx,
+		`SELECT status FROM marketplace_reports WHERE id = $1 FOR UPDATE`,
+		id,
+	).Scan(&current); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrReportNotFound
+		}
+		return fmt.Errorf("Reports.TransitionInTx: load current: %w", err)
+	}
+
+	if !current.IsValid() {
+		return fmt.Errorf("%w: stored value %q", ErrInvalidReportStatus, current)
+	}
+
+	if !CanTransition(current, newStatus) {
+		return fmt.Errorf("%w: from=%s to=%s", ErrIllegalTransition, current, newStatus)
+	}
+
+	if _, err := tx.Exec(ctx,
+		`UPDATE marketplace_reports SET status = $2 WHERE id = $1`,
+		id, newStatus,
+	); err != nil {
+		return fmt.Errorf("Reports.TransitionInTx: update: %w", err)
+	}
+	return nil
+}
+
+// GetByID fetches a single report by id under the caller's RLS context.
+// Used by the admin approve path to read the report's reason + target KB
+// before driving the state machine. Returns ErrReportNotFound when no
+// row is visible.
+func (r *Reports) GetByID(ctx context.Context, tx pgx.Tx, id uuid.UUID) (Report, error) {
+	var rep Report
+	var reporter uuid.NullUUID
+	if err := tx.QueryRow(ctx,
+		`SELECT id, reported_kb_id, reporter_user_id, reason, status, created_at
+		 FROM marketplace_reports
+		 WHERE id = $1`,
+		id,
+	).Scan(&rep.ID, &rep.ReportedKBID, &reporter, &rep.Reason, &rep.Status, &rep.CreatedAt); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Report{}, ErrReportNotFound
+		}
+		return Report{}, fmt.Errorf("Reports.GetByID: %w", err)
+	}
+	if reporter.Valid {
+		uid := reporter.UUID
+		rep.ReporterUserID = &uid
+	}
+	return rep, nil
+}
+
 // CountOpenForUser returns the number of reports in the OPEN state for
 // the given user. Exposed as a helper for callers that want to surface a
 // "you have N open reports" UI hint before submission — Create runs the

--- a/internal/marketplace/takedowns.go
+++ b/internal/marketplace/takedowns.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -57,6 +58,41 @@ func (t *Takedowns) Create(ctx context.Context, kbID uuid.UUID, source TakedownS
 		kbID, source, notesArg,
 	).Scan(&td.ID, &td.TargetKBID, &td.Source, &storedNotes, &td.CreatedAt); err != nil {
 		return Takedown{}, fmt.Errorf("Takedowns.Create: insert: %w", err)
+	}
+	if storedNotes != nil {
+		td.Notes = *storedNotes
+	}
+	return td, nil
+}
+
+// CreateInTx is the in-transaction sibling of Create. The admin approve
+// path (#734) batches the takedown write together with the report
+// transition, the KB visibility flip, and the strike increment so the
+// four side-effects commit atomically. See Reports.TransitionInTx for
+// the rationale.
+//
+// The caller is responsible for: opening the tx, switching role to
+// raven_admin (the table's RLS policy is admin-only), and committing.
+func (t *Takedowns) CreateInTx(ctx context.Context, tx pgx.Tx, kbID uuid.UUID, source TakedownSource, notes string) (Takedown, error) {
+	if !source.IsValid() {
+		return Takedown{}, ErrInvalidTakedownSource
+	}
+
+	var notesArg any
+	if notes != "" {
+		notesArg = notes
+	}
+
+	var td Takedown
+	var storedNotes *string
+	if err := tx.QueryRow(ctx,
+		`INSERT INTO marketplace_takedowns
+		   (target_kb_id, source, notes)
+		 VALUES ($1, $2, $3)
+		 RETURNING id, target_kb_id, source, notes, created_at`,
+		kbID, source, notesArg,
+	).Scan(&td.ID, &td.TargetKBID, &td.Source, &storedNotes, &td.CreatedAt); err != nil {
+		return Takedown{}, fmt.Errorf("Takedowns.CreateInTx: %w", err)
 	}
 	if storedNotes != nil {
 		td.Notes = *storedNotes

--- a/internal/middleware/platform_admin.go
+++ b/internal/middleware/platform_admin.go
@@ -1,0 +1,82 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/ravencloak-org/Raven/pkg/apierror"
+)
+
+// ContextKeyIsPlatformAdmin is the context key that the platform-admin
+// middleware sets to true when the caller passes the allow-list check.
+// Downstream handlers can branch on it without re-reading the env var.
+const ContextKeyIsPlatformAdmin contextKey = "is_platform_admin"
+
+// RequirePlatformAdmin returns a Gin handler that aborts with 403 unless
+// the caller's session email is in adminEmails. Returns 401 when no
+// session email is in context.
+//
+// ADR-0008 §line 35 mandates `raven_admin` as the only admin tier — no
+// granular admin roles in MVP. The allow-list is config-driven
+// (RAVEN_ADMIN_EMAILS) rather than DB-backed so revoking admin is a
+// config push, not a SQL UPDATE that might race a long-lived session.
+//
+// Case-insensitive comparison: email addresses are case-insensitive in
+// the local-part per RFC 5321 §2.3.11 in practice; matching strictly
+// would surprise an operator whose IdP normalises to lower-case.
+//
+// Empty adminEmails = nobody is admin (every request gets 403). That
+// is the safe default for environments where the env var has not been
+// set.
+func RequirePlatformAdmin(adminEmails []string) gin.HandlerFunc {
+	allow := make(map[string]struct{}, len(adminEmails))
+	for _, e := range adminEmails {
+		trimmed := strings.TrimSpace(strings.ToLower(e))
+		if trimmed != "" {
+			allow[trimmed] = struct{}{}
+		}
+	}
+
+	return func(c *gin.Context) {
+		emailVal, _ := c.Get(string(ContextKeyEmail))
+		email, _ := emailVal.(string)
+		if email == "" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, apierror.AppError{
+				Code:    http.StatusUnauthorized,
+				Message: "Unauthorized",
+				Detail:  "session required",
+			})
+			return
+		}
+		if _, ok := allow[strings.ToLower(email)]; !ok {
+			c.AbortWithStatusJSON(http.StatusForbidden, apierror.AppError{
+				Code:    http.StatusForbidden,
+				Message: "Forbidden",
+				Detail:  "platform admin required",
+			})
+			return
+		}
+		c.Set(string(ContextKeyIsPlatformAdmin), true)
+		c.Next()
+	}
+}
+
+// IsPlatformAdmin returns true when the caller's session email is in
+// adminEmails. Exported so non-middleware code paths (e.g. the GetMe
+// handler reporting `is_platform_admin` in the response so the frontend
+// can hide the admin nav) can run the same check without duplicating
+// the normalisation rules.
+func IsPlatformAdmin(email string, adminEmails []string) bool {
+	if email == "" {
+		return false
+	}
+	target := strings.ToLower(strings.TrimSpace(email))
+	for _, e := range adminEmails {
+		if strings.ToLower(strings.TrimSpace(e)) == target {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/middleware/platform_admin_test.go
+++ b/internal/middleware/platform_admin_test.go
@@ -1,0 +1,124 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/ravencloak-org/Raven/internal/middleware"
+)
+
+// newAdminRouter spins up a minimal gin router whose only protected
+// route is /protected gated by RequirePlatformAdmin(allow). The caller
+// provides the seed value for ContextKeyEmail so we can simulate any
+// session state.
+func newAdminRouter(t *testing.T, allow []string, email string) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		if email != "" {
+			c.Set(string(middleware.ContextKeyEmail), email)
+		}
+		c.Next()
+	})
+	r.GET("/protected", middleware.RequirePlatformAdmin(allow), func(c *gin.Context) {
+		isAdmin, _ := c.Get(string(middleware.ContextKeyIsPlatformAdmin))
+		gotBool, _ := isAdmin.(bool)
+		c.JSON(http.StatusOK, gin.H{"ok": true, "admin": gotBool})
+	})
+	return r
+}
+
+func do(t *testing.T, r *gin.Engine) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/protected", nil)
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// TestRequirePlatformAdmin_NoSession returns 401 when no session email
+// is set — the gate is upstream of session middleware but defends in
+// depth.
+func TestRequirePlatformAdmin_NoSession(t *testing.T) {
+	t.Parallel()
+	r := newAdminRouter(t, []string{"alice@example.com"}, "")
+	w := do(t, r)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status: want %d, got %d", http.StatusUnauthorized, w.Code)
+	}
+}
+
+// TestRequirePlatformAdmin_NotAllowed returns 403 when the session
+// email is present but not in the allow-list.
+func TestRequirePlatformAdmin_NotAllowed(t *testing.T) {
+	t.Parallel()
+	r := newAdminRouter(t, []string{"alice@example.com"}, "bob@example.com")
+	w := do(t, r)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status: want %d, got %d", http.StatusForbidden, w.Code)
+	}
+}
+
+// TestRequirePlatformAdmin_EmptyAllowList returns 403 for every caller
+// when the env var is unset. Safe default per ADR-0008.
+func TestRequirePlatformAdmin_EmptyAllowList(t *testing.T) {
+	t.Parallel()
+	r := newAdminRouter(t, nil, "alice@example.com")
+	w := do(t, r)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status: want %d, got %d", http.StatusForbidden, w.Code)
+	}
+}
+
+// TestRequirePlatformAdmin_HappyPath admits the listed email and sets
+// the ContextKeyIsPlatformAdmin flag so downstream handlers can branch.
+func TestRequirePlatformAdmin_HappyPath(t *testing.T) {
+	t.Parallel()
+	r := newAdminRouter(t, []string{"Alice@Example.com"}, "alice@example.com")
+	w := do(t, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("status: want 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), `"admin":true`) {
+		t.Errorf("expected admin=true in body, got %s", w.Body.String())
+	}
+}
+
+// TestRequirePlatformAdmin_CaseInsensitive pins case-insensitive
+// matching against the allow-list (operators don't have to fight
+// IdP-side email normalisation).
+func TestRequirePlatformAdmin_CaseInsensitive(t *testing.T) {
+	t.Parallel()
+	r := newAdminRouter(t, []string{"alice@example.com"}, "Alice@Example.COM")
+	w := do(t, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("status: want 200, got %d (body=%s)", w.Code, w.Body.String())
+	}
+}
+
+// TestIsPlatformAdmin_Standalone covers the standalone helper used by
+// GET /me. Same matching rules as the middleware.
+func TestIsPlatformAdmin_Standalone(t *testing.T) {
+	t.Parallel()
+	allow := []string{" alice@example.com ", "bob@example.com"}
+	cases := []struct {
+		email string
+		want  bool
+	}{
+		{"alice@example.com", true},
+		{"ALICE@example.com", true},
+		{"bob@example.com", true},
+		{"charlie@example.com", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := middleware.IsPlatformAdmin(tc.email, allow); got != tc.want {
+			t.Errorf("IsPlatformAdmin(%q): want %v, got %v", tc.email, tc.want, got)
+		}
+	}
+}


### PR DESCRIPTION
Closes #734.

## Summary

- New `AdminModeration` service runs `Approve` as ONE atomic transaction under `SET LOCAL ROLE raven_admin`: report `open → reviewing → resolved`, takedown audit row, KB `visibility → private`, `organizations.takedown_strikes += 1`. Email is intentionally outside the DB transaction — no-op `PublisherNotifier` with TODO logging until the M9 SES pipeline is wired (productionising swaps for an Asynq enqueue with dead-letter retry).
- Three new admin endpoints under `/api/v1/admin/marketplace/reports` (list, approve, dismiss) gated by a new config-driven `RequirePlatformAdmin` middleware (`RAVEN_ADMIN_EMAILS`). `raven_admin` is the only admin tier per ADR-0008.
- `GET /me` echoes `is_platform_admin` so the SPA can hide the route from non-admins. Backend middleware is the authoritative gate.
- Frontend: `AdminReportsView.vue` with status filter pills, table, and approve/dismiss confirm modals. Approve surfaces the post-increment strike count.

## Atomicity / consistency notes (self-review)

- All four side effects of approve commit in a single `pgx.Tx`. `Reports.TransitionInTx` and `Takedowns.CreateInTx` accept the caller's transaction so the role-switch ceremony stays in the orchestration layer and doesn't leak to non-admin callers.
- The two-step transition (`open → reviewing → resolved`) preserves the canonical state machine (moderation.go + DB CHECK) instead of bolting on an admin-only shortcut.
- Email failure is logged but does NOT roll back the takedown — the publisher is still entitled to know, just via a retry-able async path once Asynq is wired.
- Admin gate enforced ONLY at the HTTP boundary; service layer trusts the request.

## References

- ADR-0006 — reactive moderation only; reporter NOT notified on dismiss (harassment vector).
- ADR-0008 — `raven_admin` Postgres role gates; no granular admin roles in MVP.
- `docs/plans/marketplace-mvp.md` §4 (admin endpoints) + §5 (`/admin/marketplace/reports` Vue route).

## Test plan

- [x] Backend: `go test -short ./...` — all packages green (TestVerifyMigrationsState failures are an unrelated Docker socket issue on local colima, not caused by this PR).
- [x] Backend: handler unit tests cover 200/400/404/409 mapping via stub service.
- [x] Backend: middleware tests cover 401/403/happy paths and case-insensitive email matching.
- [x] Backend: integration tests pin the four-side-effect atomic commit, rollback-on-illegal-transition, not-found 404, and dismiss-leaves-state-untouched invariants (skipped under `-short`).
- [x] Lint: `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues.
- [x] Frontend: `vue-tsc --noEmit` — 0 errors.
- [x] Frontend: `eslint` — 0 issues.
- [x] Playwright spec compiles via `playwright test --list` (skipped without `E2E_ADMIN` env).

## Out of scope

- DMCA endpoint (`POST /api/v1/admin/marketplace/dmca`) — that's #736.
- Granular admin roles — explicitly rejected by ADR-0008 §line 35.
- Wiring the publisher takedown email — needs the M9 SES pipeline; TODO logged in `admin_moderation.go`.