### PR TITLE
feat(marketplace): DMCA inbox + two-stage counter-notice workflow (#736)

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -631,6 +631,15 @@ func main() {
 		return derivativeNotifier.NotifyDerivativeOwners(ctx, td.TargetKBID, reason)
 	})
 
+	// DMCA inbox + counter-notice workflow (issue #736, launch blocker per
+	// ADR-0006). The service drives the two-stage atomic Submit and the
+	// daily sweeper auto-takedown; the handler exposes the admin
+	// endpoints. The claimant receipt email is a no-op placeholder
+	// (logged TODO) until the M9 SES pipeline lands — same pattern as
+	// PublisherNotifier on AdminModeration.
+	dmcaSvc := marketplace.NewDMCAService(pool, takedownsRepo, marketplace.NewNoopDMCAClaimantNotifier())
+	adminDMCAHandler := handler.NewAdminDMCAHandler(dmcaSvc)
+
 	// Create router
 	router := gin.Default()
 
@@ -1072,6 +1081,15 @@ func main() {
 			adminMarket.GET("/reports", adminMarketplaceHandler.ListReports)
 			adminMarket.POST("/reports/:id/approve", adminMarketplaceHandler.Approve)
 			adminMarket.POST("/reports/:id/dismiss", adminMarketplaceHandler.Dismiss)
+
+			// DMCA inbox + counter-notice workflow (issue #736).
+			// Submit records a notice + freezes the KB; the counter-
+			// notice endpoint pivots the row to `counter_filed`. The
+			// daily sweep (jobs/marketplace_dmca_sweeper.go) handles
+			// the 14-day auto-takedown for un-contested notices.
+			adminMarket.GET("/dmca", adminDMCAHandler.List)
+			adminMarket.POST("/dmca", adminDMCAHandler.Submit)
+			adminMarket.POST("/dmca/:id/counter-notice", adminDMCAHandler.SubmitCounterNotice)
 		}
 	}
 

--- a/docs/legal/dmca.md
+++ b/docs/legal/dmca.md
@@ -1,0 +1,94 @@
+# Raven DMCA Policy
+
+Raven respects the intellectual property rights of others and expects Marketplace publishers and importers to do the same. This document is the operational reference for the DMCA workflow; the public-facing equivalent lives at [raven.ravencloak.org/legal/dmca](https://raven.ravencloak.org/legal/dmca).
+
+## Designated Agent
+
+| Field           | Value                                                |
+|-----------------|------------------------------------------------------|
+| Email           | [dmca@ravencloak.org](mailto:dmca@ravencloak.org)    |
+| Hosting Org     | Raven (ravencloak-org)                               |
+| Statute         | 17 U.S.C. § 512(c)(3) — DMCA designated-agent inbox  |
+
+`dmca@ravencloak.org` is provisioned as a Google Workspace alias that fans out to the platform-admin distribution list. The inbox MUST stay reachable before the public Marketplace ships — see ADR-0006 §Consequences.
+
+## Submitting a DMCA Notice
+
+A valid notice under 17 U.S.C. § 512(c)(3) MUST include:
+
+1. A physical or electronic signature of the copyright owner or authorised agent.
+2. Identification of the copyrighted work.
+3. Identification of the allegedly infringing material with a URL or other sufficient location data.
+4. Contact information (mailing address, phone, email).
+5. A good-faith statement that the use is not authorised.
+6. A statement under penalty of perjury that the notifier is the copyright owner or authorised agent.
+
+Notices that materially fail the statutory requirements are rejected without action; the recipient operator replies with a short rejection email pointing back at this page.
+
+## Operational Workflow
+
+```
+notice arrives at dmca@ravencloak.org
+        │
+        ▼
+admin records via /admin/marketplace/dmca           ─── (1) Submit
+        │
+        ▼ atomic
+INSERT dmca_notices (status='pending', window=14d)
+UPDATE knowledge_bases SET status='dmca_pending'
+        │
+        ▼ outside tx
+claimant receipt email (best-effort)
+        │
+        ▼ wait up to 14 days
+        │
+        ├── publisher counter-notices via dmca@      ─── (2) Counter
+        │       admin records via /admin/marketplace/
+        │           dmca/:id/counter-notice
+        │       status='counter_filed'; KB stays frozen
+        │
+        └── window expires with no counter-notice    ─── (3) Sweep
+                daily cron `scheduled:marketplace_dmca_sweep` (4am UTC)
+                per row:
+                  UPDATE dmca_notices SET status='resolved_take_down'
+                  UPDATE knowledge_bases SET visibility='private', status='active'
+                  INSERT marketplace_takedowns (source='dmca', notes=notice_id)
+                  DispatchOnTakedownCreated → derivative_notifier emails fork owners
+```
+
+The two-stage workflow lives in `internal/marketplace/dmca.go`; the sweeper lives in `internal/jobs/marketplace_dmca_sweeper.go`.
+
+### Counter-notice handling
+
+The MVP records the publisher's counter-notice through the admin (the publisher emails `dmca@ravencloak.org` with their counter-notice text; the operator pastes it into the admin UI). There is no public counter-notice form in MVP.
+
+When a counter-notice is recorded, the KB stays in `dmca_pending`. The DMCA safe harbour (17 U.S.C. § 512(g)(2)(C)) requires the OSP to hold restoration for 10 to 14 business days to give the original claimant time to file suit. The final keep-up/take-down decision is a manual admin action in MVP.
+
+## Repeat-Infringer Policy
+
+Per 17 U.S.C. § 512(i) and ADR-0006, Raven tracks confirmed takedown strikes against the publishing Organisation via `organizations.takedown_strikes`. Three strikes triggers the Organisation-suspension runbook (separate operational document, out of scope for this file). DMCA-sourced takedowns also increment the strike counter; the counter is incremented by the admin approve path (#734) and the same mechanism applies to DMCA auto-resolutions.
+
+> NOTE: The DMCA sweeper currently writes a `marketplace_takedowns` row with `source='dmca'` but does NOT increment `takedown_strikes` automatically. Whether DMCA auto-resolutions count toward strikes is a policy decision tracked separately; the implementation will follow once that decision lands.
+
+## Misrepresentation Liability
+
+17 U.S.C. § 512(f) provides a damages remedy against parties who knowingly misrepresent that material is infringing (or that material was removed by mistake). Operators rejecting bad-faith notices should keep the rejection email on file.
+
+## Implementation References
+
+| Component              | Path                                                                |
+|------------------------|---------------------------------------------------------------------|
+| Migration              | `migrations/00055_marketplace_dmca.sql`                             |
+| Service                | `internal/marketplace/dmca.go`                                      |
+| Sweeper handler        | `internal/jobs/marketplace_dmca_sweeper.go`                         |
+| Sweeper cron           | `internal/jobs/scheduler.go` — `CronMarketplaceDMCASweep`           |
+| HTTP handler           | `internal/handler/admin_dmca.go`                                    |
+| Admin UI               | `frontend/src/pages/admin/AdminDMCAView.vue`                        |
+| Public-facing page     | `frontend/src/pages/legal/DMCAPage.vue` (`/legal/dmca`)             |
+| API client             | `frontend/src/api/marketplace-admin.ts`                             |
+
+## See Also
+
+- [ADR-0006 — Mandatory licence + reactive moderation](../adr/0006-licence-and-moderation.md)
+- [ADR-0008 — Marketplace discovery + operations](../adr/0008-marketplace-discovery-and-operations.md)
+- [Marketplace MVP plan §4 (admin endpoints), §6 (DMCA inbox)](../plans/marketplace-mvp.md)

--- a/frontend/e2e/admin/marketplace-dmca.spec.ts
+++ b/frontend/e2e/admin/marketplace-dmca.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from '../fixtures'
+
+// E2E for the admin DMCA inbox + counter-notice workflow (#736, launch
+// blocker per ADR-0006).
+//
+// Skipped unless E2E_ADMIN is configured — the gate is server-side
+// (RAVEN_ADMIN_EMAILS). The `adminPage` fixture signs in as the
+// configured admin operator.
+//
+// Backend integration tests (TestDMCAService_*) pin the atomic
+// commitments (Submit two-side-effect, sweep auto-resolve, race-skip).
+// This spec exercises the SPA: navigate -> render -> modal open/close
+// -> form fields wired -> footer link to /legal/dmca renders.
+
+test.describe('Admin: DMCA inbox', () => {
+  test('renders the inbox and the status filter pills', async ({ adminPage: page }) => {
+    await page.goto('/admin/marketplace/dmca')
+    await expect(page.getByRole('heading', { name: /DMCA inbox/i })).toBeVisible()
+    await expect(page.getByRole('tab', { name: 'Pending' })).toBeVisible()
+    await expect(page.getByRole('tab', { name: 'Counter-filed' })).toBeVisible()
+    await expect(page.getByRole('tab', { name: 'Take-down' })).toBeVisible()
+  })
+
+  test('opens the record-notice modal and surfaces required fields', async ({
+    adminPage: page,
+  }) => {
+    await page.goto('/admin/marketplace/dmca')
+    await page.getByTestId('admin-dmca-record-button').click()
+    await expect(page.getByTestId('admin-dmca-target-kb-id')).toBeVisible()
+    await expect(page.getByTestId('admin-dmca-claimant-email')).toBeVisible()
+    await expect(page.getByTestId('admin-dmca-claimant-name')).toBeVisible()
+    await expect(page.getByTestId('admin-dmca-notice-text')).toBeVisible()
+
+    // Cancel closes the modal without dispatching.
+    await page.getByRole('button', { name: 'Cancel' }).click()
+    await expect(page.getByTestId('admin-dmca-target-kb-id')).not.toBeVisible()
+  })
+
+  test('counter-notice button opens the counter-notice modal on pending rows', async ({
+    adminPage: page,
+  }, testInfo) => {
+    await page.goto('/admin/marketplace/dmca')
+    const rowCount = await page.getByTestId('admin-dmca-row').count()
+    testInfo.skip(
+      rowCount === 0,
+      'No DMCA notices seeded — POST /api/v1/admin/marketplace/dmca first',
+    )
+
+    const firstRow = page.getByTestId('admin-dmca-row').first()
+    const counterButton = firstRow.locator('[data-testid^="admin-dmca-counter-"]').first()
+    const visible = await counterButton.isVisible().catch(() => false)
+    testInfo.skip(!visible, 'first row is not in pending — no counter-notice action')
+
+    await counterButton.click()
+    await expect(page.getByTestId('admin-dmca-counter-text')).toBeVisible()
+    await page.getByRole('button', { name: 'Cancel' }).click()
+  })
+})
+
+test.describe('Public: DMCA legal page', () => {
+  test('renders the designated-agent details', async ({ page }) => {
+    await page.goto('/legal/dmca')
+    await expect(page.getByRole('heading', { name: /DMCA Notice/i })).toBeVisible()
+    await expect(page.getByText(/dmca@ravencloak\.org/i)).toBeVisible()
+    await expect(page.getByText(/17 U\.S\.C\. § 512/i).first()).toBeVisible()
+  })
+})
+
+test.describe('Marketplace footer', () => {
+  test('list view exposes the DMCA legal link', async ({ adminPage: page }) => {
+    await page.goto('/marketplace')
+    const link = page.getByRole('link', { name: /DMCA policy/i })
+    await expect(link).toBeVisible()
+    await link.click()
+    await expect(page).toHaveURL(/\/legal\/dmca/)
+  })
+})

--- a/frontend/src/api/marketplace-admin.ts
+++ b/frontend/src/api/marketplace-admin.ts
@@ -103,3 +103,93 @@ export async function dismissReport(reportId: string): Promise<DismissResult> {
   })
   return jsonOrThrow<DismissResult>(res, 'dismissReport')
 }
+
+// ─── DMCA inbox + counter-notice workflow (issue #736) ─────────────────────
+
+export type DMCAStatus =
+  | 'pending'
+  | 'counter_filed'
+  | 'resolved_take_down'
+  | 'resolved_keep_up'
+  | 'withdrawn'
+
+export interface DMCANotice {
+  id: string
+  target_kb_id: string
+  notice_text: string
+  claimant_email: string
+  claimant_name: string
+  counter_notice_text?: string | null
+  counter_notice_submitted_at?: string | null
+  counter_notice_window_ends: string
+  status: DMCAStatus
+  resolved_at?: string | null
+  created_at: string
+}
+
+export interface ListDMCANoticesResponse {
+  notices: DMCANotice[]
+  limit: number
+  offset: number
+}
+
+export interface DMCASubmitInput {
+  target_kb_id: string
+  notice_text: string
+  claimant_email: string
+  claimant_name: string
+}
+
+/**
+ * Lists DMCA notices visible to admins. Status filter is optional;
+ * empty means all five statuses. The `pending` filter is the live
+ * work-view (notices still inside the 14-day counter-notice window).
+ */
+export async function listDMCANotices(
+  status?: DMCAStatus,
+  limit = 50,
+  offset = 0,
+): Promise<ListDMCANoticesResponse> {
+  const qs = new URLSearchParams({
+    limit: String(limit),
+    offset: String(offset),
+  })
+  if (status) qs.set('status', status)
+  const res = await authFetch(`/admin/marketplace/dmca?${qs.toString()}`)
+  return jsonOrThrow<ListDMCANoticesResponse>(res, 'listDMCANotices')
+}
+
+/**
+ * Records a fresh DMCA notice arriving via dmca@ravencloak.org. Atomic:
+ * the target KB flips to `kb_status='dmca_pending'` and the 14-day
+ * counter-notice clock starts. Returns the full notice including
+ * `counter_notice_window_ends` so the UI can render the countdown.
+ *
+ * 409 means the KB already has a pending notice (one-active-notice-per-
+ * KB invariant — see ADR-0006).
+ */
+export async function submitDMCANotice(input: DMCASubmitInput): Promise<DMCANotice> {
+  const res = await authFetch(`/admin/marketplace/dmca`, {
+    method: 'POST',
+    body: JSON.stringify(input),
+  })
+  return jsonOrThrow<DMCANotice>(res, 'submitDMCANotice')
+}
+
+/**
+ * Records a publisher counter-notice on the named DMCA notice. MVP
+ * simplification: admin acts on behalf of the publisher who replied
+ * to dmca@ravencloak.org. The KB stays frozen until an admin issues
+ * the final keep-up/take-down call (safe harbour requires the OSP to
+ * hold restoration for 10-14 business days per 17 U.S.C. § 512(g)(2)(C)).
+ */
+export async function submitCounterNotice(
+  noticeId: string,
+  counterNoticeText: string,
+): Promise<{ notice_id: string; status: 'counter_filed' }> {
+  const res = await authFetch(`/admin/marketplace/dmca/${noticeId}/counter-notice`, {
+    method: 'POST',
+    body: JSON.stringify({ counter_notice_text: counterNoticeText }),
+  })
+  return jsonOrThrow(res, 'submitCounterNotice')
+}

