### PR TITLE
fix(migrations): strip backticks from goose directive in 00054 prose comment

### DIFF
--- a/migrations/00054_user_passkey_labels.sql
+++ b/migrations/00054_user_passkey_labels.sql
@@ -18,8 +18,8 @@
 -- (which lists every label for the calling user in one shot). Built
 -- CONCURRENTLY so the deploy does not hold ACCESS EXCLUSIVE on the table
 -- while the index is built — this is why the migration is wrapped in
--- `+goose NO TRANSACTION` (CREATE INDEX CONCURRENTLY cannot run inside a
--- transaction block).
+-- the NO TRANSACTION goose directive (CREATE INDEX CONCURRENTLY cannot
+-- run inside a transaction block).
 --
 -- References:
 --   - docs/superpowers/specs/2026-06-04-passkey-auth-design.md §Architecture


### PR DESCRIPTION
## Summary

Line 21 of `migrations/00054_user_passkey_labels.sql` quoted the goose directive with backticks (\`+goose NO TRANSACTION\`) inside an explanatory comment. goose v3's annotation parser scans for any line containing `+goose` and treats it as an annotation candidate, producing:

```
ERROR 00054_user_passkey_labels.sql: failed to parse SQL migration file:
  failed to parse annotation line "-- \`+goose NO TRANSACTION\` (CREATE INDEX CONCURRENTLY cannot run inside a":
  "\` NO TRANSACTION\` (CREATE INDEX CONCURRENTLY cannot run inside a" not supported: invalid annotation
```

every migration run.

## Fix

Rephrase the prose to use plain words ("the NO TRANSACTION goose directive") instead of the back-quoted literal. The actual directives on lines 2 and 75 are correct and untouched.

## Why this is urgent

This regression on `main` is blocking **every open feature PR** because migration tests fail before any feature test runs. Currently affecting #789, #790, #791, #794, #795 (Marketplace MVP queue).

`go test -short ./migrations/` green locally after the fix.