### PR TITLE
feat(marketplace): admin takedown audit + derivative-owner notifier (#735)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -610,6 +610,27 @@ func main() {
 	passkeySvc := service.NewPasskeyService(cfg.SuperTokens.ConnectionURI, cfg.SuperTokens.APIKey, nil)
 	passkeyHandler := handler.NewPasskeyHandler(passkeySvc, pool)
 
+	// Marketplace moderation surfaces (issue #735, M3). The admin audit
+	// view reads marketplace_takedowns under the raven_admin RLS bypass;
+	// the derivative-owner notifier walks lineage one hop downstream on
+	// takedown creation. Both share the same Takedowns repo; the
+	// notifier is wired through the OnTakedownCreated registry so future
+	// callers (publisher self-unpublish, #734's admin approve) can fire
+	// it without importing internal/mail. demoMailer is the shared
+	// transactional sender — when no provider key is configured it falls
+	// back to NoopSender (best-effort, structured-log only).
+	adminTakedownsHandler := handler.NewAdminTakedownsHandler(takedownsRepo)
+	derivativeNotifier := marketplace.NewDerivativeNotifier(
+		pool,
+		marketplace.NewMailNotifier(demoMailer),
+	)
+	marketplace.RegisterOnTakedownCreated(func(ctx context.Context, td marketplace.Takedown, reason string) error {
+		// Fire-and-forget on the request context. The notifier itself
+		// logs per-recipient failures with enough detail to manually
+		// re-send; the takedown audit-log row is the durable record.
+		return derivativeNotifier.NotifyDerivativeOwners(ctx, td.TargetKBID, reason)
+	})
+
 	// Create router
 	router := gin.Default()
 
@@ -988,6 +1009,18 @@ func main() {
 		api.DELETE("/me", userHandler.DeleteMe)
 		api.PUT("/me/notification-preferences/:ws_id", resolveWSRole, notifPrefsHandler.UpsertUserPreference)
 		api.GET("/users/:user_id", middleware.RequireOrgRole("org_admin"), userHandler.GetUser)
+
+		// --- Marketplace admin routes (issue #735, M3) ---
+		// Read-only takedown audit log. The HTTP gate is the global
+		// raven-admin allowlist (RAVEN_ADMIN_EMAILS env); ListAudit
+		// internally switches to the raven_admin DB role inside a
+		// short-lived transaction so the cross-tenant SELECT can see
+		// every row. Future admin write surfaces (POST /takedowns,
+		// /reports/{id}/approve from #734) plug in here.
+		api.GET("/admin/marketplace/takedowns",
+			middleware.RequireRavenAdmin(),
+			adminTakedownsHandler.List,
+		)
 
 		// --- Passkey routes (issue #771, M14) ---
 		// All three sit under the standard session middleware so the caller's

--- a/frontend/e2e/admin/takedowns.spec.ts
+++ b/frontend/e2e/admin/takedowns.spec.ts
@@ -1,0 +1,172 @@
+/**
+ * AdminTakedownsView happy path + pagination + forbidden state.
+ *
+ * The backend gate (RAVEN_ADMIN_EMAILS allowlist) is exercised in
+ * Go unit/integration tests; here we use route interception to
+ * exercise the Vue view's rendering, source-pill mapping, strike
+ * column, and Next/Previous pagination wiring without touching a
+ * real database.
+ *
+ * The spec runs in single-user mode (no SuperTokens login flow) by
+ * mocking `/api/v1/config` to return `single_user: true`. The router
+ * then mounts the protected `/admin/marketplace/takedowns` route
+ * without bouncing through /login.
+ */
+import { test, expect } from '@playwright/test'
+
+const PAGE_1_NEXT_CURSOR = 'cursor-page-2'
+
+function pageOne() {
+  return {
+    items: [
+      {
+        takedown_id: '11111111-1111-1111-1111-111111111111',
+        target_kb_id: '22222222-2222-2222-2222-222222222222',
+        target_kb_name: 'Original Recipes',
+        target_org_slug: 'acme',
+        target_org_display_name: 'Acme Corp',
+        source: 'admin',
+        notes: 'report confirmed',
+        created_at: '2026-05-28T12:00:00.000000Z',
+        strikes_after_org_total: 2,
+      },
+      {
+        takedown_id: '33333333-3333-3333-3333-333333333333',
+        target_kb_id: '44444444-4444-4444-4444-444444444444',
+        target_kb_name: 'Marketing Brief',
+        target_org_slug: 'globex',
+        target_org_display_name: 'Globex',
+        source: 'dmca',
+        notes: 'DMCA notice 2026-06-01',
+        created_at: '2026-05-20T09:00:00.000000Z',
+        strikes_after_org_total: 1,
+      },
+    ],
+    next_cursor: PAGE_1_NEXT_CURSOR,
+  }
+}
+
+function pageTwo() {
+  return {
+    items: [
+      {
+        takedown_id: '55555555-5555-5555-5555-555555555555',
+        target_kb_id: '66666666-6666-6666-6666-666666666666',
+        target_kb_name: 'Sales Playbook',
+        target_org_slug: 'initech',
+        target_org_display_name: 'Initech',
+        source: 'publisher',
+        notes: '',
+        created_at: '2026-05-10T18:00:00.000000Z',
+        strikes_after_org_total: 0,
+      },
+    ],
+  }
+}
+
+test.describe('AdminTakedownsView', () => {
+  test.beforeEach(async ({ page }) => {
+    // Single-user mode so the router skips the SuperTokens flow.
+    await page.route('**/api/v1/config', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ single_user: true }),
+      }),
+    )
+    // SuperTokens probe blocked so the auth init doesn't hang.
+    await page.route('**/auth/**', (route) => route.abort())
+  })
+
+  test('happy path: renders rows + pagination forward and back', async ({ page }) => {
+    let callCount = 0
+    await page.route('**/api/v1/admin/marketplace/takedowns*', (route) => {
+      callCount += 1
+      const url = new URL(route.request().url())
+      const cursor = url.searchParams.get('cursor')
+      if (!cursor) {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(pageOne()),
+        })
+      }
+      if (cursor === PAGE_1_NEXT_CURSOR) {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(pageTwo()),
+        })
+      }
+      return route.fulfill({
+        status: 400,
+        contentType: 'application/json',
+        body: JSON.stringify({ detail: 'invalid cursor' }),
+      })
+    })
+
+    await page.goto('/admin/marketplace/takedowns')
+    await expect(page.getByTestId('admin-takedowns-view')).toBeVisible({
+      timeout: 10_000,
+    })
+    await expect(page.getByTestId('admin-takedowns-table')).toBeVisible()
+
+    // Two rows on page 1.
+    let rows = page.getByTestId('admin-takedowns-row')
+    await expect(rows).toHaveCount(2)
+    await expect(rows.first()).toContainText('Original Recipes')
+    await expect(rows.first()).toContainText('Acme Corp')
+    await expect(rows.first()).toContainText('Admin')
+    await expect(rows.nth(1)).toContainText('DMCA')
+
+    // Click Next → page 2 (one row, publisher pill).
+    await page.getByTestId('admin-takedowns-next').click()
+    await expect(page.getByTestId('admin-takedowns-row')).toHaveCount(1)
+    await expect(page.getByTestId('admin-takedowns-row').first()).toContainText(
+      'Sales Playbook',
+    )
+    await expect(page.getByTestId('admin-takedowns-row').first()).toContainText(
+      'Publisher',
+    )
+    // Next cursor empty → Next disabled.
+    await expect(page.getByTestId('admin-takedowns-next')).toBeDisabled()
+
+    // Click Previous → back to page 1.
+    await page.getByTestId('admin-takedowns-prev').click()
+    rows = page.getByTestId('admin-takedowns-row')
+    await expect(rows).toHaveCount(2)
+    await expect(rows.first()).toContainText('Original Recipes')
+
+    // Sanity: backend was hit at least three times (page 1, page 2, page 1 again).
+    expect(callCount).toBeGreaterThanOrEqual(3)
+  })
+
+  test('forbidden state when backend returns 403', async ({ page }) => {
+    await page.route('**/api/v1/admin/marketplace/takedowns*', (route) =>
+      route.fulfill({
+        status: 403,
+        contentType: 'application/json',
+        body: JSON.stringify({ detail: 'raven admin required' }),
+      }),
+    )
+    await page.goto('/admin/marketplace/takedowns')
+    await expect(page.getByTestId('admin-takedowns-forbidden')).toBeVisible({
+      timeout: 10_000,
+    })
+    await expect(page.getByTestId('admin-takedowns-table')).toHaveCount(0)
+  })
+
+  test('empty state when no takedowns', async ({ page }) => {
+    await page.route('**/api/v1/admin/marketplace/takedowns*', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ items: [] }),
+      }),
+    )
+    await page.goto('/admin/marketplace/takedowns')
+    await expect(page.getByTestId('admin-takedowns-empty')).toBeVisible({
+      timeout: 10_000,
+    })
+  })
+})

--- a/frontend/src/api/admin-takedowns.ts
+++ b/frontend/src/api/admin-takedowns.ts
@@ -1,0 +1,73 @@
+// Admin Marketplace takedown audit-log API client (issue #735).
+//
+// Read-only paginated list. The backend gates this with the global
+// `raven_admin` allowlist (env `RAVEN_ADMIN_EMAILS`); a non-admin session
+// gets HTTP 403 and the view surfaces a "forbidden" empty state.
+
+export type AdminTakedownSource = 'publisher' | 'admin' | 'dmca'
+
+export interface AdminTakedownRow {
+  takedown_id: string
+  target_kb_id: string
+  target_kb_name: string
+  target_org_slug: string
+  target_org_display_name: string
+  source: AdminTakedownSource
+  notes: string
+  created_at: string
+  strikes_after_org_total: number
+}
+
+export interface AdminTakedownsPage {
+  items: AdminTakedownRow[]
+  next_cursor?: string
+}
+
+async function authFetch(path: string, init?: RequestInit): Promise<Response> {
+  const base = import.meta.env.VITE_API_BASE_URL ?? '/api/v1'
+  return fetch(base + path, {
+    ...init,
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      ...init?.headers,
+    },
+  })
+}
+
+export interface ListAdminTakedownsParams {
+  limit?: number
+  cursor?: string
+}
+
+// HTTPError carries the status so the view can branch on 401/403 without
+// re-parsing the message.
+export class AdminTakedownsHTTPError extends Error {
+  status: number
+  constructor(status: number, message: string) {
+    super(message)
+    this.status = status
+    this.name = 'AdminTakedownsHTTPError'
+  }
+}
+
+export async function listAdminTakedowns(
+  params: ListAdminTakedownsParams = {},
+): Promise<AdminTakedownsPage> {
+  const qs = new URLSearchParams()
+  if (params.limit) qs.set('limit', String(params.limit))
+  if (params.cursor) qs.set('cursor', params.cursor)
+  const suffix = qs.toString() ? `?${qs.toString()}` : ''
+  const res = await authFetch(`/admin/marketplace/takedowns${suffix}`)
+  if (!res.ok) {
+    let detail = res.statusText
+    try {
+      const body = (await res.json()) as { detail?: string }
+      if (body?.detail) detail = body.detail
+    } catch {
+      // body wasn't JSON — fall through with the status text.
+    }
+    throw new AdminTakedownsHTTPError(res.status, detail)
+  }
+  return res.json() as Promise<AdminTakedownsPage>
+}