--- a/frontend/src/pages/admin/AdminDMCAView.vue
+++ b/frontend/src/pages/admin/AdminDMCAView.vue
@@ -1,0 +1,410 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import {
+  listDMCANotices,
+  submitDMCANotice,
+  submitCounterNotice,
+  type DMCANotice,
+  type DMCAStatus,
+  type DMCASubmitInput,
+} from '../../api/marketplace-admin'
+import ResponsiveModal from '../../components/ResponsiveModal.vue'
+
+// Admin DMCA inbox + two-stage counter-notice workflow (issue #736,
+// launch blocker per ADR-0006).
+//
+// Three operations:
+//   - List + filter notices by status pill.
+//   - Record a DMCA notice received at dmca@ravencloak.org (modal form).
+//     This atomically inserts the row + freezes the target KB into
+//     `kb_status='dmca_pending'` for the 14-day counter-notice window.
+//   - Record a publisher counter-notice on a `pending` row. MVP
+//     simplification: the admin acts on behalf of the publisher who
+//     replied to the inbox; there is no public counter-notice UI.
+//
+// What this page intentionally does NOT do (out of scope for #736):
+//   - Manual auto-takedown trigger (the daily sweeper handles it).
+//   - Restore button (resolved_keep_up). Deferred — the safe-harbour
+//     window between counter-notice and restore requires legal review.
+
+type StatusFilter = '' | DMCAStatus
+
+const STATUSES: { value: StatusFilter; label: string }[] = [
+  { value: '', label: 'All' },
+  { value: 'pending', label: 'Pending' },
+  { value: 'counter_filed', label: 'Counter-filed' },
+  { value: 'resolved_take_down', label: 'Take-down' },
+  { value: 'resolved_keep_up', label: 'Keep-up' },
+  { value: 'withdrawn', label: 'Withdrawn' },
+]
+
+const notices = ref<DMCANotice[]>([])
+const status = ref<StatusFilter>('pending')
+const loading = ref(false)
+const error = ref<string | null>(null)
+
+const recordOpen = ref(false)
+const counterOpen = ref(false)
+const submitting = ref(false)
+const targetNotice = ref<DMCANotice | null>(null)
+
+const recordForm = ref<DMCASubmitInput>({
+  target_kb_id: '',
+  notice_text: '',
+  claimant_email: '',
+  claimant_name: '',
+})
+const counterText = ref('')
+
+async function refresh() {
+  loading.value = true
+  error.value = null
+  try {
+    const res = await listDMCANotices(status.value || undefined, 100, 0)
+    notices.value = res.notices
+  } catch (e) {
+    error.value = (e as Error).message
+  } finally {
+    loading.value = false
+  }
+}
+
+function openRecord() {
+  recordForm.value = {
+    target_kb_id: '',
+    notice_text: '',
+    claimant_email: '',
+    claimant_name: '',
+  }
+  recordOpen.value = true
+}
+
+function closeRecord() {
+  if (submitting.value) return
+  recordOpen.value = false
+}
+
+async function submitRecord() {
+  // Inline validation mirrors the server's DMCANoticeInput.Validate.
+  // Catching here avoids a round-trip for the empty-field case.
+  if (
+    !recordForm.value.target_kb_id ||
+    !recordForm.value.notice_text ||
+    !recordForm.value.claimant_email ||
+    !recordForm.value.claimant_name
+  ) {
+    error.value = 'All fields are required.'
+    return
+  }
+  if (recordForm.value.notice_text.length > 8192) {
+    error.value = 'Notice text must be 8 KiB or less.'
+    return
+  }
+  submitting.value = true
+  try {
+    await submitDMCANotice(recordForm.value)
+    recordOpen.value = false
+    await refresh()
+  } catch (e) {
+    error.value = (e as Error).message
+  } finally {
+    submitting.value = false
+  }
+}
+
+function openCounter(notice: DMCANotice) {
+  targetNotice.value = notice
+  counterText.value = ''
+  counterOpen.value = true
+}
+
+function closeCounter() {
+  if (submitting.value) return
+  counterOpen.value = false
+  targetNotice.value = null
+}
+
+async function submitCounter() {
+  if (!targetNotice.value) return
+  if (!counterText.value.trim()) {
+    error.value = 'Counter-notice text is required.'
+    return
+  }
+  submitting.value = true
+  try {
+    await submitCounterNotice(targetNotice.value.id, counterText.value)
+    counterOpen.value = false
+    targetNotice.value = null
+    await refresh()
+  } catch (e) {
+    error.value = (e as Error).message
+  } finally {
+    submitting.value = false
+  }
+}
+
+// Renders "Nd Nh remaining" for the 14-day window. Negative means the
+// window has elapsed — the sweeper will pick it up at next 4am UTC.
+function formatWindow(notice: DMCANotice): string {
+  if (notice.status !== 'pending') return '—'
+  const ends = new Date(notice.counter_notice_window_ends).getTime()
+  const remaining = ends - Date.now()
+  if (remaining < 0) return 'expired (awaiting sweep)'
+  const days = Math.floor(remaining / 86_400_000)
+  const hours = Math.floor((remaining % 86_400_000) / 3_600_000)
+  return `${days}d ${hours}h remaining`
+}
+
+function formatAge(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime()
+  const hours = Math.floor(ms / 3_600_000)
+  if (hours < 1) return 'just now'
+  if (hours < 24) return `${hours}h ago`
+  return `${Math.floor(hours / 24)}d ago`
+}
+
+const counterTitle = computed(() => {
+  if (!targetNotice.value) return ''
+  return `Record counter-notice on ${targetNotice.value.id.slice(0, 8)}`
+})
+
+onMounted(refresh)
+</script>
+
+<template>
+  <div class="p-4 sm:p-6">
+    <div class="mb-4 flex flex-wrap items-center justify-between gap-3">
+      <div>
+        <h1 class="text-xl font-semibold text-slate-100">DMCA inbox</h1>
+        <p class="text-sm text-slate-400">
+          Records DMCA notices received at
+          <code>dmca&#64;ravencloak.org</code> and their counter-notices
+          (ADR-0006). Pending notices freeze the target KB for the 14-day
+          counter-notice window; the daily sweeper auto-resolves expired
+          notices to take-down.
+        </p>
+      </div>
+      <div class="flex gap-2">
+        <button
+          class="rounded border border-slate-600 px-3 py-1.5 text-sm text-slate-100 hover:bg-slate-700"
+          :disabled="loading"
+          @click="refresh"
+        >
+          Refresh
+        </button>
+        <button
+          class="rounded bg-indigo-600 px-3 py-1.5 text-sm text-white hover:bg-indigo-500"
+          data-testid="admin-dmca-record-button"
+          @click="openRecord"
+        >
+          Record DMCA notice
+        </button>
+      </div>
+    </div>
+
+    <!-- Status filter pills -->
+    <div class="mb-4 flex flex-wrap gap-2" role="tablist" aria-label="DMCA notice status filter">
+      <button
+        v-for="opt in STATUSES"
+        :key="opt.value"
+        role="tab"
+        :aria-selected="status === opt.value"
+        class="rounded-full border px-3 py-1 text-sm"
+        :class="
+          status === opt.value
+            ? 'border-indigo-400 bg-indigo-500/20 text-indigo-200'
+            : 'border-slate-600 text-slate-300 hover:bg-slate-700'
+        "
+        @click="status = opt.value; refresh()"
+      >
+        {{ opt.label }}
+      </button>
+    </div>
+
+    <div
+      v-if="error"
+      class="mb-4 rounded border border-red-500/40 bg-red-500/10 p-3 text-sm text-red-200"
+    >
+      {{ error }}
+    </div>
+
+    <div v-if="loading" class="text-sm text-slate-400">Loading…</div>
+
+    <div
+      v-else-if="notices.length === 0"
+      class="rounded border border-slate-700 p-6 text-center text-sm text-slate-400"
+      data-testid="admin-dmca-empty"
+    >
+      No DMCA notices in <strong>{{ status || 'any status' }}</strong>.
+    </div>
+
+    <div v-else class="overflow-x-auto rounded border border-slate-700">
+      <table class="min-w-full text-left text-sm">
+        <thead class="bg-slate-800 text-xs uppercase text-slate-400">
+          <tr>
+            <th class="px-3 py-2">Notice</th>
+            <th class="px-3 py-2">Target KB</th>
+            <th class="px-3 py-2">Claimant</th>
+            <th class="px-3 py-2">Status</th>
+            <th class="px-3 py-2">Window</th>
+            <th class="px-3 py-2">Filed</th>
+            <th class="px-3 py-2 text-right">Actions</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-700 bg-slate-900 text-slate-200">
+          <tr
+            v-for="n in notices"
+            :key="n.id"
+            data-testid="admin-dmca-row"
+            :data-notice-id="n.id"
+          >
+            <td class="px-3 py-2 font-mono text-xs">{{ n.id.slice(0, 8) }}</td>
+            <td class="px-3 py-2 font-mono text-xs">{{ n.target_kb_id.slice(0, 8) }}</td>
+            <td class="px-3 py-2 text-slate-300">
+              <div>{{ n.claimant_name }}</div>
+              <div class="text-xs text-slate-500">{{ n.claimant_email }}</div>
+            </td>
+            <td class="px-3 py-2">
+              <span
+                class="rounded-full px-2 py-0.5 text-xs"
+                :class="{
+                  'bg-amber-500/20 text-amber-200': n.status === 'pending',
+                  'bg-sky-500/20 text-sky-200': n.status === 'counter_filed',
+                  'bg-red-500/20 text-red-200': n.status === 'resolved_take_down',
+                  'bg-emerald-500/20 text-emerald-200': n.status === 'resolved_keep_up',
+                  'bg-slate-500/20 text-slate-200': n.status === 'withdrawn',
+                }"
+              >
+                {{ n.status }}
+              </span>
+            </td>
+            <td class="px-3 py-2 text-slate-400">{{ formatWindow(n) }}</td>
+            <td class="px-3 py-2 text-slate-400">{{ formatAge(n.created_at) }}</td>
+            <td class="px-3 py-2 text-right">
+              <button
+                v-if="n.status === 'pending'"
+                class="rounded border border-sky-500/50 px-2 py-1 text-xs text-sky-200 hover:bg-sky-500/20"
+                :data-testid="`admin-dmca-counter-${n.id}`"
+                @click="openCounter(n)"
+              >
+                Counter-notice
+              </button>
+              <span v-else class="text-xs text-slate-500">—</span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Record DMCA notice modal -->
+    <ResponsiveModal :open="recordOpen" title="Record DMCA notice" @close="closeRecord">
+      <form class="space-y-3 text-sm text-slate-200" @submit.prevent="submitRecord">
+        <p class="text-xs text-slate-400">
+          Recording a DMCA notice freezes the target KB for 14 days. The
+          sweeper auto-resolves to take-down at the end of the window if
+          no counter-notice is filed.
+        </p>
+        <label class="block">
+          <span class="text-xs text-slate-400">Target KB ID (UUID)</span>
+          <input
+            v-model="recordForm.target_kb_id"
+            type="text"
+            required
+            class="mt-1 w-full rounded border border-slate-600 bg-slate-800 px-2 py-1 text-sm font-mono"
+            data-testid="admin-dmca-target-kb-id"
+          />
+        </label>
+        <label class="block">
+          <span class="text-xs text-slate-400">Claimant name</span>
+          <input
+            v-model="recordForm.claimant_name"
+            type="text"
+            required
+            class="mt-1 w-full rounded border border-slate-600 bg-slate-800 px-2 py-1 text-sm"
+            data-testid="admin-dmca-claimant-name"
+          />
+        </label>
+        <label class="block">
+          <span class="text-xs text-slate-400">Claimant email</span>
+          <input
+            v-model="recordForm.claimant_email"
+            type="email"
+            required
+            class="mt-1 w-full rounded border border-slate-600 bg-slate-800 px-2 py-1 text-sm"
+            data-testid="admin-dmca-claimant-email"
+          />
+        </label>
+        <label class="block">
+          <span class="text-xs text-slate-400">Notice text (max 8 KiB)</span>
+          <textarea
+            v-model="recordForm.notice_text"
+            required
+            rows="6"
+            maxlength="8192"
+            class="mt-1 w-full rounded border border-slate-600 bg-slate-800 px-2 py-1 text-xs font-mono"
+            data-testid="admin-dmca-notice-text"
+          ></textarea>
+        </label>
+        <div class="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            class="rounded border border-slate-600 px-3 py-1.5 text-sm text-slate-200 hover:bg-slate-700"
+            :disabled="submitting"
+            @click="closeRecord"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            class="rounded bg-indigo-600 px-3 py-1.5 text-sm text-white hover:bg-indigo-500"
+            :disabled="submitting"
+            data-testid="admin-dmca-record-submit"
+          >
+            {{ submitting ? 'Submitting…' : 'Record notice' }}
+          </button>
+        </div>
+      </form>
+    </ResponsiveModal>
+
+    <!-- Counter-notice modal -->
+    <ResponsiveModal :open="counterOpen" :title="counterTitle" @close="closeCounter">
+      <form class="space-y-3 text-sm text-slate-200" @submit.prevent="submitCounter">
+        <p class="text-xs text-slate-400">
+          Records the publisher's counter-notice verbatim. The KB stays
+          in <code>dmca_pending</code> until an admin makes the final
+          keep-up/take-down decision (safe-harbour rules require a hold
+          window between counter-notice and restoration).
+        </p>
+        <label class="block">
+          <span class="text-xs text-slate-400">Counter-notice text (max 8 KiB)</span>
+          <textarea
+            v-model="counterText"
+            required
+            rows="8"
+            maxlength="8192"
+            class="mt-1 w-full rounded border border-slate-600 bg-slate-800 px-2 py-1 text-xs font-mono"
+            data-testid="admin-dmca-counter-text"
+          ></textarea>
+        </label>
+        <div class="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            class="rounded border border-slate-600 px-3 py-1.5 text-sm text-slate-200 hover:bg-slate-700"
+            :disabled="submitting"
+            @click="closeCounter"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            class="rounded bg-sky-600 px-3 py-1.5 text-sm text-white hover:bg-sky-500"
+            :disabled="submitting"
+            data-testid="admin-dmca-counter-submit"
+          >
+            {{ submitting ? 'Submitting…' : 'Record counter-notice' }}
+          </button>
+        </div>
+      </form>
+    </ResponsiveModal>
+  </div>
+</template>

