### PR TITLE
refactor(llm-providers): decompose 1.2k-line page into focused components

### DIFF
--- a/frontend/src/composables/useTestConnectionGate.ts
+++ b/frontend/src/composables/useTestConnectionGate.ts
@@ -1,0 +1,79 @@
+import { ref, watch, type Ref, type WatchSource } from 'vue'
+import {
+  testLlmProviderConnection,
+  type TestProviderRequest,
+} from '../api/llm-providers'
+
+export type TestConnectionStatus = 'idle' | 'testing' | 'pass' | 'fail'
+
+export interface UseTestConnectionGateOptions {
+  /**
+   * Closure that produces the payload to ship to
+   * `POST /api/v1/orgs/:org_id/llm-providers/test`. Called lazily on each
+   * `runTest()` invocation so the dialog can shape the body around its
+   * current form state (e.g. `{provider_id}` vs `{provider, api_key}`).
+   */
+  buildPayload: () => TestProviderRequest
+  /**
+   * Reactive deps that invalidate a prior pass when ANY of them changes —
+   * the gate falls back to `idle` so the user is forced to re-test. Pass
+   * getter functions (the standard `WatchSource` shape) so the consumer
+   * controls reactivity tracking.
+   */
+  invalidateOn: WatchSource[]
+  /** Current org id — re-evaluated on each `runTest()` call. */
+  orgId: () => string
+}
+
+export interface TestConnectionGate {
+  status: Ref<TestConnectionStatus>
+  detail: Ref<string>
+  runTest: () => Promise<void>
+  reset: () => void
+}
+
+/**
+ * Composable wrapper around the credential-probe state machine used by
+ * both the Create and Edit dialogs. Exposes a single `status` + `detail`
+ * pair and a `runTest()` method; every entry in `invalidateOn` rolls the
+ * status back to `idle` on change so a passing probe can't be smuggled
+ * past a later edit.
+ */
+export function useTestConnectionGate(
+  options: UseTestConnectionGateOptions,
+): TestConnectionGate {
+  const status = ref<TestConnectionStatus>('idle')
+  const detail = ref<string>('')
+
+  function reset() {
+    if (status.value !== 'idle') {
+      status.value = 'idle'
+      detail.value = ''
+    }
+  }
+
+  async function runTest() {
+    status.value = 'testing'
+    detail.value = ''
+    try {
+      const payload = options.buildPayload()
+      const result = await testLlmProviderConnection(options.orgId(), payload)
+      if (result.ok) {
+        status.value = 'pass'
+        detail.value = result.detail ?? ''
+      } else {
+        status.value = 'fail'
+        detail.value = result.detail ?? 'Probe rejected the credentials.'
+      }
+    } catch (e: unknown) {
+      status.value = 'fail'
+      detail.value = e instanceof Error ? e.message : 'Test connection failed'
+    }
+  }
+
+  watch(options.invalidateOn, () => {
+    reset()
+  })
+
+  return { status, detail, runTest, reset }
+}

--- a/frontend/src/pages/llm-providers/LlmProviderListPage.vue
+++ b/frontend/src/pages/llm-providers/LlmProviderListPage.vue
@@ -1,16 +1,16 @@
 <script setup lang="ts">
-import { computed, nextTick, onMounted, ref, watch } from 'vue'
-import { useAuthStore } from "../../stores/auth"
+import { computed, onMounted, ref } from 'vue'
+import { useAuthStore } from '../../stores/auth'
 import { useLlmProviderHealthStore } from '../../stores/llm-provider-health'
 import { useLlmProvidersStore } from '../../stores/llm-providers'
-import {
-  PROVIDER_MODELS,
-  testLlmProviderConnection,
-  type CreateLlmProviderRequest,
-  type LlmProvider,
-  type ProviderType,
-  type UpdateLlmProviderRequest,
+import type {
+  CreateLlmProviderRequest,
+  LlmProvider,
+  UpdateLlmProviderRequest,
 } from '../../api/llm-providers'
+import CreateProviderDialog from './components/CreateProviderDialog.vue'
+import EditCredentialsDialog from './components/EditCredentialsDialog.vue'
+import ProviderCard from './components/ProviderCard.vue'
 
 const store = useLlmProvidersStore()
 const authStore = useAuthStore()
@@ -27,22 +27,9 @@ const showHealthBanner = computed(
   () => defaultProvider.value !== null && !healthStore.isHealthy(),
 )
 const healthBannerDetail = computed(() => healthStore.failureReason())
-const orgId = computed(() => authStore.orgId ?? sessionStorage.getItem("raven_org_id") ?? "")
-
+const orgId = computed(() => authStore.orgId ?? sessionStorage.getItem('raven_org_id') ?? '')
 
 const showCreateDialog = ref(false)
-const form = ref<CreateLlmProviderRequest>({
-  provider: 'openai',
-  display_name: '',
-
-  base_url: null,
-  api_key: '',
-})
-// The model lives in CreateLlmProviderRequest.config rather than as a
-// top-level field — keep it as a separate component-local ref and merge
-// at submit time so the v-model on the dropdown actually round-trips.
-const selectedModel = ref<string | undefined>(undefined)
-const creating = ref(false)
 
 const showDeleteDialog = ref(false)
 const providerToDelete = ref<string | null>(null)
@@ -87,135 +74,6 @@ async function handleMakeDefault(providerId: string) {
   }
 }
 
-
-const providerTypes: { value: ProviderType; label: string }[] = [
-  { value: 'openai', label: 'OpenAI' },
-  { value: 'anthropic', label: 'Anthropic' },
-  { value: 'ollama', label: 'Ollama' },
-  { value: 'custom', label: 'Custom' },
-]
-
-// Pretty-print provider type for the card body. Keep in lockstep with
-// providerTypes above — single source of truth for label text.
-const providerTypeLabel: Record<ProviderType, string> = {
-  openai: 'OpenAI',
-  anthropic: 'Anthropic',
-  ollama: 'Ollama',
-  custom: 'Custom',
-}
-
-// Per-provider onboarding guidance shown in the Add-Provider dialog.
-// `keyHref` deep-links to the vendor's API-key console so the user can
-// mint a key without leaving the flow; `keyPrefix` is shown in the
-// placeholder so they know what shape the key should have; `helpText`
-// is a one-liner above the API-key field. Keyed off ProviderType.
-// `requiresKey=false` hides API-key inputs entirely (Edit dialog skips
-// Rotate-key for these; today only Ollama). `defaultBaseUrl` auto-fills
-// the Base URL input when the provider type flips; `baseUrlHelp` is a
-// one-liner shown below the input.
-const providerHelp: Record<ProviderType, {
-  keyHref?: string
-  keyPrefix?: string
-  helpText: string
-  requiresKey: boolean
-  defaultBaseUrl?: string
-  baseUrlHelp?: string
-}> = {
-  openai: {
-    keyHref: 'https://platform.openai.com/api-keys',
-    keyPrefix: 'sk-...',
-    helpText: 'Generate a Secret Key in the OpenAI dashboard and paste it below.',
-    requiresKey: true,
-  },
-  anthropic: {
-    keyHref: 'https://console.anthropic.com/settings/keys',
-    keyPrefix: 'sk-ant-...',
-    helpText: 'Generate an API key in the Anthropic Console and paste it below.',
-    requiresKey: true,
-  },
-  ollama: {
-    helpText: 'Ollama runs locally and needs no API key. Point Base URL at your Ollama daemon — http://localhost:11434 by default. The hosted demo can\'t reach a private LAN address, so this works for self-hosted / Tauri-desktop Raven, or expose your Ollama via a public tunnel.',
-    requiresKey: false,
-    defaultBaseUrl: 'http://localhost:11434',
-    baseUrlHelp: 'Address of the Ollama daemon (default port 11434). Must be reachable from wherever the Raven server runs.',
-  },
-  custom: {
-    keyPrefix: 'your provider\'s key',
-    helpText: 'For any OpenAI-compatible provider (Together, Groq, Fireworks, vLLM, etc.). Set Base URL to the provider root (Raven appends /v1/models, /v1/chat/completions, etc).',
-    requiresKey: true,
-  },
-}
-
-function modelsForType(type: ProviderType) {
-  return PROVIDER_MODELS[type] ?? []
-}
-
-function providerModel(provider: LlmProvider): string {
-  const m = provider.config?.model
-  return typeof m === 'string' ? m : ''
-}
-
-function onProviderTypeChange() {
-  const help = providerHelp[form.value.provider]
-  // Apply provider-specific Base URL default (Ollama → localhost:11434);
-  // null for cloud providers that don't need it; empty string for custom
-  // so the input is shown but unset.
-  if (help.defaultBaseUrl !== undefined) {
-    form.value.base_url = help.defaultBaseUrl
-  } else if (form.value.provider === 'custom') {
-    form.value.base_url = ''
-  } else {
-    form.value.base_url = null
-  }
-  // Reset the per-provider model selection to the first model in the
-  // list, so the previously-selected (and possibly unrelated) model
-  // doesn't leak when switching providers.
-  const models = modelsForType(form.value.provider)
-  selectedModel.value = models[0]?.value
-  // Ollama doesn't require an API key — clear any stale value the user
-  // typed before switching providers.
-  if (!help.requiresKey) {
-    form.value.api_key = ''
-  }
-}
-
-const createError = ref('')
-
-async function handleCreate() {
-  creating.value = true
-  createError.value = ''
-  try {
-    // Mark the first provider as default automatically — the chat / RAG
-    // path 500s ("No active 'X' provider config found") until something
-    // is the default, so a fresh org has zero chance of a working chat
-    // unless we set this on their behalf.
-    const isFirst = store.providers.length === 0
-    const help = providerHelp[form.value.provider]
-    // The Go model declares api_key as binding:"required,min=1", so
-    // keyless providers (Ollama) need a stub value to satisfy validation.
-    // Backend ignores the value for these providers — it's purely a
-    // schema artefact, not an actual credential. Note this in the comment
-    // so a future cleanup doesn't get rid of it without also relaxing
-    // the binding.
-    const api_key = help.requiresKey ? form.value.api_key : 'not-required'
-    await store.addProvider(orgId.value, {
-      ...form.value,
-      api_key,
-      ...(selectedModel.value ? { config: { ...(form.value.config ?? {}), model: selectedModel.value } } : {}),
-      ...(isFirst ? { is_default: true } : {}),
-    })
-    showCreateDialog.value = false
-    form.value = { provider: 'openai', display_name: '', base_url: null, api_key: '' }
-    selectedModel.value = undefined
-  } catch (e: unknown) {
-    createError.value = e instanceof Error ? e.message : 'Failed to create provider'
-  } finally {
-    creating.value = false
-  }
-}
-
-const currentProviderHelp = computed(() => providerHelp[form.value.provider])
-
 // ---------------------------------------------------------------------------
 // Inline editing (#744)
 //
@@ -230,11 +88,8 @@ const currentProviderHelp = computed(() => providerHelp[form.value.provider])
 // roll back the local mutation and surface a transient toast via the same
 // `showDefaultError` channel (the toast slot is generic enough to re-use).
 // ---------------------------------------------------------------------------
-const editingNameId = ref<string | null>(null)
-const editingNameDraft = ref('')
 const savedTickId = ref<string | null>(null)
 let savedTickTimer: ReturnType<typeof setTimeout> | null = null
-const nameInputRef = ref<HTMLInputElement | null>(null)
 
 function flashSavedTick(providerId: string) {
   savedTickId.value = providerId
@@ -245,32 +100,11 @@ function flashSavedTick(providerId: string) {
   }, 1500)
 }
 
