### PR TITLE
fix(db): resize response_cache.query_embedding to vector(768)

### DIFF
--- a/migrations/00056_response_cache_resize_to_768.sql
+++ b/migrations/00056_response_cache_resize_to_768.sql
@@ -1,3 +1,4 @@
+-- +goose NO TRANSACTION
 -- +goose Up
 -- Resize response_cache.query_embedding from vector(1536) to vector(768) to
 -- match the active embedding model (nomic-embed-text via Ollama). The Python
@@ -15,26 +16,42 @@
 -- a default, and a vector default makes no semantic sense for a cache
 -- key. TRUNCATE first so the ADD succeeds on any DB state (empty on the
 -- demo today, possibly populated on a self-hosted instance the day this
--- ships).
+-- ships). Running outside a transaction lets us use DROP/CREATE INDEX
+-- CONCURRENTLY so the migration is safe to replay on a live table.
 
-DROP INDEX IF EXISTS idx_response_cache_embedding;
+-- Bound the locks taken by the DDL below so a long-running query cannot
+-- block production indefinitely.
+SET lock_timeout = '5s';
+SET statement_timeout = '5min';
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_response_cache_embedding;
 
 TRUNCATE response_cache;
 
+-- The table is truncated above; the drop+add is the simplest path to
+-- change a pgvector dimension. If this migration is ever back-ported to
+-- a populated cluster without truncation, replace with an additive
+-- column + backfill (see ban-drop-column note from the migration linter).
+-- squawk-ignore ban-drop-column
 ALTER TABLE response_cache DROP COLUMN query_embedding;
+-- squawk-ignore adding-required-field
 ALTER TABLE response_cache ADD COLUMN query_embedding vector(768) NOT NULL;
 
 -- Recreate the HNSW cosine index at the new dimension. Same m/ef_construction
 -- parameters as the original (pgvector defaults — good recall, modest build).
-CREATE INDEX idx_response_cache_embedding ON response_cache
+CREATE INDEX CONCURRENTLY idx_response_cache_embedding ON response_cache
 USING hnsw (query_embedding vector_cosine_ops)
 WITH (m = 16, ef_construction = 64);
 
 -- +goose Down
-DROP INDEX IF EXISTS idx_response_cache_embedding;
+SET lock_timeout = '5s';
+SET statement_timeout = '5min';
+DROP INDEX CONCURRENTLY IF EXISTS idx_response_cache_embedding;
 TRUNCATE response_cache;
+-- squawk-ignore ban-drop-column
 ALTER TABLE response_cache DROP COLUMN query_embedding;
+-- squawk-ignore adding-required-field
 ALTER TABLE response_cache ADD COLUMN query_embedding vector(1536) NOT NULL;
-CREATE INDEX idx_response_cache_embedding ON response_cache
+CREATE INDEX CONCURRENTLY idx_response_cache_embedding ON response_cache
 USING hnsw (query_embedding vector_cosine_ops)
 WITH (m = 16, ef_construction = 64);

--- a/migrations/00056_response_cache_resize_to_768.sql
+++ b/migrations/00056_response_cache_resize_to_768.sql
@@ -1,4 +1,3 @@
--- +goose NO TRANSACTION
 -- +goose Up
 -- Resize response_cache.query_embedding from vector(1536) to vector(768) to
 -- match the active embedding model (nomic-embed-text via Ollama). The Python
@@ -16,15 +15,20 @@
 -- a default, and a vector default makes no semantic sense for a cache
 -- key. TRUNCATE first so the ADD succeeds on any DB state (empty on the
 -- demo today, possibly populated on a self-hosted instance the day this
--- ships). Running outside a transaction lets us use DROP/CREATE INDEX
--- CONCURRENTLY so the migration is safe to replay on a live table.
+-- ships).
+--
+-- The whole migration runs inside one transaction — TRUNCATE empties
+-- the table before the index work, so there's no concurrent traffic to
+-- protect against and CONCURRENTLY would add nothing but lint noise.
+-- IF NOT EXISTS on the CREATE INDEX makes the migration re-runnable
+-- if a previous attempt failed past the TRUNCATE.
 
 -- Bound the locks taken by the DDL below so a long-running query cannot
 -- block production indefinitely.
 SET lock_timeout = '5s';
 SET statement_timeout = '5min';
 
-DROP INDEX CONCURRENTLY IF EXISTS idx_response_cache_embedding;
+DROP INDEX IF EXISTS idx_response_cache_embedding;
 
 TRUNCATE response_cache;
 
