### PR TITLE
refactor(api): extract route wiring helpers from main.go

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -826,46 +826,13 @@ func main() {
 		}
 
 		// --- Airbyte connector routes (nested under org) ---
-		connectors := api.Group("/orgs/:org_id/connectors")
-		{
-			connectors.POST("", middleware.RequireOrgRole("org_admin"), airbyteHandler.Create)
-			connectors.GET("", airbyteHandler.List)
-			connectors.GET("/:connector_id", airbyteHandler.Get)
-			connectors.PUT("/:connector_id", middleware.RequireOrgRole("org_admin"), airbyteHandler.Update)
-			connectors.DELETE("/:connector_id", middleware.RequireOrgRole("org_admin"), airbyteHandler.Delete)
-			connectors.POST("/:connector_id/sync", middleware.RequireOrgRole("org_admin"), airbyteHandler.TriggerSync)
-			connectors.GET("/:connector_id/history", airbyteHandler.GetSyncHistory)
-		}
+		wireAirbyteConnectorRoutes(api, airbyteHandler)
 
 		// --- LLM Provider routes (nested under org) ---
-		llm := api.Group("/orgs/:org_id/llm-providers")
-		{
-			llm.POST("", middleware.RequireOrgRole("org_admin"), llmHandler.Create)
-			// Probe-before-create; same body as POST "" but doesn't persist.
-			// Kept admin-only since it carries the API key, even though no
-			// row is written — limits how loud bad keys can get in the logs.
-			llm.POST("/test", middleware.RequireOrgRole("org_admin"), llmHandler.TestConnection)
-			llm.GET("", llmHandler.List)
-			// Default-provider health probe used by the SPA's polling cron.
-			// Open to any authenticated org member (not just admins) since
-			// the toast lives across every authenticated page.
-			llm.GET("/default/health", llmHandler.DefaultHealth)
-			llm.GET("/:provider_id", llmHandler.Get)
-			llm.PUT("/:provider_id", middleware.RequireOrgRole("org_admin"), llmHandler.Update)
-			llm.DELETE("/:provider_id", middleware.RequireOrgRole("org_admin"), llmHandler.Delete)
-			llm.PUT("/:provider_id/default", middleware.RequireOrgRole("org_admin"), llmHandler.SetDefault)
-		}
+		wireLLMProviderRoutes(api, llmHandler)
 
 		// --- Routing rule routes (nested under org) ---
-		routing := api.Group("/orgs/:org_id/routing-rules")
-		{
-			routing.POST("", middleware.RequireOrgRole("org_admin"), routingHandler.Create)
-			routing.GET("", middleware.RequireOrgRole("org_admin"), routingHandler.List)
-			routing.GET("/:rule_id", middleware.RequireOrgRole("org_admin"), routingHandler.Get)
-			routing.PUT("/:rule_id", middleware.RequireOrgRole("org_admin"), routingHandler.Update)
-			routing.DELETE("/:rule_id", middleware.RequireOrgRole("org_admin"), routingHandler.Delete)
-			routing.POST("/resolve", middleware.RequireOrgRole("org_admin"), routingHandler.Resolve)
-		}
+		wireRoutingRuleRoutes(api, routingHandler)
 
 		// --- Catalog metadata routes (nested under org) ---
 		api.GET("/orgs/:org_id/catalog", middleware.RequireOrgRole("org_admin"), routingHandler.ListCatalog)
@@ -1032,13 +999,7 @@ func main() {
 		)
 
 		// --- Passkey routes (issue #771, M14) ---
-		// All three sit under the standard session middleware so the caller's
-		// internal user ID + SuperTokens external ID are already on the gin
-		// context. Ownership of :credential_id is verified inside the handler
-		// by listing the core's credentials for the session user.
-		api.GET("/me/passkeys", passkeyHandler.List)
-		api.PATCH("/me/passkeys/:credential_id", passkeyHandler.Patch)
-		api.DELETE("/me/passkeys/:credential_id", passkeyHandler.Delete)
+		wirePasskeyRoutes(api, passkeyHandler)
 
 		// --- DSAR routes ---
 		// GET /account/export → JSON download of the caller's data.