--- a/frontend/src/pages/legal/DMCAPage.vue
+++ b/frontend/src/pages/legal/DMCAPage.vue
@@ -1,0 +1,156 @@
+<template>
+  <div class="min-h-screen bg-gradient-to-br from-slate-900 via-indigo-950 to-slate-900">
+    <div class="mx-auto max-w-3xl px-4 py-16 sm:px-6 lg:px-8">
+      <div class="rounded-2xl bg-white p-8 shadow-2xl sm:p-12">
+        <header class="mb-10 border-b border-gray-200 pb-8">
+          <h1 class="text-3xl font-bold tracking-tight text-gray-900">
+            DMCA Notice &amp; Counter-Notice Policy
+          </h1>
+          <p class="mt-2 text-sm text-gray-500">Last updated: 2026-06-05</p>
+          <nav class="mt-4 space-x-4">
+            <RouterLink
+              to="/legal/terms"
+              class="text-sm font-medium text-indigo-600 transition-colors hover:text-indigo-800"
+            >
+              Terms of Service &rarr;
+            </RouterLink>
+            <RouterLink
+              to="/legal/privacy"
+              class="text-sm font-medium text-indigo-600 transition-colors hover:text-indigo-800"
+            >
+              Privacy Policy &rarr;
+            </RouterLink>
+          </nav>
+        </header>
+
+        <article
+          class="prose prose-indigo max-w-none prose-headings:text-gray-900 prose-p:text-gray-600 prose-a:text-indigo-600 prose-li:text-gray-600"
+        >
+          <h2>Designated Agent</h2>
+          <p>
+            Raven respects the intellectual property rights of others and
+            expects its users to do the same. Pursuant to the Digital
+            Millennium Copyright Act (17 U.S.C. § 512), Raven has designated
+            an agent to receive notifications of claimed copyright
+            infringement involving content published on the Raven
+            Marketplace.
+          </p>
+          <p>
+            <strong>Designated Agent:</strong>
+            <a href="mailto:dmca@ravencloak.org">dmca&#64;ravencloak.org</a>
+          </p>
+          <p>
+            All notices and counter-notices must be sent to the address
+            above. We do not accept DMCA correspondence through any other
+            channel.
+          </p>
+
+          <h2>Submitting a DMCA Notice</h2>
+          <p>
+            To file a DMCA notice, send an email to the address above that
+            includes all of the elements required by 17 U.S.C. § 512(c)(3):
+          </p>
+          <ol>
+            <li>
+              A physical or electronic signature of the copyright owner or
+              a person authorised to act on the owner's behalf.
+            </li>
+            <li>
+              Identification of the copyrighted work claimed to have been
+              infringed.
+            </li>
+            <li>
+              Identification of the material that is claimed to be
+              infringing and that is to be removed, including a URL or
+              other information sufficient to permit Raven to locate the
+              material (e.g. the Marketplace KB URL).
+            </li>
+            <li>
+              Contact information for the complaining party (mailing
+              address, telephone number, and email address).
+            </li>
+            <li>
+              A statement that the complaining party has a good-faith
+              belief that the use of the material in the manner complained
+              of is not authorised by the copyright owner, its agent, or
+              the law.
+            </li>
+            <li>
+              A statement that the information in the notification is
+              accurate, and under penalty of perjury, that the complaining
+              party is authorised to act on behalf of the copyright owner.
+            </li>
+          </ol>
+          <p>
+            On receipt of a notice that substantially complies with the
+            statutory requirements, Raven freezes the targeted Public
+            Knowledge Base for the 14-day counter-notice window and
+            evaluates the notice. Notices that fail to meet the statutory
+            requirements may be rejected without action.
+          </p>
+
+          <h2>Counter-Notice Rights</h2>
+          <p>
+            If you believe that material you published on the Raven
+            Marketplace was removed or frozen by mistake or
+            misidentification, you may submit a counter-notice. Reply to
+            the DMCA receipt email from
+            <a href="mailto:dmca@ravencloak.org">dmca&#64;ravencloak.org</a>
+            with all of the elements required by 17 U.S.C. § 512(g)(3):
+          </p>
+          <ol>
+            <li>Your physical or electronic signature.</li>
+            <li>
+              Identification of the material that has been removed or
+              disabled and the location at which it appeared before
+              removal.
+            </li>
+            <li>
+              A statement under penalty of perjury that you have a
+              good-faith belief that the material was removed or disabled
+              as a result of mistake or misidentification.
+            </li>
+            <li>
+              Your name, address, and telephone number, and a statement
+              that you consent to the jurisdiction of the Federal District
+              Court for the judicial district in which your address is
+              located, or if your address is outside the United States,
+              for any judicial district in which Raven may be found, and
+              that you will accept service of process from the person who
+              provided the original DMCA notice or an agent of such
+              person.
+            </li>
+          </ol>
+          <p>
+            On receipt of a valid counter-notice, Raven forwards it to the
+            complaining party. The targeted Knowledge Base remains frozen
+            for the 10 to 14 business-day hold required by 17 U.S.C.
+            § 512(g)(2)(C), giving the original claimant time to file
+            suit. If the original claimant does not notify Raven that they
+            have filed suit within that window, Raven may, at its
+            discretion, restore the material.
+          </p>
+
+          <h2>Repeat-Infringer Policy</h2>
+          <p>
+            In accordance with 17 U.S.C. § 512(i), Raven maintains a
+            policy of terminating, in appropriate circumstances, the
+            accounts of users who are repeat infringers. Organisations
+            whose Public Knowledge Bases accumulate three confirmed
+            takedown strikes are subject to account suspension. Strike
+            history is tracked internally and is not exposed to publishers.
+          </p>
+
+          <h2>Misrepresentation</h2>
+          <p>
+            Any person who knowingly materially misrepresents that
+            material or activity is infringing, or that material or
+            activity was removed or disabled by mistake or
+            misidentification, may be liable for damages under 17 U.S.C.
+            § 512(f). Submit notices and counter-notices in good faith.
+          </p>
+        </article>
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/src/pages/marketplace/MarketplaceListView.vue
+++ b/frontend/src/pages/marketplace/MarketplaceListView.vue
@@ -222,5 +222,14 @@ function onImported(payload: { orgId: string; workspaceId: string; kbId: string 
       @close="importDialogOpen = false"
       @imported="onImported"
     />
+
+    <!-- DMCA footer link (issue #736, ADR-0006 launch blocker). The link
+         is intentionally minimal — operational details live at
+         /legal/dmca. -->
+    <footer class="mt-8 border-t border-gray-200 pt-4 text-xs text-gray-500">
+      <RouterLink to="/legal/dmca" class="text-indigo-600 hover:underline">
+        DMCA policy
+      </RouterLink>
+    </footer>
   </div>
 </template>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -182,6 +182,15 @@ const router = createRouter({
           component: () => import('../pages/admin/AdminTakedownsView.vue'),
           meta: { requiresAuth: true, requiresPlatformAdmin: true },
         },
+        {
+          // DMCA inbox + two-stage counter-notice workflow (issue #736,
+          // launch blocker per ADR-0006). Same SPA-side guard as #734/#735;
+          // the backend enforces the gate via RequirePlatformAdmin.
+          path: 'admin/marketplace/dmca',
+          name: 'admin-marketplace-dmca',
+          component: () => import('../pages/admin/AdminDMCAView.vue'),
+          meta: { requiresAuth: true, requiresPlatformAdmin: true },
+        },
       ],
     },
     {
@@ -197,6 +206,13 @@ const router = createRouter({
           path: 'terms',
           name: 'terms-of-service',
           component: () => import('../pages/legal/TermsOfServicePage.vue'),
+        },
+        {
+          // Designated-agent details + counter-notice rights summary
+          // required by ADR-0006 + #736's launch-blocker scope.
+          path: 'dmca',
+          name: 'dmca',
+          component: () => import('../pages/legal/DMCAPage.vue'),
         },
       ],
     },

--- a/internal/handler/admin_dmca.go
+++ b/internal/handler/admin_dmca.go
@@ -1,0 +1,214 @@
+// Admin DMCA endpoints (issue #736, launch blocker per ADR-0006).
+//
+// Three endpoints under /api/v1/admin/marketplace/dmca:
+//
+//   GET    /admin/marketplace/dmca               — paginated DMCA notice queue.
+//   POST   /admin/marketplace/dmca               — record a fresh DMCA notice.
+//   POST   /admin/marketplace/dmca/:id/counter-notice — record a publisher
+//                                                       counter-notice.
+//
+// The HTTP gate (RequireRavenAdmin in cmd/api/main.go) runs upstream; this
+// file maps the service's structured sentinel errors to HTTP statuses and
+// trusts that gate. See admin_marketplace.go for the sibling pattern on
+// the reports queue.
+
+package handler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/ravencloak-org/Raven/internal/marketplace"
+	"github.com/ravencloak-org/Raven/pkg/apierror"
+)
+
+// AdminDMCAService is the slice of *marketplace.DMCAService this handler
+// depends on. Declared as an interface so the unit tests can pass a stub
+// that returns canned errors without a Postgres testcontainer.
+type AdminDMCAService interface {
+	Submit(ctx context.Context, in marketplace.DMCANoticeInput) (marketplace.DMCANotice, error)
+	SubmitCounterNotice(ctx context.Context, noticeID uuid.UUID, text string) error
+	ListNotices(ctx context.Context, status marketplace.DMCAStatus, limit, offset int) ([]marketplace.DMCANotice, error)
+}
+
+// AdminDMCAHandler exposes the three admin DMCA endpoints.
+type AdminDMCAHandler struct {
+	svc AdminDMCAService
+}
+
+// NewAdminDMCAHandler returns a handler bound to svc.
+func NewAdminDMCAHandler(svc AdminDMCAService) *AdminDMCAHandler {
+	return &AdminDMCAHandler{svc: svc}
+}
+
+// dmcaSubmitRequest is the wire shape POSTed by the admin UI.
+type dmcaSubmitRequest struct {
+	TargetKBID    string `json:"target_kb_id"`
+	NoticeText    string `json:"notice_text"`
+	ClaimantEmail string `json:"claimant_email"`
+	ClaimantName  string `json:"claimant_name"`
+}
+
+// dmcaCounterNoticeRequest is the wire shape for the counter-notice
+// endpoint. Body is a single string field so the admin UI can capture
+// the publisher's reply verbatim.
+type dmcaCounterNoticeRequest struct {
+	CounterNoticeText string `json:"counter_notice_text"`
+}
+
+// Submit handles POST /api/v1/admin/marketplace/dmca.
+//
+// Body: {target_kb_id, notice_text, claimant_email, claimant_name}.
+// On success returns the full DMCANotice (id + counter_notice_window_ends
+// in particular, so the UI can show the 14-day countdown without a
+// follow-up GET).
+//
+// Errors:
+//   - 400 invalid payload (non-UUID target_kb_id, empty fields, oversize
+//     notice text).
+//   - 401/403 handled upstream by RequireRavenAdmin.
+//   - 404 target KB does not exist.
+//   - 409 the KB already has a pending DMCA notice.
+func (h *AdminDMCAHandler) Submit(c *gin.Context) {
+	var req dmcaSubmitRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		_ = c.Error(apierror.NewBadRequest("invalid DMCA submit body"))
+		c.Abort()
+		return
+	}
+	targetKBID, err := uuid.Parse(req.TargetKBID)
+	if err != nil {
+		_ = c.Error(apierror.NewBadRequest("invalid target_kb_id"))
+		c.Abort()
+		return
+	}
+
+	notice, err := h.svc.Submit(c.Request.Context(), marketplace.DMCANoticeInput{
+		TargetKBID:    targetKBID,
+		NoticeText:    req.NoticeText,
+		ClaimantEmail: req.ClaimantEmail,
+		ClaimantName:  req.ClaimantName,
+	})
+	if err != nil {
+		_ = c.Error(translateDMCAError(err))
+		c.Abort()
+		return
+	}
+	c.JSON(http.StatusCreated, notice)
+}
+
+// SubmitCounterNotice handles POST /api/v1/admin/marketplace/dmca/:id/counter-notice.
+//
+// Body: {counter_notice_text}.
+// On success returns 200 with {notice_id, status: 'counter_filed'} so
+// the SPA can confirm the pivot without re-fetching the row.
+//
+// Errors:
+//   - 400 invalid payload (empty text, oversize).
+//   - 401/403 handled upstream.
+//   - 404 notice id does not resolve.
+//   - 409 notice is not in `pending` (terminal or already counter-filed).
+func (h *AdminDMCAHandler) SubmitCounterNotice(c *gin.Context) {
+	noticeID, err := parseDMCANoticeID(c)
+	if err != nil {
+		_ = c.Error(err)
+		c.Abort()
+		return
+	}
+	var req dmcaCounterNoticeRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		_ = c.Error(apierror.NewBadRequest("invalid counter-notice body"))
+		c.Abort()
+		return
+	}
+
+	if err := h.svc.SubmitCounterNotice(c.Request.Context(), noticeID, req.CounterNoticeText); err != nil {
+		_ = c.Error(translateDMCAError(err))
+		c.Abort()
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"notice_id": noticeID,
+		"status":    marketplace.DMCAStatusCounterFiled,
+	})
+}
+
+// List handles GET /api/v1/admin/marketplace/dmca.
+//
+// Query params:
+//   - status (optional): one of pending / counter_filed / resolved_take_down /
+//     resolved_keep_up / withdrawn. Empty means all.
+//   - limit / offset: paginate (defaults 50 / 0, cap 200).
+//
+// The admin UI uses this to render the DMCA queue. Cross-tenant; gated
+// upstream by RequireRavenAdmin.
+func (h *AdminDMCAHandler) List(c *gin.Context) {
+	statusStr := c.Query("status")
+	var status marketplace.DMCAStatus
+	if statusStr != "" {
+		status = marketplace.DMCAStatus(statusStr)
+		if !status.IsValid() {
+			_ = c.Error(apierror.NewBadRequest("invalid status query parameter"))
+			c.Abort()
+			return
+		}
+	}
+
+	limit, err := parsePageInt(c, "limit", 50, 200)
+	if err != nil {
+		_ = c.Error(err)
+		c.Abort()
+		return
+	}
+	offset, err := parsePageInt(c, "offset", 0, 1_000_000)
+	if err != nil {
+		_ = c.Error(err)
+		c.Abort()
+		return
+	}
+
+	notices, err := h.svc.ListNotices(c.Request.Context(), status, limit, offset)
+	if err != nil {
+		_ = c.Error(translateDMCAError(err))
+		c.Abort()
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"notices": notices,
+		"limit":   limit,
+		"offset":  offset,
+	})
+}
+
+// parseDMCANoticeID pulls :id from the URL and validates it is a UUID.
+func parseDMCANoticeID(c *gin.Context) (uuid.UUID, error) {
+	raw := c.Param("id")
+	id, err := uuid.Parse(raw)
+	if err != nil {
+		return uuid.Nil, apierror.NewBadRequest("invalid notice id")
+	}
+	return id, nil
+}
+
+// translateDMCAError maps marketplace DMCA sentinel errors to API
+// errors. Unknown errors become opaque 500s via the error handler.
+func translateDMCAError(err error) error {
+	switch {
+	case errors.Is(err, marketplace.ErrDMCAInvalidInput):
+		return apierror.NewBadRequest("invalid DMCA input")
+	case errors.Is(err, marketplace.ErrDMCATargetKBNotFound):
+		return apierror.NewNotFound("target KB not found")
+	case errors.Is(err, marketplace.ErrDMCANoticeNotFound):
+		return apierror.NewNotFound("DMCA notice not found")
+	case errors.Is(err, marketplace.ErrDMCAAlreadyPending):
+		return apierror.NewConflict("KB already has a pending DMCA notice")
+	case errors.Is(err, marketplace.ErrDMCAIllegalTransition):
+		return apierror.NewConflict("illegal DMCA status transition")
+	default:
+		return err
+	}
+}