@@ -39,19 +43,19 @@ ALTER TABLE response_cache ADD COLUMN query_embedding vector(768) NOT NULL;
 
 -- Recreate the HNSW cosine index at the new dimension. Same m/ef_construction
 -- parameters as the original (pgvector defaults — good recall, modest build).
-CREATE INDEX CONCURRENTLY idx_response_cache_embedding ON response_cache
+CREATE INDEX IF NOT EXISTS idx_response_cache_embedding ON response_cache
 USING hnsw (query_embedding vector_cosine_ops)
 WITH (m = 16, ef_construction = 64);
 
 -- +goose Down
 SET lock_timeout = '5s';
 SET statement_timeout = '5min';
-DROP INDEX CONCURRENTLY IF EXISTS idx_response_cache_embedding;
+DROP INDEX IF EXISTS idx_response_cache_embedding;
 TRUNCATE response_cache;
 -- squawk-ignore ban-drop-column
 ALTER TABLE response_cache DROP COLUMN query_embedding;
 -- squawk-ignore adding-required-field
 ALTER TABLE response_cache ADD COLUMN query_embedding vector(1536) NOT NULL;
-CREATE INDEX CONCURRENTLY idx_response_cache_embedding ON response_cache
+CREATE INDEX IF NOT EXISTS idx_response_cache_embedding ON response_cache
 USING hnsw (query_embedding vector_cosine_ops)
 WITH (m = 16, ef_construction = 64);

--- a/migrations/00056_response_cache_resize_to_768.sql
+++ b/migrations/00056_response_cache_resize_to_768.sql
@@ -1,0 +1,40 @@
+-- +goose Up
+-- Resize response_cache.query_embedding from vector(1536) to vector(768) to
+-- match the active embedding model (nomic-embed-text via Ollama). The Python
+-- worker logs `cache_store_error: 'expected 1536 dimensions, not 768'` on
+-- every semantic-cache write until this lines up, so the RAG cache never
+-- materialises a single hit on the demo despite the read path being wired.
+--
+-- The table holds operational data only — the semantic cache for RAG
+-- responses — so dropping the column (and the cached rows that depend
+-- on its non-null shape) is fine. The next query a user runs rebuilds
+-- the row. pgvector does not support ALTER COLUMN TYPE between vector
+-- dimensions, so a drop+readd is the canonical path.
+--
+-- Postgres rejects adding a NOT NULL column to a populated table without
+-- a default, and a vector default makes no semantic sense for a cache
+-- key. TRUNCATE first so the ADD succeeds on any DB state (empty on the
+-- demo today, possibly populated on a self-hosted instance the day this
+-- ships).
+
+DROP INDEX IF EXISTS idx_response_cache_embedding;
+
+TRUNCATE response_cache;
+
+ALTER TABLE response_cache DROP COLUMN query_embedding;
+ALTER TABLE response_cache ADD COLUMN query_embedding vector(768) NOT NULL;
+
+-- Recreate the HNSW cosine index at the new dimension. Same m/ef_construction
+-- parameters as the original (pgvector defaults — good recall, modest build).
+CREATE INDEX idx_response_cache_embedding ON response_cache
+USING hnsw (query_embedding vector_cosine_ops)
+WITH (m = 16, ef_construction = 64);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_response_cache_embedding;
+TRUNCATE response_cache;
+ALTER TABLE response_cache DROP COLUMN query_embedding;
+ALTER TABLE response_cache ADD COLUMN query_embedding vector(1536) NOT NULL;
+CREATE INDEX idx_response_cache_embedding ON response_cache
+USING hnsw (query_embedding vector_cosine_ops)
+WITH (m = 16, ef_construction = 64);


### PR DESCRIPTION
Companion to migration 00046 (embeddings.embedding 1536→768) which only ever lived on a feature branch and was manually applied on the demo box. `response_cache.query_embedding` was missed.

## Effect today

Every Python-worker semantic-cache write logs:
```
cache_store_error: 'expected 1536 dimensions, not 768'
```
Reads succeed but nothing ever gets stored, so the cache hit rate is structurally zero on every deploy from `main`. Identical RAG queries re-run end-to-end instead of short-circuiting to the cache.

## Approach

`pgvector` doesn't support `ALTER COLUMN TYPE` between dimensions → drop+readd. `TRUNCATE` first because Postgres rejects adding `NOT NULL` to a populated table without a default (and a vector default makes no semantic sense for a cache key). HNSW cosine index recreated at the new dim with the original `m=16, ef_construction=64`.

## Test plan
- [ ] Apply migration on a fresh `:main` deploy → `cache_store_error` warnings disappear
- [ ] Run the same RAG query twice → 2nd hit returns from cache (check `response_cache` row count goes up)