-async function startEditName(provider: LlmProvider) {
-  editingNameId.value = provider.id
-  editingNameDraft.value = provider.display_name
-  await nextTick()
-  nameInputRef.value?.focus()
-  nameInputRef.value?.select()
-}
-
-function cancelEditName() {
-  editingNameId.value = null
-  editingNameDraft.value = ''
-}
-
-async function commitEditName(provider: LlmProvider) {
-  const target = editingNameDraft.value.trim()
-  // No-op if unchanged or empty — just close the inline editor.
-  if (!target || target === provider.display_name) {
-    cancelEditName()
-    return
-  }
+async function handleRename(provider: LlmProvider, target: string) {
   const previousName = provider.display_name
   // Optimistic local mutation: paint the new name immediately.
   const idx = store.providers.findIndex((p) => p.id === provider.id)
   if (idx !== -1) store.providers[idx] = { ...store.providers[idx], display_name: target }
-  editingNameId.value = null
-  editingNameDraft.value = ''
   try {
     await store.editProvider(orgId.value, provider.id, { display_name: target })
     flashSavedTick(provider.id)
@@ -278,16 +112,19 @@ async function commitEditName(provider: LlmProvider) {
     // Roll back the optimistic name.
     const rollbackIdx = store.providers.findIndex((p) => p.id === provider.id)
     if (rollbackIdx !== -1) {
-      store.providers[rollbackIdx] = { ...store.providers[rollbackIdx], display_name: previousName }
+      store.providers[rollbackIdx] = {
+        ...store.providers[rollbackIdx],
+        display_name: previousName,
+      }
     }
     const msg = e instanceof Error ? e.message : 'Failed to save name'
     showDefaultError(`Could not save name: ${msg}`)
   }
 }
 
-async function commitModelChange(provider: LlmProvider, nextModel: string) {
+async function handleChangeModel(provider: LlmProvider, nextModel: string) {
   const previousConfig = provider.config ?? {}
-  const previousModel = providerModel(provider)
+  const previousModel = typeof previousConfig.model === 'string' ? previousConfig.model : ''
   if (nextModel === previousModel) return
   // Optimistic local mutation.
   const idx = store.providers.findIndex((p) => p.id === provider.id)
@@ -315,82 +152,19 @@ async function commitModelChange(provider: LlmProvider, nextModel: string) {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Edit-credentials dialog (#742)
-//
-// Reuses the Create dialog markup but:
-//   - provider is read-only (changing provider type is a delete-and-create);
-//   - api_key starts hidden — clicking "Rotate API key" reveals an empty
-//     input, and only then does the PUT carry `api_key`. Skip = key untouched
-//     server-side (backend preserves the stored ciphertext on partial PUT);
-//   - re-runs Test Connection when EITHER base_url changed OR the rotate
-//     input has a non-empty value. If neither changed the gate hits the
-//     /test endpoint with {provider_id} so the stored key is used without
-//     ever leaving the server;
-//   - any keystroke in provider / base_url / rotate-key rolls testStatus
-//     back to `idle`, so a passing probe can't be smuggled past a later
-//     edit.
-// ---------------------------------------------------------------------------
+// Create handler — wired to the dialog's onSubmit prop so the dialog
+// can await it and self-close on success.
+async function handleCreate(payload: CreateLlmProviderRequest) {
+  await store.addProvider(orgId.value, payload)
+}
+
+// Edit dialog state. We pass the selected provider down — the dialog
+// builds its own form state from it.
 const showEditDialog = ref(false)
 const editingProvider = ref<LlmProvider | null>(null)
-const editForm = ref<{
-  provider: ProviderType
-  display_name: string
-  base_url: string
-  model: string
-}>({
-  provider: 'openai',
-  display_name: '',
-  base_url: '',
-  model: '',
-})
-const editInitialBaseUrl = ref<string>('')
-const showRotateKey = ref(false)
-const rotateApiKey = ref('')
-const editTestStatus = ref<'idle' | 'testing' | 'pass' | 'fail'>('idle')
-const editTestDetail = ref('')
-const editError = ref('')
-const editSaving = ref(false)
-
-const editProviderHelp = computed(() => providerHelp[editForm.value.provider])
-const editProviderHasKey = computed(() => editProviderHelp.value.requiresKey)
-// Edit dialog needs Base URL whenever the provider type does — same
-// rule as Create.
-const editShowBaseUrl = computed(
-  () => editForm.value.provider === 'custom' || editForm.value.provider === 'ollama',
-)
-// Test-Connection re-gate is REQUIRED when either base_url changed from
-// what's persisted OR the user typed a new key into Rotate. Otherwise
-// nothing security-sensitive is changing and Save is allowed without
-// a probe.
-const editGateRequired = computed(() => {
-  const baseUrlChanged = editForm.value.base_url !== editInitialBaseUrl.value
-  const rotateProvided = showRotateKey.value && rotateApiKey.value.length > 0
-  return baseUrlChanged || rotateProvided
-})
-const editCanSave = computed(() => {
-  if (editSaving.value) return false
-  if (!editForm.value.display_name) return false
-  if (editGateRequired.value && editTestStatus.value !== 'pass') return false
-  return true
-})
 
 function openEditDialog(provider: LlmProvider) {
   editingProvider.value = provider
-  const model =
-    typeof provider.config?.model === 'string' ? (provider.config.model as string) : ''
-  editForm.value = {
-    provider: provider.provider,
-    display_name: provider.display_name,
-    base_url: provider.base_url ?? '',
-    model,
-  }
-  editInitialBaseUrl.value = provider.base_url ?? ''
-  showRotateKey.value = false
-  rotateApiKey.value = ''
-  editTestStatus.value = 'idle'
-  editTestDetail.value = ''
-  editError.value = ''
   showEditDialog.value = true
 }
 
@@ -399,266 +173,10 @@ function closeEditDialog() {
   editingProvider.value = null
 }
 
-// Any keystroke in fields that affect the credential probe (provider,
-// base_url, rotate-key input) invalidates a prior pass. The provider
-// is read-only in the dialog but we still watch it to stay honest in
-// case that ever changes.
-watch(
-  [
-    () => editForm.value.provider,
-    () => editForm.value.base_url,
-    () => rotateApiKey.value,
-    () => showRotateKey.value,
-  ],
-  () => {
-    if (!showEditDialog.value) return
-    if (editTestStatus.value !== 'idle') {
-      editTestStatus.value = 'idle'
-      editTestDetail.value = ''
-    }
-  },
-)
-
-async function runEditTest() {
+async function handleEditSave(payload: UpdateLlmProviderRequest) {
   if (!editingProvider.value) return
-  editTestStatus.value = 'testing'
-  editTestDetail.value = ''
-  try {
-    // Decide which body shape to send. When base_url changed OR the
-    // user typed a new key, we have inline values to probe with. When
-    // neither changed we don't have a secret in memory — fall back to
-    // the {provider_id} shape so the server uses the stored key.
-    const baseUrlChanged = editForm.value.base_url !== editInitialBaseUrl.value
-    const rotateProvided = showRotateKey.value && rotateApiKey.value.length > 0
-    const payload = rotateProvided
-      ? {
-          provider: editForm.value.provider,
-          api_key: rotateApiKey.value,
-          ...(editShowBaseUrl.value
-            ? { base_url: editForm.value.base_url || null }
-            : {}),
-        }
-      : baseUrlChanged
-        ? {
-            provider_id: editingProvider.value.id,
-            ...(editShowBaseUrl.value
-              ? { base_url: editForm.value.base_url || null }
-              : {}),
-          }
-        : { provider_id: editingProvider.value.id }
-    const result = await testLlmProviderConnection(orgId.value, payload)
-    if (result.ok) {
-      editTestStatus.value = 'pass'
-      editTestDetail.value = result.detail ?? ''
-    } else {
-      editTestStatus.value = 'fail'
-      editTestDetail.value = result.detail ?? 'Probe rejected the credentials.'
-    }
-  } catch (e: unknown) {
-    editTestStatus.value = 'fail'
-    editTestDetail.value = e instanceof Error ? e.message : 'Test connection failed'
-  }
+  await store.editProvider(orgId.value, editingProvider.value.id, payload)
 }
-
-async function handleEditSave() {
-  if (!editingProvider.value) return
-  editSaving.value = true
-  editError.value = ''
-  try {
-    const payload: UpdateLlmProviderRequest = {
-      display_name: editForm.value.display_name,
-    }
-    // base_url: include when the dialog renders it. Empty string is
-    // explicitly nulled (matches Create behaviour); a value is sent as-is.
-    if (editShowBaseUrl.value) {
-      payload.base_url = editForm.value.base_url === '' ? null : editForm.value.base_url
-    }
-    // Rotate semantics: omit api_key entirely when the user did NOT
-    // click Rotate — backend (PR #749) preserves the stored ciphertext
-    // on a partial PUT.
-    if (showRotateKey.value && rotateApiKey.value.length > 0) {
-      payload.api_key = rotateApiKey.value
-    }
-    // Persist the selected model under config.model. Merge into the
-    // existing config so unrelated keys aren't dropped.
-    if (editForm.value.model) {
-      const existingConfig = (editingProvider.value.config ?? {}) as Record<string, unknown>
-      payload.config = { ...existingConfig, model: editForm.value.model }
-    }
-    await store.editProvider(orgId.value, editingProvider.value.id, payload)
-    closeEditDialog()
-  } catch (e: unknown) {
-    editError.value = e instanceof Error ? e.message : 'Failed to save provider'
-  } finally {
-    editSaving.value = false
-  }
-}
-
-// Tunnel suggestions shown in the Ollama branch so a user on the
-// hosted demo (whose Vultr box can't reach `localhost`) has a one-liner
-// to expose their local daemon publicly. Cloudflare's `trycloudflare`
-// mode is the recommended first option — no account, no install of
-// anything Raven-side, free, auto-TLS. ngrok is the fallback for users
-// who already have it set up.
-//
-// `install` carries platform-specific install one-liners + a download
-// docs URL for users who don't already have the binary. Detecting the
-// host OS via navigator.userAgent picks the matching command; the docs
-// link is always shown as the universal fallback.
-const ollamaTunnels: {
-  label: string
-  command: string
-  note?: string
-  install: { docsHref: string; macos: string; windows: string; linux: string }
-}[] = [
-  {
-    label: 'Cloudflare Tunnel (recommended)',
-    // --http-host-header localhost is critical: Ollama's HTTP server rejects
-    // any request whose Host header isn't 127.0.0.1 / localhost (security
-    // hardening). cloudflared's default forwards the public tunnel hostname
-    // as Host, which Ollama returns 403 to with an empty body. The flag
-    // tells cloudflared to rewrite Host to "localhost" on the upstream hop
-    // so Ollama treats it as a local call.
-    command: 'cloudflared tunnel --url http://localhost:11434 --http-host-header localhost',
-    note: 'Prints an https://<random>.trycloudflare.com URL. No account needed. The --http-host-header flag is mandatory — Ollama 403s any other Host. Paste the printed URL into Base URL above.',
-    install: {
-      docsHref: 'https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/',
-      macos: 'brew install cloudflared',
-      windows: 'winget install --id Cloudflare.cloudflared',
-      linux: 'See the download page for your distro\'s package or static binary.',
-    },
-  },
-  {
-    label: 'ngrok',
-    // --host-header=rewrite serves the same purpose as cloudflared's
-    // --http-host-header: rewrites the Host on the upstream hop to
-    // 127.0.0.1:11434 so Ollama's Host-allowlist check accepts the call.
-    // Without it, ngrok forwards Host: <subdomain>.ngrok.app and Ollama 403s.
-    command: 'ngrok http 11434 --host-header=rewrite',
-    note: 'Free account required for stable URLs. The --host-header=rewrite flag is mandatory — Ollama 403s any other Host. Use the https Forwarding address.',
-    install: {
-      docsHref: 'https://ngrok.com/download',
-      macos: 'brew install ngrok',
-      windows: 'winget install ngrok.ngrok',
-      linux: 'curl -sSL https://ngrok-agent.s3.amazonaws.com/ngrok.asc | sudo tee /etc/apt/trusted.gpg.d/ngrok.asc >/dev/null && echo "deb https://ngrok-agent.s3.amazonaws.com buster main" | sudo tee /etc/apt/sources.list.d/ngrok.list && sudo apt update && sudo apt install ngrok',
-    },
-  },
-]
-
-// Best-effort platform detection — userAgent is fine here because we
-// only use it to pick a default install one-liner, not for anything
-// security-sensitive. Falls back to the docs URL if unsure.
-function detectOS(): 'macos' | 'windows' | 'linux' | 'unknown' {
-  const ua = navigator.userAgent.toLowerCase()
-  if (ua.includes('mac')) return 'macos'
-  if (ua.includes('win')) return 'windows'
-  if (ua.includes('linux')) return 'linux'
-  return 'unknown'
-}
-const userOS = detectOS()
-function installCommandForOS(t: (typeof ollamaTunnels)[number]) {
-  if (userOS === 'macos') return t.install.macos
-  if (userOS === 'windows') return t.install.windows
-  if (userOS === 'linux') return t.install.linux
-  return null
-}
-function installLabelForOS(): string {
-  if (userOS === 'macos') return 'Install on macOS'
-  if (userOS === 'windows') return 'Install on Windows'
-  if (userOS === 'linux') return 'Install on Linux'
-  return 'Install'
-}
-
-// Create-dialog test-connection state machine. createTestStatus drives
-// the icon/colour shown on the Test button and the Create button's
-// disabled state:
-//   - 'idle'  : nothing tested yet (Create is disabled if the user
-//               hasn't confirmed the creds work).
-//   - 'testing'
-//   - 'pass'  : last probe succeeded → Create unlocked.
-//   - 'fail'  : last probe failed → Create stays disabled, error
-//               surfaced in createTestDetail.
-// Any edit to the form fields rolls the state back to 'idle' so the
-// user re-tests after changing the key / endpoint.
-// NB: distinct from the page-level `testStatus` map (keyed by provider
-// id, used for the post-create "last test failed" warning on each card).
-type TestStatus = 'idle' | 'testing' | 'pass' | 'fail'
-const createTestStatus = ref<TestStatus>('idle')
-const createTestDetail = ref<string>('')
-async function runTestConnection() {
-  createTestStatus.value = 'testing'
-  createTestDetail.value = ''
-  try {
-    const help = providerHelp[form.value.provider]
-    const api_key = help.requiresKey ? form.value.api_key : 'not-required'
-    const result = await testLlmProviderConnection(orgId.value, {
-      ...form.value,
-      api_key,
-    })
-    createTestStatus.value = result.ok ? 'pass' : 'fail'
-    createTestDetail.value = result.detail ?? ''
-  } catch (e: unknown) {
-    createTestStatus.value = 'fail'
-    createTestDetail.value = e instanceof Error ? e.message : 'Test failed'
-  }
-}
-
-// Invalidate the test result whenever a form field that affects the
-// probe changes — so the user can't pass a test on one key, swap it,
-// and slip a bad config past the gate.
-watch(
-  () => [form.value.provider, form.value.api_key, form.value.base_url],
-  () => {
-    if (createTestStatus.value !== 'idle') {
-      createTestStatus.value = 'idle'
-      createTestDetail.value = ''
-    }
-  },
-)
-
-const copied = ref<string | null>(null)
-async function copyTunnel(command: string) {
-  try {
-    await navigator.clipboard.writeText(command)
-    copied.value = command
-    setTimeout(() => (copied.value === command ? (copied.value = null) : null), 1500)
-  } catch {
-    // Clipboard access can fail under restrictive permissions / older
-    // browsers — surface the command in the UI and let the user copy
-    // it manually instead of throwing.
-    copied.value = null
-  }
-}
-
-// True only when a loopback Base URL is paired with a non-loopback
-// browser origin — i.e., the user typed `http://localhost:...` while
-// hitting Raven on a real public host (demo.ravencloak.org, etc.).
-// On Raven-running-locally (desktop / self-host) the loopback address
-// works as-is and the tunnel hint would be noise.
-const isLoopbackBaseURL = computed(() => {
-  const raw = (form.value.base_url ?? '').trim().toLowerCase()
-  if (!raw) return false
-  return (
-    raw.startsWith('http://localhost') ||
-    raw.startsWith('https://localhost') ||
-    raw.startsWith('http://127.') ||
-    raw.startsWith('https://127.') ||
-    raw.startsWith('http://[::1]') ||
-    raw.startsWith('https://[::1]') ||
-    raw.startsWith('http://0.0.0.0') ||
-    raw.startsWith('https://0.0.0.0')
-  )
-})
-
-const ravenHost = computed(() => window.location.hostname)
-const ravenIsRemote = computed(() => {
-  const host = ravenHost.value
-  return host !== 'localhost' && host !== '127.0.0.1' && host !== '[::1]' && host !== '0.0.0.0'
-})
-
-const showTunnelHint = computed(
-  () => form.value.provider === 'ollama' && isLoopbackBaseURL.value && ravenIsRemote.value,
-)
 
 function confirmDelete(id: string, name: string) {
   providerToDelete.value = id
@@ -676,7 +194,6 @@ async function handleDelete() {
     deleting.value = false
   }
 }
-
 
 onMounted(() => store.fetchProviders(orgId.value))
 </script>
@@ -729,153 +246,21 @@ onMounted(() => store.fetchProviders(orgId.value))
       from #748 are preserved so e2e tests don't break.
     -->
     <div v-else class="space-y-4" data-testid="provider-list">
-      <article
+      <ProviderCard
         v-for="provider in store.providers"
         :key="provider.id"
-        class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
-        data-testid="provider-card"
-      >
-        <!-- Header row: icon + (editable name | status | default pill) -->
-        <div class="flex items-start gap-3">
-          <!-- Provider-type icon (chip glyph for visual consistency with the M13 menu). -->
-          <span
-            aria-hidden="true"
-            class="mt-0.5 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-indigo-50 text-indigo-600"
-          >
-            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <rect x="4" y="4" width="16" height="16" rx="2" />
-              <rect x="9" y="9" width="6" height="6" />
-              <path d="M9 1v3M15 1v3M9 20v3M15 20v3M1 9h3M1 15h3M20 9h3M20 15h3" />
-            </svg>
-          </span>
-
-          <div class="min-w-0 flex-1">
-            <!-- Editable display_name + status badge + default pill -->
-            <div class="flex flex-wrap items-center gap-2">
-              <input
-                v-if="editingNameId === provider.id"
-                ref="nameInputRef"
-                v-model="editingNameDraft"
-                type="text"
-                data-testid="display-name-input"
-                class="min-w-0 flex-1 rounded border border-indigo-300 px-2 py-1 text-base font-semibold text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
-                @keydown.enter.prevent="commitEditName(provider)"
-                @keydown.esc.prevent="cancelEditName"
-                @blur="commitEditName(provider)"
-              />
-              <button
-                v-else
-                type="button"
-                data-testid="display-name-label"
-                class="truncate rounded px-1 py-0.5 text-left text-base font-semibold text-gray-900 hover:bg-gray-50 focus:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-300"
-                :title="`Click to rename — ${provider.display_name}`"
-                @click="startEditName(provider)"
-              >
-                {{ provider.display_name }}
-              </button>
-              <span
-                :class="[
-                  'shrink-0 rounded-full px-2 py-0.5 text-xs font-medium',
-                  provider.status === 'active'
-                    ? 'bg-green-100 text-green-700'
-                    : 'bg-gray-100 text-gray-600',
-                ]"
-              >
-                {{ provider.status }}
-              </span>
-              <span
-                v-if="provider.is_default"
-                data-testid="default-pill"
-                class="shrink-0 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 transition duration-200 ease-out"
-              >
-                Default
-              </span>
-              <span
-                v-if="provider.is_default && !healthStore.isHealthy()"
-                data-testid="default-connection-error"
-                class="shrink-0 rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700"
-                :title="healthStore.failureReason()"
-              >
-                Connection error
-              </span>
-              <span
-                v-if="savedTickId === provider.id"
-                data-testid="saved-tick"
-                class="shrink-0 text-xs font-medium text-green-600"
-                role="status"
-                aria-live="polite"
-              >
-                Saved ✓
-              </span>
-            </div>
-
-            <!-- Type + base_url meta -->
-            <p class="mt-1 text-sm text-gray-500">
-              {{ providerTypeLabel[provider.provider] }}
-              <span v-if="provider.base_url" class="break-all"> &middot; {{ provider.base_url }}</span>
-            </p>
-
-            <!-- Inline model selector + api-key hint -->
-            <div class="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
-              <label class="flex items-center gap-2 text-xs text-gray-600">
-                <span class="shrink-0">Model</span>
-                <select
-                  data-testid="model-select"
-                  class="rounded border-gray-300 px-2 py-1 text-xs shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
-                  :value="providerModel(provider)"
-                  @change="commitModelChange(provider, ($event.target as HTMLSelectElement).value)"
-                >
-                  <option v-if="!providerModel(provider)" value="">Select model…</option>
-                  <option
-                    v-for="m in modelsForType(provider.provider)"
-                    :key="m.value"
-                    :value="m.value"
-                  >
-                    {{ m.label }}
-                  </option>
-                </select>
-              </label>
-              <span class="text-xs text-gray-400">
-                API key {{ provider.api_key_hint ? 'configured' : 'not set' }}
-              </span>
-            </div>
-
-            <p
-              v-if="!provider.is_default && testStatus[provider.id] === 'fail'"
-              class="mt-2 rounded border border-amber-300 bg-amber-50 px-2 py-1 text-xs text-amber-800"
-            >
-              Last connection test failed — switching default may break chat.
-            </p>
-          </div>
-        </div>
-
-        <!-- Action row: wraps under content on narrow viewports. -->
-        <div class="mt-3 flex flex-wrap justify-end gap-2 border-t border-gray-100 pt-3">
-          <button
-            v-if="!provider.is_default"
-            data-testid="make-default-btn"
-            :disabled="settingDefaultId === provider.id"
-            class="rounded border border-amber-300 px-3 py-1 text-xs font-medium text-amber-800 hover:bg-amber-50 disabled:opacity-50"
-            @click="handleMakeDefault(provider.id)"
-          >
-            {{ settingDefaultId === provider.id ? 'Setting...' : 'Make default' }}
-          </button>
-          <button
-            data-testid="edit-credentials-btn"
-            class="rounded border border-gray-300 px-3 py-1 text-xs text-gray-700 hover:bg-gray-50"
-            @click="openEditDialog(provider)"
-          >
-            Edit credentials
-          </button>
-          <button
-            data-testid="delete-btn"
-            class="rounded border border-red-300 px-3 py-1 text-xs text-red-700 hover:bg-red-50"
-            @click="confirmDelete(provider.id, provider.display_name)"
-          >
-            Delete
-          </button>
-        </div>
-      </article>
+        :provider="provider"
+        :is-healthy="healthStore.isHealthy()"
+        :health-failure-reason="healthStore.failureReason()"
+        :setting-default-id="settingDefaultId"
+        :test-failed-for-id="testStatus[provider.id] === 'fail'"
+        :show-saved-tick="savedTickId === provider.id"
+        @make-default="handleMakeDefault"
+        @edit-credentials="openEditDialog"
+        @delete="confirmDelete"
+        @rename="handleRename"
+        @change-model="handleChangeModel"
+      />
     </div>
 
     <!-- Default-switch error toast (non-blocking, auto-dismisses) -->
@@ -889,311 +274,21 @@ onMounted(() => store.fetchProviders(orgId.value))
       {{ defaultError }}
     </div>
 
-    <!-- Create Dialog -->
-    <div
+    <CreateProviderDialog
       v-if="showCreateDialog"
-      class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="add-llm-provider-title"
-    >
-      <div class="w-full max-w-2xl max-h-[90vh] overflow-y-auto rounded-lg bg-white p-6 shadow-xl">
-        <h2 id="add-llm-provider-title" class="mb-4 text-lg font-semibold">Add LLM Provider</h2>
-        <form class="space-y-4" @submit.prevent="handleCreate">
-          <div>
-            <label class="block text-sm font-medium text-gray-700">Provider Type</label>
-            <select v-model="form.provider" class="mt-1 block w-full rounded border-gray-300 shadow-sm" @change="onProviderTypeChange">
-              <option v-for="pt in providerTypes" :key="pt.value" :value="pt.value">{{ pt.label }}</option>
-            </select>
-          </div>
-          <div>
-            <label class="block text-sm font-medium text-gray-700">Display Name</label>
-            <input v-model="form.display_name" type="text" required class="mt-1 block w-full rounded border-gray-300 shadow-sm" placeholder="e.g. OpenAI Production" />
-          </div>
-          <div>
-            <label class="block text-sm font-medium text-gray-700">Model</label>
-            <select v-model="selectedModel" class="mt-1 block w-full rounded border-gray-300 shadow-sm">
-              <option v-for="m in modelsForType(form.provider)" :key="m.value" :value="m.value">{{ m.label }}</option>
-            </select>
-          </div>
-          <div v-if="form.provider === 'custom' || form.provider === 'ollama'">
-            <label class="block text-sm font-medium text-gray-700">Base URL</label>
-            <input
-              v-model="form.base_url"
-              type="url"
-              class="mt-1 block w-full rounded border-gray-300 shadow-sm"
-              :placeholder="currentProviderHelp.defaultBaseUrl ?? 'https://api.example.com/v1'"
-            />
-            <p v-if="currentProviderHelp.baseUrlHelp" class="mt-1 text-xs text-gray-500">
-              {{ currentProviderHelp.baseUrlHelp }}
-            </p>
-            <!-- Tunnel hints: only when the user has typed a loopback
-                 Base URL while sitting on a remote Raven (e.g. the
-                 hosted demo). For self-hosted / Tauri Raven the
-                 loopback address works as-is and the hint is noise. -->
-            <div v-if="showTunnelHint" class="mt-3 rounded-md border border-gray-200 bg-gray-50 p-3">
-              <p class="text-xs font-medium text-gray-700">
-                {{ ravenHost }} can't reach <code class="font-mono">{{ form.base_url }}</code> on your machine. Expose Ollama temporarily:
-              </p>
-              <ul class="mt-2 space-y-3">
-                <li v-for="t in ollamaTunnels" :key="t.label" class="text-xs">
-                  <div class="font-medium text-gray-600">{{ t.label }}</div>
-                  <!-- Install one-liner for the user's detected OS, with a
-                       fallback link to the upstream download docs that
-                       cover Linux distros + manual installs. -->
-                  <div v-if="installCommandForOS(t)" class="mt-0.5">
-                    <div class="text-[11px] text-gray-500">{{ installLabelForOS() }}:</div>
-                    <div class="mt-0.5 flex items-center gap-1.5">
-                      <code class="flex-1 truncate rounded bg-gray-800 px-2 py-1 text-[11px] text-gray-100">{{ installCommandForOS(t) }}</code>
-                      <button
-                        type="button"
-                        class="shrink-0 rounded border border-gray-300 bg-white px-2 py-1 text-[11px] text-gray-700 hover:bg-gray-100"
-                        @click="copyTunnel(installCommandForOS(t) ?? '')"
-                      >
-                        {{ copied === installCommandForOS(t) ? 'Copied' : 'Copy' }}
-                      </button>
-                    </div>
-                  </div>
-                  <a
-                    :href="t.install.docsHref"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="mt-1 inline-flex items-center text-[11px] text-indigo-600 underline hover:text-indigo-800"
-                  >
-                    Other install options
-                    <svg class="ml-0.5 h-3 w-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><path d="M15 3h6v6"/><path d="M10 14L21 3"/></svg>
-                  </a>
-                  <div class="mt-1.5">
-                    <div class="text-[11px] text-gray-500">Then run:</div>
-                    <div class="mt-0.5 flex items-center gap-1.5">
-                      <code class="flex-1 truncate rounded bg-gray-900 px-2 py-1 text-[11px] text-gray-100">{{ t.command }}</code>
-                      <button
-                        type="button"
-                        class="shrink-0 rounded border border-gray-300 bg-white px-2 py-1 text-[11px] text-gray-700 hover:bg-gray-100"
-                        @click="copyTunnel(t.command)"
-                      >
-                        {{ copied === t.command ? 'Copied' : 'Copy' }}
-                      </button>
-                    </div>
-                  </div>
-                  <p v-if="t.note" class="mt-0.5 text-gray-500">{{ t.note }}</p>
-                </li>
-              </ul>
-              <p class="mt-2 text-[11px] text-amber-700">
-                <strong>Heads up:</strong> a public tunnel exposes your local Ollama to anyone with the URL. Close the tunnel when you're done, or restrict by IP / auth.
-              </p>
-            </div>
-          </div>
-          <div v-if="currentProviderHelp.requiresKey">
-            <label class="block text-sm font-medium text-gray-700">API Key</label>
-            <p class="mt-1 text-xs text-gray-500">
-              {{ currentProviderHelp.helpText }}
-              <a
-                v-if="currentProviderHelp.keyHref"
-                :href="currentProviderHelp.keyHref"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="ml-1 inline-flex items-center text-indigo-600 underline hover:text-indigo-800"
-              >
-                Get a key
-                <svg class="ml-0.5 h-3 w-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><path d="M15 3h6v6"/><path d="M10 14L21 3"/></svg>
-              </a>
-            </p>
-            <input
-              v-model="form.api_key"
-              type="password"
-              autocomplete="off"
-              class="mt-2 block w-full rounded border-gray-300 shadow-sm"
-              :placeholder="currentProviderHelp.keyPrefix ?? 'sk-...'"
-            />
-          </div>
-          <p v-else class="text-xs text-gray-500">
-            {{ currentProviderHelp.helpText }}
-          </p>
-          <p v-if="store.providers.length === 0" class="text-xs text-gray-400">
-            This will be set as your default provider since it's the first one.
-          </p>
-          <p v-if="createError" class="text-red-500 text-sm">{{ createError }}</p>
-          <!-- Test-connection gate. The Create button is locked until
-               the probe returns 'pass' so a bad key / unreachable
-               endpoint can't slip into the DB. -->
-          <div class="rounded-md border p-3 text-xs" :class="{
-            'border-gray-200 bg-gray-50': createTestStatus === 'idle',
-            'border-blue-200 bg-blue-50': createTestStatus === 'testing',
-            'border-green-200 bg-green-50': createTestStatus === 'pass',
-            'border-red-200 bg-red-50': createTestStatus === 'fail',
-          }">
-            <div class="flex items-center justify-between gap-2">
-              <span class="font-medium" :class="{
-                'text-gray-700': createTestStatus === 'idle',
-                'text-blue-700': createTestStatus === 'testing',
-                'text-green-700': createTestStatus === 'pass',
-                'text-red-700': createTestStatus === 'fail',
-              }">
-                <template v-if="createTestStatus === 'idle'">Test the connection before saving</template>
-                <template v-else-if="createTestStatus === 'testing'">Testing…</template>
-                <template v-else-if="createTestStatus === 'pass'">✓ Connection looks good</template>
-                <template v-else>✕ Connection failed</template>
-              </span>
-              <button
-                type="button"
-                class="rounded border border-gray-300 bg-white px-3 py-1 text-xs text-gray-700 hover:bg-gray-100 disabled:opacity-50"
-                :disabled="createTestStatus === 'testing' || !form.display_name || (currentProviderHelp.requiresKey && !form.api_key)"
-                @click="runTestConnection"
-              >
-                {{ createTestStatus === 'pass' ? 'Re-test' : createTestStatus === 'testing' ? 'Testing…' : 'Test connection' }}
-              </button>
-            </div>
-            <p v-if="createTestDetail" class="mt-1 text-xs" :class="{
-              'text-green-700': createTestStatus === 'pass',
-              'text-red-700': createTestStatus === 'fail',
-              'text-gray-600': createTestStatus !== 'pass' && createTestStatus !== 'fail',
-            }">
-              {{ createTestDetail }}
-            </p>
-          </div>
-          <div class="flex justify-end gap-2 pt-2">
-            <button type="button" class="rounded px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" @click="showCreateDialog = false">Cancel</button>
-            <button type="submit" :disabled="creating || createTestStatus !== 'pass' || !form.display_name || (currentProviderHelp.requiresKey && !form.api_key)" class="rounded bg-indigo-600 px-4 py-2 text-sm text-white hover:bg-indigo-700 disabled:opacity-50">
-              {{ creating ? 'Creating...' : 'Create' }}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
+      :org-id="orgId"
+      :is-first-provider="store.providers.length === 0"
+      :on-submit="handleCreate"
+      @close="showCreateDialog = false"
+    />
 
-    <!-- Edit Credentials Dialog -->
-    <div v-if="showEditDialog" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div class="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
-        <h2 class="mb-4 text-lg font-semibold">Edit credentials</h2>
-        <form class="space-y-4" @submit.prevent="handleEditSave">
-          <div>
-            <label class="block text-sm font-medium text-gray-700">Provider Type</label>
-            <input
-              :value="editForm.provider"
-              type="text"
-              readonly
-              disabled
-              class="mt-1 block w-full rounded border-gray-200 bg-gray-50 text-gray-600 shadow-sm"
-            />
-            <p class="mt-1 text-xs text-gray-400">
-              Provider type can't be changed. Delete and re-create to switch.
-            </p>
-          </div>
-          <div>
-            <label class="block text-sm font-medium text-gray-700">Display Name</label>
-            <input
-              v-model="editForm.display_name"
-              type="text"
-              required
-              class="mt-1 block w-full rounded border-gray-300 shadow-sm"
-            />
-          </div>
-          <div>
-            <label class="block text-sm font-medium text-gray-700">Model</label>
-            <select v-model="editForm.model" class="mt-1 block w-full rounded border-gray-300 shadow-sm">
-              <option v-for="m in modelsForType(editForm.provider)" :key="m.value" :value="m.value">{{ m.label }}</option>
-            </select>
-          </div>
-          <div v-if="editShowBaseUrl">
-            <label class="block text-sm font-medium text-gray-700">Base URL</label>
-            <input
-              v-model="editForm.base_url"
-              type="url"
-              class="mt-1 block w-full rounded border-gray-300 shadow-sm"
-              placeholder="https://api.example.com/v1"
-            />
-          </div>
-
-          <!-- Rotate API key disclosure: hidden entirely for keyless providers (Ollama). -->
-          <div v-if="editProviderHasKey">
-            <button
-              v-if="!showRotateKey"
-              type="button"
-              class="rounded border border-gray-300 px-3 py-1 text-xs text-gray-700 hover:bg-gray-50"
-              @click="showRotateKey = true"
-            >
-              Rotate API key
-            </button>
-            <div v-else>
-              <label class="block text-sm font-medium text-gray-700">New API Key</label>
-              <p class="mt-1 text-xs text-gray-500">
-                {{ editProviderHelp.helpText }}
-                <a
-                  v-if="editProviderHelp.keyHref"
-                  :href="editProviderHelp.keyHref"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="ml-1 inline-flex items-center text-indigo-600 underline hover:text-indigo-800"
-                >
-                  Get a key
-                </a>
-              </p>
-              <input
-                v-model="rotateApiKey"
-                type="password"
-                autocomplete="off"
-                class="mt-2 block w-full rounded border-gray-300 shadow-sm"
-                :placeholder="editProviderHelp.keyPrefix ?? 'sk-...'"
-              />
-              <button
-                type="button"
-                class="mt-1 text-xs text-gray-500 hover:underline"
-                @click="showRotateKey = false; rotateApiKey = ''"
-              >
-                Cancel rotation
-              </button>
-            </div>
-          </div>
-
-          <!-- Test-Connection gate. Only visible when a credential-affecting
-               field changed; result is required to be `pass` before Save. -->
-          <div v-if="editGateRequired" class="rounded border border-gray-200 bg-gray-50 p-3">
-            <div class="flex items-center justify-between">
-              <span class="text-sm font-medium text-gray-700">Test connection</span>
-              <button
-                type="button"
-                :disabled="editTestStatus === 'testing'"
-                class="rounded bg-gray-700 px-3 py-1 text-xs text-white hover:bg-gray-800 disabled:opacity-50"
-                @click="runEditTest"
-              >
-                {{ editTestStatus === 'testing' ? 'Testing...' : 'Test now' }}
-              </button>
-            </div>
-            <p
-              v-if="editTestStatus === 'pass'"
-              class="mt-2 text-xs text-green-700"
-            >
-              ✓ Connection OK{{ editTestDetail ? ` — ${editTestDetail}` : '' }}
-            </p>
-            <p
-              v-else-if="editTestStatus === 'fail'"
-              class="mt-2 text-xs text-red-600"
-            >
-              ✕ {{ editTestDetail || 'Connection failed' }}
-            </p>
-            <p
-              v-else-if="editTestStatus === 'idle'"
-              class="mt-2 text-xs text-gray-500"
-            >
-              Required: the {{ showRotateKey && rotateApiKey ? 'new key' : 'updated Base URL' }} must pass before Save is enabled.
-            </p>
-          </div>
-
-          <p v-if="editError" class="text-red-500 text-sm">{{ editError }}</p>
-          <div class="flex justify-end gap-2 pt-2">
-            <button type="button" class="rounded px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" @click="closeEditDialog">Cancel</button>
-            <button
-              type="submit"
-              :disabled="!editCanSave"
-              class="rounded bg-indigo-600 px-4 py-2 text-sm text-white hover:bg-indigo-700 disabled:opacity-50"
-            >
-              {{ editSaving ? 'Saving...' : 'Save' }}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
+    <EditCredentialsDialog
+      v-if="showEditDialog && editingProvider"
+      :provider="editingProvider"
+      :org-id="orgId"
+      :on-submit="handleEditSave"
+      @close="closeEditDialog"
+    />
 
     <!-- Delete Confirmation -->
     <div v-if="showDeleteDialog" class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">

--- a/frontend/src/pages/llm-providers/components/CreateProviderDialog.vue
+++ b/frontend/src/pages/llm-providers/components/CreateProviderDialog.vue
@@ -1,0 +1,281 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import {
+  PROVIDER_MODELS,
+  type CreateLlmProviderRequest,
+  type ProviderType,
+  type TestProviderRequest,
+} from '../../../api/llm-providers'
+import { useTestConnectionGate } from '../../../composables/useTestConnectionGate'
+import { PROVIDER_HELP, PROVIDER_TYPES } from '../providerHelp'
+import TunnelHint from './TunnelHint.vue'
+
+const props = defineProps<{
+  orgId: string
+  isFirstProvider: boolean
+  onSubmit: (payload: CreateLlmProviderRequest) => Promise<void>
+}>()
+
+const emit = defineEmits<{
+  (e: 'close'): void
+}>()
+
+const form = ref<CreateLlmProviderRequest>({
+  provider: 'openai',
+  display_name: '',
+  base_url: null,
+  api_key: '',
+})
+// The model lives in CreateLlmProviderRequest.config rather than as a
+// top-level field — keep it as a separate component-local ref and merge
+// at submit time so the v-model on the dropdown actually round-trips.
+const selectedModel = ref<string | undefined>(undefined)
+const creating = ref(false)
+const createError = ref('')
+
+function modelsForType(type: ProviderType) {
+  return PROVIDER_MODELS[type] ?? []
+}
+
+const currentProviderHelp = computed(() => PROVIDER_HELP[form.value.provider])
+
+function onProviderTypeChange() {
+  const help = PROVIDER_HELP[form.value.provider]
+  // Apply provider-specific Base URL default (Ollama → localhost:11434);
+  // null for cloud providers that don't need it; empty string for custom
+  // so the input is shown but unset.
+  if (help.defaultBaseUrl !== undefined) {
+    form.value.base_url = help.defaultBaseUrl
+  } else if (form.value.provider === 'custom') {
+    form.value.base_url = ''
+  } else {
+    form.value.base_url = null
+  }
+  // Reset the per-provider model selection to the first model in the
+  // list, so the previously-selected (and possibly unrelated) model
+  // doesn't leak when switching providers.
+  const models = modelsForType(form.value.provider)
+  selectedModel.value = models[0]?.value
+  // Ollama doesn't require an API key — clear any stale value the user
+  // typed before switching providers.
+  if (!help.requiresKey) {
+    form.value.api_key = ''
+  }
+}
+
+// Create-dialog test-connection gate. The Create button is locked
+// until the probe returns 'pass' so a bad key / unreachable
+// endpoint can't slip into the DB. Any edit to provider / api_key /
+// base_url rolls the state back to 'idle' so the user re-tests.
+const gate = useTestConnectionGate({
+  buildPayload: (): TestProviderRequest => {
+    const help = PROVIDER_HELP[form.value.provider]
+    const api_key = help.requiresKey ? form.value.api_key : 'not-required'
+    return {
+      provider: form.value.provider,
+      api_key,
+      base_url: form.value.base_url,
+    }
+  },
+  invalidateOn: [
+    () => form.value.provider,
+    () => form.value.api_key,
+    () => form.value.base_url,
+  ],
+  orgId: () => props.orgId,
+})
+
+async function handleCreate() {
+  creating.value = true
+  createError.value = ''
+  try {
+    // Mark the first provider as default automatically — the chat / RAG
+    // path 500s ("No active 'X' provider config found") until something
+    // is the default, so a fresh org has zero chance of a working chat
+    // unless we set this on their behalf.
+    const help = PROVIDER_HELP[form.value.provider]
+    // The Go model declares api_key as binding:"required,min=1", so
+    // keyless providers (Ollama) need a stub value to satisfy validation.
+    // Backend ignores the value for these providers — it's purely a
+    // schema artefact, not an actual credential. Note this in the comment
+    // so a future cleanup doesn't get rid of it without also relaxing
+    // the binding.
+    const api_key = help.requiresKey ? form.value.api_key : 'not-required'
+    const payload: CreateLlmProviderRequest = {
+      ...form.value,
+      api_key,
+      ...(selectedModel.value
+        ? { config: { ...(form.value.config ?? {}), model: selectedModel.value } }
+        : {}),
+      ...(props.isFirstProvider ? { is_default: true } : {}),
+    }
+    await props.onSubmit(payload)
+    form.value = { provider: 'openai', display_name: '', base_url: null, api_key: '' }
+    selectedModel.value = undefined
+    emit('close')
+  } catch (e: unknown) {
+    createError.value = e instanceof Error ? e.message : 'Failed to create provider'
+  } finally {
+    creating.value = false
+  }
+}
+
+// True only when a loopback Base URL is paired with a non-loopback
+// browser origin — i.e., the user typed `http://localhost:...` while
+// hitting Raven on a real public host (demo.ravencloak.org, etc.).
+// On Raven-running-locally (desktop / self-host) the loopback address
+// works as-is and the tunnel hint would be noise.
+const isLoopbackBaseURL = computed(() => {
+  const raw = (form.value.base_url ?? '').trim().toLowerCase()
+  if (!raw) return false
+  return (
+    raw.startsWith('http://localhost') ||
+    raw.startsWith('https://localhost') ||
+    raw.startsWith('http://127.') ||
+    raw.startsWith('https://127.') ||
+    raw.startsWith('http://[::1]') ||
+    raw.startsWith('https://[::1]') ||
+    raw.startsWith('http://0.0.0.0') ||
+    raw.startsWith('https://0.0.0.0')
+  )
+})
+
+const ravenHost = computed(() => window.location.hostname)
+const ravenIsRemote = computed(() => {
+  const host = ravenHost.value
+  return host !== 'localhost' && host !== '127.0.0.1' && host !== '[::1]' && host !== '0.0.0.0'
+})
+
+const showTunnelHint = computed(
+  () => form.value.provider === 'ollama' && isLoopbackBaseURL.value && ravenIsRemote.value,
+)
+</script>
+
+<template>
+  <div
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="add-llm-provider-title"
+  >
+    <div class="w-full max-w-2xl max-h-[90vh] overflow-y-auto rounded-lg bg-white p-6 shadow-xl">
+      <h2 id="add-llm-provider-title" class="mb-4 text-lg font-semibold">Add LLM Provider</h2>
+      <form class="space-y-4" @submit.prevent="handleCreate">
+        <div>
+          <label class="block text-sm font-medium text-gray-700">Provider Type</label>
+          <select v-model="form.provider" class="mt-1 block w-full rounded border-gray-300 shadow-sm" @change="onProviderTypeChange">
+            <option v-for="pt in PROVIDER_TYPES" :key="pt.value" :value="pt.value">{{ pt.label }}</option>
+          </select>
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700">Display Name</label>
+          <input v-model="form.display_name" type="text" required class="mt-1 block w-full rounded border-gray-300 shadow-sm" placeholder="e.g. OpenAI Production" />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700">Model</label>
+          <select v-model="selectedModel" class="mt-1 block w-full rounded border-gray-300 shadow-sm">
+            <option v-for="m in modelsForType(form.provider)" :key="m.value" :value="m.value">{{ m.label }}</option>
+          </select>
+        </div>
+        <div v-if="form.provider === 'custom' || form.provider === 'ollama'">
+          <label class="block text-sm font-medium text-gray-700">Base URL</label>
+          <input
+            v-model="form.base_url"
+            type="url"
+            class="mt-1 block w-full rounded border-gray-300 shadow-sm"
+            :placeholder="currentProviderHelp.defaultBaseUrl ?? 'https://api.example.com/v1'"
+          />
+          <p v-if="currentProviderHelp.baseUrlHelp" class="mt-1 text-xs text-gray-500">
+            {{ currentProviderHelp.baseUrlHelp }}
+          </p>
+          <!-- Tunnel hints: only when the user has typed a loopback
+               Base URL while sitting on a remote Raven (e.g. the
+               hosted demo). For self-hosted / Tauri Raven the
+               loopback address works as-is and the hint is noise. -->
+          <TunnelHint
+            v-if="showTunnelHint"
+            :raven-host="ravenHost"
+            :base-url="form.base_url ?? ''"
+          />
+        </div>
+        <div v-if="currentProviderHelp.requiresKey">
+          <label class="block text-sm font-medium text-gray-700">API Key</label>
+          <p class="mt-1 text-xs text-gray-500">
+            {{ currentProviderHelp.helpText }}
+            <a
+              v-if="currentProviderHelp.keyHref"
+              :href="currentProviderHelp.keyHref"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="ml-1 inline-flex items-center text-indigo-600 underline hover:text-indigo-800"
+            >
+              Get a key
+              <svg class="ml-0.5 h-3 w-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><path d="M15 3h6v6"/><path d="M10 14L21 3"/></svg>
+            </a>
+          </p>
+          <input
+            v-model="form.api_key"
+            type="password"
+            autocomplete="off"
+            class="mt-2 block w-full rounded border-gray-300 shadow-sm"
+            :placeholder="currentProviderHelp.keyPrefix ?? 'sk-...'"
+          />
+        </div>
+        <p v-else class="text-xs text-gray-500">
+          {{ currentProviderHelp.helpText }}
+        </p>
+        <p v-if="isFirstProvider" class="text-xs text-gray-400">
+          This will be set as your default provider since it's the first one.
+        </p>
+        <p v-if="createError" class="text-red-500 text-sm">{{ createError }}</p>
+        <!-- Test-connection gate. The Create button is locked until
+             the probe returns 'pass' so a bad key / unreachable
+             endpoint can't slip into the DB. -->
+        <div
+class="rounded-md border p-3 text-xs" :class="{
+          'border-gray-200 bg-gray-50': gate.status.value === 'idle',
+          'border-blue-200 bg-blue-50': gate.status.value === 'testing',
+          'border-green-200 bg-green-50': gate.status.value === 'pass',
+          'border-red-200 bg-red-50': gate.status.value === 'fail',
+        }">
+          <div class="flex items-center justify-between gap-2">
+            <span
+class="font-medium" :class="{
+              'text-gray-700': gate.status.value === 'idle',
+              'text-blue-700': gate.status.value === 'testing',
+              'text-green-700': gate.status.value === 'pass',
+              'text-red-700': gate.status.value === 'fail',
+            }">
+              <template v-if="gate.status.value === 'idle'">Test the connection before saving</template>
+              <template v-else-if="gate.status.value === 'testing'">Testing…</template>
+              <template v-else-if="gate.status.value === 'pass'">✓ Connection looks good</template>
+              <template v-else>✕ Connection failed</template>
+            </span>
+            <button
+              type="button"
+              class="rounded border border-gray-300 bg-white px-3 py-1 text-xs text-gray-700 hover:bg-gray-100 disabled:opacity-50"
+              :disabled="gate.status.value === 'testing' || !form.display_name || (currentProviderHelp.requiresKey && !form.api_key)"
+              @click="gate.runTest"
+            >
+              {{ gate.status.value === 'pass' ? 'Re-test' : gate.status.value === 'testing' ? 'Testing…' : 'Test connection' }}
+            </button>
+          </div>
+          <p
+v-if="gate.detail.value" class="mt-1 text-xs" :class="{
+            'text-green-700': gate.status.value === 'pass',
+            'text-red-700': gate.status.value === 'fail',
+            'text-gray-600': gate.status.value !== 'pass' && gate.status.value !== 'fail',
+          }">
+            {{ gate.detail.value }}
+          </p>
+        </div>
+        <div class="flex justify-end gap-2 pt-2">
+          <button type="button" class="rounded px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" @click="emit('close')">Cancel</button>
+          <button type="submit" :disabled="creating || gate.status.value !== 'pass' || !form.display_name || (currentProviderHelp.requiresKey && !form.api_key)" class="rounded bg-indigo-600 px-4 py-2 text-sm text-white hover:bg-indigo-700 disabled:opacity-50">
+            {{ creating ? 'Creating...' : 'Create' }}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</template>