--- a/internal/handler/admin_dmca_test.go
+++ b/internal/handler/admin_dmca_test.go
@@ -1,0 +1,325 @@
+package handler_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/ravencloak-org/Raven/internal/handler"
+	"github.com/ravencloak-org/Raven/internal/marketplace"
+	"github.com/ravencloak-org/Raven/pkg/apierror"
+)
+
+// stubDMCASvc is a hand-rolled stub for AdminDMCAService so the handler
+// unit tests do not need a Postgres testcontainer. Mirrors stubAdminSvc
+// in admin_marketplace_test.go.
+type stubDMCASvc struct {
+	submitResult marketplace.DMCANotice
+	submitErr    error
+
+	counterErr error
+
+	listResult []marketplace.DMCANotice
+	listErr    error
+
+	gotIn            marketplace.DMCANoticeInput
+	gotNoticeID      uuid.UUID
+	gotCounterText   string
+	gotListStatus    marketplace.DMCAStatus
+	gotListLimit     int
+	gotListOffset    int
+	gotListCalled    bool
+	gotSubmitCalled  bool
+	gotCounterCalled bool
+}
+
+func (s *stubDMCASvc) Submit(_ context.Context, in marketplace.DMCANoticeInput) (marketplace.DMCANotice, error) {
+	s.gotSubmitCalled = true
+	s.gotIn = in
+	return s.submitResult, s.submitErr
+}
+func (s *stubDMCASvc) SubmitCounterNotice(_ context.Context, id uuid.UUID, text string) error {
+	s.gotCounterCalled = true
+	s.gotNoticeID = id
+	s.gotCounterText = text
+	return s.counterErr
+}
+func (s *stubDMCASvc) ListNotices(_ context.Context, status marketplace.DMCAStatus, limit, offset int) ([]marketplace.DMCANotice, error) {
+	s.gotListCalled = true
+	s.gotListStatus = status
+	s.gotListLimit = limit
+	s.gotListOffset = offset
+	return s.listResult, s.listErr
+}
+
+// newDMCARouter wires the admin DMCA handler on a minimal gin engine.
+// Skips auth — the platform-admin gate is unit-tested separately.
+func newDMCARouter(t *testing.T, svc handler.AdminDMCAService) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(apierror.ErrorHandler())
+	h := handler.NewAdminDMCAHandler(svc)
+	r.GET("/admin/marketplace/dmca", h.List)
+	r.POST("/admin/marketplace/dmca", h.Submit)
+	r.POST("/admin/marketplace/dmca/:id/counter-notice", h.SubmitCounterNotice)
+	return r
+}
+
+// validSubmitBody returns a JSON body that passes inline validation.
+func validSubmitBody(t *testing.T, kbID uuid.UUID) *bytes.Buffer {
+	t.Helper()
+	body := map[string]string{
+		"target_kb_id":   kbID.String(),
+		"notice_text":    "Material at /marketplace/foo/bar infringes my copyright. — signed.",
+		"claimant_email": "rights@example.com",
+		"claimant_name":  "Acme Rights Holder",
+	}
+	buf, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return bytes.NewBuffer(buf)
+}
+
+// ── Submit ──────────────────────────────────────────────────────────────────
+
+func TestSubmit_HappyPath(t *testing.T) {
+	t.Parallel()
+	kbID := uuid.New()
+	noticeID := uuid.New()
+	svc := &stubDMCASvc{
+		submitResult: marketplace.DMCANotice{
+			ID:                      noticeID,
+			TargetKBID:              kbID,
+			NoticeText:              "ok",
+			ClaimantEmail:           "rights@example.com",
+			ClaimantName:            "Acme",
+			CounterNoticeWindowEnds: time.Now().Add(14 * 24 * time.Hour),
+			Status:                  marketplace.DMCAStatusPending,
+		},
+	}
+	r := newDMCARouter(t, svc)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/admin/marketplace/dmca", validSubmitBody(t, kbID))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status: want 201, got %d (body=%s)", w.Code, w.Body.String())
+	}
+	if !svc.gotSubmitCalled {
+		t.Fatal("svc.Submit was not called")
+	}
+	if svc.gotIn.TargetKBID != kbID {
+		t.Errorf("Submit input target_kb_id: want %s, got %s", kbID, svc.gotIn.TargetKBID)
+	}
+	var got marketplace.DMCANotice
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got.ID != noticeID {
+		t.Errorf("response id: want %s, got %s", noticeID, got.ID)
+	}
+}
+
+func TestSubmit_BadJSON(t *testing.T) {
+	t.Parallel()
+	svc := &stubDMCASvc{}
+	r := newDMCARouter(t, svc)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/admin/marketplace/dmca", strings.NewReader(`{not json`))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status: want 400, got %d", w.Code)
+	}
+	if svc.gotSubmitCalled {
+		t.Error("svc.Submit should not be called on bad JSON")
+	}
+}
+
+func TestSubmit_BadTargetUUID(t *testing.T) {
+	t.Parallel()
+	svc := &stubDMCASvc{}
+	r := newDMCARouter(t, svc)
+	w := httptest.NewRecorder()
+	body := strings.NewReader(`{"target_kb_id":"not-a-uuid","notice_text":"x","claimant_email":"a@b","claimant_name":"a"}`)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/admin/marketplace/dmca", body)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status: want 400, got %d", w.Code)
+	}
+}
+
+func TestSubmit_NotFound(t *testing.T) {
+	t.Parallel()
+	svc := &stubDMCASvc{submitErr: marketplace.ErrDMCATargetKBNotFound}
+	r := newDMCARouter(t, svc)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/admin/marketplace/dmca", validSubmitBody(t, uuid.New()))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status: want 404, got %d (body=%s)", w.Code, w.Body.String())
+	}
+}
+
+func TestSubmit_AlreadyPending409(t *testing.T) {
+	t.Parallel()
+	svc := &stubDMCASvc{submitErr: errors.Join(marketplace.ErrDMCAAlreadyPending, errors.New("inner"))}
+	r := newDMCARouter(t, svc)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/admin/marketplace/dmca", validSubmitBody(t, uuid.New()))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Errorf("status: want 409, got %d (body=%s)", w.Code, w.Body.String())
+	}
+}
+
+func TestSubmit_InvalidInput400(t *testing.T) {
+	t.Parallel()
+	svc := &stubDMCASvc{submitErr: marketplace.ErrDMCAInvalidInput}
+	r := newDMCARouter(t, svc)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/admin/marketplace/dmca", validSubmitBody(t, uuid.New()))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status: want 400, got %d", w.Code)
+	}
+}
+
+// ── SubmitCounterNotice ────────────────────────────────────────────────────
+
+func TestCounterNotice_HappyPath(t *testing.T) {
+	t.Parallel()
+	svc := &stubDMCASvc{}
+	r := newDMCARouter(t, svc)
+	id := uuid.New()
+	body := strings.NewReader(`{"counter_notice_text":"the takedown was a mistake — signed."}`)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/admin/marketplace/dmca/"+id.String()+"/counter-notice", body)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d (body=%s)", w.Code, w.Body.String())
+	}
+	if !svc.gotCounterCalled {
+		t.Fatal("svc.SubmitCounterNotice was not called")
+	}
+	if svc.gotNoticeID != id {
+		t.Errorf("notice id: want %s, got %s", id, svc.gotNoticeID)
+	}
+	if !strings.Contains(w.Body.String(), `"status":"counter_filed"`) {
+		t.Errorf("expected counter_filed echo, got %s", w.Body.String())
+	}
+}
+
+func TestCounterNotice_BadUUID(t *testing.T) {
+	t.Parallel()
+	svc := &stubDMCASvc{}
+	r := newDMCARouter(t, svc)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/admin/marketplace/dmca/not-a-uuid/counter-notice", strings.NewReader(`{"counter_notice_text":"x"}`))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status: want 400, got %d", w.Code)
+	}
+	if svc.gotCounterCalled {
+		t.Error("service should not be called on bad UUID")
+	}
+}
+
+func TestCounterNotice_NotFound(t *testing.T) {
+	t.Parallel()
+	svc := &stubDMCASvc{counterErr: marketplace.ErrDMCANoticeNotFound}
+	r := newDMCARouter(t, svc)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/admin/marketplace/dmca/"+uuid.NewString()+"/counter-notice", strings.NewReader(`{"counter_notice_text":"x"}`))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status: want 404, got %d", w.Code)
+	}
+}
+
+func TestCounterNotice_IllegalTransition409(t *testing.T) {
+	t.Parallel()
+	svc := &stubDMCASvc{counterErr: marketplace.ErrDMCAIllegalTransition}
+	r := newDMCARouter(t, svc)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/admin/marketplace/dmca/"+uuid.NewString()+"/counter-notice", strings.NewReader(`{"counter_notice_text":"x"}`))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Errorf("status: want 409, got %d", w.Code)
+	}
+}
+
+// ── List ──────────────────────────────────────────────────────────────────
+
+func TestList_HappyPath(t *testing.T) {
+	t.Parallel()
+	svc := &stubDMCASvc{listResult: []marketplace.DMCANotice{
+		{ID: uuid.New(), Status: marketplace.DMCAStatusPending},
+	}}
+	r := newDMCARouter(t, svc)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/marketplace/dmca?status=pending&limit=10", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d (body=%s)", w.Code, w.Body.String())
+	}
+	if svc.gotListStatus != marketplace.DMCAStatusPending {
+		t.Errorf("list status: want pending, got %q", svc.gotListStatus)
+	}
+	if svc.gotListLimit != 10 {
+		t.Errorf("list limit: want 10, got %d", svc.gotListLimit)
+	}
+}
+
+func TestList_InvalidStatus400(t *testing.T) {
+	t.Parallel()
+	svc := &stubDMCASvc{}
+	r := newDMCARouter(t, svc)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/marketplace/dmca?status=bogus", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status: want 400, got %d", w.Code)
+	}
+	if svc.gotListCalled {
+		t.Error("service should not be called on bad status filter")
+	}
+}
+
+func TestList_EmptyStatusOK(t *testing.T) {
+	t.Parallel()
+	svc := &stubDMCASvc{listResult: []marketplace.DMCANotice{}}
+	r := newDMCARouter(t, svc)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/admin/marketplace/dmca", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("status: want 200, got %d (body=%s)", w.Code, w.Body.String())
+	}
+	if svc.gotListStatus != "" {
+		t.Errorf("empty status filter should pass through as empty string, got %q", svc.gotListStatus)
+	}
+}

--- a/internal/jobs/marketplace_dmca_sweeper.go
+++ b/internal/jobs/marketplace_dmca_sweeper.go
@@ -1,0 +1,76 @@
+// Package jobs — marketplace_dmca_sweeper: daily cron handler that
+// auto-resolves DMCA notices whose 14-day counter-notice window has
+// expired (issue #736, ADR-0006 launch blocker).
+//
+// The actual orchestration (re-checking each row under FOR UPDATE,
+// flipping the KB, writing the takedown audit row, dispatching the
+// OnTakedownCreated registry) lives in marketplace.DMCAService —
+// keeping it in the service layer means the integration test can call
+// it directly without spinning up an Asynq harness.
+//
+// This handler is the thin cron seam: unmarshal the payload, invoke
+// the service, log the structured counter, return any orchestration
+// error so Asynq retries per the configured MaxRetry.
+
+package jobs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/hibiken/asynq"
+
+	"github.com/ravencloak-org/Raven/internal/marketplace"
+)
+
+// DMCASweeper is the Asynq handler for TypeMarketplaceDMCASweep.
+type DMCASweeper struct {
+	svc    *marketplace.DMCAService
+	logger *slog.Logger
+}
+
+// NewDMCASweeper returns a handler bound to svc. A nil logger falls
+// back to slog.Default so the handler never panics for a missing
+// dependency.
+func NewDMCASweeper(svc *marketplace.DMCAService, logger *slog.Logger) *DMCASweeper {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &DMCASweeper{svc: svc, logger: logger}
+}
+
+// ProcessTask implements asynq.Handler. Decodes the payload (currently
+// empty — the sweep always scans every expired pending notice),
+// invokes SweepExpired, and emits a structured log line.
+//
+// Errors are propagated so Asynq retries per MaxRetry. The DMCAService
+// already swallows per-notice failures and continues the loop — a
+// non-nil return here indicates a setup-level failure (DB pool down,
+// payload parse error) where retry is the right answer.
+func (h *DMCASweeper) ProcessTask(ctx context.Context, task *asynq.Task) error {
+	var payload MarketplaceDMCASweepPayload
+	if err := json.Unmarshal(task.Payload(), &payload); err != nil {
+		return fmt.Errorf("unmarshal MarketplaceDMCASweepPayload: %w", err)
+	}
+	if h.svc == nil {
+		// Defensive: the cron is registered before the service in
+		// cmd/api/main.go only if a wiring bug lands. Emit a structured
+		// warn and no-op so the queue doesn't accumulate retry pressure
+		// against a known-broken handler.
+		h.logger.WarnContext(ctx, "DMCA sweeper invoked without service wired; skipping")
+		return nil
+	}
+
+	h.logger.InfoContext(ctx, "starting DMCA counter-notice sweep")
+	result, err := h.svc.SweepExpired(ctx)
+	if err != nil {
+		return fmt.Errorf("DMCA sweep: %w", err)
+	}
+	h.logger.InfoContext(ctx, "DMCA counter-notice sweep complete",
+		"examined", result.Examined,
+		"resolved", result.Resolved,
+	)
+	return nil
+}

--- a/internal/jobs/marketplace_dmca_sweeper_test.go
+++ b/internal/jobs/marketplace_dmca_sweeper_test.go
@@ -1,0 +1,48 @@
+package jobs
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/hibiken/asynq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewMarketplaceDMCASweepTask pins the task-type constant and payload
+// round-trip. Mirrors TestNewCleanupTask in scheduler_test.go.
+func TestNewMarketplaceDMCASweepTask(t *testing.T) {
+	p := MarketplaceDMCASweepPayload{}
+	task, err := NewMarketplaceDMCASweepTask(p)
+	require.NoError(t, err)
+	assert.Equal(t, TypeMarketplaceDMCASweep, task.Type())
+
+	var got MarketplaceDMCASweepPayload
+	err = json.Unmarshal(task.Payload(), &got)
+	require.NoError(t, err)
+	assert.Equal(t, p, got)
+}
+
+// TestDMCASweeper_NilServiceIsNoop verifies the defensive check inside
+// ProcessTask: a missing DMCAService is treated as a wiring bug, logged,
+// and returns nil so Asynq does not accumulate retry pressure.
+func TestDMCASweeper_NilServiceIsNoop(t *testing.T) {
+	h := NewDMCASweeper(nil, nil)
+	task, err := NewMarketplaceDMCASweepTask(MarketplaceDMCASweepPayload{})
+	require.NoError(t, err)
+
+	if err := h.ProcessTask(context.Background(), task); err != nil {
+		t.Errorf("nil svc should no-op, got %v", err)
+	}
+}
+
+// TestDMCASweeper_BadPayloadReturnsError verifies the payload-parse
+// failure surfaces as an Asynq-retryable error.
+func TestDMCASweeper_BadPayloadReturnsError(t *testing.T) {
+	h := NewDMCASweeper(nil, nil)
+	bad := asynq.NewTask(TypeMarketplaceDMCASweep, []byte("not json"))
+	if err := h.ProcessTask(context.Background(), bad); err == nil {
+		t.Error("expected error on malformed payload, got nil")
+	}
+}

--- a/internal/jobs/scheduler.go
+++ b/internal/jobs/scheduler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/ravencloak-org/Raven/internal/config"
+	"github.com/ravencloak-org/Raven/internal/marketplace"
 	"github.com/ravencloak-org/Raven/internal/queue"
 )
 
