### PR TITLE
refactor(db): extract withRLSVar helper for WithOrgID/WithUserID

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -21,23 +21,37 @@ func New(ctx context.Context, databaseURL string) (*pgxpool.Pool, error) {
 	return pool, nil
 }
 
-// WithOrgID executes fn inside a transaction with app.current_org_id set for RLS.
-// The transaction is automatically rolled back on error and committed on success.
-// orgID is passed as a parameter to set_config to prevent SQL injection.
-func WithOrgID(ctx context.Context, pool *pgxpool.Pool, orgID string, fn func(tx pgx.Tx) error) error {
+// withRLSVar runs fn in a transaction with a single Postgres GUC set via
+// set_config so RLS policies that read it (e.g. current_setting('app.current_org_id'))
+// see the scoped value. Both the variable name and its value are passed as
+// parameters to set_config, so neither is string-interpolated into SQL.
+// Private — callers should use the WithOrgID / WithUserID wrappers.
+func withRLSVar(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	varName, varValue string,
+	fn func(tx pgx.Tx) error,
+) error {
 	tx, err := pool.Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
 	}
 	defer tx.Rollback(ctx) //nolint:errcheck
 
-	if _, err := tx.Exec(ctx, "SELECT set_config('app.current_org_id', $1, true)", orgID); err != nil {
-		return fmt.Errorf("set org_id: %w", err)
+	if _, err := tx.Exec(ctx, "SELECT set_config($1, $2, true)", varName, varValue); err != nil {
+		return fmt.Errorf("set %s: %w", varName, err)
 	}
 	if err := fn(tx); err != nil {
 		return err
 	}
 	return tx.Commit(ctx)
+}
+
+// WithOrgID executes fn inside a transaction with app.current_org_id set for RLS.
+// The transaction is automatically rolled back on error and committed on success.
+// orgID is passed as a parameter to set_config to prevent SQL injection.
+func WithOrgID(ctx context.Context, pool *pgxpool.Pool, orgID string, fn func(tx pgx.Tx) error) error {
+	return withRLSVar(ctx, pool, "app.current_org_id", orgID, fn)
 }
 
 // WithUserID executes fn inside a transaction with app.current_user_id set for
@@ -47,17 +61,5 @@ func WithOrgID(ctx context.Context, pool *pgxpool.Pool, orgID string, fn func(tx
 //
 // userID is passed as a parameter to set_config to prevent SQL injection.
 func WithUserID(ctx context.Context, pool *pgxpool.Pool, userID string, fn func(tx pgx.Tx) error) error {
-	tx, err := pool.Begin(ctx)
-	if err != nil {
-		return fmt.Errorf("begin tx: %w", err)
-	}
-	defer tx.Rollback(ctx) //nolint:errcheck
-
-	if _, err := tx.Exec(ctx, "SELECT set_config('app.current_user_id', $1, true)", userID); err != nil {
-		return fmt.Errorf("set user_id: %w", err)
-	}
-	if err := fn(tx); err != nil {
-		return err
-	}
-	return tx.Commit(ctx)
+	return withRLSVar(ctx, pool, "app.current_user_id", userID, fn)
 }

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ravencloak-org/Raven/internal/db"
+	"github.com/ravencloak-org/Raven/internal/testutil"
 )
 
 // TestWithOrgID_SignatureStable confirms the exported symbol is callable
@@ -34,4 +36,45 @@ func TestWithOrgID_NilPool_Panics(t *testing.T) {
 		t.Fatal("fn should not be called with nil pool")
 		return nil
 	})
+}
+
+// TestWithRLSVar_ParameterisedSetConfig is the safety net for the
+// withRLSVar refactor: both WithOrgID and WithUserID delegate to one helper
+// that passes the GUC name as $1 and the value as $2 to set_config. If
+// Postgres ever rejects a parameterised first arg to set_config, this test
+// flips red before callers do.
+func TestWithRLSVar_ParameterisedSetConfig(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	pool := testutil.NewTestDB(t)
+
+	const (
+		orgID  = "00000000-0000-0000-0000-0000000000aa"
+		userID = "00000000-0000-0000-0000-0000000000bb"
+	)
+
+	// WithOrgID must make current_setting('app.current_org_id') visible to fn.
+	require.NoError(t, db.WithOrgID(ctx, pool, orgID, func(tx pgx.Tx) error {
+		var got string
+		if err := tx.QueryRow(ctx,
+			`SELECT current_setting('app.current_org_id', true)`,
+		).Scan(&got); err != nil {
+			return err
+		}
+		require.Equal(t, orgID, got)
+		return nil
+	}))
+
+	// WithUserID must make current_setting('app.current_user_id') visible to fn.
+	require.NoError(t, db.WithUserID(ctx, pool, userID, func(tx pgx.Tx) error {
+		var got string
+		if err := tx.QueryRow(ctx,
+			`SELECT current_setting('app.current_user_id', true)`,
+		).Scan(&got); err != nil {
+			return err
+		}
+		require.Equal(t, userID, got)
+		return nil
+	}))
 }


### PR DESCRIPTION
## What

`db.WithOrgID` and `db.WithUserID` were near-identical: same begin-tx + `set_config` + rollback-on-error + commit-on-success shape, only the GUC name (`app.current_org_id` vs `app.current_user_id`) and value differed. Pull the shared body into a private `withRLSVar` helper. The two public functions become 1-line wrappers that pin the variable name.

## Why

Two copies of a 12-line transaction-handling block is two places to forget `defer tx.Rollback`, two places to wrap errors, two places to update if the RLS pattern ever changes (e.g. a third tenant axis). One helper, two thin wrappers.

## What changed

- `internal/db/db.go`
  - New private `withRLSVar(ctx, pool, varName, varValue, fn)` — owns the tx lifecycle and calls `SELECT set_config($1, $2, true)` with **both** arguments parameterised.
  - `WithOrgID` / `WithUserID` reduced to 1-line wrappers.
  - Public signatures unchanged → no caller edits needed.
- `internal/db/db_test.go`
  - New `TestWithRLSVar_ParameterisedSetConfig` (live DB via `testutil.NewTestDB`) — calls both wrappers, then reads back `current_setting('app.current_org_id')` and `current_setting('app.current_user_id')` from inside the tx. Locks in that Postgres accepts a parameterised first arg to `set_config`, the core assumption behind the refactor.

## Verification

- `go build ./...` and `go vet ./...` clean.
- `golangci-lint run --new-from-rev=origin/main ./...` → 0 issues.
- DB-less unit tests in `internal/db` pass locally (`TestWithOrgID_SignatureStable`, `TestWithOrgID_NilPool_Panics`).
- Live-DB tests (the new `TestWithRLSVar_ParameterisedSetConfig` and the pre-existing `TestVerifyMigrationsState_*`) cannot be exercised on this worktree host — the testcontainers Ryuk reaper can't mount the colima docker.sock. CI runs them on a clean docker host.

## Acceptance check

- [x] One `withRLSVar` helper + two 1-line public wrappers.
- [x] All existing `db.WithOrgID` / `db.WithUserID` call sites compile unchanged (`go build ./...` passes).
- [x] New test exercises both wrappers and confirms `current_setting('app.current_org_id')` / `current_setting('app.current_user_id')` return the expected values.