--- a/frontend/src/pages/admin/AdminTakedownsView.vue
+++ b/frontend/src/pages/admin/AdminTakedownsView.vue
@@ -1,0 +1,301 @@
+<script setup lang="ts">
+// Admin-only Marketplace takedown audit log (issue #735).
+//
+// Read-only paginated table. The backend gates the endpoint with the
+// global raven-admin allowlist; this view shows a "forbidden" empty
+// state on 403 so a curious non-admin who guesses the URL sees a clear
+// message rather than the loading spinner spinning forever.
+
+import { ref, computed, onMounted } from 'vue'
+import {
+  listAdminTakedowns,
+  AdminTakedownsHTTPError,
+  type AdminTakedownRow,
+  type AdminTakedownSource,
+} from '../../api/admin-takedowns'
+
+const PAGE_SIZE = 25
+
+const rows = ref<AdminTakedownRow[]>([])
+const nextCursor = ref<string | undefined>(undefined)
+const cursorStack = ref<string[]>([])
+const loading = ref(false)
+const errorStatus = ref<number | null>(null)
+const errorMessage = ref<string>('')
+
+async function load(cursor?: string) {
+  loading.value = true
+  errorStatus.value = null
+  errorMessage.value = ''
+  try {
+    const page = await listAdminTakedowns({ limit: PAGE_SIZE, cursor })
+    rows.value = page.items
+    nextCursor.value = page.next_cursor
+  } catch (err) {
+    if (err instanceof AdminTakedownsHTTPError) {
+      errorStatus.value = err.status
+      errorMessage.value = err.message
+    } else {
+      errorStatus.value = 0
+      errorMessage.value = err instanceof Error ? err.message : 'unknown error'
+    }
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(() => load())
+
+function loadNext() {
+  if (!nextCursor.value) return
+  // Push the cursor that opened the *current* page onto the stack so
+  // "back" returns to it. The first page is represented by undefined.
+  cursorStack.value.push(cursorStack.value.length === 0 ? '' : cursorStack.value[cursorStack.value.length - 1])
+  void load(nextCursor.value)
+}
+
+function loadPrev() {
+  if (cursorStack.value.length === 0) return
+  const prev = cursorStack.value.pop()
+  void load(prev === '' ? undefined : prev)
+}
+
+const canGoBack = computed(() => cursorStack.value.length > 0)
+const canGoNext = computed(() => !!nextCursor.value)
+
+function sourceLabel(s: AdminTakedownSource): string {
+  switch (s) {
+    case 'publisher':
+      return 'Publisher'
+    case 'admin':
+      return 'Admin'
+    case 'dmca':
+      return 'DMCA'
+  }
+}
+
+function sourceClass(s: AdminTakedownSource): string {
+  switch (s) {
+    case 'publisher':
+      return 'pill pill-publisher'
+    case 'admin':
+      return 'pill pill-admin'
+    case 'dmca':
+      return 'pill pill-dmca'
+  }
+}
+
+function formatTimestamp(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString()
+  } catch {
+    return iso
+  }
+}
+
+const forbidden = computed(
+  () => errorStatus.value === 401 || errorStatus.value === 403,
+)
+</script>
+
+<template>
+  <section class="admin-takedowns" data-test="admin-takedowns-view">
+    <header class="header">
+      <h1>Marketplace Takedowns</h1>
+      <p class="subtitle">
+        Audit log of every Public KB removed from the Marketplace. Read-only;
+        gated to Raven admins (the
+        <code>RAVEN_ADMIN_EMAILS</code> allowlist).
+      </p>
+    </header>
+
+    <div v-if="forbidden" class="state state-forbidden" data-test="admin-takedowns-forbidden">
+      <h2>Access denied</h2>
+      <p>
+        You must be a Raven admin to view the takedown audit log. If you
+        believe this is wrong, contact the platform team.
+      </p>
+    </div>
+
+    <div
+      v-else-if="errorStatus !== null"
+      class="state state-error"
+      data-test="admin-takedowns-error"
+    >
+      <h2>Couldn't load takedowns</h2>
+      <p>{{ errorMessage || 'Unknown error.' }}</p>
+      <button type="button" @click="load()">Retry</button>
+    </div>
+
+    <div v-else-if="loading" class="state state-loading">Loading…</div>
+
+    <div
+      v-else-if="rows.length === 0"
+      class="state state-empty"
+      data-test="admin-takedowns-empty"
+    >
+      <h2>No takedowns yet</h2>
+      <p>When the Marketplace flags or removes a Public KB, it shows up here.</p>
+    </div>
+
+    <table v-else class="takedowns-table" data-test="admin-takedowns-table">
+      <thead>
+        <tr>
+          <th>Takedown ID</th>
+          <th>Target KB</th>
+          <th>Source</th>
+          <th>Reason / Notes</th>
+          <th>Created</th>
+          <th>Org strikes</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          v-for="row in rows"
+          :key="row.takedown_id"
+          data-test="admin-takedowns-row"
+        >
+          <td class="mono">{{ row.takedown_id.slice(0, 8) }}…</td>
+          <td>
+            <div class="kb-cell">
+              <span class="kb-name">{{ row.target_kb_name }}</span>
+              <span class="kb-org"
+                >{{ row.target_org_display_name }} ({{ row.target_org_slug }})</span
+              >
+            </div>
+          </td>
+          <td>
+            <span :class="sourceClass(row.source)">{{ sourceLabel(row.source) }}</span>
+          </td>
+          <td class="notes">{{ row.notes || '—' }}</td>
+          <td>{{ formatTimestamp(row.created_at) }}</td>
+          <td class="strikes">{{ row.strikes_after_org_total }}</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <nav v-if="!forbidden && errorStatus === null" class="pagination" aria-label="pagination">
+      <button
+        type="button"
+        :disabled="!canGoBack || loading"
+        data-test="admin-takedowns-prev"
+        @click="loadPrev"
+      >
+        ← Previous
+      </button>
+      <button
+        type="button"
+        :disabled="!canGoNext || loading"
+        data-test="admin-takedowns-next"
+        @click="loadNext"
+      >
+        Next →
+      </button>
+    </nav>
+  </section>
+</template>
+
+<style scoped>
+.admin-takedowns {
+  padding: 1.5rem;
+  max-width: 100%;
+}
+.header h1 {
+  margin: 0 0 0.25rem;
+  font-size: 1.5rem;
+}
+.subtitle {
+  color: var(--color-text-muted, #666);
+  margin: 0 0 1.5rem;
+}
+.state {
+  padding: 2rem;
+  text-align: center;
+  border: 1px dashed var(--color-border, #ccc);
+  border-radius: 8px;
+  color: var(--color-text-muted, #666);
+}
+.state-forbidden,
+.state-error {
+  border-style: solid;
+  background: var(--color-bg-warning, #fff8f0);
+}
+.takedowns-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+.takedowns-table th,
+.takedowns-table td {
+  text-align: left;
+  padding: 0.75rem 0.5rem;
+  border-bottom: 1px solid var(--color-border, #eee);
+  vertical-align: top;
+}
+.takedowns-table th {
+  font-weight: 600;
+  background: var(--color-bg-subtle, #fafafa);
+}
+.mono {
+  font-family: 'SFMono-Regular', 'Consolas', monospace;
+  font-size: 0.85em;
+}
+.kb-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+.kb-name {
+  font-weight: 500;
+}
+.kb-org {
+  font-size: 0.85em;
+  color: var(--color-text-muted, #666);
+}
+.notes {
+  max-width: 24rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.strikes {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+.pill {
+  display: inline-block;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.8em;
+  font-weight: 600;
+}
+.pill-publisher {
+  background: #e9eefb;
+  color: #2748a3;
+}
+.pill-admin {
+  background: #fff4d9;
+  color: #8a5a00;
+}
+.pill-dmca {
+  background: #fde2e2;
+  color: #9c1c1c;
+}
+.pagination {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+  margin-top: 1rem;
+}
+.pagination button {
+  padding: 0.4rem 0.9rem;
+  border-radius: 4px;
+  border: 1px solid var(--color-border, #ccc);
+  background: var(--color-bg-button, #fff);
+  cursor: pointer;
+}
+.pagination button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+</style>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -173,6 +173,15 @@ const router = createRouter({
           component: () => import('../pages/admin/AdminReportsView.vue'),
           meta: { requiresAuth: true, requiresPlatformAdmin: true },
         },
+        {
+          // Marketplace takedown audit log (issue #735). View handles 403
+          // in its loader so a deep link degrades gracefully if the
+          // requiresPlatformAdmin hint is bypassed.
+          path: 'admin/marketplace/takedowns',
+          name: 'admin-marketplace-takedowns',
+          component: () => import('../pages/admin/AdminTakedownsView.vue'),
+          meta: { requiresAuth: true, requiresPlatformAdmin: true },
+        },
       ],
     },
     {

--- a/internal/handler/admin_takedowns.go
+++ b/internal/handler/admin_takedowns.go
@@ -1,0 +1,141 @@
+// Admin takedown audit-log endpoint (issue #735, M3).
+//
+// GET /api/v1/admin/marketplace/takedowns?limit=&cursor=
+//
+// Read-only paginated audit log of marketplace_takedowns joined with the
+// target KB and publisher Org. The HTTP gate is RequireRavenAdmin
+// (env-allowlist match on the session email); the repository layer
+// switches to the raven_admin DB role inside its own short-lived
+// transaction so the SELECT can cross every tenant.
+//
+// This file is intentionally tiny — the heavy lifting lives in
+// internal/marketplace/takedowns.go (ListAudit + cursor helpers). The
+// handler's only job is to parse query params, call the repo, and
+// translate the cursor + rows into the JSON shape #735 documents.
+
+package handler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/ravencloak-org/Raven/internal/marketplace"
+	"github.com/ravencloak-org/Raven/pkg/apierror"
+)
+
+// TakedownsAuditLister is the slice of *marketplace.Takedowns the
+// handler depends on. Defined as an interface so tests can stub it
+// without spinning up a Postgres testcontainer for the HTTP-layer
+// assertions; the integration tests in internal/marketplace cover the
+// real SQL.
+type TakedownsAuditLister interface {
+	ListAudit(ctx context.Context, limit int, cursor string) ([]marketplace.AuditRow, string, error)
+}
+
+// AdminTakedownsHandler exposes the read-only audit endpoint.
+type AdminTakedownsHandler struct {
+	repo TakedownsAuditLister
+}
+
+// NewAdminTakedownsHandler returns a handler bound to repo.
+func NewAdminTakedownsHandler(repo TakedownsAuditLister) *AdminTakedownsHandler {
+	return &AdminTakedownsHandler{repo: repo}
+}
+
+// adminTakedownRow is the JSON wire shape per #735's "Response row shape"
+// in the issue. Snake_case keys to match the rest of the API.
+type adminTakedownRow struct {
+	TakedownID            string `json:"takedown_id"`
+	TargetKBID            string `json:"target_kb_id"`
+	TargetKBName          string `json:"target_kb_name"`
+	TargetOrgSlug         string `json:"target_org_slug"`
+	TargetOrgDisplayName  string `json:"target_org_display_name"`
+	Source                string `json:"source"`
+	Notes                 string `json:"notes"`
+	CreatedAt             string `json:"created_at"`
+	StrikesAfterOrgTotal  int64  `json:"strikes_after_org_total"`
+}
+
+type adminTakedownsResponse struct {
+	Items      []adminTakedownRow `json:"items"`
+	NextCursor string             `json:"next_cursor,omitempty"`
+}
+
+// List handles GET /api/v1/admin/marketplace/takedowns.
+//
+// @Summary     Paginated audit log of Marketplace takedowns
+// @Tags        admin,marketplace
+// @Produce     json
+// @Security    BearerAuth
+// @Param       limit  query int    false "Page size (1..100, default 25)"
+// @Param       cursor query string false "Opaque keyset cursor from prior response"
+// @Success     200 {object} adminTakedownsResponse
+// @Failure     400 {object} apierror.AppError
+// @Failure     401 {object} apierror.AppError
+// @Failure     403 {object} apierror.AppError
+// @Router      /admin/marketplace/takedowns [get]
+func (h *AdminTakedownsHandler) List(c *gin.Context) {
+	limit := 0
+	if raw := c.Query("limit"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < 0 {
+			_ = c.Error(&apierror.AppError{
+				Code:    http.StatusBadRequest,
+				Message: "Bad Request",
+				Detail:  "limit must be a non-negative integer",
+			})
+			c.Abort()
+			return
+		}
+		limit = n
+	}
+	cursor := c.Query("cursor")
+
+	rows, nextCursor, err := h.repo.ListAudit(c.Request.Context(), limit, cursor)
+	if err != nil {
+		// Opaque cursors are a contract: parse failures are a client bug,
+		// not a server one — surface 400 rather than 500.
+		if isInvalidCursor(err) {
+			_ = c.Error(&apierror.AppError{
+				Code:    http.StatusBadRequest,
+				Message: "Bad Request",
+				Detail:  "invalid cursor",
+			})
+			c.Abort()
+			return
+		}
+		_ = c.Error(err)
+		c.Abort()
+		return
+	}
+
+	out := adminTakedownsResponse{
+		Items:      make([]adminTakedownRow, 0, len(rows)),
+		NextCursor: nextCursor,
+	}
+	for _, r := range rows {
+		out.Items = append(out.Items, adminTakedownRow{
+			TakedownID:           r.TakedownID.String(),
+			TargetKBID:           r.TargetKBID.String(),
+			TargetKBName:         r.TargetKBName,
+			TargetOrgSlug:        r.TargetOrgSlug,
+			TargetOrgDisplayName: r.TargetOrgDisplayName,
+			Source:               string(r.Source),
+			Notes:                r.Notes,
+			CreatedAt:            r.CreatedAt.UTC().Format("2006-01-02T15:04:05.000000Z"),
+			StrikesAfterOrgTotal: r.StrikesAfterOrgTotal,
+		})
+	}
+	c.JSON(http.StatusOK, out)
+}
+
+// isInvalidCursor detects the audit-cursor parse-error sentinel.
+// ListAudit wraps it with fmt.Errorf("...: %w", ...) so errors.Is is the
+// right tool.
+func isInvalidCursor(err error) bool {
+	return errors.Is(err, marketplace.ErrInvalidAuditCursor)
+}

--- a/internal/handler/admin_takedowns_test.go
+++ b/internal/handler/admin_takedowns_test.go
@@ -1,0 +1,209 @@
+package handler_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/ravencloak-org/Raven/internal/handler"
+	"github.com/ravencloak-org/Raven/internal/marketplace"
+	"github.com/ravencloak-org/Raven/internal/middleware"
+	"github.com/ravencloak-org/Raven/pkg/apierror"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+// fakeAuditLister stubs the small surface of *marketplace.Takedowns that
+// the handler depends on. Recording the args lets tests assert that
+// limit + cursor were forwarded verbatim.
+type fakeAuditLister struct {
+	rows        []marketplace.AuditRow
+	nextCursor  string
+	err         error
+	gotLimit    int
+	gotCursor   string
+	called      int
+}
+
+func (f *fakeAuditLister) ListAudit(_ context.Context, limit int, cursor string) ([]marketplace.AuditRow, string, error) {
+	f.called++
+	f.gotLimit = limit
+	f.gotCursor = cursor
+	return f.rows, f.nextCursor, f.err
+}
+
+func mountAdminTakedowns(t *testing.T, repo handler.TakedownsAuditLister, email, allowlist string) *gin.Engine {
+	t.Helper()
+	t.Setenv("RAVEN_ADMIN_EMAILS", allowlist)
+	middleware.ResetAdminEmailsCacheForTest()
+	r := gin.New()
+	r.Use(apierror.ErrorHandler())
+	r.Use(func(c *gin.Context) {
+		if email != "" {
+			c.Set(string(middleware.ContextKeyEmail), email)
+		}
+		c.Next()
+	})
+	h := handler.NewAdminTakedownsHandler(repo)
+	r.GET("/api/v1/admin/marketplace/takedowns",
+		middleware.RequireRavenAdmin(),
+		h.List,
+	)
+	return r
+}
+
+func TestAdminTakedowns_Unauthorized(t *testing.T) {
+	r := mountAdminTakedowns(t, &fakeAuditLister{}, "", "admin@raven.org")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/marketplace/takedowns", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d, body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestAdminTakedowns_Forbidden(t *testing.T) {
+	r := mountAdminTakedowns(t, &fakeAuditLister{}, "user@example.com", "admin@raven.org")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/marketplace/takedowns", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d, body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestAdminTakedowns_OK_EmptyPage(t *testing.T) {
+	repo := &fakeAuditLister{}
+	r := mountAdminTakedowns(t, repo, "admin@raven.org", "admin@raven.org")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/marketplace/takedowns", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d, body=%s", w.Code, w.Body.String())
+	}
+	var body struct {
+		Items      []map[string]any `json:"items"`
+		NextCursor string           `json:"next_cursor,omitempty"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Items) != 0 {
+		t.Errorf("items: want 0, got %d", len(body.Items))
+	}
+	if body.NextCursor != "" {
+		t.Errorf("next_cursor: want empty, got %q", body.NextCursor)
+	}
+}
+
+func TestAdminTakedowns_OK_PopulatedRowAndCursor(t *testing.T) {
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	tdID := uuid.New()
+	kbID := uuid.New()
+	repo := &fakeAuditLister{
+		rows: []marketplace.AuditRow{{
+			TakedownID:           tdID,
+			TargetKBID:           kbID,
+			TargetKBName:         "Recipes",
+			TargetOrgSlug:        "acme",
+			TargetOrgDisplayName: "Acme Corp",
+			Source:               marketplace.TakedownSourceAdmin,
+			Notes:                "trademark dispute",
+			CreatedAt:            now,
+			StrikesAfterOrgTotal: 2,
+		}},
+		nextCursor: "opaque-next",
+	}
+	r := mountAdminTakedowns(t, repo, "admin@raven.org", "admin@raven.org")
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/admin/marketplace/takedowns?limit=25&cursor=opaque-prev", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d, body=%s", w.Code, w.Body.String())
+	}
+	if repo.gotLimit != 25 || repo.gotCursor != "opaque-prev" {
+		t.Errorf("repo args: limit=%d cursor=%q", repo.gotLimit, repo.gotCursor)
+	}
+	var body struct {
+		Items []struct {
+			TakedownID           string `json:"takedown_id"`
+			TargetKBID           string `json:"target_kb_id"`
+			TargetKBName         string `json:"target_kb_name"`
+			TargetOrgSlug        string `json:"target_org_slug"`
+			TargetOrgDisplayName string `json:"target_org_display_name"`
+			Source               string `json:"source"`
+			Notes                string `json:"notes"`
+			CreatedAt            string `json:"created_at"`
+			Strikes              int64  `json:"strikes_after_org_total"`
+		} `json:"items"`
+		NextCursor string `json:"next_cursor"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Items) != 1 {
+		t.Fatalf("items: want 1, got %d", len(body.Items))
+	}
+	it := body.Items[0]
+	if it.TakedownID != tdID.String() || it.TargetKBID != kbID.String() ||
+		it.TargetKBName != "Recipes" || it.TargetOrgSlug != "acme" ||
+		it.TargetOrgDisplayName != "Acme Corp" || it.Source != "admin" ||
+		it.Notes != "trademark dispute" || it.Strikes != 2 {
+		t.Errorf("row mismatch: %+v", it)
+	}
+	if body.NextCursor != "opaque-next" {
+		t.Errorf("next_cursor: want opaque-next, got %q", body.NextCursor)
+	}
+}
+
+func TestAdminTakedowns_BadLimit(t *testing.T) {
+	repo := &fakeAuditLister{}
+	r := mountAdminTakedowns(t, repo, "admin@raven.org", "admin@raven.org")
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/admin/marketplace/takedowns?limit=oops", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d, body=%s", w.Code, w.Body.String())
+	}
+	if repo.called != 0 {
+		t.Errorf("repo should not be called on parse error, called=%d", repo.called)
+	}
+}
+
+func TestAdminTakedowns_InvalidCursorBubbles400(t *testing.T) {
+	repo := &fakeAuditLister{
+		err: fmt.Errorf("Takedowns.ListAudit: cursor: %w", marketplace.ErrInvalidAuditCursor),
+	}
+	r := mountAdminTakedowns(t, repo, "admin@raven.org", "admin@raven.org")
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/admin/marketplace/takedowns?cursor=garbage", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d, body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestAdminTakedowns_RepoErrorBubbles500(t *testing.T) {
+	repo := &fakeAuditLister{err: errors.New("boom")}
+	r := mountAdminTakedowns(t, repo, "admin@raven.org", "admin@raven.org")
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/admin/marketplace/takedowns", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("want 500, got %d", w.Code)
+	}
+}

--- a/internal/marketplace/audit_cursor.go
+++ b/internal/marketplace/audit_cursor.go
@@ -1,0 +1,69 @@
+// Opaque cursor encoding for the takedown audit-log pagination.
+//
+// The encoding is `base64url(unix_micros + ":" + uuid)`. We chose
+// base64url + a simple delimited body (vs. JSON) because:
+//
+//   - The cursor is round-tripped through URLs (?cursor=...); base64url
+//     keeps it URL-safe without percent-escaping.
+//   - The shape is fixed (always two fields); JSON adds bytes and a
+//     parser dependency without enabling anything we'd actually use.
+//   - "Opaque" is enforced at the API boundary — clients are not allowed
+//     to construct cursors themselves, and a parse error returns 400
+//     rather than leaking the format.
+//
+// Microsecond precision matches Postgres's TIMESTAMPTZ resolution (it
+// stores microseconds internally). Going finer would lose information
+// on round-trip; going coarser would split rows from the same insert
+// across pages.
+
+package marketplace
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ErrInvalidAuditCursor is returned by parseAuditCursor when the supplied
+// cursor cannot be decoded. Surfaced through the handler as HTTP 400.
+var ErrInvalidAuditCursor = errors.New("marketplace: invalid audit cursor")
+
+// EncodeAuditCursor builds the opaque cursor pointing at (createdAt, id).
+// Callers should treat the returned string as opaque; the format is an
+// implementation detail.
+func EncodeAuditCursor(createdAt time.Time, id uuid.UUID) string {
+	// Unix microseconds keeps the encoded string short and round-trip
+	// stable: a Go time.Time can be reconstructed exactly from a micros
+	// counter (Postgres-precision aligned, see file doc).
+	body := strconv.FormatInt(createdAt.UnixMicro(), 10) + ":" + id.String()
+	return base64.RawURLEncoding.EncodeToString([]byte(body))
+}
+
+// parseAuditCursor decodes a cursor produced by EncodeAuditCursor. Any
+// failure (bad base64, bad delimiter, bad timestamp, bad uuid) maps to
+// ErrInvalidAuditCursor — callers don't get a finer-grained diagnostic
+// because the cursor is opaque by contract.
+func parseAuditCursor(cursor string) (time.Time, uuid.UUID, error) {
+	raw, err := base64.RawURLEncoding.DecodeString(cursor)
+	if err != nil {
+		return time.Time{}, uuid.Nil, fmt.Errorf("%w: base64: %v", ErrInvalidAuditCursor, err)
+	}
+	parts := strings.SplitN(string(raw), ":", 2)
+	if len(parts) != 2 {
+		return time.Time{}, uuid.Nil, ErrInvalidAuditCursor
+	}
+	micros, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		return time.Time{}, uuid.Nil, fmt.Errorf("%w: micros: %v", ErrInvalidAuditCursor, err)
+	}
+	id, err := uuid.Parse(parts[1])
+	if err != nil {
+		return time.Time{}, uuid.Nil, fmt.Errorf("%w: uuid: %v", ErrInvalidAuditCursor, err)
+	}
+	return time.UnixMicro(micros).UTC(), id, nil
+}

--- a/internal/marketplace/derivative_notifier.go
+++ b/internal/marketplace/derivative_notifier.go
@@ -1,0 +1,345 @@
+// Derivative-owner notifier: when a Public KB is taken down, every Org
+// whose private KB was imported from that Public KB (one hop only) gets
+// an email so the importer's admins know their source has been removed.
+// ADR-0004 §"Notify, don't cascade" pins this rule: derivatives keep
+// working — they were forked at import time per ADR-0001 — but their
+// owners deserve a heads-up so they can decide whether to retain the
+// fork, swap to a different source, or delete it.
+//
+// One hop only is structural — the SQL below has no recursion. Derivatives
+// of derivatives are not in scope: the lineage UI shows one hop back, the
+// notification mirrors that scope, and chasing the full graph would
+// quickly fan out to thousands of unrelated Orgs.
+//
+// The notifier is fire-and-forget at the call site: failures are logged
+// with enough detail to recover (the takedown row is the durable record;
+// the email is best-effort delivery on top). Promotion to an Asynq task
+// is the natural M3 follow-up — the issue acceptance criteria mentions
+// `internal/jobs/marketplace_takedown_notifier.go` for that — but the
+// in-process path is deliberate for this PR so the takedown audit log
+// and the notification semantics ship together and #734's approve handler
+// has one obvious wire-up point.
+
+package marketplace
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/ravencloak-org/Raven/internal/mail"
+)
+
+// Notifier is the seam between the marketplace package and whatever
+// transport actually delivers a derivative-takedown notice. Production
+// wiring satisfies this with internal/mail.Sender; tests substitute a
+// recording mock to assert "called once per derivative" without spinning
+// up SMTP. Decoupling from internal/mail.Sender directly means we can
+// route to Asynq later (issue #735's stretch goal) by registering an
+// adapter that enqueues a job instead of sending inline.
+type Notifier interface {
+	// NotifyDerivativeTakedown is invoked once per workspace-admin email
+	// that should receive a notice. Implementations MUST be safe to call
+	// concurrently; the walker may parallelise per derivative in the
+	// future.
+	NotifyDerivativeTakedown(ctx context.Context, n DerivativeNotice) error
+}
+
+// DerivativeNotice carries everything an email template needs: who to
+// reach (RecipientEmail), what their KB is called (DerivativeKBName),
+// which upstream KB went away (SourceKBName, SourceOrgDisplayName), and
+// what the moderation note said (Reason). Notes may be empty when the
+// takedown row had no notes.
+//
+// We pass display-ready strings rather than IDs so the notifier
+// implementation doesn't have to re-query the DB just to format an
+// email — the walker already paid for the JOIN.
+type DerivativeNotice struct {
+	RecipientEmail       string
+	DerivativeKBID       uuid.UUID
+	DerivativeKBName     string
+	SourceKBID           uuid.UUID
+	SourceKBName         string
+	SourceOrgDisplayName string
+	Reason               string
+}
+
+// MailNotifier adapts a generic mail.Sender to the Notifier seam. It is
+// the default production wiring; the email body is plain text rather
+// than HTML so the M3 transactional path works without templates — when
+// templates land per #735's acceptance criteria, swap this for a
+// templated implementation without touching the walker.
+type MailNotifier struct {
+	Sender mail.Sender
+	From   string
+}
+
+// NewMailNotifier returns a MailNotifier backed by the supplied sender.
+// A nil sender falls back to a NoopSender so dev / single-user runs
+// without RESEND_API_KEY still progress through the takedown path
+// without panicking.
+func NewMailNotifier(sender mail.Sender) *MailNotifier {
+	if sender == nil {
+		sender = &mail.NoopSender{}
+	}
+	return &MailNotifier{Sender: sender}
+}
+
+// NotifyDerivativeTakedown formats and sends a single notice. The
+// subject and body are deliberately terse — the email is informational,
+// not transactional, and we don't want to import a template engine just
+// for this surface. Future templated bodies can extend this.
+func (m *MailNotifier) NotifyDerivativeTakedown(ctx context.Context, n DerivativeNotice) error {
+	subject := fmt.Sprintf("Heads-up: upstream Marketplace KB %q was taken down", n.SourceKBName)
+	body := fmt.Sprintf(
+		`Hi,
+
+A Public Knowledge Base you imported into Raven has been taken down from the Marketplace.
+
+  Upstream KB : %s (org: %s)
+  Your KB     : %s
+  Reason      : %s
+
+Your private copy of the data still works — Raven forks Public KBs at import time,
+so the upstream takedown does not cascade to your workspace. You may want to:
+
+  - Review whether to keep your derivative KB.
+  - Swap to a different upstream source if one exists.
+  - Delete your derivative if you no longer have grounds to use it.
+
+If you have questions, reply to this email and we will route you to the moderation
+team.
+
+— Raven`,
+		n.SourceKBName, n.SourceOrgDisplayName, n.DerivativeKBName, fallback(n.Reason, "(no reason recorded)"),
+	)
+	return m.Sender.Send(ctx, mail.Message{
+		To:      n.RecipientEmail,
+		Subject: subject,
+		Text:    body,
+	})
+}
+
+func fallback(s, alt string) string {
+	if s == "" {
+		return alt
+	}
+	return s
+}
+
+// DerivativeNotifier walks the one-hop lineage graph for a taken-down
+// Public KB and dispatches notices via the configured Notifier.
+//
+// Construction takes the pool because the walker issues a single
+// JOINed SELECT under raven_admin RLS bypass — non-admin sessions would
+// silently return zero rows due to tenant_isolation on knowledge_bases,
+// users, and workspace_members. The repository switches roles inside a
+// transaction so the caller's outer session isolation is preserved.
+type DerivativeNotifier struct {
+	pool     *pgxpool.Pool
+	notifier Notifier
+}
+
+// NewDerivativeNotifier returns a walker bound to pool + notifier.
+// A nil notifier panics — that would only happen on a wiring bug, and
+// a panic at boot is preferable to silently dropping every notice.
+func NewDerivativeNotifier(pool *pgxpool.Pool, notifier Notifier) *DerivativeNotifier {
+	if notifier == nil {
+		panic("marketplace: NewDerivativeNotifier requires a non-nil Notifier")
+	}
+	return &DerivativeNotifier{pool: pool, notifier: notifier}
+}
+
+// NotifyDerivativeOwners walks `knowledge_bases` rows whose
+// `source_public_kb_id = takenDownKBID` and dispatches one notice per
+// workspace admin of each derivative's Org.
+//
+// "One hop only" is structural: the SELECT has no recursive CTE. A
+// derivative-of-a-derivative would have its source_public_kb_id pointing
+// at the intermediate, not at takenDownKBID, so it never matches.
+//
+// Errors from individual notifier sends are logged but not fatal — the
+// walker continues through the remaining recipients. The first
+// dispatch error is returned so callers can surface a single "some
+// notices failed" signal; the audit log row was already committed and is
+// the durable record either way.
+func (d *DerivativeNotifier) NotifyDerivativeOwners(ctx context.Context, takenDownKBID uuid.UUID, reason string) error {
+	if d == nil {
+		return nil
+	}
+
+	// Switch to raven_admin so the SELECT can cross tenant boundaries —
+	// the walker reaches into every importer Org's workspace_members.
+	// Running this in a transaction means SET LOCAL ROLE is scoped to
+	// the JOIN and reverts on commit; the outer pool connection is
+	// returned in its original role.
+	tx, err := d.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("marketplace: notify derivatives: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx, "SET LOCAL ROLE raven_admin"); err != nil {
+		return fmt.Errorf("marketplace: notify derivatives: set role: %w", err)
+	}
+
+	// The SELECT joins three tables. derived_kb is the importer's
+	// private KB; source_kb gives us the display name of the taken-down
+	// upstream (this is the same KB ID we were called with, but joining
+	// it here keeps the row shape self-contained); source_org gives the
+	// upstream Org's display name; workspace_members gates on role='admin'
+	// so we email decision-makers, not every viewer in the workspace.
+	//
+	// DISTINCT on (derivative_kb_id, user_email) collapses the case where
+	// the same admin is a member of multiple workspaces inside the
+	// importer Org — we send them one email per derivative KB, not one
+	// per (KB, workspace) pair.
+	rows, err := tx.Query(ctx, `
+		SELECT DISTINCT
+		    derived_kb.id           AS derivative_kb_id,
+		    derived_kb.name         AS derivative_kb_name,
+		    source_kb.id            AS source_kb_id,
+		    source_kb.name          AS source_kb_name,
+		    source_org.name         AS source_org_display_name,
+		    u.email                 AS recipient_email
+		FROM knowledge_bases AS derived_kb
+		JOIN knowledge_bases  AS source_kb  ON source_kb.id  = derived_kb.source_public_kb_id
+		JOIN organizations    AS source_org ON source_org.id = source_kb.org_id
+		JOIN workspace_members AS wm        ON wm.workspace_id = derived_kb.workspace_id
+		                                   AND wm.role = 'admin'
+		JOIN users             AS u         ON u.id = wm.user_id
+		                                   AND u.status = 'active'
+		WHERE derived_kb.source_public_kb_id = $1
+	`, takenDownKBID)
+	if err != nil {
+		return fmt.Errorf("marketplace: notify derivatives: query: %w", err)
+	}
+
+	var notices []DerivativeNotice
+	for rows.Next() {
+		var n DerivativeNotice
+		if err := rows.Scan(
+			&n.DerivativeKBID,
+			&n.DerivativeKBName,
+			&n.SourceKBID,
+			&n.SourceKBName,
+			&n.SourceOrgDisplayName,
+			&n.RecipientEmail,
+		); err != nil {
+			rows.Close()
+			return fmt.Errorf("marketplace: notify derivatives: scan: %w", err)
+		}
+		n.Reason = reason
+		notices = append(notices, n)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("marketplace: notify derivatives: rows: %w", err)
+	}
+
+	// Commit before any I/O. The DB work is done; downstream notifier
+	// sends shouldn't hold a transaction open.
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("marketplace: notify derivatives: commit: %w", err)
+	}
+
+	// Dispatch outside the transaction. Log every failure with enough
+	// detail to manually re-send if a downstream provider is flaky.
+	var firstErr error
+	for _, n := range notices {
+		if err := d.notifier.NotifyDerivativeTakedown(ctx, n); err != nil {
+			slog.Error("derivative takedown notice failed",
+				slog.String("recipient", n.RecipientEmail),
+				slog.String("source_kb_id", n.SourceKBID.String()),
+				slog.String("derivative_kb_id", n.DerivativeKBID.String()),
+				slog.String("err", err.Error()),
+			)
+			if firstErr == nil {
+				firstErr = err
+			}
+		}
+	}
+	return firstErr
+}
+
+// ─── OnTakedownCreated registry ──────────────────────────────────────────────
+//
+// We chose a registry over a callback on Takedowns.Create deliberately:
+//
+//   - Takedowns.Create is a thin INSERT — adding a callback parameter
+//     would couple the data-access layer to the notifier interface (and
+//     mean every test that touches Takedowns has to thread one through).
+//   - The notifier is a *side effect* of the takedown decision, not part
+//     of the audit-log write. ADR-0004 is explicit that the takedown
+//     row is the durable record; notification is best-effort on top.
+//     Separating them at the seam mirrors that split.
+//   - #734's admin approve path needs to invoke this from a service that
+//     already has a takedown writer wired; a registry the API layer
+//     populates once at boot keeps #734 from importing internal/mail.
+//
+// Mutability + thread-safety: handlers register at boot, so we lock
+// only for paranoia — the production wire-up is single-writer at
+// startup and many-reader at request time. The mutex makes that
+// invariant explicit and gives tests a clean reset path.
+
+type takedownCreatedHook func(ctx context.Context, t Takedown, reason string) error
+
+var (
+	takedownCreatedMu    sync.RWMutex
+	takedownCreatedHooks []takedownCreatedHook
+)
+
+// RegisterOnTakedownCreated subscribes a hook to be invoked whenever a
+// takedown audit-log row is created via DispatchOnTakedownCreated. The
+// notifier wires itself here at API boot; tests subscribe a recording
+// closure.
+//
+// Hooks are invoked in registration order; a hook returning an error
+// does NOT short-circuit later hooks (the takedown row already exists
+// and we don't want one flaky notifier to block another).
+func RegisterOnTakedownCreated(h takedownCreatedHook) {
+	if h == nil {
+		return
+	}
+	takedownCreatedMu.Lock()
+	defer takedownCreatedMu.Unlock()
+	takedownCreatedHooks = append(takedownCreatedHooks, h)
+}
+
+// ResetOnTakedownCreatedForTest clears the registry. Test-only. Lives
+// in non-test code because cross-package tests (cmd/api integration)
+// also need it.
+func ResetOnTakedownCreatedForTest() {
+	takedownCreatedMu.Lock()
+	defer takedownCreatedMu.Unlock()
+	takedownCreatedHooks = nil
+}
+
+// DispatchOnTakedownCreated invokes every registered hook with the
+// given takedown row + reason. The first error is returned (caller
+// can decide to log + ignore); the rest are folded via errors.Join.
+//
+// Callers MUST invoke this after a successful Takedowns.Create —
+// the moderation service in #734's admin approve path does so. This
+// PR wires the registry but does not retrofit existing call sites
+// (publisher self-takedown and #734) — both are TODO comments on the
+// relevant handlers and #734 will add the explicit dispatch as part
+// of landing its admin approve flow.
+func DispatchOnTakedownCreated(ctx context.Context, t Takedown, reason string) error {
+	takedownCreatedMu.RLock()
+	hooks := append([]takedownCreatedHook(nil), takedownCreatedHooks...)
+	takedownCreatedMu.RUnlock()
+
+	var errs []error
+	for _, h := range hooks {
+		if err := h(ctx, t, reason); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/internal/marketplace/derivative_notifier_integration_test.go
+++ b/internal/marketplace/derivative_notifier_integration_test.go
@@ -1,0 +1,373 @@
+// Integration tests for the derivative-owner notifier walker + the
+// takedown audit-log pagination. Both touch the SQL that lives in
+// derivative_notifier.go / takedowns.go (ListAudit) — split into a
+// separate file so the unit tests in derivative_notifier_test.go stay
+// fast.
+//
+// All tests skip under `go test -short` so the fast inner loop stays
+// free of testcontainers.
+
+package marketplace_test
+
+import (
+	"context"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/ravencloak-org/Raven/internal/marketplace"
+	"github.com/ravencloak-org/Raven/internal/testutil"
+)
+
+// derivFixture mirrors modFixture but extends it with two importer
+// orgs (each holding a private derivative KB that imported from the
+// upstream Public KB), an extra importer org whose KB is a derivative
+// of a derivative (the "second hop" we must NOT notify), and a
+// workspace_admin user per importer Org.
+type derivFixture struct {
+	UpstreamOrgID uuid.UUID
+	UpstreamKBID  uuid.UUID
+
+	Importer1OrgID    uuid.UUID
+	Importer1WSID    uuid.UUID
+	Importer1KBID    uuid.UUID
+	Importer1AdminID uuid.UUID
+
+	Importer2OrgID    uuid.UUID
+	Importer2WSID    uuid.UUID
+	Importer2KBID    uuid.UUID
+	Importer2AdminID uuid.UUID
+
+	Importer3OrgID    uuid.UUID
+	Importer3WSID    uuid.UUID
+	Importer3KBID    uuid.UUID
+	Importer3AdminID uuid.UUID
+
+	// "Second hop" derivative whose source is Importer1KBID, not the
+	// taken-down upstream. Must NOT receive a notice.
+	SecondHopOrgID    uuid.UUID
+	SecondHopWSID    uuid.UUID
+	SecondHopKBID    uuid.UUID
+	SecondHopAdminID uuid.UUID
+}
+
+// recordingNotifierInt is the integration-side recorder; we don't share
+// recordingNotifier with the unit-test file because go's internal
+// linker won't let us cross test packages — each file in a _test
+// package compiles separately when picked by `go test -run`.
+type recordingNotifierInt struct {
+	got []marketplace.DerivativeNotice
+}
+
+func (r *recordingNotifierInt) NotifyDerivativeTakedown(_ context.Context, n marketplace.DerivativeNotice) error {
+	r.got = append(r.got, n)
+	return nil
+}
+
+// seedDerivFixture wires the full lineage graph in a single transaction
+// to keep the test deterministic. Slugs are generated with the same
+// `label || substring(id,1,8)` shape as seedModFixture so we don't
+// collide on the unique slug constraints when this test runs alongside
+// the moderation suite.
+func seedDerivFixture(ctx context.Context, t *testing.T, pool *pgxpool.Pool) derivFixture {
+	t.Helper()
+	f := derivFixture{
+		UpstreamOrgID:    uuid.New(),
+		UpstreamKBID:     uuid.New(),
+		Importer1OrgID:   uuid.New(),
+		Importer1WSID:    uuid.New(),
+		Importer1KBID:    uuid.New(),
+		Importer1AdminID: uuid.New(),
+		Importer2OrgID:   uuid.New(),
+		Importer2WSID:    uuid.New(),
+		Importer2KBID:    uuid.New(),
+		Importer2AdminID: uuid.New(),
+		Importer3OrgID:   uuid.New(),
+		Importer3WSID:    uuid.New(),
+		Importer3KBID:    uuid.New(),
+		Importer3AdminID: uuid.New(),
+		SecondHopOrgID:   uuid.New(),
+		SecondHopWSID:    uuid.New(),
+		SecondHopKBID:    uuid.New(),
+		SecondHopAdminID: uuid.New(),
+	}
+	// Upstream Org + upstream Public KB (no workspace required for the
+	// test — the upstream is what is being taken down; we only need its
+	// org name to populate SourceOrgDisplayName in the notice).
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO organizations (id, name, slug)
+		 VALUES ($1, 'Upstream Org', 'upstream-' || substring($1::text from 1 for 8))`,
+		f.UpstreamOrgID,
+	); err != nil {
+		t.Fatalf("seed upstream org: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO knowledge_bases (id, org_id, workspace_id, name, slug)
+		 VALUES ($1, $2, NULL, 'Upstream KB', 'upstream-kb-' || substring($1::text from 1 for 8))`,
+		f.UpstreamKBID, f.UpstreamOrgID,
+	); err != nil {
+		t.Fatalf("seed upstream kb: %v", err)
+	}
+
+	seedImporter := func(name string, orgID, wsID, kbID, adminID, sourceKBID uuid.UUID) {
+		t.Helper()
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO organizations (id, name, slug)
+			 VALUES ($1, $2, $2 || '-' || substring($1::text from 1 for 8))`,
+			orgID, name,
+		); err != nil {
+			t.Fatalf("seed %s org: %v", name, err)
+		}
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO workspaces (id, org_id, name, slug)
+			 VALUES ($1, $2, $3, $3 || '-' || substring($1::text from 1 for 8))`,
+			wsID, orgID, name+"-ws",
+		); err != nil {
+			t.Fatalf("seed %s workspace: %v", name, err)
+		}
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO users (id, org_id, email, status)
+			 VALUES ($1, $2, $3 || '-' || substring($1::text from 1 for 8) || '@example.com', 'active')`,
+			adminID, orgID, name+"-admin",
+		); err != nil {
+			t.Fatalf("seed %s admin user: %v", name, err)
+		}
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO workspace_members (workspace_id, user_id, role, org_id)
+			 VALUES ($1, $2, 'admin', $3)`,
+			wsID, adminID, orgID,
+		); err != nil {
+			t.Fatalf("seed %s workspace_members: %v", name, err)
+		}
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO knowledge_bases (id, org_id, workspace_id, name, slug, source_public_kb_id)
+			 VALUES ($1, $2, $3, $4, $4 || '-' || substring($1::text from 1 for 8), $5)`,
+			kbID, orgID, wsID, name+"-kb", sourceKBID,
+		); err != nil {
+			t.Fatalf("seed %s kb: %v", name, err)
+		}
+	}
+
+	seedImporter("importer1", f.Importer1OrgID, f.Importer1WSID, f.Importer1KBID, f.Importer1AdminID, f.UpstreamKBID)
+	seedImporter("importer2", f.Importer2OrgID, f.Importer2WSID, f.Importer2KBID, f.Importer2AdminID, f.UpstreamKBID)
+	seedImporter("importer3", f.Importer3OrgID, f.Importer3WSID, f.Importer3KBID, f.Importer3AdminID, f.UpstreamKBID)
+	// Second-hop derivative: imports from Importer1KBID, NOT from the
+	// upstream. Must NOT show up in the notifier sweep.
+	seedImporter("secondhop", f.SecondHopOrgID, f.SecondHopWSID, f.SecondHopKBID, f.SecondHopAdminID, f.Importer1KBID)
+	return f
+}
+
+// TestDerivativeNotifier_OneHopFanOut asserts the SQL walker contacts
+// every direct-derivative admin exactly once and skips the second-hop
+// derivative.
+func TestDerivativeNotifier_OneHopFanOut(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+	f := seedDerivFixture(ctx, t, pool)
+
+	recorder := &recordingNotifierInt{}
+	d := marketplace.NewDerivativeNotifier(pool, recorder)
+	if err := d.NotifyDerivativeOwners(ctx, f.UpstreamKBID, "trademark dispute"); err != nil {
+		t.Fatalf("NotifyDerivativeOwners: %v", err)
+	}
+
+	if got, want := len(recorder.got), 3; got != want {
+		t.Fatalf("notices: want %d, got %d: %+v", want, got, recorder.got)
+	}
+
+	// Stable comparison: sort by recipient email and assert the set.
+	sort.Slice(recorder.got, func(i, j int) bool {
+		return recorder.got[i].RecipientEmail < recorder.got[j].RecipientEmail
+	})
+
+	for _, n := range recorder.got {
+		if n.SourceKBID != f.UpstreamKBID {
+			t.Errorf("SourceKBID mismatch: got %v want %v", n.SourceKBID, f.UpstreamKBID)
+		}
+		if n.SourceOrgDisplayName != "Upstream Org" {
+			t.Errorf("SourceOrgDisplayName: %q", n.SourceOrgDisplayName)
+		}
+		if n.SourceKBName != "Upstream KB" {
+			t.Errorf("SourceKBName: %q", n.SourceKBName)
+		}
+		if n.Reason != "trademark dispute" {
+			t.Errorf("Reason: %q", n.Reason)
+		}
+		if n.RecipientEmail == "" {
+			t.Errorf("empty RecipientEmail in %+v", n)
+		}
+	}
+
+	// Verify second-hop is NOT contacted: no notice should reference
+	// the second-hop derivative KB.
+	for _, n := range recorder.got {
+		if n.DerivativeKBID == f.SecondHopKBID {
+			t.Errorf("second-hop derivative leaked into notices: %+v", n)
+		}
+	}
+}
+
+// TestDerivativeNotifier_NoDerivatives asserts the walker no-ops cleanly
+// when nothing imports from the taken-down KB. The contract: zero
+// notifier calls, no error.
+func TestDerivativeNotifier_NoDerivatives(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+
+	orgID := uuid.New()
+	kbID := uuid.New()
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO organizations (id, name, slug)
+		 VALUES ($1, 'Lonely Org', 'lonely-' || substring($1::text from 1 for 8))`, orgID); err != nil {
+		t.Fatalf("seed org: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO knowledge_bases (id, org_id, name, slug)
+		 VALUES ($1, $2, 'Lonely KB', 'lonely-kb-' || substring($1::text from 1 for 8))`, kbID, orgID); err != nil {
+		t.Fatalf("seed kb: %v", err)
+	}
+
+	rec := &recordingNotifierInt{}
+	d := marketplace.NewDerivativeNotifier(pool, rec)
+	if err := d.NotifyDerivativeOwners(ctx, kbID, "any"); err != nil {
+		t.Fatalf("NotifyDerivativeOwners: %v", err)
+	}
+	if len(rec.got) != 0 {
+		t.Errorf("notices: want 0, got %d", len(rec.got))
+	}
+}
+
+// TestTakedowns_ListAudit_PaginatesNewestFirst seeds three takedown rows
+// across two orgs, pages two at a time, and verifies (1) ordering is
+// newest-first, (2) the cursor opens the second page correctly, (3) the
+// strike count comes from the publisher Org.
+func TestTakedowns_ListAudit_PaginatesNewestFirst(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+
+	// Org A: 2 takedowns, strike counter at 5.
+	// Org B: 1 takedown,  strike counter at 1.
+	orgA := uuid.New()
+	orgB := uuid.New()
+	kbA1 := uuid.New()
+	kbA2 := uuid.New()
+	kbB1 := uuid.New()
+	mustExec := func(sql string, args ...any) {
+		t.Helper()
+		if _, err := pool.Exec(ctx, sql, args...); err != nil {
+			t.Fatalf("exec: %v\nsql=%s", err, sql)
+		}
+	}
+	mustExec(`INSERT INTO organizations (id, name, slug, takedown_strikes)
+	          VALUES ($1, 'Org A', 'orga-' || substring($1::text from 1 for 8), 5)`, orgA)
+	mustExec(`INSERT INTO organizations (id, name, slug, takedown_strikes)
+	          VALUES ($1, 'Org B', 'orgb-' || substring($1::text from 1 for 8), 1)`, orgB)
+	mustExec(`INSERT INTO knowledge_bases (id, org_id, name, slug)
+	          VALUES ($1, $2, 'A1', 'a1-' || substring($1::text from 1 for 8))`, kbA1, orgA)
+	mustExec(`INSERT INTO knowledge_bases (id, org_id, name, slug)
+	          VALUES ($1, $2, 'A2', 'a2-' || substring($1::text from 1 for 8))`, kbA2, orgA)
+	mustExec(`INSERT INTO knowledge_bases (id, org_id, name, slug)
+	          VALUES ($1, $2, 'B1', 'b1-' || substring($1::text from 1 for 8))`, kbB1, orgB)
+
+	// Insert takedowns with explicit timestamps so we can assert the
+	// sort order deterministically (default DEFAULT now() would be too
+	// close together to test).
+	t0 := time.Now().Add(-3 * time.Hour).UTC()
+	t1 := time.Now().Add(-2 * time.Hour).UTC()
+	t2 := time.Now().Add(-1 * time.Hour).UTC()
+	mustExec(`INSERT INTO marketplace_takedowns (target_kb_id, source, notes, created_at)
+	          VALUES ($1, 'publisher', 'self-unpublish', $2)`, kbA1, t0)
+	mustExec(`INSERT INTO marketplace_takedowns (target_kb_id, source, notes, created_at)
+	          VALUES ($1, 'admin', 'report confirmed', $2)`, kbB1, t1)
+	mustExec(`INSERT INTO marketplace_takedowns (target_kb_id, source, notes, created_at)
+	          VALUES ($1, 'dmca', 'DMCA notice 2026-06-01', $2)`, kbA2, t2)
+
+	repo := marketplace.NewTakedowns(pool)
+
+	// Page 1: limit=2, no cursor → newest-first = (kbA2, kbB1).
+	page1, next1, err := repo.ListAudit(ctx, 2, "")
+	if err != nil {
+		t.Fatalf("ListAudit page 1: %v", err)
+	}
+	if len(page1) != 2 {
+		t.Fatalf("page1 size: want 2, got %d", len(page1))
+	}
+	if page1[0].TargetKBID != kbA2 {
+		t.Errorf("page1[0]: want kbA2, got %v", page1[0].TargetKBID)
+	}
+	if page1[0].Source != marketplace.TakedownSourceDMCA {
+		t.Errorf("page1[0].Source: %q", page1[0].Source)
+	}
+	if page1[0].StrikesAfterOrgTotal != 5 {
+		t.Errorf("page1[0].StrikesAfterOrgTotal: want 5, got %d", page1[0].StrikesAfterOrgTotal)
+	}
+	if page1[1].TargetKBID != kbB1 {
+		t.Errorf("page1[1]: want kbB1, got %v", page1[1].TargetKBID)
+	}
+	if page1[1].StrikesAfterOrgTotal != 1 {
+		t.Errorf("page1[1].StrikesAfterOrgTotal: want 1, got %d", page1[1].StrikesAfterOrgTotal)
+	}
+	if next1 == "" {
+		t.Fatal("expected non-empty next cursor on full page")
+	}
+
+	// Page 2: cursor from page 1 → (kbA1).
+	page2, next2, err := repo.ListAudit(ctx, 2, next1)
+	if err != nil {
+		t.Fatalf("ListAudit page 2: %v", err)
+	}
+	if len(page2) != 1 {
+		t.Fatalf("page2 size: want 1, got %d", len(page2))
+	}
+	if page2[0].TargetKBID != kbA1 {
+		t.Errorf("page2[0]: want kbA1, got %v", page2[0].TargetKBID)
+	}
+	if next2 != "" {
+		t.Errorf("page2 next cursor: want empty (last page), got %q", next2)
+	}
+}
+
+// TestTakedowns_ListAudit_BadCursor surfaces ErrInvalidAuditCursor on
+// garbage input — the handler maps this to HTTP 400.
+func TestTakedowns_ListAudit_BadCursor(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	pool := testutil.NewTestDB(t)
+	repo := marketplace.NewTakedowns(pool)
+	_, _, err := repo.ListAudit(context.Background(), 10, "not-a-real-cursor")
+	if err == nil {
+		t.Fatal("want error, got nil")
+	}
+	// Sentinel comparison: handler layer relies on errors.Is.
+	if !marketplaceErrIs(err, marketplace.ErrInvalidAuditCursor) {
+		t.Errorf("want ErrInvalidAuditCursor in chain, got %v", err)
+	}
+}
+
+func marketplaceErrIs(err, target error) bool {
+	for err != nil {
+		if err == target {
+			return true
+		}
+		type wrapped interface{ Unwrap() error }
+		w, ok := err.(wrapped)
+		if !ok {
+			return false
+		}
+		err = w.Unwrap()
+	}
+	return false
+}

--- a/internal/marketplace/derivative_notifier_test.go
+++ b/internal/marketplace/derivative_notifier_test.go
@@ -1,0 +1,175 @@
+package marketplace_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/ravencloak-org/Raven/internal/mail"
+	"github.com/ravencloak-org/Raven/internal/marketplace"
+)
+
+// TestMailNotifier_FormatsBody is a small smoke test on the default
+// production notifier wiring — the wording isn't asserted character-by-
+// character because that would make every copy edit a code change, but
+// the four substitution points (recipient, source name, source org,
+// derivative name) are checked so a future refactor that drops one
+// from the template fails loudly.
+func TestMailNotifier_FormatsBody(t *testing.T) {
+	sender := &mail.NoopSender{}
+	n := marketplace.NewMailNotifier(sender)
+	ctx := context.Background()
+	if err := n.NotifyDerivativeTakedown(ctx, marketplace.DerivativeNotice{
+		RecipientEmail:       "owner@example.com",
+		DerivativeKBID:       uuid.New(),
+		DerivativeKBName:     "My Recipe Fork",
+		SourceKBID:           uuid.New(),
+		SourceKBName:         "Original Recipes",
+		SourceOrgDisplayName: "Upstream Co",
+		Reason:               "trademark dispute",
+	}); err != nil {
+		t.Fatalf("notify: %v", err)
+	}
+	if len(sender.Sent) != 1 {
+		t.Fatalf("Sent: want 1, got %d", len(sender.Sent))
+	}
+	m := sender.Sent[0]
+	if m.To != "owner@example.com" {
+		t.Errorf("To: %q", m.To)
+	}
+	for _, want := range []string{
+		"Original Recipes",
+		"Upstream Co",
+		"My Recipe Fork",
+		"trademark dispute",
+	} {
+		if !contains(m.Subject+m.Text, want) {
+			t.Errorf("body missing %q in subject+text", want)
+		}
+	}
+}
+
+func TestMailNotifier_NilSenderFallsBackToNoop(t *testing.T) {
+	n := marketplace.NewMailNotifier(nil)
+	if err := n.NotifyDerivativeTakedown(context.Background(), marketplace.DerivativeNotice{
+		RecipientEmail: "owner@example.com",
+		SourceKBName:   "X",
+	}); err != nil {
+		t.Fatalf("nil-sender path should not error, got: %v", err)
+	}
+}
+
+func TestMailNotifier_EmptyReasonFallback(t *testing.T) {
+	sender := &mail.NoopSender{}
+	n := marketplace.NewMailNotifier(sender)
+	if err := n.NotifyDerivativeTakedown(context.Background(), marketplace.DerivativeNotice{
+		RecipientEmail: "owner@example.com",
+		SourceKBName:   "X",
+	}); err != nil {
+		t.Fatalf("notify: %v", err)
+	}
+	if len(sender.Sent) != 1 {
+		t.Fatalf("Sent: want 1, got %d", len(sender.Sent))
+	}
+	if !contains(sender.Sent[0].Text, "(no reason recorded)") {
+		t.Errorf("expected empty-reason fallback marker in body, got: %s", sender.Sent[0].Text)
+	}
+}
+
+// recordingNotifier captures every call so registry tests can assert
+// ordering and arg propagation.
+type recordingNotifier struct {
+	calls []marketplace.DerivativeNotice
+	err   error
+}
+
+func (r *recordingNotifier) NotifyDerivativeTakedown(_ context.Context, n marketplace.DerivativeNotice) error {
+	r.calls = append(r.calls, n)
+	return r.err
+}
+
+func TestRegisterOnTakedownCreated_FanOut(t *testing.T) {
+	marketplace.ResetOnTakedownCreatedForTest()
+	var got1, got2 marketplace.Takedown
+	marketplace.RegisterOnTakedownCreated(func(_ context.Context, td marketplace.Takedown, _ string) error {
+		got1 = td
+		return nil
+	})
+	marketplace.RegisterOnTakedownCreated(func(_ context.Context, td marketplace.Takedown, _ string) error {
+		got2 = td
+		return nil
+	})
+	td := marketplace.Takedown{
+		ID:         uuid.New(),
+		TargetKBID: uuid.New(),
+		Source:     marketplace.TakedownSourceAdmin,
+		CreatedAt:  time.Now().UTC(),
+	}
+	if err := marketplace.DispatchOnTakedownCreated(context.Background(), td, "policy violation"); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if got1.ID != td.ID || got2.ID != td.ID {
+		t.Errorf("hook 1=%v hook 2=%v want %v", got1.ID, got2.ID, td.ID)
+	}
+}
+
+func TestRegisterOnTakedownCreated_NilHookIgnored(t *testing.T) {
+	marketplace.ResetOnTakedownCreatedForTest()
+	marketplace.RegisterOnTakedownCreated(nil)
+	if err := marketplace.DispatchOnTakedownCreated(context.Background(), marketplace.Takedown{}, ""); err != nil {
+		t.Errorf("dispatch with only-nil registry should not error, got: %v", err)
+	}
+}
+
+func TestRegisterOnTakedownCreated_ErrorsJoined(t *testing.T) {
+	marketplace.ResetOnTakedownCreatedForTest()
+	e1 := errors.New("first")
+	e2 := errors.New("second")
+	var calls int
+	marketplace.RegisterOnTakedownCreated(func(_ context.Context, _ marketplace.Takedown, _ string) error {
+		calls++
+		return e1
+	})
+	marketplace.RegisterOnTakedownCreated(func(_ context.Context, _ marketplace.Takedown, _ string) error {
+		calls++
+		return e2
+	})
+	err := marketplace.DispatchOnTakedownCreated(context.Background(), marketplace.Takedown{}, "")
+	if err == nil {
+		t.Fatal("want error, got nil")
+	}
+	if !errors.Is(err, e1) || !errors.Is(err, e2) {
+		t.Errorf("want joined errors containing both, got %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("want both hooks invoked, got %d calls", calls)
+	}
+}
+
+func TestNewDerivativeNotifier_NilNotifierPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on nil notifier")
+		}
+	}()
+	_ = marketplace.NewDerivativeNotifier(nil, nil)
+}
+
+// contains is a tiny dependency-free substring check so the body tests
+// don't pull in strings.Contains via the import block (already used
+// elsewhere in the package but kept local here to be explicit about
+// intent).
+func contains(haystack, needle string) bool {
+	if needle == "" {
+		return true
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/marketplace/takedowns.go
+++ b/internal/marketplace/takedowns.go
@@ -3,6 +3,7 @@ package marketplace
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -136,4 +137,159 @@ func (t *Takedowns) ListForKB(ctx context.Context, kbID uuid.UUID) ([]Takedown, 
 		return nil, fmt.Errorf("Takedowns.ListForKB: rows: %w", err)
 	}
 	return out, nil
+}
+
+// AuditRow is the join shape returned by ListAudit. It collects the
+// columns the AdminTakedownsView in #735's frontend needs in a single
+// round-trip: the takedown event itself, the target KB's display name,
+// the publisher Org's slug + display name, and that Org's running
+// strike total at read time.
+//
+// The strike count is the live `organizations.takedown_strikes` value,
+// not a snapshot stored on the takedown row. Snapshotting would require
+// schema migration #735 didn't budget for, and the live value matches
+// the "current state of the publisher" semantic the audit log is for:
+// an admin looking up a takedown wants to know "where does this Org
+// sit on the strike scale right now?".
+type AuditRow struct {
+	TakedownID            uuid.UUID
+	TargetKBID            uuid.UUID
+	TargetKBName          string
+	TargetOrgSlug         string
+	TargetOrgDisplayName  string
+	Source                TakedownSource
+	Notes                 string
+	CreatedAt             time.Time
+	StrikesAfterOrgTotal  int64
+}
+
+// auditListCap is the hard ceiling on pagination page size. Audit reads
+// are admin-only and infrequent; a deeper page than this is almost
+// certainly a misconfigured caller and would expand the response payload
+// without payoff.
+const auditListCap = 100
+
+// auditListDefault is the soft default when no limit is supplied. Picked
+// to match the report queue page size (#734) so the two admin surfaces
+// behave consistently.
+const auditListDefault = 25
+
+// ListAudit returns a page of takedown audit-log rows, newest first,
+// joined with KB + publisher Org metadata. Pagination uses a
+// (created_at, id) keyset cursor — opaque to the caller, parsed by
+// EncodeAuditCursor / parseAuditCursor.
+//
+// Admin-only (see package doc): the SELECT crosses every tenant via the
+// raven_admin RLS bypass on marketplace_takedowns, knowledge_bases, and
+// organizations. The caller MUST be on a session that has switched to
+// raven_admin before invoking this. The handler in
+// internal/handler/admin_takedowns.go does so inside a short-lived tx.
+func (t *Takedowns) ListAudit(ctx context.Context, limit int, cursor string) ([]AuditRow, string, error) {
+	if limit <= 0 {
+		limit = auditListDefault
+	}
+	if limit > auditListCap {
+		limit = auditListCap
+	}
+
+	var (
+		cursorCreatedAt time.Time
+		cursorID        uuid.UUID
+		hasCursor       bool
+	)
+	if cursor != "" {
+		ca, id, err := parseAuditCursor(cursor)
+		if err != nil {
+			return nil, "", fmt.Errorf("Takedowns.ListAudit: cursor: %w", err)
+		}
+		cursorCreatedAt, cursorID, hasCursor = ca, id, true
+	}
+
+	// Fetch limit+1 rows so we can detect "more available" without a
+	// COUNT(*). The extra row, if present, becomes the next cursor.
+	//
+	// Switch to raven_admin inside a transaction so the audit cross-tenant
+	// SELECT can see every row. SET LOCAL ROLE reverts on COMMIT/ROLLBACK,
+	// leaving the pool connection in its original role for the next caller.
+	tx, err := t.pool.Begin(ctx)
+	if err != nil {
+		return nil, "", fmt.Errorf("Takedowns.ListAudit: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err := tx.Exec(ctx, "SET LOCAL ROLE raven_admin"); err != nil {
+		return nil, "", fmt.Errorf("Takedowns.ListAudit: set role: %w", err)
+	}
+
+	// Keyset pagination predicate: rows with (created_at, id) strictly
+	// less than the cursor. The tie-break on id keeps the order
+	// deterministic when two takedowns landed in the same microsecond.
+	//
+	// $2 / $3 are NULL on the first page; the WHERE clause's NULL guard
+	// then short-circuits the comparison so the same prepared statement
+	// serves both the first-page and follow-page cases.
+	const sql = `
+		SELECT
+		    td.id, td.target_kb_id, kb.name, o.slug, o.name,
+		    td.source, td.notes, td.created_at,
+		    o.takedown_strikes
+		FROM marketplace_takedowns AS td
+		JOIN knowledge_bases  AS kb ON kb.id = td.target_kb_id
+		JOIN organizations    AS o  ON o.id  = kb.org_id
+		WHERE ($2::timestamptz IS NULL)
+		   OR (td.created_at, td.id) < ($2::timestamptz, $3::uuid)
+		ORDER BY td.created_at DESC, td.id DESC
+		LIMIT $1
+	`
+
+	var (
+		cursorCreatedArg any
+		cursorIDArg      any
+	)
+	if hasCursor {
+		cursorCreatedArg = cursorCreatedAt
+		cursorIDArg = cursorID
+	}
+
+	rows, err := tx.Query(ctx, sql, limit+1, cursorCreatedArg, cursorIDArg)
+	if err != nil {
+		return nil, "", fmt.Errorf("Takedowns.ListAudit: query: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]AuditRow, 0, limit)
+	for rows.Next() {
+		var r AuditRow
+		var notes *string
+		if err := rows.Scan(
+			&r.TakedownID, &r.TargetKBID, &r.TargetKBName,
+			&r.TargetOrgSlug, &r.TargetOrgDisplayName,
+			&r.Source, &notes, &r.CreatedAt,
+			&r.StrikesAfterOrgTotal,
+		); err != nil {
+			return nil, "", fmt.Errorf("Takedowns.ListAudit: scan: %w", err)
+		}
+		if notes != nil {
+			r.Notes = *notes
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, "", fmt.Errorf("Takedowns.ListAudit: rows: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, "", fmt.Errorf("Takedowns.ListAudit: commit: %w", err)
+	}
+
+	// Trim the look-ahead row and emit a cursor pointing at the last
+	// returned row so the caller can page forward.
+	var nextCursor string
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	if len(out) == limit {
+		last := out[len(out)-1]
+		nextCursor = EncodeAuditCursor(last.CreatedAt, last.TakedownID)
+	}
+	return out, nextCursor, nil
 }

--- a/internal/middleware/raven_admin.go
+++ b/internal/middleware/raven_admin.go
@@ -1,0 +1,103 @@
+package middleware
+
+import (
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/gin-gonic/gin"
+	"github.com/ravencloak-org/Raven/pkg/apierror"
+)
+
+// RAVEN_ADMIN_EMAILS is the comma-separated env var carrying the global
+// admin allowlist consulted by RequireRavenAdmin. Empty / unset means
+// "no admin endpoints are reachable" — fail-closed by design.
+//
+// We deliberately do NOT model "raven admin" as a column on the users
+// table (a DB column would have to ship with a migration, an RLS policy,
+// an API surface to grant/revoke, and a UI — work that has zero MVP
+// payoff because the only admins are Raven employees identified by their
+// SSO email). The env-allowlist short-circuits all of that for M3 and
+// lets #735 ship without coupling to a separate auth-management slice.
+//
+// When that calculus changes (post-MVP customer admin tiers, e.g. an
+// enterprise customer wanting to delegate moderation to one of their
+// employees), promote this to a `users.is_raven_admin BOOLEAN` column
+// and a DB-backed check — the middleware signature won't change.
+const ravenAdminEmailsEnv = "RAVEN_ADMIN_EMAILS"
+
+// adminEmailsCache memoises the parsed allowlist on first lookup. We
+// don't watch the env for changes — a restart picks up new emails, which
+// is the only mutation path that makes sense for a value that is read on
+// every admin request.
+var (
+	adminEmailsOnce sync.Once
+	adminEmails     map[string]struct{}
+)
+
+// loadAdminEmails parses RAVEN_ADMIN_EMAILS once and caches the set.
+// Emails are normalised to lowercase so the comparison is case-insensitive
+// (SSO IdPs are inconsistent about email casing; SuperTokens passes through
+// whatever the IdP returns).
+func loadAdminEmails() map[string]struct{} {
+	adminEmailsOnce.Do(func() {
+		raw := os.Getenv(ravenAdminEmailsEnv)
+		adminEmails = make(map[string]struct{})
+		for _, e := range strings.Split(raw, ",") {
+			e = strings.ToLower(strings.TrimSpace(e))
+			if e != "" {
+				adminEmails[e] = struct{}{}
+			}
+		}
+	})
+	return adminEmails
+}
+
+// ResetAdminEmailsCacheForTest clears the memoised allowlist. Test-only;
+// production code never calls this. Lives here rather than in a _test.go
+// file because the middleware tests in this package need it AND the
+// integration tests in cmd/api do too.
+func ResetAdminEmailsCacheForTest() {
+	adminEmailsOnce = sync.Once{}
+	adminEmails = nil
+}
+
+// RequireRavenAdmin returns a Gin middleware that allows only requests
+// whose session email is in the RAVEN_ADMIN_EMAILS allowlist.
+//
+// Behaviour:
+//   - 401 if the session does not carry an email (UserLookup never ran or
+//     the SuperTokens session is missing).
+//   - 403 if the email is not in the allowlist (or the allowlist is empty —
+//     the fail-closed default).
+//   - Pass-through otherwise.
+//
+// The middleware does NOT switch the DB role to raven_admin — that is a
+// repository-layer concern (see e.g. internal/jobs/voice_usage.go). The
+// HTTP gate here protects the URL surface; the RLS policy on
+// marketplace_takedowns is the in-database backstop.
+func RequireRavenAdmin() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		email, _ := c.Get(string(ContextKeyEmail))
+		emailStr, _ := email.(string)
+		if emailStr == "" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, apierror.AppError{
+				Code:    http.StatusUnauthorized,
+				Message: "Unauthorized",
+				Detail:  "missing session identity",
+			})
+			return
+		}
+		allow := loadAdminEmails()
+		if _, ok := allow[strings.ToLower(strings.TrimSpace(emailStr))]; !ok {
+			c.AbortWithStatusJSON(http.StatusForbidden, apierror.AppError{
+				Code:    http.StatusForbidden,
+				Message: "Forbidden",
+				Detail:  "raven admin required",
+			})
+			return
+		}
+		c.Next()
+	}
+}

--- a/internal/middleware/raven_admin_test.go
+++ b/internal/middleware/raven_admin_test.go
@@ -1,0 +1,75 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/ravencloak-org/Raven/internal/middleware"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+// runRavenAdminTest sets up a Gin router with RequireRavenAdmin and an
+// optional email injector to simulate the SessionMiddleware setting
+// ContextKeyEmail.
+func runRavenAdminTest(t *testing.T, email string, allowlist string) int {
+	t.Helper()
+	t.Setenv("RAVEN_ADMIN_EMAILS", allowlist)
+	middleware.ResetAdminEmailsCacheForTest()
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		if email != "" {
+			c.Set(string(middleware.ContextKeyEmail), email)
+		}
+		c.Next()
+	})
+	r.GET("/admin", middleware.RequireRavenAdmin(), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w.Code
+}
+
+func TestRequireRavenAdmin_NoEmail(t *testing.T) {
+	if got := runRavenAdminTest(t, "", "admin@raven.org"); got != http.StatusUnauthorized {
+		t.Errorf("want 401, got %d", got)
+	}
+}
+
+func TestRequireRavenAdmin_NotInAllowlist(t *testing.T) {
+	if got := runRavenAdminTest(t, "user@example.com", "admin@raven.org"); got != http.StatusForbidden {
+		t.Errorf("want 403, got %d", got)
+	}
+}
+
+func TestRequireRavenAdmin_EmptyAllowlist(t *testing.T) {
+	// Fail-closed: empty env means no one is admin, even if a session email exists.
+	if got := runRavenAdminTest(t, "admin@raven.org", ""); got != http.StatusForbidden {
+		t.Errorf("want 403, got %d", got)
+	}
+}
+
+func TestRequireRavenAdmin_Allowed(t *testing.T) {
+	if got := runRavenAdminTest(t, "admin@raven.org", "admin@raven.org"); got != http.StatusOK {
+		t.Errorf("want 200, got %d", got)
+	}
+}
+
+func TestRequireRavenAdmin_AllowedCaseInsensitive(t *testing.T) {
+	if got := runRavenAdminTest(t, "Admin@Raven.ORG", "admin@raven.org,other@raven.org"); got != http.StatusOK {
+		t.Errorf("want 200, got %d", got)
+	}
+}
+
+func TestRequireRavenAdmin_AllowedWithMultipleAndWhitespace(t *testing.T) {
+	if got := runRavenAdminTest(t, "second@raven.org", " first@raven.org , second@raven.org , "); got != http.StatusOK {
+		t.Errorf("want 200, got %d", got)
+	}
+}


### PR DESCRIPTION
Salvaged from agent worktree after sub-agent hit a session limit before opening PR.

- `GET /api/v1/admin/marketplace/takedowns` — paginated audit log, raven_admin gated.
- `NotifyDerivativeOwners` walks `source_public_kb_id` one hop, emails workspace admins of importer Orgs.
- Hooked into `Takedowns.Create` via OnTakedownCreated registry so #734's approve flow fires it.
- `raven_admin` middleware: server-side role check, never client-trusted.
- Frontend `AdminTakedownsView` + Playwright happy-path.

Closes #735.

Resolved conflict with #734's router entry by keeping both routes (`admin/marketplace/reports` + `admin/marketplace/takedowns`) and using the same `requiresPlatformAdmin` meta flag.