--- a/frontend/src/pages/llm-providers/components/EditCredentialsDialog.vue
+++ b/frontend/src/pages/llm-providers/components/EditCredentialsDialog.vue
@@ -1,0 +1,294 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import {
+  PROVIDER_MODELS,
+  type LlmProvider,
+  type ProviderType,
+  type TestProviderRequest,
+  type UpdateLlmProviderRequest,
+} from '../../../api/llm-providers'
+import { useTestConnectionGate } from '../../../composables/useTestConnectionGate'
+import { PROVIDER_HELP } from '../providerHelp'
+
+// ---------------------------------------------------------------------------
+// Edit-credentials dialog (#742)
+//
+// Reuses the Create dialog markup but:
+//   - provider is read-only (changing provider type is a delete-and-create);
+//   - api_key starts hidden — clicking "Rotate API key" reveals an empty
+//     input, and only then does the PUT carry `api_key`. Skip = key untouched
+//     server-side (backend preserves the stored ciphertext on partial PUT);
+//   - re-runs Test Connection when EITHER base_url changed OR the rotate
+//     input has a non-empty value. If neither changed the gate hits the
+//     /test endpoint with {provider_id} so the stored key is used without
+//     ever leaving the server;
+//   - any keystroke in provider / base_url / rotate-key rolls the gate
+//     status back to `idle`, so a passing probe can't be smuggled past a
+//     later edit.
+// ---------------------------------------------------------------------------
+
+const props = defineProps<{
+  provider: LlmProvider
+  orgId: string
+  onSubmit: (payload: UpdateLlmProviderRequest) => Promise<void>
+}>()
+
+const emit = defineEmits<{
+  (e: 'close'): void
+}>()
+
+const editForm = ref<{
+  provider: ProviderType
+  display_name: string
+  base_url: string
+  model: string
+}>({
+  provider: props.provider.provider,
+  display_name: props.provider.display_name,
+  base_url: props.provider.base_url ?? '',
+  model:
+    typeof props.provider.config?.model === 'string'
+      ? (props.provider.config.model as string)
+      : '',
+})
+const editInitialBaseUrl = ref<string>(props.provider.base_url ?? '')
+const showRotateKey = ref(false)
+const rotateApiKey = ref('')
+const editError = ref('')
+const editSaving = ref(false)
+
+function modelsForType(type: ProviderType) {
+  return PROVIDER_MODELS[type] ?? []
+}
+
+const editProviderHelp = computed(() => PROVIDER_HELP[editForm.value.provider])
+const editProviderHasKey = computed(() => editProviderHelp.value.requiresKey)
+// Edit dialog needs Base URL whenever the provider type does — same
+// rule as Create.
+const editShowBaseUrl = computed(
+  () => editForm.value.provider === 'custom' || editForm.value.provider === 'ollama',
+)
+// Test-Connection re-gate is REQUIRED when either base_url changed from
+// what's persisted OR the user typed a new key into Rotate. Otherwise
+// nothing security-sensitive is changing and Save is allowed without
+// a probe.
+const editGateRequired = computed(() => {
+  const baseUrlChanged = editForm.value.base_url !== editInitialBaseUrl.value
+  const rotateProvided = showRotateKey.value && rotateApiKey.value.length > 0
+  return baseUrlChanged || rotateProvided
+})
+
+// Any keystroke in fields that affect the credential probe (provider,
+// base_url, rotate-key input) invalidates a prior pass. The provider
+// is read-only in the dialog but we still watch it to stay honest in
+// case that ever changes.
+const gate = useTestConnectionGate({
+  buildPayload: (): TestProviderRequest => {
+    // Decide which body shape to send. When base_url changed OR the
+    // user typed a new key, we have inline values to probe with. When
+    // neither changed we don't have a secret in memory — fall back to
+    // the {provider_id} shape so the server uses the stored key.
+    const baseUrlChanged = editForm.value.base_url !== editInitialBaseUrl.value
+    const rotateProvided = showRotateKey.value && rotateApiKey.value.length > 0
+    if (rotateProvided) {
+      return {
+        provider: editForm.value.provider,
+        api_key: rotateApiKey.value,
+        ...(editShowBaseUrl.value
+          ? { base_url: editForm.value.base_url || null }
+          : {}),
+      }
+    }
+    if (baseUrlChanged) {
+      return {
+        provider_id: props.provider.id,
+        ...(editShowBaseUrl.value
+          ? { base_url: editForm.value.base_url || null }
+          : {}),
+      }
+    }
+    return { provider_id: props.provider.id }
+  },
+  invalidateOn: [
+    () => editForm.value.provider,
+    () => editForm.value.base_url,
+    () => rotateApiKey.value,
+    () => showRotateKey.value,
+  ],
+  orgId: () => props.orgId,
+})
+
+const editCanSave = computed(() => {
+  if (editSaving.value) return false
+  if (!editForm.value.display_name) return false
+  if (editGateRequired.value && gate.status.value !== 'pass') return false
+  return true
+})
+
+async function handleEditSave() {
+  editSaving.value = true
+  editError.value = ''
+  try {
+    const payload: UpdateLlmProviderRequest = {
+      display_name: editForm.value.display_name,
+    }
+    // base_url: include when the dialog renders it. Empty string is
+    // explicitly nulled (matches Create behaviour); a value is sent as-is.
+    if (editShowBaseUrl.value) {
+      payload.base_url = editForm.value.base_url === '' ? null : editForm.value.base_url
+    }
+    // Rotate semantics: omit api_key entirely when the user did NOT
+    // click Rotate — backend (PR #749) preserves the stored ciphertext
+    // on a partial PUT.
+    if (showRotateKey.value && rotateApiKey.value.length > 0) {
+      payload.api_key = rotateApiKey.value
+    }
+    // Persist the selected model under config.model. Merge into the
+    // existing config so unrelated keys aren't dropped.
+    if (editForm.value.model) {
+      const existingConfig = (props.provider.config ?? {}) as Record<string, unknown>
+      payload.config = { ...existingConfig, model: editForm.value.model }
+    }
+    await props.onSubmit(payload)
+    emit('close')
+  } catch (e: unknown) {
+    editError.value = e instanceof Error ? e.message : 'Failed to save provider'
+  } finally {
+    editSaving.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+    <div class="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+      <h2 class="mb-4 text-lg font-semibold">Edit credentials</h2>
+      <form class="space-y-4" @submit.prevent="handleEditSave">
+        <div>
+          <label class="block text-sm font-medium text-gray-700">Provider Type</label>
+          <input
+            :value="editForm.provider"
+            type="text"
+            readonly
+            disabled
+            class="mt-1 block w-full rounded border-gray-200 bg-gray-50 text-gray-600 shadow-sm"
+          />
+          <p class="mt-1 text-xs text-gray-400">
+            Provider type can't be changed. Delete and re-create to switch.
+          </p>
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700">Display Name</label>
+          <input
+            v-model="editForm.display_name"
+            type="text"
+            required
+            class="mt-1 block w-full rounded border-gray-300 shadow-sm"
+          />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700">Model</label>
+          <select v-model="editForm.model" class="mt-1 block w-full rounded border-gray-300 shadow-sm">
+            <option v-for="m in modelsForType(editForm.provider)" :key="m.value" :value="m.value">{{ m.label }}</option>
+          </select>
+        </div>
+        <div v-if="editShowBaseUrl">
+          <label class="block text-sm font-medium text-gray-700">Base URL</label>
+          <input
+            v-model="editForm.base_url"
+            type="url"
+            class="mt-1 block w-full rounded border-gray-300 shadow-sm"
+            placeholder="https://api.example.com/v1"
+          />
+        </div>
+
+        <!-- Rotate API key disclosure: hidden entirely for keyless providers (Ollama). -->
+        <div v-if="editProviderHasKey">
+          <button
+            v-if="!showRotateKey"
+            type="button"
+            class="rounded border border-gray-300 px-3 py-1 text-xs text-gray-700 hover:bg-gray-50"
+            @click="showRotateKey = true"
+          >
+            Rotate API key
+          </button>
+          <div v-else>
+            <label class="block text-sm font-medium text-gray-700">New API Key</label>
+            <p class="mt-1 text-xs text-gray-500">
+              {{ editProviderHelp.helpText }}
+              <a
+                v-if="editProviderHelp.keyHref"
+                :href="editProviderHelp.keyHref"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="ml-1 inline-flex items-center text-indigo-600 underline hover:text-indigo-800"
+              >
+                Get a key
+              </a>
+            </p>
+            <input
+              v-model="rotateApiKey"
+              type="password"
+              autocomplete="off"
+              class="mt-2 block w-full rounded border-gray-300 shadow-sm"
+              :placeholder="editProviderHelp.keyPrefix ?? 'sk-...'"
+            />
+            <button
+              type="button"
+              class="mt-1 text-xs text-gray-500 hover:underline"
+              @click="showRotateKey = false; rotateApiKey = ''"
+            >
+              Cancel rotation
+            </button>
+          </div>
+        </div>
+
+        <!-- Test-Connection gate. Only visible when a credential-affecting
+             field changed; result is required to be `pass` before Save. -->
+        <div v-if="editGateRequired" class="rounded border border-gray-200 bg-gray-50 p-3">
+          <div class="flex items-center justify-between">
+            <span class="text-sm font-medium text-gray-700">Test connection</span>
+            <button
+              type="button"
+              :disabled="gate.status.value === 'testing'"
+              class="rounded bg-gray-700 px-3 py-1 text-xs text-white hover:bg-gray-800 disabled:opacity-50"
+              @click="gate.runTest"
+            >
+              {{ gate.status.value === 'testing' ? 'Testing...' : 'Test now' }}
+            </button>
+          </div>
+          <p
+            v-if="gate.status.value === 'pass'"
+            class="mt-2 text-xs text-green-700"
+          >
+            ✓ Connection OK{{ gate.detail.value ? ` — ${gate.detail.value}` : '' }}
+          </p>
+          <p
+            v-else-if="gate.status.value === 'fail'"
+            class="mt-2 text-xs text-red-600"
+          >
+            ✕ {{ gate.detail.value || 'Connection failed' }}
+          </p>
+          <p
+            v-else-if="gate.status.value === 'idle'"
+            class="mt-2 text-xs text-gray-500"
+          >
+            Required: the {{ showRotateKey && rotateApiKey ? 'new key' : 'updated Base URL' }} must pass before Save is enabled.
+          </p>
+        </div>
+
+        <p v-if="editError" class="text-red-500 text-sm">{{ editError }}</p>
+        <div class="flex justify-end gap-2 pt-2">
+          <button type="button" class="rounded px-4 py-2 text-sm text-gray-700 hover:bg-gray-100" @click="emit('close')">Cancel</button>
+          <button
+            type="submit"
+            :disabled="!editCanSave"
+            class="rounded bg-indigo-600 px-4 py-2 text-sm text-white hover:bg-indigo-700 disabled:opacity-50"
+          >
+            {{ editSaving ? 'Saving...' : 'Save' }}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</template>

--- a/frontend/src/pages/llm-providers/components/ProviderCard.vue
+++ b/frontend/src/pages/llm-providers/components/ProviderCard.vue
@@ -1,0 +1,219 @@
+<script setup lang="ts">
+import { nextTick, ref } from 'vue'
+import {
+  PROVIDER_MODELS,
+  type LlmProvider,
+  type ProviderType,
+} from '../../../api/llm-providers'
+import { PROVIDER_TYPE_LABEL } from '../providerHelp'
+
+const props = defineProps<{
+  provider: LlmProvider
+  isHealthy: boolean
+  healthFailureReason: string
+  /** Provider id whose "Make default" request is currently in-flight. */
+  settingDefaultId: string | null
+  /** Provider id with the "Last test failed" warning. */
+  testFailedForId: boolean
+  /** Provider id flashing the "Saved ✓" tick. */
+  showSavedTick: boolean
+}>()
+
+const emit = defineEmits<{
+  (e: 'make-default', id: string): void
+  (e: 'edit-credentials', provider: LlmProvider): void
+  (e: 'delete', id: string, name: string): void
+  (e: 'rename', provider: LlmProvider, nextName: string): void
+  (e: 'change-model', provider: LlmProvider, nextModel: string): void
+}>()
+
+function modelsForType(type: ProviderType) {
+  return PROVIDER_MODELS[type] ?? []
+}
+
+function providerModel(provider: LlmProvider): string {
+  const m = provider.config?.model
+  return typeof m === 'string' ? m : ''
+}
+
+// Inline display-name editor (#744): click-to-edit input. Enter / blur
+// saves through the rename emit; Esc cancels. The page owns the
+// optimistic mutation + rollback — the card only manages the local
+// editor state.
+const editing = ref(false)
+const draft = ref('')
+const nameInputRef = ref<HTMLInputElement | null>(null)
+
+async function startEditName() {
+  editing.value = true
+  draft.value = props.provider.display_name
+  await nextTick()
+  nameInputRef.value?.focus()
+  nameInputRef.value?.select()
+}
+
+function cancelEditName() {
+  editing.value = false
+  draft.value = ''
+}
+
+function commitEditName() {
+  const target = draft.value.trim()
+  // No-op if unchanged or empty — just close the inline editor.
+  if (!target || target === props.provider.display_name) {
+    cancelEditName()
+    return
+  }
+  editing.value = false
+  draft.value = ''
+  emit('rename', props.provider, target)
+}
+</script>
+
+<template>
+  <article
+    class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
+    data-testid="provider-card"
+  >
+    <!-- Header row: icon + (editable name | status | default pill) -->
+    <div class="flex items-start gap-3">
+      <!-- Provider-type icon (chip glyph for visual consistency with the M13 menu). -->
+      <span
+        aria-hidden="true"
+        class="mt-0.5 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-indigo-50 text-indigo-600"
+      >
+        <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <rect x="4" y="4" width="16" height="16" rx="2" />
+          <rect x="9" y="9" width="6" height="6" />
+          <path d="M9 1v3M15 1v3M9 20v3M15 20v3M1 9h3M1 15h3M20 9h3M20 15h3" />
+        </svg>
+      </span>
+
+      <div class="min-w-0 flex-1">
+        <!-- Editable display_name + status badge + default pill -->
+        <div class="flex flex-wrap items-center gap-2">
+          <input
+            v-if="editing"
+            ref="nameInputRef"
+            v-model="draft"
+            type="text"
+            data-testid="display-name-input"
+            class="min-w-0 flex-1 rounded border border-indigo-300 px-2 py-1 text-base font-semibold text-gray-900 shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+            @keydown.enter.prevent="commitEditName"
+            @keydown.esc.prevent="cancelEditName"
+            @blur="commitEditName"
+          />
+          <button
+            v-else
+            type="button"
+            data-testid="display-name-label"
+            class="truncate rounded px-1 py-0.5 text-left text-base font-semibold text-gray-900 hover:bg-gray-50 focus:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-300"
+            :title="`Click to rename — ${provider.display_name}`"
+            @click="startEditName"
+          >
+            {{ provider.display_name }}
+          </button>
+          <span
+            :class="[
+              'shrink-0 rounded-full px-2 py-0.5 text-xs font-medium',
+              provider.status === 'active'
+                ? 'bg-green-100 text-green-700'
+                : 'bg-gray-100 text-gray-600',
+            ]"
+          >
+            {{ provider.status }}
+          </span>
+          <span
+            v-if="provider.is_default"
+            data-testid="default-pill"
+            class="shrink-0 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 transition duration-200 ease-out"
+          >
+            Default
+          </span>
+          <span
+            v-if="provider.is_default && !isHealthy"
+            data-testid="default-connection-error"
+            class="shrink-0 rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700"
+            :title="healthFailureReason"
+          >
+            Connection error
+          </span>
+          <span
+            v-if="showSavedTick"
+            data-testid="saved-tick"
+            class="shrink-0 text-xs font-medium text-green-600"
+            role="status"
+            aria-live="polite"
+          >
+            Saved ✓
+          </span>
+        </div>
+
+        <!-- Type + base_url meta -->
+        <p class="mt-1 text-sm text-gray-500">
+          {{ PROVIDER_TYPE_LABEL[provider.provider] }}
+          <span v-if="provider.base_url" class="break-all"> &middot; {{ provider.base_url }}</span>
+        </p>
+
+        <!-- Inline model selector + api-key hint -->
+        <div class="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
+          <label class="flex items-center gap-2 text-xs text-gray-600">
+            <span class="shrink-0">Model</span>
+            <select
+              data-testid="model-select"
+              class="rounded border-gray-300 px-2 py-1 text-xs shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              :value="providerModel(provider)"
+              @change="emit('change-model', provider, ($event.target as HTMLSelectElement).value)"
+            >
+              <option v-if="!providerModel(provider)" value="">Select model…</option>
+              <option
+                v-for="m in modelsForType(provider.provider)"
+                :key="m.value"
+                :value="m.value"
+              >
+                {{ m.label }}
+              </option>
+            </select>
+          </label>
+          <span class="text-xs text-gray-400">
+            API key {{ provider.api_key_hint ? 'configured' : 'not set' }}
+          </span>
+        </div>
+
+        <p
+          v-if="!provider.is_default && testFailedForId"
+          class="mt-2 rounded border border-amber-300 bg-amber-50 px-2 py-1 text-xs text-amber-800"
+        >
+          Last connection test failed — switching default may break chat.
+        </p>
+      </div>
+    </div>
+
+    <!-- Action row: wraps under content on narrow viewports. -->
+    <div class="mt-3 flex flex-wrap justify-end gap-2 border-t border-gray-100 pt-3">
+      <button
+        v-if="!provider.is_default"
+        data-testid="make-default-btn"
+        :disabled="settingDefaultId === provider.id"
+        class="rounded border border-amber-300 px-3 py-1 text-xs font-medium text-amber-800 hover:bg-amber-50 disabled:opacity-50"
+        @click="emit('make-default', provider.id)"
+      >
+        {{ settingDefaultId === provider.id ? 'Setting...' : 'Make default' }}
+      </button>
+      <button
+        data-testid="edit-credentials-btn"
+        class="rounded border border-gray-300 px-3 py-1 text-xs text-gray-700 hover:bg-gray-50"
+        @click="emit('edit-credentials', provider)"
+      >
+        Edit credentials
+      </button>
+      <button
+        data-testid="delete-btn"
+        class="rounded border border-red-300 px-3 py-1 text-xs text-red-700 hover:bg-red-50"
+        @click="emit('delete', provider.id, provider.display_name)"
+      >
+        Delete
+      </button>
+    </div>
+  </article>
+</template>

--- a/frontend/src/pages/llm-providers/components/TunnelHint.vue
+++ b/frontend/src/pages/llm-providers/components/TunnelHint.vue
@@ -1,0 +1,154 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+
+defineProps<{
+  ravenHost: string
+  baseUrl: string
+}>()
+
+// Tunnel suggestions shown in the Ollama branch so a user on the
+// hosted demo (whose Vultr box can't reach `localhost`) has a one-liner
+// to expose their local daemon publicly. Cloudflare's `trycloudflare`
+// mode is the recommended first option — no account, no install of
+// anything Raven-side, free, auto-TLS. ngrok is the fallback for users
+// who already have it set up.
+//
+// `install` carries platform-specific install one-liners + a download
+// docs URL for users who don't already have the binary. Detecting the
+// host OS via navigator.userAgent picks the matching command; the docs
+// link is always shown as the universal fallback.
+const ollamaTunnels: {
+  label: string
+  command: string
+  note?: string
+  install: { docsHref: string; macos: string; windows: string; linux: string }
+}[] = [
+  {
+    label: 'Cloudflare Tunnel (recommended)',
+    // --http-host-header localhost is critical: Ollama's HTTP server rejects
+    // any request whose Host header isn't 127.0.0.1 / localhost (security
+    // hardening). cloudflared's default forwards the public tunnel hostname
+    // as Host, which Ollama returns 403 to with an empty body. The flag
+    // tells cloudflared to rewrite Host to "localhost" on the upstream hop
+    // so Ollama treats it as a local call.
+    command: 'cloudflared tunnel --url http://localhost:11434 --http-host-header localhost',
+    note: 'Prints an https://<random>.trycloudflare.com URL. No account needed. The --http-host-header flag is mandatory — Ollama 403s any other Host. Paste the printed URL into Base URL above.',
+    install: {
+      docsHref:
+        'https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/',
+      macos: 'brew install cloudflared',
+      windows: 'winget install --id Cloudflare.cloudflared',
+      linux: "See the download page for your distro's package or static binary.",
+    },
+  },
+  {
+    label: 'ngrok',
+    // --host-header=rewrite serves the same purpose as cloudflared's
+    // --http-host-header: rewrites the Host on the upstream hop to
+    // 127.0.0.1:11434 so Ollama's Host-allowlist check accepts the call.
+    // Without it, ngrok forwards Host: <subdomain>.ngrok.app and Ollama 403s.
+    command: 'ngrok http 11434 --host-header=rewrite',
+    note: 'Free account required for stable URLs. The --host-header=rewrite flag is mandatory — Ollama 403s any other Host. Use the https Forwarding address.',
+    install: {
+      docsHref: 'https://ngrok.com/download',
+      macos: 'brew install ngrok',
+      windows: 'winget install ngrok.ngrok',
+      linux:
+        'curl -sSL https://ngrok-agent.s3.amazonaws.com/ngrok.asc | sudo tee /etc/apt/trusted.gpg.d/ngrok.asc >/dev/null && echo "deb https://ngrok-agent.s3.amazonaws.com buster main" | sudo tee /etc/apt/sources.list.d/ngrok.list && sudo apt update && sudo apt install ngrok',
+    },
+  },
+]
+
+// Best-effort platform detection — userAgent is fine here because we
+// only use it to pick a default install one-liner, not for anything
+// security-sensitive. Falls back to the docs URL if unsure.
+function detectOS(): 'macos' | 'windows' | 'linux' | 'unknown' {
+  const ua = navigator.userAgent.toLowerCase()
+  if (ua.includes('mac')) return 'macos'
+  if (ua.includes('win')) return 'windows'
+  if (ua.includes('linux')) return 'linux'
+  return 'unknown'
+}
+const userOS = detectOS()
+function installCommandForOS(t: (typeof ollamaTunnels)[number]) {
+  if (userOS === 'macos') return t.install.macos
+  if (userOS === 'windows') return t.install.windows
+  if (userOS === 'linux') return t.install.linux
+  return null
+}
+function installLabelForOS(): string {
+  if (userOS === 'macos') return 'Install on macOS'
+  if (userOS === 'windows') return 'Install on Windows'
+  if (userOS === 'linux') return 'Install on Linux'
+  return 'Install'
+}
+
+const copied = ref<string | null>(null)
+async function copyTunnel(command: string) {
+  try {
+    await navigator.clipboard.writeText(command)
+    copied.value = command
+    setTimeout(() => (copied.value === command ? (copied.value = null) : null), 1500)
+  } catch {
+    // Clipboard access can fail under restrictive permissions / older
+    // browsers — surface the command in the UI and let the user copy
+    // it manually instead of throwing.
+    copied.value = null
+  }
+}
+</script>
+
+<template>
+  <div class="mt-3 rounded-md border border-gray-200 bg-gray-50 p-3">
+    <p class="text-xs font-medium text-gray-700">
+      {{ ravenHost }} can't reach <code class="font-mono">{{ baseUrl }}</code> on your machine. Expose Ollama temporarily:
+    </p>
+    <ul class="mt-2 space-y-3">
+      <li v-for="t in ollamaTunnels" :key="t.label" class="text-xs">
+        <div class="font-medium text-gray-600">{{ t.label }}</div>
+        <!-- Install one-liner for the user's detected OS, with a
+             fallback link to the upstream download docs that
+             cover Linux distros + manual installs. -->
+        <div v-if="installCommandForOS(t)" class="mt-0.5">
+          <div class="text-[11px] text-gray-500">{{ installLabelForOS() }}:</div>
+          <div class="mt-0.5 flex items-center gap-1.5">
+            <code class="flex-1 truncate rounded bg-gray-800 px-2 py-1 text-[11px] text-gray-100">{{ installCommandForOS(t) }}</code>
+            <button
+              type="button"
+              class="shrink-0 rounded border border-gray-300 bg-white px-2 py-1 text-[11px] text-gray-700 hover:bg-gray-100"
+              @click="copyTunnel(installCommandForOS(t) ?? '')"
+            >
+              {{ copied === installCommandForOS(t) ? 'Copied' : 'Copy' }}
+            </button>
+          </div>
+        </div>
+        <a
+          :href="t.install.docsHref"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="mt-1 inline-flex items-center text-[11px] text-indigo-600 underline hover:text-indigo-800"
+        >
+          Other install options
+          <svg class="ml-0.5 h-3 w-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><path d="M15 3h6v6"/><path d="M10 14L21 3"/></svg>
+        </a>
+        <div class="mt-1.5">
+          <div class="text-[11px] text-gray-500">Then run:</div>
+          <div class="mt-0.5 flex items-center gap-1.5">
+            <code class="flex-1 truncate rounded bg-gray-900 px-2 py-1 text-[11px] text-gray-100">{{ t.command }}</code>
+            <button
+              type="button"
+              class="shrink-0 rounded border border-gray-300 bg-white px-2 py-1 text-[11px] text-gray-700 hover:bg-gray-100"
+              @click="copyTunnel(t.command)"
+            >
+              {{ copied === t.command ? 'Copied' : 'Copy' }}
+            </button>
+          </div>
+        </div>
+        <p v-if="t.note" class="mt-0.5 text-gray-500">{{ t.note }}</p>
+      </li>
+    </ul>
+    <p class="mt-2 text-[11px] text-amber-700">
+      <strong>Heads up:</strong> a public tunnel exposes your local Ollama to anyone with the URL. Close the tunnel when you're done, or restrict by IP / auth.
+    </p>
+  </div>
+</template>

--- a/frontend/src/pages/llm-providers/providerHelp.ts
+++ b/frontend/src/pages/llm-providers/providerHelp.ts
@@ -1,0 +1,64 @@
+import type { ProviderType } from '../../api/llm-providers'
+
+export interface ProviderHelpEntry {
+  keyHref?: string
+  keyPrefix?: string
+  helpText: string
+  requiresKey: boolean
+  defaultBaseUrl?: string
+  baseUrlHelp?: string
+}
+
+// Per-provider onboarding guidance shown in the Add-Provider dialog.
+// `keyHref` deep-links to the vendor's API-key console so the user can
+// mint a key without leaving the flow; `keyPrefix` is shown in the
+// placeholder so they know what shape the key should have; `helpText`
+// is a one-liner above the API-key field. Keyed off ProviderType.
+// `requiresKey=false` hides API-key inputs entirely (Edit dialog skips
+// Rotate-key for these; today only Ollama). `defaultBaseUrl` auto-fills
+// the Base URL input when the provider type flips; `baseUrlHelp` is a
+// one-liner shown below the input.
+export const PROVIDER_HELP: Record<ProviderType, ProviderHelpEntry> = {
+  openai: {
+    keyHref: 'https://platform.openai.com/api-keys',
+    keyPrefix: 'sk-...',
+    helpText: 'Generate a Secret Key in the OpenAI dashboard and paste it below.',
+    requiresKey: true,
+  },
+  anthropic: {
+    keyHref: 'https://console.anthropic.com/settings/keys',
+    keyPrefix: 'sk-ant-...',
+    helpText: 'Generate an API key in the Anthropic Console and paste it below.',
+    requiresKey: true,
+  },
+  ollama: {
+    helpText:
+      "Ollama runs locally and needs no API key. Point Base URL at your Ollama daemon — http://localhost:11434 by default. The hosted demo can't reach a private LAN address, so this works for self-hosted / Tauri-desktop Raven, or expose your Ollama via a public tunnel.",
+    requiresKey: false,
+    defaultBaseUrl: 'http://localhost:11434',
+    baseUrlHelp:
+      'Address of the Ollama daemon (default port 11434). Must be reachable from wherever the Raven server runs.',
+  },
+  custom: {
+    keyPrefix: "your provider's key",
+    helpText:
+      'For any OpenAI-compatible provider (Together, Groq, Fireworks, vLLM, etc.). Set Base URL to the provider root (Raven appends /v1/models, /v1/chat/completions, etc).',
+    requiresKey: true,
+  },
+}
+
+export const PROVIDER_TYPES: { value: ProviderType; label: string }[] = [
+  { value: 'openai', label: 'OpenAI' },
+  { value: 'anthropic', label: 'Anthropic' },
+  { value: 'ollama', label: 'Ollama' },
+  { value: 'custom', label: 'Custom' },
+]
+
+// Pretty-print provider type for the card body. Keep in lockstep with
+// PROVIDER_TYPES above — single source of truth for label text.
+export const PROVIDER_TYPE_LABEL: Record<ProviderType, string> = {
+  openai: 'OpenAI',
+  anthropic: 'Anthropic',
+  ollama: 'Ollama',
+  custom: 'Custom',
+}


### PR DESCRIPTION
## Summary

Decomposes `frontend/src/pages/llm-providers/LlmProviderListPage.vue` (was **1212 lines**) into focused components plus a reusable composable. **No behaviour changes.**

## New layout

| File | Lines |
|---|---:|
| `frontend/src/pages/llm-providers/LlmProviderListPage.vue` | **307** |
| `frontend/src/pages/llm-providers/components/ProviderCard.vue` | 219 |
| `frontend/src/pages/llm-providers/components/CreateProviderDialog.vue` | 281 |
| `frontend/src/pages/llm-providers/components/EditCredentialsDialog.vue` | 294 |
| `frontend/src/pages/llm-providers/components/TunnelHint.vue` | 154 |
| `frontend/src/pages/llm-providers/providerHelp.ts` | 64 |
| `frontend/src/composables/useTestConnectionGate.ts` | 79 |

## Composable contract

`useTestConnectionGate({ buildPayload, invalidateOn, orgId })` returns `{ status, detail, runTest, reset }`. `buildPayload` is a closure called lazily on each `runTest()` so the consumer shapes the request body around its current form state; `invalidateOn` is an array of `WatchSource` getters that roll `status` back to `idle` on any change so a passing probe can't be smuggled past a later edit. Both Create and Edit dialogs now hold a single `gate` instance — the duplicated `createTestStatus` / `editTestStatus` machines are gone.

## Test plan

- [x] `npx vue-tsc -b` clean
- [x] `npm run lint` — 3 pre-existing warnings remain, no new ones
- [x] `npm run test:unit` — 159/159 pass
- [x] All `data-testid` attributes preserved on the same DOM nodes (`provider-card`, `make-default-btn`, `edit-credentials-btn`, `display-name-input`, `display-name-label`, `model-select`, `default-pill`, `default-connection-error`, `saved-tick`, `delete-btn`, `provider-list`, `llm-health-banner`, `default-error-toast`)
- [ ] Playwright e2e flows still pass (selectors unchanged; not run locally)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added connection testing for LLM providers before saving configuration
* Redesigned provider management with dialog-based add and edit workflows
* Improved provider cards with inline name editing, model selection, and action buttons
* Added setup guidance for remote Ollama configurations with tunnel options (Cloudflare Tunnel and ngrok)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->