@@ -25,6 +26,11 @@ const (
 
 	// CronUsageAggregation runs the usage aggregation every hour at minute 5.
 	CronUsageAggregation = "5 * * * *"
+
+	// CronMarketplaceDMCASweep runs the DMCA counter-notice-window sweep
+	// daily at 4 AM UTC. Offset from cleanup (2 AM) and trial-lifecycle
+	// (3 AM) so the daily-cluster doesn't all hit the DB pool at once.
+	CronMarketplaceDMCASweep = "0 4 * * *"
 )
 
 // SchedulerConfig holds the dependencies needed to set up the cron scheduler.
@@ -34,6 +40,14 @@ type SchedulerConfig struct {
 	QueueClient *queue.Client
 	Logger      *slog.Logger
 	Asynq       config.AsynqConfig
+
+	// DMCAService drives the daily DMCA counter-notice-window sweep
+	// (issue #736). Optional — when nil the DMCA cron is not registered
+	// so the worker can boot in environments where the Marketplace is
+	// disabled (e.g. self-hosted edge nodes). cmd/api/main.go wires
+	// this; integration tests that don't exercise the sweep can leave
+	// it nil.
+	DMCAService *marketplace.DMCAService
 }
 
 // Scheduler wraps an asynq.Scheduler and the handler mux for processing
@@ -116,6 +130,21 @@ func NewScheduler(cfg SchedulerConfig) (*Scheduler, error) {
 		return nil, fmt.Errorf("register trial lifecycle cron: %w", err)
 	}
 
+	// Marketplace DMCA sweep — only registered when the DMCAService is
+	// wired (skipped on edge nodes that disable the marketplace).
+	if cfg.DMCAService != nil {
+		dmcaTask, err := NewMarketplaceDMCASweepTask(MarketplaceDMCASweepPayload{})
+		if err != nil {
+			return nil, fmt.Errorf("create DMCA sweep task: %w", err)
+		}
+		if _, err := scheduler.Register(CronMarketplaceDMCASweep, dmcaTask,
+			asynq.Queue("low"),
+			asynq.MaxRetry(2),
+		); err != nil {
+			return nil, fmt.Errorf("register DMCA sweep cron: %w", err)
+		}
+	}
+
 	// Build a ServeMux with handlers for each scheduled task type.
 	mux := asynq.NewServeMux()
 