--- a/cmd/api/wire_routes.go
+++ b/cmd/api/wire_routes.go
@@ -1,0 +1,71 @@
+package main
+
+// Route-wiring helpers. Each `wireXxxRoutes` function registers a single
+// logical group of routes under a caller-supplied *gin.RouterGroup. This
+// keeps main.go readable: a 1127-line file used to inline every route, which
+// led to duplicate registrations being merged without anyone seeing the
+// existing entry (see PR #689 vs PR #749). New feature groups should be
+// added here rather than inlined in main.go.
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"github.com/ravencloak-org/Raven/internal/handler"
+	"github.com/ravencloak-org/Raven/internal/middleware"
+)
+
+// wirePasskeyRoutes registers the M14 passkey management routes
+// (issue #771). All three sit under the standard session middleware that the
+// caller has already mounted on `api`, so the caller's internal user ID +
+// SuperTokens external ID are already on the gin context. Ownership of
+// :credential_id is verified inside the handler by listing the core's
+// credentials for the session user.
+func wirePasskeyRoutes(api *gin.RouterGroup, h *handler.PasskeyHandler) {
+	api.GET("/me/passkeys", h.List)
+	api.PATCH("/me/passkeys/:credential_id", h.Patch)
+	api.DELETE("/me/passkeys/:credential_id", h.Delete)
+}
+
+// wireLLMProviderRoutes registers /orgs/:org_id/llm-providers routes. The
+// `/test` probe is admin-only because it accepts the API key in the request
+// body even though no row is written. The `/default/health` probe is open
+// to any authenticated org member because the connectivity toast lives on
+// every authenticated page.
+func wireLLMProviderRoutes(api *gin.RouterGroup, h *handler.LLMProviderHandler) {
+	g := api.Group("/orgs/:org_id/llm-providers")
+	g.POST("", middleware.RequireOrgRole("org_admin"), h.Create)
+	g.POST("/test", middleware.RequireOrgRole("org_admin"), h.TestConnection)
+	g.GET("", h.List)
+	g.GET("/default/health", h.DefaultHealth)
+	g.GET("/:provider_id", h.Get)
+	g.PUT("/:provider_id", middleware.RequireOrgRole("org_admin"), h.Update)
+	g.DELETE("/:provider_id", middleware.RequireOrgRole("org_admin"), h.Delete)
+	g.PUT("/:provider_id/default", middleware.RequireOrgRole("org_admin"), h.SetDefault)
+}
+
+// wireAirbyteConnectorRoutes registers /orgs/:org_id/connectors routes for
+// Airbyte source-connector management. Mutation routes are admin-only; read
+// routes are open to any authenticated org member.
+func wireAirbyteConnectorRoutes(api *gin.RouterGroup, h *handler.AirbyteHandler) {
+	g := api.Group("/orgs/:org_id/connectors")
+	g.POST("", middleware.RequireOrgRole("org_admin"), h.Create)
+	g.GET("", h.List)
+	g.GET("/:connector_id", h.Get)
+	g.PUT("/:connector_id", middleware.RequireOrgRole("org_admin"), h.Update)
+	g.DELETE("/:connector_id", middleware.RequireOrgRole("org_admin"), h.Delete)
+	g.POST("/:connector_id/sync", middleware.RequireOrgRole("org_admin"), h.TriggerSync)
+	g.GET("/:connector_id/history", h.GetSyncHistory)
+}
+
+// wireRoutingRuleRoutes registers /orgs/:org_id/routing-rules routes that
+// control which LLM provider answers which kind of request. The entire
+// surface is admin-only since routing changes affect every chat completion.
+func wireRoutingRuleRoutes(api *gin.RouterGroup, h *handler.RoutingHandler) {
+	g := api.Group("/orgs/:org_id/routing-rules", middleware.RequireOrgRole("org_admin"))
+	g.POST("", h.Create)
+	g.GET("", h.List)
+	g.GET("/:rule_id", h.Get)
+	g.PUT("/:rule_id", h.Update)
+	g.DELETE("/:rule_id", h.Delete)
+	g.POST("/resolve", h.Resolve)
+}


### PR DESCRIPTION
## Why

`cmd/api/main.go` was 1152 lines, with every route registered inline. The duplicate `/llm-providers/test` row that PR #689 merged on top of PR #749's existing line happened because nobody could hold all 154 routes in their head while reading the file. Hoist each logical group into a small `wireXxxRoutes` helper so the active route surface fits on one screen.

## What

New file `cmd/api/wire_routes.go` introduces the pattern:

```go
func wirePasskeyRoutes(api *gin.RouterGroup, h *handler.PasskeyHandler) {
    api.GET("/me/passkeys", h.List)
    api.PATCH("/me/passkeys/:credential_id", h.Patch)
    api.DELETE("/me/passkeys/:credential_id", h.Delete)
}
```

`main.go` shrinks each group from 8–18 lines to a one-line call. Seeded with four groups (the two named in the spec, plus two more small org-scoped ones to show the pattern at scale):

- `wirePasskeyRoutes` — `/me/passkeys` (M14, issue #771)
- `wireLLMProviderRoutes` — `/orgs/:org_id/llm-providers`
- `wireAirbyteConnectorRoutes` — `/orgs/:org_id/connectors`
- `wireRoutingRuleRoutes` — `/orgs/:org_id/routing-rules`

Future feature groups should be added as new `wireXxxRoutes` helpers rather than inlined.

## Semantics preserved

Verified by parsing old `main.go` and new `main.go` + `wire_routes.go` (expanding helper calls), then diffing the resulting `(method, path)` set:

- OLD: 154 routes
- NEW: 154 routes
- Missing: 0  ·  Added: 0

Every path, every middleware position, every per-route role gate is identical.

The one deliberate cleanup: in `wireRoutingRuleRoutes`, every route in the group already had `middleware.RequireOrgRole("org_admin")` inline. The gate moves to the group level — semantically equivalent because gin runs group middleware in order before route handlers.

## Duplicate-route findings

**None.** Scanned all 154 effective `(method, path)` registrations on `origin/main` with a regex-based parser that tracks `Group(...)` prefix chains — zero duplicates. The bug that motivated this refactor (#689 vs #749) was already fixed on main by a prior PR, so there is nothing to flag for human triage.

## Line count

| File | Before | After | Delta |
|------|-------:|------:|------:|
| `cmd/api/main.go` | 1152 | 1113 | **−39** |
| `cmd/api/wire_routes.go` | — | 71 | +71 (new) |

`main.go` strictly decreases past the −30 target.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./cmd/api/...` — clean
- [x] `go test ./cmd/api/...` — `ok` (0.88s)
- [x] `go test -count=1 -short ./internal/handler/...` — `ok` (0.79s)
- [x] `golangci-lint run --new-from-rev=origin/main ./cmd/...` — 0 issues
- [x] Route-set diff old vs new — 154 routes both sides, zero drift

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized API route registration logic into reusable helper functions for improved code maintainability and reduced duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->