### PR TITLE
refactor(passkey): collapse layering and make writes atomic

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -603,12 +603,13 @@ func main() {
 	seedSvc := service.NewSeedService(orgSvc, wsSvc, kbSvc, docRepo, pool, tmdbClient, storageClient, queueClient)
 	seedHandler := handler.NewSeedHandler(seedSvc)
 
-	// Passkey management (issue #771, M14). Talks to the SuperTokens core
-	// over REST for the credential lifecycle and to the local
-	// user_passkey_labels table (migration 00054) for human-readable labels.
-	// See docs/superpowers/specs/2026-06-04-passkey-auth-design.md.
-	passkeySvc := service.NewPasskeyService(cfg.SuperTokens.ConnectionURI, cfg.SuperTokens.APIKey, nil)
-	passkeyHandler := handler.NewPasskeyHandler(passkeySvc, pool)
+	// Passkey management (issue #771, M14). One service bundles the
+	// SuperTokens core REST client and the local user_passkey_labels
+	// repository (migration 00054); the handler depends on a single
+	// interface. See docs/superpowers/specs/2026-06-04-passkey-auth-design.md.
+	passkeyLabelRepo := repository.NewPasskeyLabelRepository(pool)
+	passkeySvc := service.NewPasskeyService(cfg.SuperTokens.ConnectionURI, cfg.SuperTokens.APIKey, nil, passkeyLabelRepo)
+	passkeyHandler := handler.NewPasskeyHandler(passkeySvc)
 
 	// Marketplace moderation surfaces (issue #735, M3). The admin audit
 	// view reads marketplace_takedowns under the raven_admin RLS bypass;

--- a/internal/handler/passkey.go
+++ b/internal/handler/passkey.go
@@ -2,6 +2,20 @@
 // management endpoints under /api/v1/me/passkeys. All routes assume the
 // session middleware has populated ContextKeyUserID + ContextKeyExternalID
 // (i.e. they sit under the standard authenticated /api/v1 group).
+//
+// Ownership model:
+//
+//   - GET is naturally scoped to the session user (the core list call
+//     takes the external user ID, and the label join is by user_id).
+//   - PATCH and DELETE prove ownership atomically inside each write,
+//     rather than via a pre-flight ListByUser round-trip to the
+//     SuperTokens core. PATCH relies on the (credential_id, user_id)
+//     WHERE clause of the UPDATE — 0 rows means "not yours" (or
+//     "doesn't exist", which is the same 404 from the caller's
+//     point of view). DELETE relies on the core's own ownership
+//     check inside its DELETE /recipe/webauthn/user/credential
+//     handler; a credential_id that does not belong to the calling
+//     user surfaces as ErrPasskeyNotFound, which we map to 404.
 package handler
 
 import (
@@ -11,58 +25,37 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 
-	"github.com/ravencloak-org/Raven/internal/db"
 	"github.com/ravencloak-org/Raven/internal/middleware"
 	"github.com/ravencloak-org/Raven/internal/service"
 	"github.com/ravencloak-org/Raven/pkg/apierror"
 )
 
-// PasskeyServicer is the subset of *service.PasskeyService the handler
-// needs. Defined as an interface so handler tests can inject a stub
-// without touching the live SuperTokens core.
-type PasskeyServicer interface {
+// PasskeyService is the full interface the handler requires. One
+// implementation (service.PasskeyService) bundles both the SuperTokens
+// core HTTP client and the label repository, and one fake serves both
+// sides in tests.
+type PasskeyService interface {
+	// Core (SuperTokens) side.
 	ListByUser(ctx context.Context, externalUserID string) ([]service.PasskeyCredential, error)
 	DeleteCredential(ctx context.Context, externalUserID, credentialID string) error
-}
 
-// PasskeyLabelStore is the subset of *pgxpool.Pool the handler exercises.
-// Allowing nil + a labelStoreOverride field on the handler keeps tests free
-// of the pool entirely — they can simulate the DB by injecting a fake.
-type PasskeyLabelStore interface {
-	ListLabelsForUser(ctx context.Context, userID string) (map[string]passkeyLabelRow, error)
-	UpsertLabel(ctx context.Context, userID, credentialID, label string) error
+	// Label persistence side.
+	ListLabelsForUser(ctx context.Context, userID string) (map[string]service.PasskeyLabel, error)
+	UpdateLabel(ctx context.Context, userID, credentialID, label string) error
 	DeleteLabel(ctx context.Context, userID, credentialID string) error
 }
 
-// passkeyLabelRow is the projected shape we need from
-// user_passkey_labels for the GET join.
-type passkeyLabelRow struct {
-	Label      string
-	CreatedAt  time.Time
-	LastUsedAt *time.Time
-}
-
-// PasskeyHandler wires the SuperTokens core (via PasskeyServicer) to the
-// local user_passkey_labels table.
+// PasskeyHandler wires the unified PasskeyService into Gin routes.
 type PasskeyHandler struct {
-	svc   PasskeyServicer
-	store PasskeyLabelStore
+	svc PasskeyService
 }
 
-// NewPasskeyHandler constructs a handler backed by the supplied service and
-// a real pgxpool-backed label store. Tests construct the handler with
-// NewPasskeyHandlerWithStore so they can substitute a fake store.
-func NewPasskeyHandler(svc PasskeyServicer, pool *pgxpool.Pool) *PasskeyHandler {
-	return &PasskeyHandler{svc: svc, store: &pgxPasskeyLabelStore{pool: pool}}
-}
-
-// NewPasskeyHandlerWithStore is the test seam — pass a fake PasskeyLabelStore
-// and the handler will route every DB call through it.
-func NewPasskeyHandlerWithStore(svc PasskeyServicer, store PasskeyLabelStore) *PasskeyHandler {
-	return &PasskeyHandler{svc: svc, store: store}
+// NewPasskeyHandler constructs a handler backed by the supplied service.
+// Production wiring passes *service.PasskeyService (which itself holds
+// the core client + label repo); tests pass a hand-written fake.
+func NewPasskeyHandler(svc PasskeyService) *PasskeyHandler {
+	return &PasskeyHandler{svc: svc}
 }
 
 // passkeyResponseItem is one row in the merged GET response.
@@ -101,7 +94,7 @@ func (h *PasskeyHandler) List(c *gin.Context) {
 		return
 	}
 
-	labels, err := h.store.ListLabelsForUser(c.Request.Context(), userID)
+	labels, err := h.svc.ListLabelsForUser(c.Request.Context(), userID)
 	if err != nil {
 		_ = c.Error(apierror.NewInternal("passkey label lookup failed: " + err.Error()))
 		c.Abort()
@@ -138,6 +131,10 @@ func (h *PasskeyHandler) List(c *gin.Context) {
 
 // Patch handles PATCH /api/v1/me/passkeys/:credential_id.
 //
+// Ownership is enforced atomically by the UPDATE's WHERE clause: a row
+// is only touched when (credential_id, user_id) matches. 0 rows → 404.
+// No pre-flight ListByUser call is required.
+//
 // @Summary     Relabel a passkey owned by the caller
 // @Tags        passkeys
 // @Accept      json
@@ -146,11 +143,11 @@ func (h *PasskeyHandler) List(c *gin.Context) {
 // @Param       credential_id path string true "Credential ID"
 // @Param       request body passkeyPatchRequest true "New label"
 // @Success     204
-// @Failure     403 {object} apierror.AppError
+// @Failure     404 {object} apierror.AppError
 // @Failure     422 {object} apierror.AppError
 // @Router      /me/passkeys/{credential_id} [patch]
 func (h *PasskeyHandler) Patch(c *gin.Context) {
-	userID, externalID, ok := h.requireSession(c)
+	userID, _, ok := h.requireSession(c)
 	if !ok {
 		return
 	}
@@ -172,12 +169,13 @@ func (h *PasskeyHandler) Patch(c *gin.Context) {
 		return
 	}
 
-	if !h.ownsCredential(c, externalID, credentialID) {
-		return
-	}
-
-	if err := h.store.UpsertLabel(c.Request.Context(), userID, credentialID, req.Label); err != nil {
-		_ = c.Error(apierror.NewInternal("passkey label upsert failed: " + err.Error()))
+	if err := h.svc.UpdateLabel(c.Request.Context(), userID, credentialID, req.Label); err != nil {
+		if errors.Is(err, service.ErrPasskeyLabelNotFound) {
+			_ = c.Error(apierror.NewNotFound("passkey not found"))
+			c.Abort()
+			return
+		}
+		_ = c.Error(apierror.NewInternal("passkey label update failed: " + err.Error()))
 		c.Abort()
 		return
 	}
@@ -187,12 +185,17 @@ func (h *PasskeyHandler) Patch(c *gin.Context) {
 
 // Delete handles DELETE /api/v1/me/passkeys/:credential_id.
 //
+// Ownership is enforced by the SuperTokens core's own DELETE handler: a
+// credential_id that does not belong to the calling external user is
+// reported back as ErrPasskeyNotFound, which we surface as 404. The
+// label row delete that follows is best-effort and absorbs missing rows
+// at the repository level.
+//
 // @Summary     Delete a passkey owned by the caller
 // @Tags        passkeys
 // @Security    BearerAuth
 // @Param       credential_id path string true "Credential ID"
 // @Success     204
-// @Failure     403 {object} apierror.AppError
 // @Failure     404 {object} apierror.AppError
 // @Router      /me/passkeys/{credential_id} [delete]
 func (h *PasskeyHandler) Delete(c *gin.Context) {
@@ -207,16 +210,9 @@ func (h *PasskeyHandler) Delete(c *gin.Context) {
 		return
 	}
 
-	if !h.ownsCredential(c, externalID, credentialID) {
-		return
-	}
-
-	// Core delete first: if the core fails we don't want to leave Raven's
-	// label row pointing at a credential the user still has. The label-row
-	// delete is best-effort — if it fails after the core succeeded we
-	// surface the error but the credential is already gone from the core
-	// and a stale label row is harmless (the next GET will simply not see
-	// it since the join is by credential_id).
+	// Core delete first: the core's own ownership check is the
+	// authorisation. If the core rejects with "not found" we never touch
+	// the label row.
 	if err := h.svc.DeleteCredential(c.Request.Context(), externalID, credentialID); err != nil {
 		if errors.Is(err, service.ErrPasskeyNotFound) {
 			_ = c.Error(apierror.NewNotFound("passkey not found"))
@@ -228,7 +224,12 @@ func (h *PasskeyHandler) Delete(c *gin.Context) {
 		return
 	}
 
-	if err := h.store.DeleteLabel(c.Request.Context(), userID, credentialID); err != nil {
+	// Label-row delete is best-effort. A missing row is harmless (the
+	// credential is already gone from the core; the next GET will not
+	// see it either way), but a write error after the core succeeded
+	// would leave the user looking at a stale label they cannot clear,
+	// so we surface those.
+	if err := h.svc.DeleteLabel(c.Request.Context(), userID, credentialID); err != nil {
 		_ = c.Error(apierror.NewInternal("passkey label cleanup failed: " + err.Error()))
 		c.Abort()
 		return
@@ -251,98 +252,4 @@ func (h *PasskeyHandler) requireSession(c *gin.Context) (userID, externalID stri
 		return "", "", false
 	}
 	return uid, ext, true
-}
-
-// ownsCredential confirms the caller actually owns the credential by
-// listing the core's credentials for the session user and checking
-// membership. Returns true when ownership is confirmed; otherwise writes
-// a 403 (or 500 on lookup failure) and returns false.
-//
-// This is the authorisation backstop: the routes already sit under the
-// session middleware, but PATCH/DELETE accept the credential ID as a URL
-// parameter and we must not trust it.
-func (h *PasskeyHandler) ownsCredential(c *gin.Context, externalID, credentialID string) bool {
-	creds, err := h.svc.ListByUser(c.Request.Context(), externalID)
-	if err != nil {
-		_ = c.Error(apierror.NewInternal("passkey ownership check failed: " + err.Error()))
-		c.Abort()
-		return false
-	}
-	for _, cred := range creds {
-		if cred.CredentialID == credentialID {
-			return true
-		}
-	}
-	_ = c.Error(&apierror.AppError{
-		Code:    http.StatusForbidden,
-		Message: "Forbidden",
-		Detail:  "credential does not belong to caller",
-	})
-	c.Abort()
-	return false
-}
-
-// pgxPasskeyLabelStore implements PasskeyLabelStore against the live
-// user_passkey_labels table. RLS is enforced by setting
-// app.current_user_id inside the wrapping transaction (db.WithUserID).
-type pgxPasskeyLabelStore struct {
-	pool *pgxpool.Pool
-}
-
-// ListLabelsForUser returns label rows keyed by credential_id.
-func (s *pgxPasskeyLabelStore) ListLabelsForUser(ctx context.Context, userID string) (map[string]passkeyLabelRow, error) {
-	out := make(map[string]passkeyLabelRow)
-	err := db.WithUserID(ctx, s.pool, userID, func(tx pgx.Tx) error {
-		rows, err := tx.Query(ctx,
-			`SELECT credential_id, label, created_at, last_used_at
-			 FROM user_passkey_labels
-			 WHERE user_id = $1`, userID)
-		if err != nil {
-			return err
-		}
-		defer rows.Close()
-		for rows.Next() {
-			var (
-				credID     string
-				row        passkeyLabelRow
-				lastUsedAt *time.Time
-			)
-			if err := rows.Scan(&credID, &row.Label, &row.CreatedAt, &lastUsedAt); err != nil {
-				return err
-			}
-			row.LastUsedAt = lastUsedAt
-			out[credID] = row
-		}
-		return rows.Err()
-	})
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-// UpsertLabel inserts a new row or updates the label on an existing one.
-// Behaviour is intentionally "label only" — created_at is never touched on
-// update, and last_used_at is owned by the SuperTokens hook path (set when
-// the credential is used for sign-in).
-func (s *pgxPasskeyLabelStore) UpsertLabel(ctx context.Context, userID, credentialID, label string) error {
-	return db.WithUserID(ctx, s.pool, userID, func(tx pgx.Tx) error {
-		_, err := tx.Exec(ctx,
-			`INSERT INTO user_passkey_labels (user_id, credential_id, label)
-			 VALUES ($1, $2, $3)
-			 ON CONFLICT (credential_id) DO UPDATE SET label = EXCLUDED.label`,
-			userID, credentialID, label)
-		return err
-	})
-}
-
-// DeleteLabel removes a single label row. It is the caller's responsibility
-// to have already deleted the credential from the SuperTokens core.
-func (s *pgxPasskeyLabelStore) DeleteLabel(ctx context.Context, userID, credentialID string) error {
-	return db.WithUserID(ctx, s.pool, userID, func(tx pgx.Tx) error {
-		_, err := tx.Exec(ctx,
-			`DELETE FROM user_passkey_labels WHERE user_id = $1 AND credential_id = $2`,
-			userID, credentialID)
-		return err
-	})
 }

--- a/internal/handler/passkey_test.go
+++ b/internal/handler/passkey_test.go
@@ -20,17 +20,30 @@ import (
 
 // --- fakes -----------------------------------------------------------------
 
-// fakePasskeySvc is a hand-written stub. Each test pre-loads the credentials
-// the SuperTokens core would have returned and (optionally) primes errors on
-// list / delete.
-type fakePasskeySvc struct {
+// fakePasskeyService is a hand-written stub of the full handler-facing
+// interface — core list/delete plus label list/update/delete. Tests
+// pre-load credentials and label rows, optionally prime errors, and
+// inspect the captured-call slices to assert on writes.
+type fakePasskeyService struct {
+	// Core side.
 	credentials []service.PasskeyCredential
 	listErr     error
 	deleteErr   error
 	deletedID   string
+
+	// Label side.
+	rows           map[string]service.PasskeyLabel
+	listLabelsErr  error
+	updateErr      error
+	deleteLabelErr error
+	updateCalls    []labelUpdateCall
+	deleteCalls    []labelDeleteCall
 }
 
-func (f *fakePasskeySvc) ListByUser(_ context.Context, _ string) ([]service.PasskeyCredential, error) {
+type labelUpdateCall struct{ userID, credentialID, label string }
+type labelDeleteCall struct{ userID, credentialID string }
+
+func (f *fakePasskeyService) ListByUser(_ context.Context, _ string) ([]service.PasskeyCredential, error) {
 	if f.listErr != nil {
 		return nil, f.listErr
 	}
@@ -39,7 +52,7 @@ func (f *fakePasskeySvc) ListByUser(_ context.Context, _ string) ([]service.Pass
 	return out, nil
 }
 
-func (f *fakePasskeySvc) DeleteCredential(_ context.Context, _, credentialID string) error {
+func (f *fakePasskeyService) DeleteCredential(_ context.Context, _, credentialID string) error {
 	if f.deleteErr != nil {
 		return f.deleteErr
 	}
@@ -47,39 +60,36 @@ func (f *fakePasskeySvc) DeleteCredential(_ context.Context, _, credentialID str
 	return nil
 }
 
-// fakeLabelStore captures every call so tests can assert on writes without
-// needing a live Postgres. ListRows is keyed by credential_id.
-type fakeLabelStore struct {
-	rows         map[string]passkeyLabelRow
-	upsertCalls  []labelUpsertCall
-	deleteCalls  []labelDeleteCall
-	listErr      error
-	upsertErr    error
-	deleteLabErr error
-}
-
-type labelUpsertCall struct{ userID, credentialID, label string }
-type labelDeleteCall struct{ userID, credentialID string }
-
-func (f *fakeLabelStore) ListLabelsForUser(_ context.Context, _ string) (map[string]passkeyLabelRow, error) {
-	if f.listErr != nil {
-		return nil, f.listErr
+func (f *fakePasskeyService) ListLabelsForUser(_ context.Context, _ string) (map[string]service.PasskeyLabel, error) {
+	if f.listLabelsErr != nil {
+		return nil, f.listLabelsErr
 	}
-	out := make(map[string]passkeyLabelRow, len(f.rows))
+	out := make(map[string]service.PasskeyLabel, len(f.rows))
 	for k, v := range f.rows {
 		out[k] = v
 	}
 	return out, nil
 }
 
-func (f *fakeLabelStore) UpsertLabel(_ context.Context, userID, credentialID, label string) error {
-	f.upsertCalls = append(f.upsertCalls, labelUpsertCall{userID, credentialID, label})
-	return f.upsertErr
+func (f *fakePasskeyService) UpdateLabel(_ context.Context, userID, credentialID, label string) error {
+	f.updateCalls = append(f.updateCalls, labelUpdateCall{userID, credentialID, label})
+	if f.updateErr != nil {
+		return f.updateErr
+	}
+	// Mirror real repository semantics: 0 rows ⇒ ErrPasskeyLabelNotFound.
+	// Tests that want the "happy path" pre-load f.rows with the credential.
+	row, ok := f.rows[credentialID]
+	if !ok {
+		return service.ErrPasskeyLabelNotFound
+	}
+	row.Label = label
+	f.rows[credentialID] = row
+	return nil
 }
 
-func (f *fakeLabelStore) DeleteLabel(_ context.Context, userID, credentialID string) error {
+func (f *fakePasskeyService) DeleteLabel(_ context.Context, userID, credentialID string) error {
 	f.deleteCalls = append(f.deleteCalls, labelDeleteCall{userID, credentialID})
-	return f.deleteLabErr
+	return f.deleteLabelErr
 }
 
 // newPasskeyCtx constructs a gin context with the session keys populated so
@@ -126,7 +136,7 @@ func TestPasskeyHandler_List(t *testing.T) {
 	tests := []struct {
 		name        string
 		creds       []service.PasskeyCredential
-		labels      map[string]passkeyLabelRow
+		labels      map[string]service.PasskeyLabel
 		wantStatus  int
 		wantBodyHas []string
 	}{
@@ -136,9 +146,9 @@ func TestPasskeyHandler_List(t *testing.T) {
 				{CredentialID: "cred-1", CreatedAt: createdAt, LastUsedAt: &lastUsed},
 				{CredentialID: "cred-2", CreatedAt: createdAt},
 			},
-			labels: map[string]passkeyLabelRow{
-				"cred-1": {Label: "MacBook Pro Touch ID", CreatedAt: labelCreated, LastUsedAt: &lastUsed},
-				"cred-2": {Label: "iPhone Face ID", CreatedAt: labelCreated},
+			labels: map[string]service.PasskeyLabel{
+				"cred-1": {CredentialID: "cred-1", Label: "MacBook Pro Touch ID", CreatedAt: labelCreated, LastUsedAt: &lastUsed},
+				"cred-2": {CredentialID: "cred-2", Label: "iPhone Face ID", CreatedAt: labelCreated},
 			},
 			wantStatus:  http.StatusOK,
 			wantBodyHas: []string{`"credential_id":"cred-1"`, `"label":"MacBook Pro Touch ID"`, `"label":"iPhone Face ID"`},
@@ -148,14 +158,14 @@ func TestPasskeyHandler_List(t *testing.T) {
 			creds: []service.PasskeyCredential{
 				{CredentialID: "cred-orphan", CreatedAt: createdAt},
 			},
-			labels:      map[string]passkeyLabelRow{}, // no label rows yet
+			labels:      map[string]service.PasskeyLabel{},
 			wantStatus:  http.StatusOK,
 			wantBodyHas: []string{`"credential_id":"cred-orphan"`, `"label":"Passkey"`},
 		},
 		{
 			name:        "empty everything returns empty array, not null",
 			creds:       []service.PasskeyCredential{},
-			labels:      map[string]passkeyLabelRow{},
+			labels:      map[string]service.PasskeyLabel{},
 			wantStatus:  http.StatusOK,
 			wantBodyHas: []string{`[]`},
 		},
@@ -163,9 +173,8 @@ func TestPasskeyHandler_List(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc := &fakePasskeySvc{credentials: tt.creds}
-			store := &fakeLabelStore{rows: tt.labels}
-			h := NewPasskeyHandlerWithStore(svc, store)
+			svc := &fakePasskeyService{credentials: tt.creds, rows: tt.labels}
+			h := NewPasskeyHandler(svc)
 
 			c, rec := newPasskeyCtx(http.MethodGet, "/api/v1/me/passkeys", "", "")
 			h.List(c)
@@ -183,9 +192,8 @@ func TestPasskeyHandler_List(t *testing.T) {
 }
 
 func TestPasskeyHandler_List_CoreUnavailable(t *testing.T) {
-	svc := &fakePasskeySvc{listErr: errors.New("connection refused")}
-	store := &fakeLabelStore{rows: map[string]passkeyLabelRow{}}
-	h := NewPasskeyHandlerWithStore(svc, store)
+	svc := &fakePasskeyService{listErr: errors.New("connection refused")}
+	h := NewPasskeyHandler(svc)
 
 	c, rec := newPasskeyCtx(http.MethodGet, "/api/v1/me/passkeys", "", "")
 	// Wire the gin error chain so the handler's _ = c.Error(...) gets surfaced
@@ -205,39 +213,32 @@ func TestPasskeyHandler_List_CoreUnavailable(t *testing.T) {
 // --- Patch -----------------------------------------------------------------
 
 func TestPasskeyHandler_Patch(t *testing.T) {
+	// New ownership model: PATCH only succeeds when a label row already
+	// exists for (credential_id, user_id). The registration hook is
+	// responsible for inserting the initial row; the user-facing PATCH
+	// only renames it.
 	tests := []struct {
 		name           string
 		body           string
-		existingCreds  []service.PasskeyCredential
-		existingLabels map[string]passkeyLabelRow
+		existingLabels map[string]service.PasskeyLabel
 		wantStatus     int
-		wantUpsert     bool
+		wantUpdate     bool
 		wantLabel      string
 	}{
 		{
-			name:          "insert when no row exists",
-			body:          `{"label":"Yubikey 5C"}`,
-			existingCreds: []service.PasskeyCredential{{CredentialID: "cred-1"}},
-			wantStatus:    http.StatusNoContent,
-			wantUpsert:    true,
-			wantLabel:     "Yubikey 5C",
-		},
-		{
-			name:           "update when row already exists",
+			name:           "rename existing label",
 			body:           `{"label":"Renamed"}`,
-			existingCreds:  []service.PasskeyCredential{{CredentialID: "cred-1"}},
-			existingLabels: map[string]passkeyLabelRow{"cred-1": {Label: "Old"}},
+			existingLabels: map[string]service.PasskeyLabel{"cred-1": {CredentialID: "cred-1", Label: "Old"}},
 			wantStatus:     http.StatusNoContent,
-			wantUpsert:     true,
+			wantUpdate:     true,
 			wantLabel:      "Renamed",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc := &fakePasskeySvc{credentials: tt.existingCreds}
-			store := &fakeLabelStore{rows: tt.existingLabels}
-			h := NewPasskeyHandlerWithStore(svc, store)
+			svc := &fakePasskeyService{rows: tt.existingLabels}
+			h := NewPasskeyHandler(svc)
 
 			c, rec := newPasskeyCtx(http.MethodPatch, "/api/v1/me/passkeys/cred-1", "cred-1", tt.body)
 			h.Patch(c)
@@ -245,50 +246,53 @@ func TestPasskeyHandler_Patch(t *testing.T) {
 			if got := gotStatus(c, rec); got != tt.wantStatus {
 				t.Fatalf("status = %d, want %d (body=%s, errs=%v)", got, tt.wantStatus, rec.Body.String(), c.Errors)
 			}
-			if tt.wantUpsert {
-				if len(store.upsertCalls) != 1 {
-					t.Fatalf("expected 1 upsert call, got %d", len(store.upsertCalls))
+			if tt.wantUpdate {
+				if len(svc.updateCalls) != 1 {
+					t.Fatalf("expected 1 update call, got %d", len(svc.updateCalls))
 				}
-				call := store.upsertCalls[0]
+				call := svc.updateCalls[0]
 				if call.label != tt.wantLabel {
-					t.Errorf("upsert label = %q, want %q", call.label, tt.wantLabel)
+					t.Errorf("update label = %q, want %q", call.label, tt.wantLabel)
 				}
 				if call.credentialID != "cred-1" {
-					t.Errorf("upsert credentialID = %q, want cred-1", call.credentialID)
+					t.Errorf("update credentialID = %q, want cred-1", call.credentialID)
 				}
 				if call.userID != "user-uuid-1" {
-					t.Errorf("upsert userID = %q, want user-uuid-1", call.userID)
+					t.Errorf("update userID = %q, want user-uuid-1", call.userID)
 				}
+			}
+			// PATCH must NOT call into the SuperTokens core — that is the
+			// whole point of the ownsCredential removal.
+			if svc.deletedID != "" {
+				t.Errorf("PATCH must not trigger any core write; got delete for %q", svc.deletedID)
 			}
 		})
 	}
 }
 
-func TestPasskeyHandler_Patch_OwnershipForbidden(t *testing.T) {
-	// The core returns a different user's credentials — patching cred-evil
-	// must 403 and never call the label store.
-	svc := &fakePasskeySvc{credentials: []service.PasskeyCredential{{CredentialID: "cred-mine"}}}
-	store := &fakeLabelStore{}
-	h := NewPasskeyHandlerWithStore(svc, store)
+func TestPasskeyHandler_Patch_UnknownCredentialReturns404(t *testing.T) {
+	// The label store is empty, so the atomic UPDATE matches 0 rows. The
+	// handler must surface that as 404 (and never call into the core).
+	svc := &fakePasskeyService{rows: map[string]service.PasskeyLabel{}}
+	h := NewPasskeyHandler(svc)
 
 	c, _ := newPasskeyCtx(http.MethodPatch, "/api/v1/me/passkeys/cred-evil", "cred-evil", `{"label":"hax"}`)
 	h.Patch(c)
 
 	if len(c.Errors) == 0 {
-		t.Fatalf("expected an error; got none")
+		t.Fatalf("expected a 404 error; got none")
 	}
-	if !strings.Contains(c.Errors.Last().Error(), "credential does not belong") {
+	if !strings.Contains(c.Errors.Last().Error(), "passkey not found") {
 		t.Errorf("unexpected error: %v", c.Errors.Last())
 	}
-	if len(store.upsertCalls) != 0 {
-		t.Errorf("ownership-failed patch must not write a label; got %d calls", len(store.upsertCalls))
+	if len(svc.updateCalls) != 1 {
+		t.Errorf("expected exactly one UpdateLabel attempt, got %d", len(svc.updateCalls))
 	}
 }
 
 func TestPasskeyHandler_Patch_BadBody(t *testing.T) {
-	svc := &fakePasskeySvc{credentials: []service.PasskeyCredential{{CredentialID: "cred-1"}}}
-	store := &fakeLabelStore{}
-	h := NewPasskeyHandlerWithStore(svc, store)
+	svc := &fakePasskeyService{rows: map[string]service.PasskeyLabel{"cred-1": {CredentialID: "cred-1"}}}
+	h := NewPasskeyHandler(svc)
 
 	c, _ := newPasskeyCtx(http.MethodPatch, "/api/v1/me/passkeys/cred-1", "cred-1", `{}`)
 	h.Patch(c)
@@ -296,14 +300,19 @@ func TestPasskeyHandler_Patch_BadBody(t *testing.T) {
 	if len(c.Errors) == 0 {
 		t.Fatalf("expected validation error; got none")
 	}
+	if len(svc.updateCalls) != 0 {
+		t.Errorf("bad body must not reach the service; got %d update calls", len(svc.updateCalls))
+	}
 }
 
 // --- Delete ---------------------------------------------------------------
 
 func TestPasskeyHandler_Delete(t *testing.T) {
-	svc := &fakePasskeySvc{credentials: []service.PasskeyCredential{{CredentialID: "cred-1"}}}
-	store := &fakeLabelStore{rows: map[string]passkeyLabelRow{"cred-1": {Label: "Mac"}}}
-	h := NewPasskeyHandlerWithStore(svc, store)
+	svc := &fakePasskeyService{
+		credentials: []service.PasskeyCredential{{CredentialID: "cred-1"}},
+		rows:        map[string]service.PasskeyLabel{"cred-1": {CredentialID: "cred-1", Label: "Mac"}},
+	}
+	h := NewPasskeyHandler(svc)
 
 	c, rec := newPasskeyCtx(http.MethodDelete, "/api/v1/me/passkeys/cred-1", "cred-1", "")
 	h.Delete(c)
@@ -314,34 +323,19 @@ func TestPasskeyHandler_Delete(t *testing.T) {
 	if svc.deletedID != "cred-1" {
 		t.Errorf("svc.Delete saw credentialID %q, want cred-1", svc.deletedID)
 	}
-	if len(store.deleteCalls) != 1 || store.deleteCalls[0].credentialID != "cred-1" {
-		t.Errorf("expected one label-store delete for cred-1; got %v", store.deleteCalls)
-	}
-}
-
-func TestPasskeyHandler_Delete_OwnershipForbidden(t *testing.T) {
-	svc := &fakePasskeySvc{credentials: []service.PasskeyCredential{{CredentialID: "someone-elses"}}}
-	store := &fakeLabelStore{}
-	h := NewPasskeyHandlerWithStore(svc, store)
-
-	c, _ := newPasskeyCtx(http.MethodDelete, "/api/v1/me/passkeys/cred-1", "cred-1", "")
-	h.Delete(c)
-
-	if len(c.Errors) == 0 {
-		t.Fatalf("expected 403 error; got none")
-	}
-	if svc.deletedID != "" {
-		t.Errorf("ownership-failed delete must not call core; got delete for %q", svc.deletedID)
+	if len(svc.deleteCalls) != 1 || svc.deleteCalls[0].credentialID != "cred-1" {
+		t.Errorf("expected one label-store delete for cred-1; got %v", svc.deleteCalls)
 	}
 }
 
 func TestPasskeyHandler_Delete_CoreReturnsNotFound(t *testing.T) {
-	svc := &fakePasskeySvc{
+	// Ownership is now enforced by the core's own 404. The handler must
+	// surface that as 404 and never touch the label row.
+	svc := &fakePasskeyService{
 		credentials: []service.PasskeyCredential{{CredentialID: "cred-1"}},
 		deleteErr:   service.ErrPasskeyNotFound,
 	}
-	store := &fakeLabelStore{}
-	h := NewPasskeyHandlerWithStore(svc, store)
+	h := NewPasskeyHandler(svc)
 
 	c, _ := newPasskeyCtx(http.MethodDelete, "/api/v1/me/passkeys/cred-1", "cred-1", "")
 	h.Delete(c)
@@ -351,6 +345,9 @@ func TestPasskeyHandler_Delete_CoreReturnsNotFound(t *testing.T) {
 	}
 	if !strings.Contains(c.Errors.Last().Error(), "passkey not found") {
 		t.Errorf("unexpected error: %v", c.Errors.Last())
+	}
+	if len(svc.deleteCalls) != 0 {
+		t.Errorf("core-not-found delete must not touch label store; got %d calls", len(svc.deleteCalls))
 	}
 }
 
@@ -386,7 +383,7 @@ func TestPasskeyService_ListByUser(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	svc := service.NewPasskeyService(srv.URL, "test-api-key", nil)
+	svc := service.NewPasskeyService(srv.URL, "test-api-key", nil, nil)
 	got, err := svc.ListByUser(context.Background(), "st-user-1")
 	if err != nil {
 		t.Fatalf("ListByUser err: %v", err)
@@ -412,7 +409,7 @@ func TestPasskeyService_DeleteCredential_NotFound(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	svc := service.NewPasskeyService(srv.URL, "", nil)
+	svc := service.NewPasskeyService(srv.URL, "", nil, nil)
 	err := svc.DeleteCredential(context.Background(), "st-user-1", "cred-missing")
 	if !errors.Is(err, service.ErrPasskeyNotFound) {
 		t.Fatalf("err = %v, want ErrPasskeyNotFound", err)
@@ -426,7 +423,7 @@ func TestPasskeyService_DeleteCredential_OK(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	svc := service.NewPasskeyService(srv.URL, "", nil)
+	svc := service.NewPasskeyService(srv.URL, "", nil, nil)
 	if err := svc.DeleteCredential(context.Background(), "st-user-1", "cred-1"); err != nil {
 		t.Fatalf("DeleteCredential err: %v", err)
 	}
@@ -438,7 +435,7 @@ func TestPasskeyService_ListByUser_CoreError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	svc := service.NewPasskeyService(srv.URL, "", nil)
+	svc := service.NewPasskeyService(srv.URL, "", nil, nil)
 	_, err := svc.ListByUser(context.Background(), "st-user-1")
 	if err == nil {
 		t.Fatalf("expected error from 500 response")

--- a/internal/repository/passkey_label.go
+++ b/internal/repository/passkey_label.go
@@ -1,0 +1,143 @@
+// Package repository — passkey_label.go is the pgx-backed persistence layer
+// for the user_passkey_labels table (migration 00054). It mirrors the shape
+// of the other repositories in this package (e.g. llm_provider.go, chunk.go)
+// but is user-scoped rather than org-scoped: RLS reads
+// app.current_user_id, set by db.WithUserID.
+package repository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/ravencloak-org/Raven/internal/db"
+)
+
+// PasskeyLabel is the projected shape of one row of user_passkey_labels
+// returned to callers. The wire-level JSON shape lives in the handler;
+// this is the domain model the service layer trades in.
+type PasskeyLabel struct {
+	CredentialID string
+	Label        string
+	CreatedAt    time.Time
+	LastUsedAt   *time.Time
+}
+
+// ErrPasskeyLabelNotFound signals that a write targeted no rows — typically
+// because the credential is not owned by the caller (or has never had a
+// label persisted). Service / handler layers map this to HTTP 404.
+var ErrPasskeyLabelNotFound = errors.New("passkey label not found")
+
+// PasskeyLabelRepository handles database operations for the
+// user_passkey_labels table. Each method opens its own RLS-scoped tx via
+// db.WithUserID — single-statement reads/writes don't benefit from sharing
+// a transaction with anything else in the request, and keeping the tx
+// hidden inside the repo lets the service layer stay free of pgx.
+type PasskeyLabelRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewPasskeyLabelRepository creates a new PasskeyLabelRepository.
+func NewPasskeyLabelRepository(pool *pgxpool.Pool) *PasskeyLabelRepository {
+	return &PasskeyLabelRepository{pool: pool}
+}
+
+// ListForUser returns every label row owned by userID, keyed by
+// credential_id for a cheap join against the SuperTokens core list.
+func (r *PasskeyLabelRepository) ListForUser(ctx context.Context, userID string) (map[string]PasskeyLabel, error) {
+	out := make(map[string]PasskeyLabel)
+	err := db.WithUserID(ctx, r.pool, userID, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx,
+			`SELECT credential_id, label, created_at, last_used_at
+			 FROM user_passkey_labels
+			 WHERE user_id = $1`, userID)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var (
+				row        PasskeyLabel
+				lastUsedAt *time.Time
+			)
+			if err := rows.Scan(&row.CredentialID, &row.Label, &row.CreatedAt, &lastUsedAt); err != nil {
+				return err
+			}
+			row.LastUsedAt = lastUsedAt
+			out[row.CredentialID] = row
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, fmt.Errorf("PasskeyLabelRepository.ListForUser: %w", err)
+	}
+	return out, nil
+}
+
+// Upsert inserts a new row or updates the label on an existing one.
+// Behaviour is intentionally "label only" — created_at is never touched on
+// update, and last_used_at is owned by the SuperTokens hook path (set when
+// the credential is used for sign-in).
+func (r *PasskeyLabelRepository) Upsert(ctx context.Context, userID, credentialID, label string) error {
+	err := db.WithUserID(ctx, r.pool, userID, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx,
+			`INSERT INTO user_passkey_labels (user_id, credential_id, label)
+			 VALUES ($1, $2, $3)
+			 ON CONFLICT (credential_id) DO UPDATE SET label = EXCLUDED.label`,
+			userID, credentialID, label)
+		return err
+	})
+	if err != nil {
+		return fmt.Errorf("PasskeyLabelRepository.Upsert: %w", err)
+	}
+	return nil
+}
+
+// UpdateLabel atomically renames the label for an existing row owned by
+// userID. It returns ErrPasskeyLabelNotFound when no row matches (either
+// the credential never had a label persisted, or it belongs to another
+// user — both are 404 from the caller's point of view). The single
+// UPDATE is the ownership check: no pre-query is required.
+func (r *PasskeyLabelRepository) UpdateLabel(ctx context.Context, userID, credentialID, label string) error {
+	var rowsAffected int64
+	err := db.WithUserID(ctx, r.pool, userID, func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx,
+			`UPDATE user_passkey_labels
+			 SET label = $1
+			 WHERE credential_id = $2 AND user_id = $3`,
+			label, credentialID, userID)
+		if err != nil {
+			return err
+		}
+		rowsAffected = tag.RowsAffected()
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("PasskeyLabelRepository.UpdateLabel: %w", err)
+	}
+	if rowsAffected == 0 {
+		return ErrPasskeyLabelNotFound
+	}
+	return nil
+}
+
+// Delete removes a single label row. Callers should treat a missing row
+// as success — the SuperTokens core is the source of truth for whether
+// the credential itself was deleted; a missing label row just means the
+// user never renamed the credential.
+func (r *PasskeyLabelRepository) Delete(ctx context.Context, userID, credentialID string) error {
+	err := db.WithUserID(ctx, r.pool, userID, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx,
+			`DELETE FROM user_passkey_labels WHERE user_id = $1 AND credential_id = $2`,
+			userID, credentialID)
+		return err
+	})
+	if err != nil {
+		return fmt.Errorf("PasskeyLabelRepository.Delete: %w", err)
+	}
+	return nil
+}

--- a/internal/service/passkey.go
+++ b/internal/service/passkey.go
@@ -1,9 +1,11 @@
 // Package service contains the business-logic layer for Raven.
 //
-// passkey.go is a thin wrapper around the SuperTokens core's WebAuthn REST
-// API. It exists so the handler layer can stay HTTP-transport-agnostic and
-// tests can inject a fake HTTP client (via httptest.NewServer) without
-// reaching for the real SuperTokens SDK.
+// passkey.go is the unified passkey service: a thin wrapper around the
+// SuperTokens core's WebAuthn REST API plus the local
+// user_passkey_labels persistence layer (via
+// repository.PasskeyLabelRepository). The handler depends on this single
+// service through a 5-method interface; tests inject a fake
+// implementation rather than mocking the core and the repo separately.
 package service
 
 import (
@@ -16,7 +18,18 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/ravencloak-org/Raven/internal/repository"
 )
+
+// PasskeyLabel re-exports the repository row shape so handler code can
+// trade in service-package types only.
+type PasskeyLabel = repository.PasskeyLabel
+
+// ErrPasskeyLabelNotFound is the canonical "no row" sentinel for label
+// writes, re-exported from the repository so handlers can errors.Is
+// against the service package alone.
+var ErrPasskeyLabelNotFound = repository.ErrPasskeyLabelNotFound
 
 // PasskeyCredential represents one WebAuthn credential as the SuperTokens
 // core returns it on a list response. We intentionally model only the
@@ -60,7 +73,10 @@ type httpDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
-// PasskeyService talks to the SuperTokens core's WebAuthn recipe over REST.
+// PasskeyService talks to the SuperTokens core's WebAuthn recipe over REST
+// and persists user-supplied labels via PasskeyLabelRepository. Bundling
+// both responsibilities lets the handler depend on one interface and lets
+// tests substitute a single fake instead of two.
 type PasskeyService struct {
 	// baseURL is the SuperTokens core base URL (e.g. http://supertokens:3567).
 	// Trailing slashes are stripped on construction so paths join cleanly.
@@ -72,16 +88,21 @@ type PasskeyService struct {
 	// client is the HTTP client used for every outbound call. Injectable so
 	// tests can swap in a transport that points at httptest.NewServer.
 	client httpDoer
+	// labels persists user-supplied labels for credentials. May be nil in
+	// the HTTP-only test setup; the label-store methods will return an
+	// explicit error rather than panic in that case.
+	labels *repository.PasskeyLabelRepository
 }
 
 // NewPasskeyService constructs a service. connectionURI is the same value
 // the Go SDK uses (RAVEN_SUPERTOKENS_CONNECTION_URI / config.supertokens.
-// connection_uri). apiKey may be empty.
+// connection_uri). apiKey may be empty. labels persists user-supplied
+// labels and may be nil for tests that only exercise the core HTTP path.
 //
 // If client is nil a default *http.Client with a 5-second timeout is used —
 // passkey list/delete are interactive paths so a long stall would hang the
 // caller's Settings page.
-func NewPasskeyService(connectionURI, apiKey string, client httpDoer) *PasskeyService {
+func NewPasskeyService(connectionURI, apiKey string, client httpDoer, labels *repository.PasskeyLabelRepository) *PasskeyService {
 	if client == nil {
 		client = &http.Client{Timeout: 5 * time.Second}
 	}
@@ -89,7 +110,53 @@ func NewPasskeyService(connectionURI, apiKey string, client httpDoer) *PasskeySe
 		baseURL: strings.TrimRight(connectionURI, "/"),
 		apiKey:  apiKey,
 		client:  client,
+		labels:  labels,
 	}
+}
+
+// errLabelsUnconfigured signals that a caller invoked a label-store method
+// on a PasskeyService constructed without a repository. In production this
+// can never happen (cmd/api/main.go always passes one); the guard exists
+// purely to keep the HTTP-level tests from segfaulting if a future change
+// accidentally calls into the label path.
+var errLabelsUnconfigured = errors.New("PasskeyService: label repository not configured")
+
+// ListLabelsForUser returns every label row owned by userID, keyed by
+// credential_id. Delegated to the repository.
+func (s *PasskeyService) ListLabelsForUser(ctx context.Context, userID string) (map[string]PasskeyLabel, error) {
+	if s.labels == nil {
+		return nil, errLabelsUnconfigured
+	}
+	return s.labels.ListForUser(ctx, userID)
+}
+
+// UpsertLabel inserts a new label row or updates an existing one. Used
+// only by the SuperTokens registration hook path — the user-facing PATCH
+// goes through UpdateLabel so it can return 404 on missing rows.
+func (s *PasskeyService) UpsertLabel(ctx context.Context, userID, credentialID, label string) error {
+	if s.labels == nil {
+		return errLabelsUnconfigured
+	}
+	return s.labels.Upsert(ctx, userID, credentialID, label)
+}
+
+// UpdateLabel atomically renames the label for an existing row. Returns
+// ErrPasskeyLabelNotFound when no row matches — ownership is enforced by
+// the (credential_id, user_id) WHERE clause rather than a pre-check.
+func (s *PasskeyService) UpdateLabel(ctx context.Context, userID, credentialID, label string) error {
+	if s.labels == nil {
+		return errLabelsUnconfigured
+	}
+	return s.labels.UpdateLabel(ctx, userID, credentialID, label)
+}
+
+// DeleteLabel removes a single label row. Best-effort; missing rows are
+// silently absorbed by the repository.
+func (s *PasskeyService) DeleteLabel(ctx context.Context, userID, credentialID string) error {
+	if s.labels == nil {
+		return errLabelsUnconfigured
+	}
+	return s.labels.Delete(ctx, userID, credentialID)
 }
 
 // ListByUser returns every WebAuthn credential the SuperTokens core has


### PR DESCRIPTION
## Summary

Refactors the passkey backend in three layered moves:

1. **SQL out of the handler.** `internal/handler/passkey.go` no longer contains
   `pgxPasskeyLabelStore`. The pgxpool-backed implementation has moved into a
   new `internal/repository/passkey_label.go` (`PasskeyLabelRepository`),
   mirroring the shape of `llm_provider.go` / `chunk.go`. The handler no
   longer imports `db`, `pgx`, or `pgxpool`.

2. **One interface, one constructor.** `PasskeyServicer` (2 methods, core
   side) and `PasskeyLabelStore` (3 methods, db side) collapse into a single
   `PasskeyService` interface (5 methods). The production
   `service.PasskeyService` struct now bundles the SuperTokens core HTTP
   client and the new `PasskeyLabelRepository`. The two handler constructors
   (`NewPasskeyHandler` + `NewPasskeyHandlerWithStore`) collapse into one
   `NewPasskeyHandler(svc PasskeyService)`. Tests inject a single
   `fakePasskeyService` implementing all five methods.

3. **Atomic ownership.** `ownsCredential` is deleted. The pre-flight
   `ListByUser` round-trip to the SuperTokens core on every PATCH/DELETE is
   gone:
   - **PATCH** uses `UPDATE user_passkey_labels SET label = $1 WHERE
     credential_id = $2 AND user_id = $3` and treats `rowsAffected == 0` as
     `ErrPasskeyLabelNotFound` → HTTP 404. The labels table's (credential_id,
     user_id) tuple is the ownership boundary.
   - **DELETE** calls the SuperTokens core directly. The core's own ownership
     check is the authorisation — `CREDENTIAL_NOT_FOUND_ERROR` from the core
     surfaces as `service.ErrPasskeyNotFound` → HTTP 404. The label-row
     delete that follows is best-effort; missing rows are absorbed.

Handler shrinks from 348 → 255 lines. Pure refactor: behaviour is now
"single-round-trip atomic writes" where it was previously "two-round-trip
pre-checked writes", and the legitimate-user happy path is unchanged.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/handler/... ./internal/service/...` — all pass
- [x] `go vet ./...` — clean
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] Tests adapted to the new shape: single fake, single constructor,
      new ownership semantics covered (`Patch_UnknownCredentialReturns404`,
      `Delete_CoreReturnsNotFound`)
- [ ] Integration smoke once deployed: GET / PATCH / DELETE
      `/api/v1/me/passkeys/:credential_id` against a SuperTokens core