@@ -143,13 +172,22 @@ func NewScheduler(cfg SchedulerConfig) (*Scheduler, error) {
 	trialLifecycleHandler := NewTrialLifecycleHandler(cfg.Pool, cfg.QueueClient, cfg.Logger)
 	mux.Handle(TypeTrialLifecycle, trialLifecycleHandler)
 
-	cfg.Logger.Info("scheduler configured",
+	if cfg.DMCAService != nil {
+		dmcaHandler := NewDMCASweeper(cfg.DMCAService, cfg.Logger)
+		mux.Handle(TypeMarketplaceDMCASweep, dmcaHandler)
+	}
+
+	logFields := []any{
 		"recrawl_cron", CronRecrawl,
 		"cleanup_cron", CronCleanup,
 		"usage_aggregation_cron", CronUsageAggregation,
 		"voice_usage_aggregation_cron", CronVoiceUsageAggregation,
 		"trial_lifecycle_cron", CronTrialLifecycle,
-	)
+	}
+	if cfg.DMCAService != nil {
+		logFields = append(logFields, "marketplace_dmca_sweep_cron", CronMarketplaceDMCASweep)
+	}
+	cfg.Logger.Info("scheduler configured", logFields...)
 
 	return &Scheduler{
 		scheduler: scheduler,

--- a/internal/jobs/tasks.go
+++ b/internal/jobs/tasks.go
@@ -27,6 +27,11 @@ const (
 
 	// TypeTrialLifecycle advances subscriptions through the trial→grace→archive→delete pipeline.
 	TypeTrialLifecycle = "scheduled:trial_lifecycle"
+
+	// TypeMarketplaceDMCASweep auto-resolves DMCA notices whose 14-day
+	// counter-notice window has expired (issue #736, ADR-0006). Runs
+	// daily; see internal/jobs/marketplace_dmca_sweeper.go.
+	TypeMarketplaceDMCASweep = "scheduled:marketplace_dmca_sweep"
 )
 
 // RecrawlPayload is the payload for the source re-crawl scheduled task.
@@ -101,4 +106,20 @@ func NewTrialLifecycleTask(p TrialLifecyclePayload) (*asynq.Task, error) {
 		return nil, fmt.Errorf("marshal TrialLifecyclePayload: %w", err)
 	}
 	return asynq.NewTask(TypeTrialLifecycle, data), nil
+}
+
+// MarketplaceDMCASweepPayload is the payload for the daily DMCA sweep
+// cron task. Empty in MVP — the sweep always scans every pending notice
+// whose 14-day window has expired. The struct exists so future
+// payloads (limit, dry-run flag) do not require a task-type rename.
+type MarketplaceDMCASweepPayload struct{}
+
+// NewMarketplaceDMCASweepTask creates a new Asynq task for the DMCA
+// counter-notice-window sweep.
+func NewMarketplaceDMCASweepTask(p MarketplaceDMCASweepPayload) (*asynq.Task, error) {
+	data, err := json.Marshal(p)
+	if err != nil {
+		return nil, fmt.Errorf("marshal MarketplaceDMCASweepPayload: %w", err)
+	}
+	return asynq.NewTask(TypeMarketplaceDMCASweep, data), nil
 }

--- a/internal/marketplace/dmca.go
+++ b/internal/marketplace/dmca.go
@@ -1,0 +1,690 @@
+// Package marketplace — dmca: the DMCA inbox + two-stage counter-notice
+// workflow service (issue #736, launch blocker per ADR-0006).
+//
+// The DMCA flow has three distinct write paths, each isolated behind
+// SET LOCAL ROLE raven_admin so the admin-bypass RLS policy on
+// dmca_notices (and marketplace_takedowns from #735) lets the writes
+// through:
+//
+//  1. Submit — admin records a freshly arrived notice. Atomic: insert
+//     the notice row AND flip the target KB into `kb_status='dmca_pending'`.
+//     The 14-day counter-notice window clock is materialised at this
+//     point (counter_notice_window_ends = now() + 14d) so the sweeper
+//     can run a flat `< now()` filter without recomputing per row.
+//     The claimant receipt email is sent OUTSIDE the transaction — same
+//     justification as AdminModeration.Approve (the takedown decision
+//     is the durable record; email is best-effort retry-able async).
+//
+//  2. SubmitCounterNotice — admin records a publisher counter-notice
+//     (MVP simplification: admin acts on behalf of the publisher, who
+//     replies via the dmca@ravencloak.org inbox; there is no public
+//     counter-notice UI in MVP). Transitions the row to `counter_filed`
+//     and stamps counter_notice_submitted_at. The KB stays in
+//     `dmca_pending` until an admin makes the final keep-up / take-down
+//     decision — we do NOT thaw to `active` on counter-notice submission
+//     because the DMCA safe harbour requires the OSP to hold the
+//     restoration for 10-14 business days to give the claimant time to
+//     file suit (17 U.S.C. § 512(g)(2)(C)). The final decision is a
+//     manual admin step in MVP; productionising adds a second timer.
+//
+//  3. The sweeper (jobs/marketplace_dmca_sweeper.go) drives the
+//     auto-takedown for pending notices whose window has expired. The
+//     sweep is a separate service method (SweepExpired) so the cron
+//     handler stays thin and the integration test can call it directly.
+//
+// Why a dedicated file (mirrors admin_moderation.go's rationale):
+//   - The dmca_notices repository CRUD does not warrant its own file
+//     for a single-table, three-statement service. Combining the table
+//     access with the multi-table orchestration keeps the call sites
+//     in one place.
+//   - The KB-status flip cuts across knowledge_bases; rather than
+//     duplicate UPDATE statements in a hypothetical dmca_repo.go, we
+//     keep the orchestration here next to its sibling Approve flow.
+//
+// HTTP gating: every public method assumes the caller has already
+// passed RequireRavenAdmin. The service does NOT re-check the gate.
+
+package marketplace
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// CounterNoticeWindow is the statutory 14-day window during which a
+// publisher can file a counter-notice before the auto-takedown sweeper
+// finalises the DMCA action. The window length is hard-coded — ADR-0006
+// pins it and the DMCA statute does not allow shortening.
+//
+// Exported so tests can refer to the same constant when seeding
+// past-due notices without hard-coding "14*24*time.Hour" in two places.
+const CounterNoticeWindow = 14 * 24 * time.Hour
+
+// DMCAStatus is the canonical type for dmca_notices.status. The state
+// machine is intentionally simple — terminal states are write-once
+// from the service layer's perspective:
+//
+//	pending           -> counter_filed | resolved_take_down | withdrawn
+//	counter_filed     -> resolved_keep_up | resolved_take_down
+//	resolved_*        -> (terminal)
+//	withdrawn         -> (terminal)
+type DMCAStatus string
+
+const (
+	// DMCAStatusPending is the initial state — notice received, the
+	// 14-day counter-notice clock is ticking, the KB is frozen.
+	DMCAStatusPending DMCAStatus = "pending"
+
+	// DMCAStatusCounterFiled means the publisher has filed a counter-
+	// notice. The KB stays frozen until the admin makes the final call.
+	DMCAStatusCounterFiled DMCAStatus = "counter_filed"
+
+	// DMCAStatusResolvedTakeDown is the terminal "claimant wins"
+	// outcome — KB stays private, takedown audit row exists. The
+	// sweeper writes this row when the window expires with no counter-
+	// notice; admin can also set it manually after reviewing a
+	// counter-notice.
+	DMCAStatusResolvedTakeDown DMCAStatus = "resolved_take_down"
+
+	// DMCAStatusResolvedKeepUp is the terminal "publisher wins" or
+	// "claimant withdrew" outcome — KB restored. MVP does not expose
+	// the restore button to admins (out of scope for the launch
+	// blocker); the status is here so the runbook can document the
+	// post-MVP restoration path.
+	DMCAStatusResolvedKeepUp DMCAStatus = "resolved_keep_up"
+
+	// DMCAStatusWithdrawn means the claimant rescinded the notice
+	// before resolution. Same end state as resolved_keep_up but
+	// auditable as a distinct event.
+	DMCAStatusWithdrawn DMCAStatus = "withdrawn"
+)
+
+// IsValid reports whether s is one of the five legal DMCAStatus values.
+// The DB CHECK is the backstop; this guards inputs at the service edge.
+func (s DMCAStatus) IsValid() bool {
+	switch s {
+	case DMCAStatusPending, DMCAStatusCounterFiled,
+		DMCAStatusResolvedTakeDown, DMCAStatusResolvedKeepUp,
+		DMCAStatusWithdrawn:
+		return true
+	}
+	return false
+}
+
+// DMCANotice is the wire+storage shape for a row in dmca_notices.
+// Optional fields use pointers so a NULL counter-notice does not
+// surface as the empty string in JSON.
+type DMCANotice struct {
+	ID                       uuid.UUID  `json:"id"`
+	TargetKBID               uuid.UUID  `json:"target_kb_id"`
+	NoticeText               string     `json:"notice_text"`
+	ClaimantEmail            string     `json:"claimant_email"`
+	ClaimantName             string     `json:"claimant_name"`
+	CounterNoticeText        *string    `json:"counter_notice_text,omitempty"`
+	CounterNoticeSubmittedAt *time.Time `json:"counter_notice_submitted_at,omitempty"`
+	CounterNoticeWindowEnds  time.Time  `json:"counter_notice_window_ends"`
+	Status                   DMCAStatus `json:"status"`
+	ResolvedAt               *time.Time `json:"resolved_at,omitempty"`
+	CreatedAt                time.Time  `json:"created_at"`
+}
+
+// DMCANoticeInput is the payload accepted by Submit. NoticeText length
+// is validated server-side against the same 1..8192 range the DB
+// CHECK enforces — we surface the 400 from the service rather than
+// letting a pgx CHECK violation bubble up as an opaque 500.
+type DMCANoticeInput struct {
+	TargetKBID    uuid.UUID
+	NoticeText    string
+	ClaimantEmail string
+	ClaimantName  string
+}
+
+// Validate runs the inline payload checks. Returns nil on success.
+func (in DMCANoticeInput) Validate() error {
+	if in.TargetKBID == uuid.Nil {
+		return ErrDMCAInvalidInput
+	}
+	if l := len(in.NoticeText); l < 1 || l > 8192 {
+		return ErrDMCAInvalidInput
+	}
+	if in.ClaimantEmail == "" || in.ClaimantName == "" {
+		return ErrDMCAInvalidInput
+	}
+	return nil
+}
+
+// Sentinel errors. The HTTP handler maps these to status codes.
+var (
+	// ErrDMCAInvalidInput — Submit/SubmitCounterNotice payload failed
+	// the inline validation. Surfaces as 400.
+	ErrDMCAInvalidInput = errors.New("marketplace: invalid DMCA input")
+
+	// ErrDMCATargetKBNotFound — the target KB does not exist. Surfaces
+	// as 404. A KB hard-deleted mid-flight surfaces here too because
+	// the FOR UPDATE in Submit returns ErrNoRows.
+	ErrDMCATargetKBNotFound = errors.New("marketplace: DMCA target KB not found")
+
+	// ErrDMCAAlreadyPending — the KB already has a pending DMCA notice.
+	// Surfaces as 409. The DMCA workflow is one-active-notice-per-KB
+	// in MVP; a second notice would race the sweep timer and confuse
+	// the audit log.
+	ErrDMCAAlreadyPending = errors.New("marketplace: DMCA notice already pending for KB")
+
+	// ErrDMCANoticeNotFound — the notice id supplied to
+	// SubmitCounterNotice does not exist. Surfaces as 404.
+	ErrDMCANoticeNotFound = errors.New("marketplace: DMCA notice not found")
+
+	// ErrDMCAIllegalTransition — counter-notice was filed against a
+	// notice that is not in `pending`. Surfaces as 409.
+	ErrDMCAIllegalTransition = errors.New("marketplace: illegal DMCA status transition")
+)
+
+// DMCAClaimantNotifier sends the "we received your notice" receipt
+// email. Default is a no-op (logs a TODO at INFO) — see PublisherNotifier
+// in admin_moderation.go for the same pattern and rationale.
+type DMCAClaimantNotifier interface {
+	NotifyClaimantReceipt(ctx context.Context, notice DMCANotice) error
+}
+
+// noopDMCAClaimantNotifier is the safe default. Logs a TODO at INFO
+// so an operator can see the would-be email.
+type noopDMCAClaimantNotifier struct{}
+
+func (noopDMCAClaimantNotifier) NotifyClaimantReceipt(ctx context.Context, n DMCANotice) error {
+	slog.InfoContext(ctx, "marketplace: TODO wire DMCA claimant receipt email",
+		"notice_id", n.ID, "kb_id", n.TargetKBID, "claimant_email", n.ClaimantEmail)
+	return nil
+}
+
+// NewNoopDMCAClaimantNotifier returns the no-op notifier. Exported so
+// cmd/api/main.go wires it explicitly.
+func NewNoopDMCAClaimantNotifier() DMCAClaimantNotifier {
+	return noopDMCAClaimantNotifier{}
+}
+
+// DMCAService handles the DMCA inbox + counter-notice + sweep flow.
+//
+// All transactional writes use SET LOCAL ROLE raven_admin (the
+// dmca_notices and marketplace_takedowns tables are admin-only via
+// RLS). SET LOCAL is used (not SET) so the role reverts when the
+// transaction ends — no leaked admin privilege on the next caller to
+// grab this pool connection.
+type DMCAService struct {
+	pool      *pgxpool.Pool
+	takedowns *Takedowns
+	notifier  DMCAClaimantNotifier
+
+	// now is overridable for the sweeper's time-travel tests. Production
+	// callers leave it nil and the service uses time.Now.
+	now func() time.Time
+}
+
+// NewDMCAService constructs a DMCAService bound to pool and the takedown
+// audit writer. A nil notifier is treated as the no-op notifier.
+func NewDMCAService(pool *pgxpool.Pool, takedowns *Takedowns, notifier DMCAClaimantNotifier) *DMCAService {
+	if notifier == nil {
+		notifier = noopDMCAClaimantNotifier{}
+	}
+	return &DMCAService{
+		pool:      pool,
+		takedowns: takedowns,
+		notifier:  notifier,
+	}
+}
+
+// WithClock overrides the service's time source. Test-only — production
+// callers should not use this.
+func (s *DMCAService) WithClock(now func() time.Time) *DMCAService {
+	s.now = now
+	return s
+}
+
+// nowFn returns the service's time source, defaulting to time.Now.
+func (s *DMCAService) nowFn() time.Time {
+	if s.now != nil {
+		return s.now()
+	}
+	return time.Now()
+}
+
+// Submit records a fresh DMCA notice. Atomic two-table write:
+//
+//  1. INSERT the dmca_notices row with counter_notice_window_ends =
+//     now() + 14d and status='pending'.
+//  2. UPDATE the target KB to status='dmca_pending' (the kb_status
+//     gate downstream blocks chat/ingestion while the hold is active).
+//
+// Both side-effects commit together; if either fails the whole thing
+// rolls back. The claimant receipt email is sent OUTSIDE the
+// transaction (best-effort, logged on failure).
+//
+// Errors:
+//   - ErrDMCAInvalidInput: payload validation failed (400).
+//   - ErrDMCATargetKBNotFound: target_kb_id does not resolve (404).
+//   - ErrDMCAAlreadyPending: KB already has a pending notice (409).
+//   - Any pgx error from the underlying round-trips (500).
+func (s *DMCAService) Submit(ctx context.Context, in DMCANoticeInput) (DMCANotice, error) {
+	if err := in.Validate(); err != nil {
+		return DMCANotice{}, err
+	}
+
+	var notice DMCANotice
+	if err := s.runAdminTx(ctx, func(tx pgx.Tx) error {
+		// 1. Guard: reject if a pending notice already exists for this
+		//    KB. The unique-active invariant is enforced at the service
+		//    layer rather than via a partial unique index because we
+		//    want a structured 409 here, not a constraint-violation
+		//    bubble-up at INSERT time. A partial unique index would also
+		//    race against the sweep auto-resolve in a tight window.
+		var existingCount int
+		if err := tx.QueryRow(ctx,
+			`SELECT COUNT(*) FROM dmca_notices
+			  WHERE target_kb_id = $1 AND status = 'pending'`,
+			in.TargetKBID,
+		).Scan(&existingCount); err != nil {
+			return fmt.Errorf("DMCAService.Submit: dup check: %w", err)
+		}
+		if existingCount > 0 {
+			return ErrDMCAAlreadyPending
+		}
+
+		// 2. Verify the target KB exists. UPDATE … RETURNING gives us
+		//    both the existence check and the status flip in one round-
+		//    trip. The kb_status enum value 'dmca_pending' was added in
+		//    migration 00049.
+		var kbID uuid.UUID
+		if err := tx.QueryRow(ctx,
+			`UPDATE knowledge_bases
+			    SET status = 'dmca_pending'
+			  WHERE id = $1
+			  RETURNING id`,
+			in.TargetKBID,
+		).Scan(&kbID); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return ErrDMCATargetKBNotFound
+			}
+			return fmt.Errorf("DMCAService.Submit: KB status flip: %w", err)
+		}
+
+		// 3. Insert the notice row. Materialise the 14-day window now
+		//    so the sweep query is a flat `< now()` filter.
+		windowEnds := s.nowFn().Add(CounterNoticeWindow)
+		if err := tx.QueryRow(ctx,
+			`INSERT INTO dmca_notices
+			   (target_kb_id, notice_text, claimant_email, claimant_name,
+			    counter_notice_window_ends, status)
+			 VALUES ($1, $2, $3, $4, $5, 'pending')
+			 RETURNING id, target_kb_id, notice_text, claimant_email,
+			           claimant_name, counter_notice_text,
+			           counter_notice_submitted_at,
+			           counter_notice_window_ends, status,
+			           resolved_at, created_at`,
+			in.TargetKBID, in.NoticeText, in.ClaimantEmail, in.ClaimantName,
+			windowEnds,
+		).Scan(
+			&notice.ID, &notice.TargetKBID, &notice.NoticeText,
+			&notice.ClaimantEmail, &notice.ClaimantName,
+			&notice.CounterNoticeText, &notice.CounterNoticeSubmittedAt,
+			&notice.CounterNoticeWindowEnds, &notice.Status,
+			&notice.ResolvedAt, &notice.CreatedAt,
+		); err != nil {
+			return fmt.Errorf("DMCAService.Submit: notice insert: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return DMCANotice{}, err
+	}
+
+	// Email outside the transaction. A logged failure is acceptable —
+	// the notice + KB freeze have committed.
+	if err := s.notifier.NotifyClaimantReceipt(ctx, notice); err != nil {
+		slog.WarnContext(ctx, "marketplace: DMCA claimant receipt failed",
+			"notice_id", notice.ID, "claimant_email", notice.ClaimantEmail,
+			"error", err)
+	}
+	return notice, nil
+}
+
+// SubmitCounterNotice records a publisher counter-notice on the named
+// notice. The DB row pivots to `counter_filed`; the KB stays in
+// `dmca_pending` (see file header for the safe-harbour rationale).
+//
+// Errors:
+//   - ErrDMCAInvalidInput: counterText empty.
+//   - ErrDMCANoticeNotFound: id does not resolve (404).
+//   - ErrDMCAIllegalTransition: notice is not in `pending` (409).
+//   - Any pgx error (500).
+func (s *DMCAService) SubmitCounterNotice(ctx context.Context, noticeID uuid.UUID, counterText string) error {
+	if noticeID == uuid.Nil || counterText == "" {
+		return ErrDMCAInvalidInput
+	}
+	if len(counterText) > 8192 {
+		return ErrDMCAInvalidInput
+	}
+
+	return s.runAdminTx(ctx, func(tx pgx.Tx) error {
+		// FOR UPDATE locks the row so a concurrent sweep cannot auto-
+		// resolve it underneath us mid-counter-notice.
+		var current DMCAStatus
+		if err := tx.QueryRow(ctx,
+			`SELECT status FROM dmca_notices WHERE id = $1 FOR UPDATE`,
+			noticeID,
+		).Scan(&current); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return ErrDMCANoticeNotFound
+			}
+			return fmt.Errorf("DMCAService.SubmitCounterNotice: load: %w", err)
+		}
+		if current != DMCAStatusPending {
+			return ErrDMCAIllegalTransition
+		}
+
+		now := s.nowFn()
+		if _, err := tx.Exec(ctx,
+			`UPDATE dmca_notices
+			    SET counter_notice_text         = $2,
+			        counter_notice_submitted_at = $3,
+			        status                      = 'counter_filed'
+			  WHERE id = $1`,
+			noticeID, counterText, now,
+		); err != nil {
+			return fmt.Errorf("DMCAService.SubmitCounterNotice: update: %w", err)
+		}
+		return nil
+	})
+}
+
+// SweepResult summarises a sweep run. Returned by SweepExpired so the
+// cron handler can log structured counters and the integration test can
+// assert per-run effects.
+type SweepResult struct {
+	// Examined is the number of pending notices the sweep scanned.
+	Examined int
+	// Resolved is the number successfully auto-resolved to
+	// `resolved_take_down`. Examined - Resolved = errors hit per-row
+	// (the sweep continues past a single failure).
+	Resolved int
+}
+
+// SweepExpired auto-resolves every `pending` notice whose 14-day
+// counter-notice window has expired. For each row it:
+//
+//  1. Transitions status -> resolved_take_down + stamps resolved_at.
+//  2. Flips the target KB to visibility='private' AND status='active'
+//     (so the kb_status gate releases — the legal hold has resolved
+//     to a takedown decision; the KB now sits in the same state as
+//     any publisher-initiated unpublish).
+//  3. Writes a marketplace_takedowns row with source='dmca' and the
+//     notice id in the notes column.
+//  4. Dispatches the OnTakedownCreated registry (DerivativeNotifier
+//     fires the lineage-walk email outside the transaction).
+//
+// One transaction per notice keeps a slow downstream notifier from
+// holding the sweep's overall lock. Per-row errors are logged and the
+// loop continues — a transient FK or network failure on row N must not
+// block rows N+1..M.
+//
+// Called by the cron handler in jobs/marketplace_dmca_sweeper.go and
+// directly by the integration test. The sweep is idempotent: re-running
+// it picks up only rows still in `pending`.
+func (s *DMCAService) SweepExpired(ctx context.Context) (SweepResult, error) {
+	var result SweepResult
+	now := s.nowFn()
+
+	// Collect candidate IDs first under a short SELECT-only transaction
+	// so we don't hold a snapshot across the per-row writes. Reading
+	// under raven_admin role to satisfy the admin-bypass RLS policy.
+	ids, err := s.listExpiredPending(ctx, now)
+	if err != nil {
+		return result, fmt.Errorf("DMCAService.SweepExpired: list: %w", err)
+	}
+	result.Examined = len(ids)
+
+	// Per-notice resolution. Each call runs its own raven_admin tx and
+	// fires the takedown dispatch outside that tx.
+	for _, id := range ids {
+		td, err := s.resolveExpiredOne(ctx, id, now)
+		if err != nil {
+			slog.ErrorContext(ctx, "marketplace: DMCA sweep notice failed",
+				"notice_id", id, "error", err)
+			continue
+		}
+		result.Resolved++
+
+		// Outside-tx side-effect: fire the derivative-owner notifier.
+		// The takedown row has committed; a notifier failure is
+		// best-effort and must not block the sweep.
+		if err := DispatchOnTakedownCreated(ctx, td, "dmca:"+id.String()); err != nil {
+			slog.WarnContext(ctx, "marketplace: DMCA takedown dispatch failed",
+				"notice_id", id, "takedown_id", td.ID, "error", err)
+		}
+	}
+	return result, nil
+}
+
+// listExpiredPending returns notice IDs whose 14-day window has expired
+// and which are still in `pending`. Runs under raven_admin so the
+// admin-bypass RLS policy lets the SELECT see every row.
+func (s *DMCAService) listExpiredPending(ctx context.Context, now time.Time) ([]uuid.UUID, error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("listExpiredPending: begin: %w", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	if _, err := tx.Exec(ctx, "SET LOCAL ROLE raven_admin"); err != nil {
+		return nil, fmt.Errorf("listExpiredPending: set role: %w", err)
+	}
+
+	rows, err := tx.Query(ctx,
+		`SELECT id FROM dmca_notices
+		  WHERE status = 'pending' AND counter_notice_window_ends < $1
+		  ORDER BY counter_notice_window_ends ASC`,
+		now,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("listExpiredPending: query: %w", err)
+	}
+	defer rows.Close()
+
+	var ids []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("listExpiredPending: scan: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("listExpiredPending: rows: %w", err)
+	}
+	return ids, tx.Commit(ctx)
+}
+
+// resolveExpiredOne atomically auto-resolves one expired pending
+// notice. Returns the takedown audit row so the caller can dispatch
+// the OnTakedownCreated registry outside the transaction.
+//
+// The same-row pivot: SELECT FOR UPDATE prevents a racing
+// SubmitCounterNotice from re-stating the row while we resolve it.
+// If the row has already transitioned (e.g. counter_filed mid-sweep),
+// we skip it and return a sentinel that the caller logs at INFO.
+func (s *DMCAService) resolveExpiredOne(ctx context.Context, noticeID uuid.UUID, now time.Time) (Takedown, error) {
+	var td Takedown
+	if err := s.runAdminTx(ctx, func(tx pgx.Tx) error {
+		// Lock + re-check. Required: between listExpiredPending and
+		// this transaction, a SubmitCounterNotice could have raced in.
+		var current DMCAStatus
+		var targetKBID uuid.UUID
+		if err := tx.QueryRow(ctx,
+			`SELECT status, target_kb_id FROM dmca_notices
+			  WHERE id = $1 FOR UPDATE`,
+			noticeID,
+		).Scan(&current, &targetKBID); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return ErrDMCANoticeNotFound
+			}
+			return fmt.Errorf("resolveExpiredOne: re-load: %w", err)
+		}
+		if current != DMCAStatusPending {
+			// Lost the race to a counter-notice. Treat as success-skip
+			// (no error returned to the loop, caller increments
+			// Resolved as 0 by virtue of this path NOT returning a
+			// valid takedown row — see SweepExpired's check below).
+			return errSweepSkip
+		}
+
+		// 1. Resolve the notice row.
+		if _, err := tx.Exec(ctx,
+			`UPDATE dmca_notices
+			    SET status      = 'resolved_take_down',
+			        resolved_at = $2
+			  WHERE id = $1`,
+			noticeID, now,
+		); err != nil {
+			return fmt.Errorf("resolveExpiredOne: resolve notice: %w", err)
+		}
+
+		// 2. Flip the target KB. We set visibility=private (it may
+		//    already be) AND status=active (so the dmca_pending freeze
+		//    lifts — the legal hold has been resolved into a takedown).
+		//    The marketplace_takedowns row below is the durable audit
+		//    record for the action.
+		if _, err := tx.Exec(ctx,
+			`UPDATE knowledge_bases
+			    SET visibility = 'private',
+			        status     = 'active'
+			  WHERE id = $1`,
+			targetKBID,
+		); err != nil {
+			return fmt.Errorf("resolveExpiredOne: KB flip: %w", err)
+		}
+
+		// 3. Write the takedown audit row. Notes column carries the
+		//    notice id for forensic linkage; this is the same shape
+		//    AdminModeration.Approve uses (notes=report.Reason).
+		created, err := s.takedowns.CreateInTx(ctx, tx, targetKBID, TakedownSourceDMCA, "dmca_notice_id="+noticeID.String())
+		if err != nil {
+			return fmt.Errorf("resolveExpiredOne: takedown insert: %w", err)
+		}
+		td = created
+		return nil
+	}); err != nil {
+		if errors.Is(err, errSweepSkip) {
+			// Racing counter-notice — treat as non-fatal skip.
+			slog.InfoContext(ctx, "marketplace: DMCA sweep skipped (counter-notice raced in)",
+				"notice_id", noticeID)
+			return Takedown{}, errSweepSkip
+		}
+		return Takedown{}, err
+	}
+	return td, nil
+}
+
+// errSweepSkip is a sentinel returned by resolveExpiredOne when a
+// concurrent counter-notice raced in. SweepExpired handles it by
+// continuing without counting it as a resolution.
+var errSweepSkip = errors.New("marketplace: DMCA sweep skipped (counter-notice raced)")
+
+// ListNotices returns paginated DMCA notices for the admin UI. status
+// filters the list (empty means all). limit/offset honour the same
+// caps as the report queue.
+//
+// Runs under SET LOCAL ROLE raven_admin so the admin-bypass RLS policy
+// lets the cross-tenant read through.
+func (s *DMCAService) ListNotices(ctx context.Context, status DMCAStatus, limit, offset int) ([]DMCANotice, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 200 {
+		limit = 200
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	var out []DMCANotice
+	if err := s.runAdminTx(ctx, func(tx pgx.Tx) error {
+		var rows pgx.Rows
+		var err error
+		if status == "" {
+			rows, err = tx.Query(ctx,
+				`SELECT id, target_kb_id, notice_text, claimant_email,
+				        claimant_name, counter_notice_text,
+				        counter_notice_submitted_at,
+				        counter_notice_window_ends, status,
+				        resolved_at, created_at
+				   FROM dmca_notices
+				  ORDER BY created_at DESC
+				  LIMIT $1 OFFSET $2`,
+				limit, offset)
+		} else {
+			if !status.IsValid() {
+				return ErrDMCAInvalidInput
+			}
+			rows, err = tx.Query(ctx,
+				`SELECT id, target_kb_id, notice_text, claimant_email,
+				        claimant_name, counter_notice_text,
+				        counter_notice_submitted_at,
+				        counter_notice_window_ends, status,
+				        resolved_at, created_at
+				   FROM dmca_notices
+				  WHERE status = $1
+				  ORDER BY created_at DESC
+				  LIMIT $2 OFFSET $3`,
+				status, limit, offset)
+		}
+		if err != nil {
+			return fmt.Errorf("DMCAService.ListNotices: query: %w", err)
+		}
+		defer rows.Close()
+
+		out = make([]DMCANotice, 0, limit)
+		for rows.Next() {
+			var n DMCANotice
+			if err := rows.Scan(
+				&n.ID, &n.TargetKBID, &n.NoticeText,
+				&n.ClaimantEmail, &n.ClaimantName,
+				&n.CounterNoticeText, &n.CounterNoticeSubmittedAt,
+				&n.CounterNoticeWindowEnds, &n.Status,
+				&n.ResolvedAt, &n.CreatedAt,
+			); err != nil {
+				return fmt.Errorf("DMCAService.ListNotices: scan: %w", err)
+			}
+			out = append(out, n)
+		}
+		return rows.Err()
+	}); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// runAdminTx opens a transaction, switches to the raven_admin role,
+// runs fn, and commits. Rolls back on any returned error. Identical
+// shape to AdminModeration.runAdminTx — kept duplicated rather than
+// promoted to a shared helper because the call sites are exactly two
+// and the helper would have to live in a third file.
+func (s *DMCAService) runAdminTx(ctx context.Context, fn func(pgx.Tx) error) error {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("DMCA admin tx begin: %w", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	if _, err := tx.Exec(ctx, "SET LOCAL ROLE raven_admin"); err != nil {
+		return fmt.Errorf("DMCA admin tx set role: %w", err)
+	}
+
+	if err := fn(tx); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}

--- a/internal/marketplace/dmca_integration_test.go
+++ b/internal/marketplace/dmca_integration_test.go
@@ -1,0 +1,475 @@
+// Integration tests for DMCAService (issue #736, ADR-0006 launch blocker).
+// Drive Submit → SubmitCounterNotice → SweepExpired through a real
+// Postgres container, asserting the atomic-side-effect contracts:
+//
+//   - Submit flips kb_status=dmca_pending AND inserts a pending notice
+//     row in ONE transaction (rollback test: a forced FK failure leaves
+//     the KB alone).
+//   - SubmitCounterNotice pivots to counter_filed; subsequent sweep does
+//     NOT auto-resolve a counter-filed row.
+//   - SweepExpired auto-resolves expired pending rows, writes the
+//     takedowns row with source='dmca', and dispatches the
+//     OnTakedownCreated registry.
+//
+// Skipped under `go test -short` so the fast unit loop stays free of
+// testcontainers (mirrors the existing moderation integration tests).
+
+package marketplace_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/ravencloak-org/Raven/internal/marketplace"
+	"github.com/ravencloak-org/Raven/internal/testutil"
+)
+
+// dmcaNoticeStatus reads the current status of a DMCA notice. The
+// SELECT runs under the testcontainer superuser so RLS is bypassed.
+func dmcaNoticeStatus(ctx context.Context, t *testing.T, pool *pgxpool.Pool, id uuid.UUID) string {
+	t.Helper()
+	var s string
+	if err := pool.QueryRow(ctx, `SELECT status FROM dmca_notices WHERE id = $1`, id).Scan(&s); err != nil {
+		t.Fatalf("read DMCA notice status: %v", err)
+	}
+	return s
+}
+
+// kbStatus reads the lifecycle status of the given KB row.
+func kbStatus(ctx context.Context, t *testing.T, pool *pgxpool.Pool, kbID uuid.UUID) string {
+	t.Helper()
+	var s string
+	if err := pool.QueryRow(ctx, `SELECT status FROM knowledge_bases WHERE id = $1`, kbID).Scan(&s); err != nil {
+		t.Fatalf("read KB status: %v", err)
+	}
+	return s
+}
+
+// rewindWindow forces a notice's counter_notice_window_ends into the
+// past so SweepExpired picks it up without waiting 14 real days.
+func rewindWindow(ctx context.Context, t *testing.T, pool *pgxpool.Pool, noticeID uuid.UUID, into time.Duration) {
+	t.Helper()
+	if _, err := pool.Exec(ctx,
+		`UPDATE dmca_notices SET counter_notice_window_ends = now() - $2::interval WHERE id = $1`,
+		noticeID, into.String(),
+	); err != nil {
+		t.Fatalf("rewind window: %v", err)
+	}
+}
+
+// recordingHook captures every OnTakedownCreated dispatch. Used by the
+// sweep tests to assert that the derivative-notifier registry fires
+// exactly once per auto-resolved notice.
+type recordingHook struct {
+	mu      sync.Mutex
+	dispatched []marketplace.Takedown
+	reasons    []string
+}
+
+func (r *recordingHook) hook(_ context.Context, td marketplace.Takedown, reason string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.dispatched = append(r.dispatched, td)
+	r.reasons = append(r.reasons, reason)
+	return nil
+}
+
+// TestDMCAService_Submit_HappyPath drives the atomic two-side-effect
+// commit: dmca_notices row inserted + knowledge_bases.status flipped to
+// dmca_pending. Asserts the 14-day window was materialised correctly.
+func TestDMCAService_Submit_HappyPath(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+	f := seedModFixture(ctx, t, pool, "dmca-sub")
+
+	svc := marketplace.NewDMCAService(pool, marketplace.NewTakedowns(pool), nil)
+
+	before := time.Now()
+	notice, err := svc.Submit(ctx, marketplace.DMCANoticeInput{
+		TargetKBID:    f.KBID,
+		NoticeText:    "alleged copyright infringement at /marketplace/foo — signed.",
+		ClaimantEmail: "rights@example.com",
+		ClaimantName:  "Acme Rights Holder",
+	})
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+
+	// Notice row persisted with pending status.
+	if got := dmcaNoticeStatus(ctx, t, pool, notice.ID); got != "pending" {
+		t.Errorf("notice status: want pending, got %q", got)
+	}
+
+	// KB flipped to dmca_pending.
+	if got := kbStatus(ctx, t, pool, f.KBID); got != "dmca_pending" {
+		t.Errorf("KB status: want dmca_pending, got %q", got)
+	}
+
+	// Window is ~14 days out (allow a generous slack so a slow CI doesn't flap).
+	wantEnd := before.Add(marketplace.CounterNoticeWindow)
+	delta := notice.CounterNoticeWindowEnds.Sub(wantEnd).Abs()
+	if delta > 5*time.Second {
+		t.Errorf("window end drift: |%v - %v| = %v (>5s)", notice.CounterNoticeWindowEnds, wantEnd, delta)
+	}
+}
+
+// TestDMCAService_Submit_AlreadyPending409 asserts the "one active
+// notice per KB" invariant: a second Submit against a KB with a pending
+// notice returns ErrDMCAAlreadyPending.
+func TestDMCAService_Submit_AlreadyPending409(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+	f := seedModFixture(ctx, t, pool, "dmca-dup")
+
+	svc := marketplace.NewDMCAService(pool, marketplace.NewTakedowns(pool), nil)
+	in := marketplace.DMCANoticeInput{
+		TargetKBID:    f.KBID,
+		NoticeText:    "first notice",
+		ClaimantEmail: "a@example.com",
+		ClaimantName:  "A",
+	}
+	if _, err := svc.Submit(ctx, in); err != nil {
+		t.Fatalf("first submit: %v", err)
+	}
+	_, err := svc.Submit(ctx, in)
+	if !errors.Is(err, marketplace.ErrDMCAAlreadyPending) {
+		t.Errorf("second submit: want ErrDMCAAlreadyPending, got %v", err)
+	}
+}
+
+// TestDMCAService_Submit_TargetKBNotFound asserts the 404 mapping.
+func TestDMCAService_Submit_TargetKBNotFound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+
+	svc := marketplace.NewDMCAService(pool, marketplace.NewTakedowns(pool), nil)
+	_, err := svc.Submit(ctx, marketplace.DMCANoticeInput{
+		TargetKBID:    uuid.New(),
+		NoticeText:    "doesn't matter",
+		ClaimantEmail: "a@example.com",
+		ClaimantName:  "A",
+	})
+	if !errors.Is(err, marketplace.ErrDMCATargetKBNotFound) {
+		t.Errorf("missing KB: want ErrDMCATargetKBNotFound, got %v", err)
+	}
+}
+
+// TestDMCAService_Submit_InvalidInput400 covers the inline validation.
+func TestDMCAService_Submit_InvalidInput400(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+	svc := marketplace.NewDMCAService(pool, marketplace.NewTakedowns(pool), nil)
+
+	cases := []struct {
+		name string
+		in   marketplace.DMCANoticeInput
+	}{
+		{"nil_uuid", marketplace.DMCANoticeInput{NoticeText: "x", ClaimantEmail: "a@b", ClaimantName: "A"}},
+		{"empty_text", marketplace.DMCANoticeInput{TargetKBID: uuid.New(), ClaimantEmail: "a@b", ClaimantName: "A"}},
+		{"empty_email", marketplace.DMCANoticeInput{TargetKBID: uuid.New(), NoticeText: "x", ClaimantName: "A"}},
+		{"empty_name", marketplace.DMCANoticeInput{TargetKBID: uuid.New(), NoticeText: "x", ClaimantEmail: "a@b"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := svc.Submit(ctx, tc.in); !errors.Is(err, marketplace.ErrDMCAInvalidInput) {
+				t.Errorf("%s: want ErrDMCAInvalidInput, got %v", tc.name, err)
+			}
+		})
+	}
+}
+
+// TestDMCAService_SubmitCounterNotice_PreventsSweep is the headline
+// counter-notice flow. After a counter-notice is filed, the row's
+// status is `counter_filed`; subsequent SweepExpired must NOT touch it.
+func TestDMCAService_SubmitCounterNotice_PreventsSweep(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+	f := seedModFixture(ctx, t, pool, "dmca-cn")
+
+	svc := marketplace.NewDMCAService(pool, marketplace.NewTakedowns(pool), nil)
+	notice, err := svc.Submit(ctx, marketplace.DMCANoticeInput{
+		TargetKBID:    f.KBID,
+		NoticeText:    "alleged",
+		ClaimantEmail: "a@b",
+		ClaimantName:  "A",
+	})
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+
+	if err := svc.SubmitCounterNotice(ctx, notice.ID, "this is my counter-notice — signed."); err != nil {
+		t.Fatalf("SubmitCounterNotice: %v", err)
+	}
+	if got := dmcaNoticeStatus(ctx, t, pool, notice.ID); got != "counter_filed" {
+		t.Errorf("after counter: want counter_filed, got %q", got)
+	}
+
+	// Force the window into the past — the sweep should NOT pick up a
+	// counter-filed row.
+	rewindWindow(ctx, t, pool, notice.ID, 1*time.Hour)
+
+	result, err := svc.SweepExpired(ctx)
+	if err != nil {
+		t.Fatalf("SweepExpired: %v", err)
+	}
+	if result.Examined != 0 {
+		t.Errorf("sweep examined: want 0 (counter-filed row should not match), got %d", result.Examined)
+	}
+	if got := dmcaNoticeStatus(ctx, t, pool, notice.ID); got != "counter_filed" {
+		t.Errorf("after sweep: want counter_filed, got %q", got)
+	}
+}
+
+// TestDMCAService_SubmitCounterNotice_NotPending409 asserts that a
+// counter-notice cannot be filed against a terminal-state notice.
+func TestDMCAService_SubmitCounterNotice_NotPending409(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+	f := seedModFixture(ctx, t, pool, "dmca-illegal")
+
+	svc := marketplace.NewDMCAService(pool, marketplace.NewTakedowns(pool), nil)
+	notice, err := svc.Submit(ctx, marketplace.DMCANoticeInput{
+		TargetKBID:    f.KBID,
+		NoticeText:    "x",
+		ClaimantEmail: "a@b",
+		ClaimantName:  "A",
+	})
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+
+	// Manually flip to resolved_take_down so the next call is on a
+	// terminal-state row.
+	if _, err := pool.Exec(ctx,
+		`UPDATE dmca_notices SET status='resolved_take_down' WHERE id=$1`, notice.ID); err != nil {
+		t.Fatalf("setup terminal: %v", err)
+	}
+
+	err = svc.SubmitCounterNotice(ctx, notice.ID, "counter")
+	if !errors.Is(err, marketplace.ErrDMCAIllegalTransition) {
+		t.Errorf("counter on terminal: want ErrDMCAIllegalTransition, got %v", err)
+	}
+}
+
+// TestDMCAService_SubmitCounterNotice_NotFound asserts the 404 mapping.
+func TestDMCAService_SubmitCounterNotice_NotFound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+	svc := marketplace.NewDMCAService(pool, marketplace.NewTakedowns(pool), nil)
+
+	if err := svc.SubmitCounterNotice(ctx, uuid.New(), "doesn't matter"); !errors.Is(err, marketplace.ErrDMCANoticeNotFound) {
+		t.Errorf("missing notice: want ErrDMCANoticeNotFound, got %v", err)
+	}
+}
+
+// TestDMCAService_SweepExpired_AutoTakedown is the headline sweep test.
+// A pending notice with an expired window must (a) transition to
+// resolved_take_down, (b) flip the KB to private + status=active,
+// (c) write a takedowns row with source='dmca', and (d) dispatch the
+// OnTakedownCreated registry exactly once.
+func TestDMCAService_SweepExpired_AutoTakedown(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+	f := seedModFixture(ctx, t, pool, "dmca-sweep")
+
+	// Subscribe a recording hook. ResetOnTakedownCreatedForTest is
+	// idempotent and isolates this test from any global registration.
+	marketplace.ResetOnTakedownCreatedForTest()
+	t.Cleanup(marketplace.ResetOnTakedownCreatedForTest)
+	rec := &recordingHook{}
+	marketplace.RegisterOnTakedownCreated(rec.hook)
+
+	svc := marketplace.NewDMCAService(pool, marketplace.NewTakedowns(pool), nil)
+	notice, err := svc.Submit(ctx, marketplace.DMCANoticeInput{
+		TargetKBID:    f.KBID,
+		NoticeText:    "alleged",
+		ClaimantEmail: "a@b",
+		ClaimantName:  "A",
+	})
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+
+	rewindWindow(ctx, t, pool, notice.ID, 1*time.Hour)
+
+	result, err := svc.SweepExpired(ctx)
+	if err != nil {
+		t.Fatalf("SweepExpired: %v", err)
+	}
+	if result.Examined != 1 {
+		t.Errorf("sweep examined: want 1, got %d", result.Examined)
+	}
+	if result.Resolved != 1 {
+		t.Errorf("sweep resolved: want 1, got %d", result.Resolved)
+	}
+
+	// (a) Notice transitioned to resolved_take_down.
+	if got := dmcaNoticeStatus(ctx, t, pool, notice.ID); got != "resolved_take_down" {
+		t.Errorf("notice status: want resolved_take_down, got %q", got)
+	}
+
+	// (b) KB flipped to private + status=active (dmca_pending freeze lifted).
+	if v := kbVisibility(ctx, t, pool, f.KBID); v != "private" {
+		t.Errorf("KB visibility: want private, got %q", v)
+	}
+	if s := kbStatus(ctx, t, pool, f.KBID); s != "active" {
+		t.Errorf("KB status: want active, got %q", s)
+	}
+
+	// (c) Takedowns row with source='dmca'.
+	var (
+		tdCount  int
+		tdSource string
+	)
+	if err := pool.QueryRow(ctx,
+		`SELECT COUNT(*), MIN(source) FROM marketplace_takedowns WHERE target_kb_id = $1`,
+		f.KBID,
+	).Scan(&tdCount, &tdSource); err != nil {
+		t.Fatalf("query takedowns: %v", err)
+	}
+	if tdCount != 1 || tdSource != "dmca" {
+		t.Errorf("takedowns: count=%d source=%q (want 1, dmca)", tdCount, tdSource)
+	}
+
+	// (d) Registry fired exactly once.
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	if got := len(rec.dispatched); got != 1 {
+		t.Errorf("OnTakedownCreated dispatched: want 1, got %d", got)
+	}
+}
+
+// TestDMCAService_SweepExpired_Idempotent verifies the sweep is safe to
+// re-run — a second sweep finds zero expired pending rows.
+func TestDMCAService_SweepExpired_Idempotent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+	f := seedModFixture(ctx, t, pool, "dmca-idem")
+
+	marketplace.ResetOnTakedownCreatedForTest()
+	t.Cleanup(marketplace.ResetOnTakedownCreatedForTest)
+
+	svc := marketplace.NewDMCAService(pool, marketplace.NewTakedowns(pool), nil)
+	notice, err := svc.Submit(ctx, marketplace.DMCANoticeInput{
+		TargetKBID:    f.KBID,
+		NoticeText:    "alleged",
+		ClaimantEmail: "a@b",
+		ClaimantName:  "A",
+	})
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	rewindWindow(ctx, t, pool, notice.ID, 1*time.Hour)
+
+	if _, err := svc.SweepExpired(ctx); err != nil {
+		t.Fatalf("first sweep: %v", err)
+	}
+	second, err := svc.SweepExpired(ctx)
+	if err != nil {
+		t.Fatalf("second sweep: %v", err)
+	}
+	if second.Examined != 0 {
+		t.Errorf("second sweep examined: want 0, got %d", second.Examined)
+	}
+}
+
+// TestDMCAService_SweepExpired_RaceCounterNotice verifies the FOR
+// UPDATE re-check inside resolveExpiredOne: when a counter-notice
+// raced between listExpiredPending and the per-row resolution, the
+// sweep skips the row without writing a takedown.
+//
+// We simulate the race by:
+//  1. Submit + rewind so the row is in the candidate list.
+//  2. SubmitCounterNotice — flips the row OUT of pending.
+//  3. SweepExpired runs against the now-stale candidate list and must
+//     skip cleanly (no takedowns row).
+func TestDMCAService_SweepExpired_RaceCounterNotice(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	pool := testutil.NewTestDB(t)
+	ctx := context.Background()
+	f := seedModFixture(ctx, t, pool, "dmca-race")
+
+	svc := marketplace.NewDMCAService(pool, marketplace.NewTakedowns(pool), nil)
+	notice, err := svc.Submit(ctx, marketplace.DMCANoticeInput{
+		TargetKBID:    f.KBID,
+		NoticeText:    "alleged",
+		ClaimantEmail: "a@b",
+		ClaimantName:  "A",
+	})
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	rewindWindow(ctx, t, pool, notice.ID, 1*time.Hour)
+
+	// The "race" — counter-notice arrives before sweep gets the FOR UPDATE
+	// lock. In our serial test this is a plain pre-sweep call; the sweep's
+	// inside-tx re-check is what actually exercises the FOR UPDATE.
+	if err := svc.SubmitCounterNotice(ctx, notice.ID, "counter"); err != nil {
+		t.Fatalf("counter: %v", err)
+	}
+
+	result, err := svc.SweepExpired(ctx)
+	if err != nil {
+		t.Fatalf("SweepExpired: %v", err)
+	}
+	if result.Resolved != 0 {
+		t.Errorf("sweep resolved: want 0 (counter-notice raced), got %d", result.Resolved)
+	}
+
+	// No takedown row was written.
+	var n int
+	if err := pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM marketplace_takedowns WHERE target_kb_id = $1`,
+		f.KBID,
+	).Scan(&n); err != nil {
+		t.Fatalf("count takedowns: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("takedowns: want 0 (race skipped), got %d", n)
+	}
+}

--- a/migrations/00055_marketplace_dmca.sql
+++ b/migrations/00055_marketplace_dmca.sql
@@ -1,0 +1,116 @@
+-- +goose Up
+--
+-- Marketplace MVP (issue #736, launch blocker per ADR-0006).
+--
+-- Stand up the DMCA inbox + two-stage counter-notice workflow:
+--
+--   - dmca_notices — one row per incoming DMCA notice received at
+--     dmca@ravencloak.org. Pending notices freeze the target KB into
+--     `kb_status='dmca_pending'` for the 14-day statutory counter-notice
+--     window (17 U.S.C. § 512(g)(2)(B)). If the publisher files a
+--     counter-notice through the admin (MVP simplification — admin
+--     acts on behalf of publisher), the row records the counter-notice
+--     text and pivots to `counter_filed`; the KB stays in
+--     `dmca_pending` until the admin issues a final keep-up / take-down
+--     decision. Notices with no counter-notice when the window expires
+--     are auto-resolved by the daily sweeper (see
+--     internal/jobs/marketplace_dmca_sweeper.go), which flips the KB
+--     to `visibility='private'` and writes a `source='dmca'` row to
+--     marketplace_takedowns.
+--
+-- RLS: admin-only read+write (same shape as marketplace_takedowns from
+-- 00053 — non-admin sessions cannot even see the table). The sweeper
+-- runs under `SET LOCAL ROLE raven_admin` inside its sweep transaction.
+--
+-- Out of scope (deliberately):
+--   - kb_status 'dmca_pending' enum value — already in place from
+--     migration 00049.
+--   - marketplace_takedowns table — already in place from migration
+--     00053. The sweep auto-resolve writes into it via Takedowns.Create.
+--
+-- See:
+--   docs/plans/marketplace-mvp.md §4 (admin DMCA endpoints), §6 (DMCA inbox).
+--   docs/adr/0006-licence-and-moderation.md (14-day counter-notice window).
+--   docs/adr/0008-marketplace-discovery-and-operations.md (admin queue).
+--   migrations/00053_marketplace_moderation.sql (admin-bypass policy pattern).
+
+-- Bound long-running locks: the table is brand new, so the only risk
+-- is the CREATE TABLE itself blocking behind an unrelated long
+-- transaction. 5s is the project convention (see e.g. 00050).
+SET lock_timeout = '5s';
+SET statement_timeout = '60s';
+
+-- ─── dmca_notices ────────────────────────────────────────────────────────────
+--
+-- The `notice_text` body is bounded between 1 and 8192 chars — empty
+-- notices are rejected, and 8 KiB comfortably accommodates a 17 U.S.C.
+-- § 512(c)(3) compliant notice including a full URL list and
+-- good-faith / accuracy declarations without becoming an unbounded
+-- write target.
+--
+-- claimant_email / claimant_name are NOT NULL so every notice has a
+-- responsible party on file (statutory requirement). They are stored
+-- verbatim — no normalisation, no FK to users (claimants are external
+-- third parties, not Raven accounts).
+--
+-- counter_notice_text / counter_notice_submitted_at are nullable: they
+-- stay NULL until / unless the publisher files a counter-notice via
+-- the admin endpoint. We do not duplicate the publisher's email here —
+-- the publisher Org is reachable via target_kb_id → knowledge_bases →
+-- organizations and lookups happen at admin-action time.
+--
+-- counter_notice_window_ends materialises the 14-day clock at notice
+-- submission time so the sweep query can run a simple `< now()` filter
+-- without recomputing `created_at + interval '14 days'` on every row.
+-- This also lets the admin extend the window with a single UPDATE if
+-- the statute or our policy ever calls for it (out of scope for MVP).
+
+CREATE TABLE dmca_notices (
+    id                          UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    target_kb_id                UUID NOT NULL REFERENCES knowledge_bases(id) ON DELETE CASCADE,
+    notice_text                 TEXT NOT NULL
+                                CHECK (length(notice_text) BETWEEN 1 AND 8192),
+    claimant_email              TEXT NOT NULL,
+    claimant_name               TEXT NOT NULL,
+    counter_notice_text         TEXT NULL,
+    counter_notice_submitted_at TIMESTAMPTZ NULL,
+    counter_notice_window_ends  TIMESTAMPTZ NOT NULL,
+    status                      TEXT NOT NULL DEFAULT 'pending'
+                                CHECK (status IN ('pending', 'counter_filed', 'resolved_take_down', 'resolved_keep_up', 'withdrawn')),
+    resolved_at                 TIMESTAMPTZ NULL,
+    created_at                  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Sweep-query covering index: the daily sweeper's primary query is
+--   WHERE status = 'pending' AND counter_notice_window_ends < now()
+-- A composite b-tree on (status, counter_notice_window_ends) lets the
+-- planner pick it directly without consulting the heap until the
+-- window-end filter has eliminated most rows.
+CREATE INDEX idx_dmca_notices_sweep
+    ON dmca_notices (status, counter_notice_window_ends);
+
+-- Per-KB lookup: admin UI lists "is there an active DMCA hold on this
+-- KB?" via target_kb_id. The CASCADE on target_kb_id means hard-
+-- deleting a KB cleans up its notices; the takedown audit log (from
+-- 00053) preserves the long-term record.
+CREATE INDEX idx_dmca_notices_target_kb
+    ON dmca_notices (target_kb_id);
+
+ALTER TABLE dmca_notices ENABLE ROW LEVEL SECURITY;
+
+-- Admin-only read+write. No tenant policy is defined — non-admin
+-- sessions see zero rows because no USING clause matches. Mirrors the
+-- marketplace_takedowns shape from 00053 (internal-only legal record).
+CREATE POLICY admin_bypass ON dmca_notices
+    FOR ALL TO raven_admin
+    USING (true);
+
+-- +goose Down
+--
+-- Reverse in dependency order: policy → indexes → table. No reversal
+-- needed for the lock_timeout / statement_timeout SETs — they are
+-- scoped to the migration transaction.
+DROP POLICY IF EXISTS admin_bypass ON dmca_notices;
+DROP INDEX IF EXISTS idx_dmca_notices_target_kb;
+DROP INDEX IF EXISTS idx_dmca_notices_sweep;
+DROP TABLE IF EXISTS dmca_notices;


### PR DESCRIPTION
## Summary

Lands the DMCA inbox + two-stage counter-notice workflow — a Marketplace **launch blocker** per ADR-0006.

- **Migration `00055_marketplace_dmca.sql`** — `dmca_notices` table (admin-only RLS, sweep-covering index, 14-day window materialised at insert).
- **`internal/marketplace/dmca.go`** — `DMCAService` with:
  - `Submit` — atomic two-side-effect tx: insert notice + flip target KB to `kb_status='dmca_pending'`. Claimant receipt email runs outside the tx.
  - `SubmitCounterNotice` — transitions row to `counter_filed`. KB stays frozen until admin issues a final decision (DMCA safe harbour 17 U.S.C. § 512(g)(2)(C) requires a 10–14 business-day hold between counter-notice and restoration).
  - `SweepExpired` — daily cron sweep with `FOR UPDATE` re-check against counter-notice races. Flips KB to `visibility=private, status=active`, writes `marketplace_takedowns` row with `source='dmca'`, dispatches `OnTakedownCreated` registry so the derivative-owner notifier from #735 fires automatically.
- **`internal/jobs/marketplace_dmca_sweeper.go`** + scheduler wiring (04:00 UTC daily).
- **Handlers** — `POST /admin/marketplace/dmca`, `POST /admin/marketplace/dmca/:id/counter-notice`, `GET /admin/marketplace/dmca` gated by `RequirePlatformAdmin` (RAVEN_ADMIN_EMAILS).
- **Frontend** — `AdminDMCAView.vue` (status pills + record/counter-notice modals), `DMCAPage.vue` at `/legal/dmca`, footer link on the Marketplace list view.
- **Docs** — `docs/legal/dmca.md` operator runbook.

### MVP simplification

The counter-notice endpoint is admin-driven: publishers reply to `dmca@ravencloak.org` and the operator records the counter-notice text on their behalf. There is no public counter-notice UI in this PR; the runbook documents the path.

### Strike counter on DMCA auto-resolutions

The DMCA sweeper currently does NOT increment `organizations.takedown_strikes` on auto-resolution — whether DMCA-sourced takedowns count toward the 3-strike Org-suspension threshold is a policy decision tracked separately (called out in `docs/legal/dmca.md`).

## Test plan

- [x] `go test -short ./internal/handler/ ./internal/marketplace/ ./internal/jobs/ ./cmd/...` — green locally
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 issues
- [x] `vue-tsc -b` — clean
- [x] `npm run lint` — no new errors
- [ ] CI runs the integration tests (testcontainers can't run in this sandbox)
- [ ] Playwright admin DMCA + legal page specs (added; gated by E2E_ADMIN like sibling specs)
- [ ] DMCA inbox `dmca@ravencloak.org` Google Workspace alias provisioned (ops, out of code-scope)

## References

- ADR-0006 — Mandatory licence + reactive moderation
- ADR-0008 — Marketplace discovery + operations (admin tier)
- `docs/plans/marketplace-mvp.md` §4 (admin endpoints), §5 (Vue route), §6 (DMCA inbox)
- Builds on #735 (admin takedown audit + `OnTakedownCreated` registry + derivative notifier)

Closes #736