### PR TITLE
fix(test): unblock main CI — pg arg signature + pgx type inference

### DIFF
--- a/internal/marketplace/moderation_integration_test.go
+++ b/internal/marketplace/moderation_integration_test.go
@@ -45,30 +45,36 @@ func seedModFixture(ctx context.Context, t *testing.T, pool *pgxpool.Pool, label
 		KBID:   uuid.New(),
 	}
 
+	// pgx + PG18 reject `$N || ... substring($1::text...)` shapes when the
+	// same placeholder appears in both a column slot AND a text-concat
+	// expression — parameter type inference deduces incompatible types
+	// and aborts with SQLSTATE 42P08. Casting each placeholder explicitly
+	// at every use site pins the type at parse time and dodges the inference
+	// loop entirely.
 	if _, err := pool.Exec(ctx,
 		`INSERT INTO organizations (id, name, slug)
-		 VALUES ($1, $2, $2 || '-' || substring($1::text from 1 for 8))`,
+		 VALUES ($1::uuid, $2::text, $2::text || '-' || substring($1::uuid::text from 1 for 8))`,
 		f.OrgID, label+"-org",
 	); err != nil {
 		t.Fatalf("seed organization: %v", err)
 	}
 	if _, err := pool.Exec(ctx,
 		`INSERT INTO workspaces (id, org_id, name, slug)
-		 VALUES ($1, $2, $3, $3 || '-' || substring($1::text from 1 for 8))`,
+		 VALUES ($1::uuid, $2::uuid, $3::text, $3::text || '-' || substring($1::uuid::text from 1 for 8))`,
 		f.WSID, f.OrgID, label+"-ws",
 	); err != nil {
 		t.Fatalf("seed workspace: %v", err)
 	}
 	if _, err := pool.Exec(ctx,
 		`INSERT INTO users (id, org_id, email, status)
-		 VALUES ($1, $2, $3 || '-' || substring($1::text from 1 for 8) || '@example.com', 'active')`,
+		 VALUES ($1::uuid, $2::uuid, $3::text || '-' || substring($1::uuid::text from 1 for 8) || '@example.com', 'active')`,
 		f.UserID, f.OrgID, label,
 	); err != nil {
 		t.Fatalf("seed user: %v", err)
 	}
 	if _, err := pool.Exec(ctx,
 		`INSERT INTO knowledge_bases (id, org_id, workspace_id, name, slug)
-		 VALUES ($1, $2, $3, $4, $4 || '-' || substring($1::text from 1 for 8))`,
+		 VALUES ($1::uuid, $2::uuid, $3::uuid, $4::text, $4::text || '-' || substring($1::uuid::text from 1 for 8))`,
 		f.KBID, f.OrgID, f.WSID, label+"-kb",
 	); err != nil {
 		t.Fatalf("seed knowledge_base: %v", err)

--- a/migrations/migrations_test.go
+++ b/migrations/migrations_test.go
@@ -796,7 +796,9 @@ func TestMigrationsUpAndDown(t *testing.T) {
 		cases := []sigCheck{
 			{
 				fnName:     "marketplace_list_public_kbs",
-				args:       "text, text, text[], integer, integer",
+				// pg_get_function_arguments reconstructs the CREATE FUNCTION
+				// arg list including parameter names, not just types.
+				args:       "q text, sort text, licenses text[], page_limit integer, page_offset integer",
 				wantSecDef: true,
 				wantOwner:  "raven_admin",
 				wantCols: []string{
@@ -814,7 +816,7 @@ func TestMigrationsUpAndDown(t *testing.T) {
 			},
 			{
 				fnName:     "marketplace_preview_kb",
-				args:       "uuid",
+				args:       "p_public_kb_id uuid",
 				wantSecDef: true,
 				wantOwner:  "raven_admin",
 				wantCols:   []string{"chunk_id", "ordinal", "text"},


### PR DESCRIPTION
Two pre-existing main-side test failures that have been blocking every PR's CI run:

## 1. \`migrations/migrations_test.go\` — `marketplace_functions_signature` subtest

\`pg_get_function_arguments()\` reconstructs the CREATE FUNCTION arg list **including parameter names**, not just types. The test expected type-only strings and never matched:

\`\`\`
fail: function marketplace_list_public_kbs(text, text, text[], integer, integer)
       not found: sql: no rows in result set
\`\`\`

Updated expected strings to match Postgres' actual output:
- `marketplace_list_public_kbs`: \`q text, sort text, licenses text[], page_limit integer, page_offset integer\`
- `marketplace_preview_kb`: \`p_public_kb_id uuid\`

## 2. \`internal/marketplace/moderation_integration_test.go\` — \`seedModFixture\` SQLSTATE 42P08

Postgres parameter type inference rejects the same placeholder appearing in **both a column slot and a text-concat expression** with:

\`\`\`
seed organization: ERROR: inconsistent types deduced for parameter \$1 (SQLSTATE 42P08)
\`\`\`

Every admin_moderation / dmca / derivative_notifier integration test short-circuits here on the first INSERT (organizations).

Pinned types at parse time with explicit casts at every reuse: \`\$1::uuid, \$2::text, \$2::text || '-' || substring(\$1::uuid::text...)\`. Applied to all four INSERTs in seedModFixture.

## Impact

Both regressions are independent of any current PR's diff — they're infrastructure bugs surfaced by PG18 + recent pgx type inference. Landing this turns green every PR currently failing on \`Unit Tests\` / \`Integration Tests\` with the SQLSTATE 42P08 trace or the \`marketplace_functions_signature\` subtest.